### PR TITLE
Fix the PTAC and PTHP setStandardEfficiencyAndCurves to take into account zone Multiplier

### DIFF
--- a/openstudio-standards/lib/openstudio-standards.rb
+++ b/openstudio-standards/lib/openstudio-standards.rb
@@ -5,7 +5,7 @@ module OpenstudioStandards
   require 'json' # Used to load standards JSON files
   
   # HVAC sizing
-  require 'openstudio-standards/hvac_sizing/Siz.Model'
+  require_relative 'openstudio-standards/hvac_sizing/Siz.Model'
 
   # Prototype Inputs
   require_relative 'openstudio-standards/prototypes/Prototype.Model'

--- a/openstudio-standards/lib/openstudio-standards/standards/Standards.CoilCoolingDXSingleSpeed.rb
+++ b/openstudio-standards/lib/openstudio-standards/standards/Standards.CoilCoolingDXSingleSpeed.rb
@@ -258,8 +258,7 @@ class OpenStudio::Model::CoilCoolingDXSingleSpeed
       return successfully_set_all_properties
     end    
 
-    # Convert capacity to Btu/hr
-    capacity_btu_per_hr = OpenStudio.convert(capacity_w, "W", "Btu/hr").get
+
 
 
     # If it's a PTAC or PTHP System, we need to divide the capacity by the potential zone multiplier
@@ -270,13 +269,16 @@ class OpenStudio::Model::CoilCoolingDXSingleSpeed
       if comp.is_initialized && comp.get.thermalZone.is_initialized
         mult = comp.get.thermalZone.get.multiplier
         if mult > 1
-          capacity_btu_per_hr /= mult
-          OpenStudio::logFree(OpenStudio::Info, 'openstudio.standards.CoilCoolingDXSingleSpeed', "For #{self.name} capacity was divided by the zone multiplier of #{mult}.")
+          total_cap = capacity_w
+          capacity_w /= mult
+          OpenStudio::logFree(OpenStudio::Info, 'openstudio.standards.CoilCoolingDXSingleSpeed', "For #{self.name}, total capacity of #{OpenStudio.convert(total_cap, "W", "kBtu/hr").get.round(2)}kBTU/hr was divided by the zone multiplier of #{mult} to give #{capacity_kbtu_per_hr = OpenStudio.convert(capacity_w, "W", "kBtu/hr").get.round(2)}kBTU/hr.")
         end
       end
     end
 
-    capacity_kbtu_per_hr = capacity_btu_per_hr / 1000.0
+    # Convert capacity to Btu/hr
+    capacity_btu_per_hr = OpenStudio.convert(capacity_w, "W", "Btu/hr").get
+    capacity_kbtu_per_hr = OpenStudio.convert(capacity_w, "W", "kBtu/hr").get
 
     # Lookup efficiencies depending on whether it is a unitary AC or a heat pump
     ac_props = nil
@@ -380,7 +382,7 @@ class OpenStudio::Model::CoilCoolingDXSingleSpeed
       ptac_eer = ptac_eer_coeff_1 + (ptac_eer_coeff_2 * capacity_btu_per_hr)
       cop = eer_to_cop(ptac_eer)
       new_comp_name = "#{self.name} #{capacity_kbtu_per_hr.round}kBtu/hr #{ptac_eer.round(1)}EER"
-      OpenStudio::logFree(OpenStudio::Info, 'openstudio.standards.CoilCoolingDXSingleSpeed',  "For #{template}: #{self.name}: #{cooling_type} #{heating_type} #{subcategory} Capacity = #{capacity_kbtu_per_hr.round}kBtu/hr; EER = #{ptac_eer}")      
+      OpenStudio::logFree(OpenStudio::Info, 'openstudio.standards.CoilCoolingDXSingleSpeed',  "For #{template}: #{self.name}: #{cooling_type} #{heating_type} #{subcategory} Capacity = #{capacity_kbtu_per_hr.round}kBtu/hr; EER = #{ptac_eer.round(2)}")
     end
     
     # If specified as SEER

--- a/openstudio-standards/lib/openstudio-standards/standards/Standards.CoilCoolingDXSingleSpeed.rb
+++ b/openstudio-standards/lib/openstudio-standards/standards/Standards.CoilCoolingDXSingleSpeed.rb
@@ -269,7 +269,7 @@ class OpenStudio::Model::CoilCoolingDXSingleSpeed
       comp = self.containingZoneHVACComponent
       if comp.is_initialized && comp.get.thermalZone.is_initialized
         mult = comp.get.thermalZone.get.multiplier
-        capacity_btu_per_hr /= comp.thermalZone.get.multiplier
+        capacity_btu_per_hr /= mult
         OpenStudio::logFree(OpenStudio::Info, 'openstudio.standards.CoilCoolingDXSingleSpeed', "For #{self.name} capacity was divided by the zone multiplier of #{mult}.")
       end
     end

--- a/openstudio-standards/lib/openstudio-standards/standards/Standards.CoilCoolingDXSingleSpeed.rb
+++ b/openstudio-standards/lib/openstudio-standards/standards/Standards.CoilCoolingDXSingleSpeed.rb
@@ -269,13 +269,15 @@ class OpenStudio::Model::CoilCoolingDXSingleSpeed
       comp = self.containingZoneHVACComponent
       if comp.is_initialized && comp.get.thermalZone.is_initialized
         mult = comp.get.thermalZone.get.multiplier
-        capacity_btu_per_hr /= mult
-        OpenStudio::logFree(OpenStudio::Info, 'openstudio.standards.CoilCoolingDXSingleSpeed', "For #{self.name} capacity was divided by the zone multiplier of #{mult}.")
+        if mult > 1
+          capacity_btu_per_hr /= mult
+          OpenStudio::logFree(OpenStudio::Info, 'openstudio.standards.CoilCoolingDXSingleSpeed', "For #{self.name} capacity was divided by the zone multiplier of #{mult}.")
+        end
       end
     end
 
-    capacity_kbtu_per_hr = OpenStudio.convert(capacity_w, "W", "kBtu/hr").get
-    
+    capacity_kbtu_per_hr = capacity_btu_per_hr / 1000.0
+
     # Lookup efficiencies depending on whether it is a unitary AC or a heat pump
     ac_props = nil
     if heat_pump == true

--- a/openstudio-standards/lib/openstudio-standards/standards/Standards.PlantLoop.rb
+++ b/openstudio-standards/lib/openstudio-standards/standards/Standards.PlantLoop.rb
@@ -380,7 +380,7 @@ lcnwt_f = lcnwt_10f_approach if lcnwt_10f_approach < 85
       # and therefore less heating capacity is likely required.
       decrease_f = 30.0
       hwt_at_hi_oat_f = hwt_at_lo_oat_f - decrease_f 
-      hwt_at_hi_oat_c = OpenStudio.convert(hwt_at_hi_oat_f, 'C', 'F').get
+      hwt_at_hi_oat_c = OpenStudio.convert(hwt_at_hi_oat_f, 'F', 'C').get
 
       # Define the high and low outdoor air temperatures
       lo_oat_f = 20

--- a/openstudio-standards/lib/openstudio-standards/standards/Standards.PlantLoop.rb
+++ b/openstudio-standards/lib/openstudio-standards/standards/Standards.PlantLoop.rb
@@ -357,7 +357,7 @@ lcnwt_f = lcnwt_10f_approach if lcnwt_10f_approach < 85
     # and determine if already has temperature reset
     spms = self.supplyOutletNode.setpointManagers
     spms.each do |spm|
-      if spm.to_SetpointManagerOutdoorAirReset
+      if spm.to_SetpointManagerOutdoorAirReset.is_initialized
         OpenStudio::logFree(OpenStudio::Info, 'openstudio.standards.PlantLoop', "For #{self.name}: supply water temperature reset is already enabled.")
         return false
       end
@@ -365,9 +365,9 @@ lcnwt_f = lcnwt_10f_approach if lcnwt_10f_approach < 85
 
     # Get the design water temperature
     sizing_plant = self.sizingPlant
-    design_temp_c = sizing_plant.loopDesignExitTemperature
+    design_temp_c = sizing_plant.designLoopExitTemperature
     design_temp_f = OpenStudio.convert(design_temp_c,'C','F').get
-    loop_type = self.loopType
+    loop_type = sizing_plant.loopType
     
     # Apply the reset, depending on the type of loop.
     case loop_type


### PR DESCRIPTION
Currently if you a zone that has a need for 10 kTBU/hr and a multiplier or 10, the COP is calculated based on the total load of 100 kBTU/hr and leads to a COP lower than it should be.