### PR TITLE
fixes simulation.rb to work with 2x OS

### DIFF
--- a/openstudio-standards/lib/openstudio-standards/utilities/simulation.rb
+++ b/openstudio-standards/lib/openstudio-standards/utilities/simulation.rb
@@ -39,7 +39,7 @@ class OpenStudio::Model::Model
     begin
       workflow = OpenStudio::WorkflowJSON.new
       use_runmanager = false
-    rescue LoadError
+    rescue NameError
       use_runmanager = true
     end
 


### PR DESCRIPTION
2x code is based on what is used for reporting measure tests. Create
OSW and run that with CLI.

@asparke2 test in measure repo runs fine with these updates. I don't have a 1x to test but I shouldn't have changed what happens for 1.x.