### PR TITLE
Enable warehouse

### DIFF
--- a/measures/create_DOE_prototype_building/measure.rb
+++ b/measures/create_DOE_prototype_building/measure.rb
@@ -32,7 +32,7 @@ class CreateDOEPrototypeBuilding < OpenStudio::Ruleset::ModelUserScript
     building_type_chs << 'LargeOffice'
     building_type_chs << 'SmallHotel'
     building_type_chs << 'LargeHotel'
-    #building_type_chs << 'Warehouse'
+    building_type_chs << 'Warehouse'
     building_type_chs << 'RetailStandalone'
     building_type_chs << 'RetailStripmall'
     building_type_chs << 'QuickServiceRestaurant'


### PR DESCRIPTION
This enables warehouse as an option for the measure when creating the prototype buildings.

Caveat: The newer vintages align well with the legacy IDFs but the older vintages do not at the time of this pull request.

The Pre-1980 and Post-1980 Warehouse models have very high cooling and fan energy which still need to be investigated further.