### PR TITLE
Fix method redefining issue 144

### DIFF
--- a/openstudio-standards/Rakefile
+++ b/openstudio-standards/Rakefile
@@ -79,6 +79,9 @@ require 'rake/testtask'
 desc 'Run test nrel group 3'
 Rake::TestTask.new('test:gem_nrel_group_3') do |task|
   task.test_files = FileList[
+  'openstudio-standards/test/test_full_service_restaurant.rb', # 10 min
+  'openstudio-standards/test/test_retail_standalone.rb', # 6 min
+  'openstudio-standards/test/test_small_hotel.rb', # 80 min
   'openstudio-standards/test/test_small_office.rb' # 7 min
   ]
 end

--- a/openstudio-standards/Rakefile
+++ b/openstudio-standards/Rakefile
@@ -36,11 +36,11 @@ Rake::TestTask.new('test:gem_group_0') do |task|
   task.test_files = FileList[
   'openstudio-standards/test/test_find_ashrae_hot_water_demand.rb',
   'openstudio-standards/test/test_find_construction_properties_data.rb',
-  'openstudio-standards/test/test_find_space_type_standards_data.rb',
-  'openstudio-standards/test/test_find_target_eui.rb',
-  'openstudio-standards/test/test_find_target_eui_by_end_use.rb',
-  'openstudio-standards/test/test_primary_school.rb', # 9 min
-  'openstudio-standards/test/test_warehouse.rb'#
+  'openstudio-standards/test/test_find_space_type_standards_data.rb', # 0 min
+  'openstudio-standards/test/test_find_target_eui.rb', # 0 min
+  'openstudio-standards/test/test_find_target_eui_by_end_use.rb', # 0 min
+  'openstudio-standards/test/test_primary_school.rb', # 4 min
+  'openstudio-standards/test/test_warehouse.rb'# 1 min
   ]
 end
 
@@ -48,11 +48,9 @@ require 'rake/testtask'
 desc 'Run test group 1'
 Rake::TestTask.new('test:gem_group_1') do |task|
   task.test_files = FileList[
-  'openstudio-standards/test/test_secondary_school.rb', # 70 min
-  'openstudio-standards/test/test_medium_office.rb',
+  'openstudio-standards/test/test_secondary_school.rb', # 6 min
+  'openstudio-standards/test/test_medium_office.rb', # 2 min
   'openstudio-standards/test/test_mid_rise_apartment.rb' # 7 min
-
-
   ]
 end
 
@@ -60,29 +58,52 @@ require 'rake/testtask'
 desc 'Run test group 2'
 Rake::TestTask.new('test:gem_group_2') do |task|
   task.test_files = FileList[
-  'openstudio-standards/test/test_large_hotel.rb', # 5 min
-  'openstudio-standards/test/test_large_office.rb', # 4 min
+  'openstudio-standards/test/test_large_hotel.rb', # 3 min
+  'openstudio-standards/test/test_large_office.rb', # 2 min
   'openstudio-standards/test/test_quick_service_restaurant.rb', # 1 min
   'openstudio-standards/test/test_strip_mall.rb', # 2 min
-  'openstudio-standards/test/test_high_rise_apartment.rb',# 7 min
-  'openstudio-standards/test/test_outpatient.rb' #
-
-  
+  'openstudio-standards/test/test_outpatient.rb' # 10 min 
   ]
 end
 
-desc 'Run test group 3'
-task 'test:gem_group_3' => ['test:gem_nrel_group_3', 'test:necb-buildings']
-
-
 require 'rake/testtask'
-desc 'Run test nrel group 3'
+desc 'Run test group 3'
 Rake::TestTask.new('test:gem_nrel_group_3') do |task|
   task.test_files = FileList[
-  'openstudio-standards/test/test_full_service_restaurant.rb', # 10 min
+  'openstudio-standards/test/test_full_service_restaurant.rb', # 1 min
   'openstudio-standards/test/test_retail_standalone.rb', # 6 min
   'openstudio-standards/test/test_small_hotel.rb', # 80 min
-  'openstudio-standards/test/test_small_office.rb' # 7 min
+  'openstudio-standards/test/test_small_office.rb', # 7 min
+  # NECB Buildings
+  'openstudio-standards/test/test_necb_airloop_sizing_parameters.rb',
+  'openstudio-standards/test/test_necb_bldg_full_service_restaurant.rb',
+  'openstudio-standards/test/test_necb_bldg_high_rise_apartment.rb',
+  'openstudio-standards/test/test_necb_bldg_large_hotel.rb',
+  'openstudio-standards/test/test_necb_bldg_large_office.rb',
+  'openstudio-standards/test/test_necb_bldg_medium_office.rb',
+  'openstudio-standards/test/test_necb_bldg_midrise_apartment_office.rb',
+  'openstudio-standards/test/test_necb_bldg_outpatient.rb',
+  'openstudio-standards/test/test_necb_bldg_primary_school.rb',
+  'openstudio-standards/test/test_necb_bldg_quick_service_restaurant.rb',
+  'openstudio-standards/test/test_necb_bldg_retail_standalone.rb',
+  'openstudio-standards/test/test_necb_bldg_retail_stripmall.rb',
+  'openstudio-standards/test/test_necb_bldg_secondary_school.rb',
+  'openstudio-standards/test/test_necb_bldg_small_hotel.rb',
+  'openstudio-standards/test/test_necb_bldg_small_office.rb',
+  'openstudio-standards/test/test_necb_bldg_warehouse.rb',
+  'openstudio-standards/test/test_necb_boiler_rules.rb',
+  'openstudio-standards/test/test_necb_chiller_rules.rb', #42s
+  'openstudio-standards/test/test_necb_constructions_fdwr.rb', #19s
+  'openstudio-standards/test/test_necb_coolingtower_rules.rb',
+  'openstudio-standards/test/test_necb_default_spacetypes.rb', #30s
+  'openstudio-standards/test/test_necb_default_system_selection.rb',
+  'openstudio-standards/test/test_necb_fan_rules.rb',
+  'openstudio-standards/test/test_necb_heatpump_rules.rb',
+  'openstudio-standards/test/test_necb_hrv_rules.rb',
+  'openstudio-standards/test/test_necb_loop_rules.rb',
+  'openstudio-standards/test/test_necb_unitary_rules.rb',
+  'openstudio-standards/test/test_necb_waterheater_rules.rb',
+  'openstudio-standards/test/test_necb_weather.rb'
   ]
 end
 
@@ -90,7 +111,7 @@ require 'rake/testtask'
 desc 'Run test group 4'
 Rake::TestTask.new('test:gem_group_4') do |task|
   task.test_files = FileList[
-  'openstudio-standards/test/test_create_performance_rating_method_baseline_building.rb'
+  'openstudio-standards/test/test_create_performance_rating_method_baseline_building.rb' # 33 min
   ]
 end
 
@@ -98,7 +119,7 @@ require 'rake/testtask'
 desc 'Run test group 5'
 Rake::TestTask.new('test:gem_group_5') do |task|
   task.test_files = FileList[
-  'openstudio-standards/test/test_create_performance_rating_method_baseline_bldg_2.rb'
+  'openstudio-standards/test/test_create_performance_rating_method_baseline_bldg_2.rb' # 32 min
   ]
 end
 
@@ -106,7 +127,7 @@ require 'rake/testtask'
 desc 'Run test group 6'
 Rake::TestTask.new('test:gem_group_6') do |task|
   task.test_files = FileList[
-  'openstudio-standards/test/test_create_performance_rating_method_baseline_bldg_3.rb'
+  'openstudio-standards/test/test_create_performance_rating_method_baseline_bldg_3.rb' # 65 min
   ]
 end
 
@@ -117,7 +138,8 @@ Rake::TestTask.new('test:gem_group_7') do |task|
   'openstudio-standards/test/test_boiler_hot_water.rb',
   'openstudio-standards/test/test_chiller_electric_eir.rb',
   'openstudio-standards/test/test_coil_dx.rb',
-  'openstudio-standards/test/test_get_building_climate_zone_and_building_type.rb'
+  'openstudio-standards/test/test_get_building_climate_zone_and_building_type.rb',
+  'openstudio-standards/test/test_high_rise_apartment.rb', # 54 min
   ]
 end
 
@@ -186,26 +208,8 @@ Rake::TestTask.new('test:gem') do |task|
   task.test_files = FileList['openstudio-standards/test/test_*.rb']
 end
 
-require 'rake/testtask'
-desc 'Run the measure tests'
-Rake::TestTask.new('test:measures') do |task|
-  task.test_files = FileList[
-  # TOO LONG 'measures/apply_system1/tests/full_hvac_test.rb',
-  #'measures/btap_apply_necb_rules/tests/apply_necb_rules_Test.rb',
-  # TOO LONG 'measures/btap_campus_classic/tests/btap_coldlake_classic_test.rb',
-  #'measures/btap_change_building_location/tests/btap_change_location_test.rb',
-  #'measures/btap_create_doe_necb_models/tests/DOE2NECB_Model_Test.rb',
-  #'measures/btap_equest_converter/tests/btap_equest_converter_test.rb',
-  #'measures/btap_replace_model/tests/ReplaceModel_Test.rb',
-  #'measures/btap_set_default_construction_set/tests/set_default_construction_set_test.rb',
-  # TOO Long 'measures/create_DOE_prototype_building/tests/create_DOE_prototype_building_test.rb',
-  #'measures/UtilityTariffs/tests/UtilityTariffs_Test.rb'
-  ]
-end
-
 desc 'Run all tests'
 task 'test:all' => ['test:prm', 'test:gem', 'test:measures']
-
 
 
 

--- a/openstudio-standards/Rakefile
+++ b/openstudio-standards/Rakefile
@@ -50,9 +50,8 @@ Rake::TestTask.new('test:gem_group_1') do |task|
   task.test_files = FileList[
   'openstudio-standards/test/test_secondary_school.rb', # 70 min
   'openstudio-standards/test/test_medium_office.rb',
-  'openstudio-standards/test/test_mid_rise_apartment.rb', # 7 min
-  'openstudio-standards/test/test_high_rise_apartment.rb',#, # 7 min
-  'openstudio-standards/test/test_outpatient.rb' #
+  'openstudio-standards/test/test_mid_rise_apartment.rb' # 7 min
+
 
   ]
 end
@@ -64,8 +63,9 @@ Rake::TestTask.new('test:gem_group_2') do |task|
   'openstudio-standards/test/test_large_hotel.rb', # 5 min
   'openstudio-standards/test/test_large_office.rb', # 4 min
   'openstudio-standards/test/test_quick_service_restaurant.rb', # 1 min
-  'openstudio-standards/test/test_strip_mall.rb' # 2 min
-
+  'openstudio-standards/test/test_strip_mall.rb', # 2 min
+  'openstudio-standards/test/test_high_rise_apartment.rb',# 7 min
+  'openstudio-standards/test/test_outpatient.rb' #
 
   
   ]

--- a/openstudio-standards/Rakefile
+++ b/openstudio-standards/Rakefile
@@ -79,9 +79,6 @@ require 'rake/testtask'
 desc 'Run test nrel group 3'
 Rake::TestTask.new('test:gem_nrel_group_3') do |task|
   task.test_files = FileList[
-  'openstudio-standards/test/test_full_service_restaurant.rb', # 10 min
-  'openstudio-standards/test/test_retail_standalone.rb', # 6 min
-  'openstudio-standards/test/test_small_hotel.rb', # 80 min
   'openstudio-standards/test/test_small_office.rb' # 7 min
   ]
 end

--- a/openstudio-standards/Rakefile
+++ b/openstudio-standards/Rakefile
@@ -68,7 +68,7 @@ end
 
 require 'rake/testtask'
 desc 'Run test group 3'
-Rake::TestTask.new('test:gem_nrel_group_3') do |task|
+Rake::TestTask.new('test:gem_group_3') do |task|
   task.test_files = FileList[
   'openstudio-standards/test/test_full_service_restaurant.rb', # 1 min
   'openstudio-standards/test/test_retail_standalone.rb', # 6 min

--- a/openstudio-standards/lib/openstudio-standards/prototypes/Prototype.Model.rb
+++ b/openstudio-standards/lib/openstudio-standards/prototypes/Prototype.Model.rb
@@ -158,7 +158,7 @@ class OpenStudio::Model::Model
 
     # For some building types, stories are defined explicitly 
     if building_type == 'SmallHotel'
-      building_story_map = define_building_story_map(building_type, template, climate_zone)
+      building_story_map = PrototypeBuilding::SmallHotel.define_building_story_map(building_type, template, climate_zone)
       assign_building_story(building_type, template, climate_zone, building_story_map)
     end
 
@@ -184,13 +184,13 @@ class OpenStudio::Model::Model
     # for 90.1-2010 Outpatient, AHU2 set minimum outdoor air flow rate as 0
     # AHU1 doesn't have economizer
     if building_type == 'Outpatient'
-      modify_oa_controller(template)
+      PrototypeBuilding::Outpatient.modify_oa_controller(template, self)
       # For operating room 1&2 in 2010 and 2013, VAV minimum air flow is set by schedule
-      reset_or_room_vav_minimum_damper(prototype_input, template)
+      PrototypeBuilding::Outpatient.reset_or_room_vav_minimum_damper(prototype_input, template, self)
     end
 
     if building_type == 'Hospital'
-      modify_hospital_oa_controller(template)
+      PrototypeBuilding::Hospital.modify_hospital_oa_controller(template, self)
     end
 
     # Apply the HVAC efficiency standard
@@ -200,28 +200,23 @@ class OpenStudio::Model::Model
     # only four zones in large hotel have daylighting controls
     # todo: YXC to merge to the main function
     if building_type == 'LargeHotel'
-      large_hotel_add_daylighting_controls(template)
+      PrototypeBuilding::LargeHotel.large_hotel_add_daylighting_controls(template, self)
     elsif building_type == 'Hospital'
-      hospital_add_daylighting_controls(template)
+      PrototypeBuilding::Hospital.hospital_add_daylighting_controls(template, self)
     else
       add_daylighting_controls(template)
     end
 
-    if building_type == 'QuickServiceRestaurant' || building_type == 'FullServiceRestaurant' || building_type == 'Outpatient'
-      update_exhaust_fan_efficiency(template)
+    if building_type == 'QuickServiceRestaurant'
+      PrototypeBuilding::QuickServiceRestaurant.update_exhaust_fan_efficiency(template, self)
+    elsif building_type == 'FullServiceRestaurant'
+      PrototypeBuilding::FullServiceRestaurant.update_exhaust_fan_efficiency(template, self)
+    elsif building_type == 'Outpatient'
+      PrototypeBuilding::Outpatient.update_exhaust_fan_efficiency(template, self)
     end
 
     if building_type == 'HighriseApartment'
-      update_fan_efficiency
-    end
-
-    # Add output variables for debugging
-    # AHU1 doesn't have economizer
-    if building_type == 'Outpatient'
-      # remove the controller:mechanical ventilation for AHU1 OA
-      modify_oa_controller(template)
-      # For operating room 1&2 in 2010 and 2013, VAV minimum air flow is set by schedule
-      reset_or_room_vav_minimum_damper(prototype_input, template)
+      PrototypeBuilding::HighriseApartment.update_fan_efficiency(self)
     end
 
     # Add output variables for debugging
@@ -239,7 +234,6 @@ class OpenStudio::Model::Model
   # Get the name of the building type used in lookups
   #
   # @param building_type [String] the building type
-  #   a .osm file in the /resources directory
   # @return [String] returns the lookup name as a string
   # @todo Unify the lookup names and eliminate this method
   def get_lookup_name(building_type)
@@ -856,8 +850,14 @@ class OpenStudio::Model::Model
 
     # This map define the multipliers for spaces with multipliers not equals to 1
     case building_type
-    when 'LargeHotel', 'MidriseApartment', 'LargeOffice', 'Hospital'
-      space_multiplier_map = define_space_multiplier
+    when 'LargeHotel'
+      space_multiplier_map = PrototypeBuilding::LargeHotel.define_space_multiplier
+    when 'MidriseApartment'
+      space_multiplier_map = PrototypeBuilding::MidriseApartment.define_space_multiplier
+    when 'LargeOffice'
+      space_multiplier_map = PrototypeBuilding::LargeOffice.define_space_multiplier
+    when 'Hospital'
+      space_multiplier_map = PrototypeBuilding::Hospital.define_space_multiplier
     else
       space_multiplier_map = {}
     end

--- a/openstudio-standards/lib/openstudio-standards/prototypes/Prototype.Model.swh.rb
+++ b/openstudio-standards/lib/openstudio-standards/prototypes/Prototype.Model.swh.rb
@@ -183,12 +183,12 @@ class OpenStudio::Model::Model
       else
 
         # Attaches the end uses if specified by space type
+        space_type_map = define_space_type_map(building_type, template, climate_zone)
 
         if template == 'NECB 2011'
           building_type = 'Space Function'
         end
 
-        space_type_map = define_space_type_map(building_type, template, climate_zone)
         space_type_map.each do |space_type_name, space_names|
           search_criteria = {
             'template' => template,

--- a/openstudio-standards/lib/openstudio-standards/prototypes/Prototype.building_specific_methods.rb
+++ b/openstudio-standards/lib/openstudio-standards/prototypes/Prototype.building_specific_methods.rb
@@ -1,0 +1,163 @@
+
+# Extend the class to add Medium Office specific stuff
+class OpenStudio::Model::Model
+  def define_space_type_map(building_type, template, climate_zone)
+    case building_type
+    when 'SecondarySchool'
+      return PrototypeBuilding::SecondarySchool.define_space_type_map(building_type, template, climate_zone)
+    when 'PrimarySchool'
+      return PrototypeBuilding::PrimarySchool.define_space_type_map(building_type, template, climate_zone)
+    when 'SmallOffice'
+      return PrototypeBuilding::SmallOffice.define_space_type_map(building_type, template, climate_zone)
+    when 'MediumOffice'
+      return PrototypeBuilding::MediumOffice.define_space_type_map(building_type, template, climate_zone)
+    when 'LargeOffice'
+      return PrototypeBuilding::LargeOffice.define_space_type_map(building_type, template, climate_zone)
+    when 'SmallHotel'
+      return PrototypeBuilding::SmallHotel.define_space_type_map(building_type, template, climate_zone)
+    when 'LargeHotel'
+      return PrototypeBuilding::LargeHotel.define_space_type_map(building_type, template, climate_zone)
+    when 'Warehouse'
+      return PrototypeBuilding::Warehouse.define_space_type_map(building_type, template, climate_zone)
+    when 'RetailStandalone'
+      return PrototypeBuilding::RetailStandalone.define_space_type_map(building_type, template, climate_zone)
+    when 'RetailStripmall'
+      return PrototypeBuilding::RetailStripmall.define_space_type_map(building_type, template, climate_zone)
+    when 'QuickServiceRestaurant'
+      return PrototypeBuilding::QuickServiceRestaurant.define_space_type_map(building_type, template, climate_zone)
+    when 'FullServiceRestaurant'
+      return PrototypeBuilding::FullServiceRestaurant.define_space_type_map(building_type, template, climate_zone)
+    when 'Hospital'
+      return PrototypeBuilding::Hospital.define_space_type_map(building_type, template, climate_zone)
+    when 'Outpatient'
+      return PrototypeBuilding::Outpatient.define_space_type_map(building_type, template, climate_zone)
+    when 'MidriseApartment'
+      return PrototypeBuilding::MidriseApartment.define_space_type_map(building_type, template, climate_zone)
+    when 'HighriseApartment'
+      return PrototypeBuilding::HighriseApartment.define_space_type_map(building_type, template, climate_zone)
+    else
+      OpenStudio.logFree(OpenStudio::Error, 'openstudio.model.Model.define_space_type_map', "Building Type = #{building_type} not recognized")
+      return false
+    end
+  end
+
+  def define_hvac_system_map(building_type, template, climate_zone)
+    case building_type
+    when 'SecondarySchool'
+      return PrototypeBuilding::SecondarySchool.define_hvac_system_map(building_type, template, climate_zone)
+    when 'PrimarySchool'
+      return PrototypeBuilding::PrimarySchool.define_hvac_system_map(building_type, template, climate_zone)
+    when 'SmallOffice'
+      return PrototypeBuilding::SmallOffice.define_hvac_system_map(building_type, template, climate_zone)
+    when 'MediumOffice'
+      return PrototypeBuilding::MediumOffice.define_hvac_system_map(building_type, template, climate_zone)
+    when 'LargeOffice'
+      return PrototypeBuilding::LargeOffice.define_hvac_system_map(building_type, template, climate_zone)
+    when 'SmallHotel'
+      return PrototypeBuilding::SmallHotel.define_hvac_system_map(building_type, template, climate_zone)
+    when 'LargeHotel'
+      return PrototypeBuilding::LargeHotel.define_hvac_system_map(building_type, template, climate_zone)
+    when 'Warehouse'
+      return PrototypeBuilding::Warehouse.define_hvac_system_map(building_type, template, climate_zone)
+    when 'RetailStandalone'
+      return PrototypeBuilding::RetailStandalone.define_hvac_system_map(building_type, template, climate_zone)
+    when 'RetailStripmall'
+      return PrototypeBuilding::RetailStripmall.define_hvac_system_map(building_type, template, climate_zone)
+    when 'QuickServiceRestaurant'
+      return PrototypeBuilding::QuickServiceRestaurant.define_hvac_system_map(building_type, template, climate_zone)
+    when 'FullServiceRestaurant'
+      return PrototypeBuilding::FullServiceRestaurant.define_hvac_system_map(building_type, template, climate_zone)
+    when 'Hospital'
+      return PrototypeBuilding::Hospital.define_hvac_system_map(building_type, template, climate_zone)
+    when 'Outpatient'
+      return PrototypeBuilding::Outpatient.define_hvac_system_map(building_type, template, climate_zone)
+    when 'MidriseApartment'
+      return PrototypeBuilding::MidriseApartment.define_hvac_system_map(building_type, template, climate_zone)
+    when 'HighriseApartment'
+      return PrototypeBuilding::HighriseApartment.define_hvac_system_map(building_type, template, climate_zone)
+    else
+      OpenStudio.logFree(OpenStudio::Error, 'openstudio.model.Model.define_hvac_system_map', "Building Type = #{building_type} not recognized")
+      return false
+    end
+  end
+
+  def custom_hvac_tweaks(building_type, template, climate_zone, prototype_input, model)
+    case building_type
+    when 'SecondarySchool'
+      return PrototypeBuilding::SecondarySchool.custom_hvac_tweaks(building_type, template, climate_zone, prototype_input, model)
+    when 'PrimarySchool'
+      return PrototypeBuilding::PrimarySchool.custom_hvac_tweaks(building_type, template, climate_zone, prototype_input, model)
+    when 'SmallOffice'
+      return PrototypeBuilding::SmallOffice.custom_hvac_tweaks(building_type, template, climate_zone, prototype_input, model)
+    when 'MediumOffice'
+      return PrototypeBuilding::MediumOffice.custom_hvac_tweaks(building_type, template, climate_zone, prototype_input, model)
+    when 'LargeOffice'
+      return PrototypeBuilding::LargeOffice.custom_hvac_tweaks(building_type, template, climate_zone, prototype_input, model)
+    when 'SmallHotel'
+      return PrototypeBuilding::SmallHotel.custom_hvac_tweaks(building_type, template, climate_zone, prototype_input, model)
+    when 'LargeHotel'
+      return PrototypeBuilding::LargeHotel.custom_hvac_tweaks(building_type, template, climate_zone, prototype_input, model)
+    when 'Warehouse'
+      return PrototypeBuilding::Warehouse.custom_hvac_tweaks(building_type, template, climate_zone, prototype_input, model)
+    when 'RetailStandalone'
+      return PrototypeBuilding::RetailStandalone.custom_hvac_tweaks(building_type, template, climate_zone, prototype_input, model)
+    when 'RetailStripmall'
+      return PrototypeBuilding::RetailStripmall.custom_hvac_tweaks(building_type, template, climate_zone, prototype_input, model)
+    when 'QuickServiceRestaurant'
+      return PrototypeBuilding::QuickServiceRestaurant.custom_hvac_tweaks(building_type, template, climate_zone, prototype_input, model)
+    when 'FullServiceRestaurant'
+      return PrototypeBuilding::FullServiceRestaurant.custom_hvac_tweaks(building_type, template, climate_zone, prototype_input, model)
+    when 'Hospital'
+      return PrototypeBuilding::Hospital.custom_hvac_tweaks(building_type, template, climate_zone, prototype_input, model)
+    when 'Outpatient'
+      return PrototypeBuilding::Outpatient.custom_hvac_tweaks(building_type, template, climate_zone, prototype_input, model)
+    when 'MidriseApartment'
+      return PrototypeBuilding::MidriseApartment.custom_hvac_tweaks(building_type, template, climate_zone, prototype_input, model)
+    when 'HighriseApartment'
+      return PrototypeBuilding::HighriseApartment.custom_hvac_tweaks(building_type, template, climate_zone, prototype_input, model)
+    else
+      OpenStudio.logFree(OpenStudio::Error, 'openstudio.model.Model.custom_hvac_tweaks', "Building Type = #{building_type} not recognized")
+      return false
+    end
+  end
+
+  def custom_swh_tweaks(building_type, template, climate_zone, prototype_input, model)
+    case building_type
+    when 'SecondarySchool'
+      return PrototypeBuilding::SecondarySchool.custom_swh_tweaks(building_type, template, climate_zone, prototype_input, model)
+    when 'PrimarySchool'
+      return PrototypeBuilding::PrimarySchool.custom_swh_tweaks(building_type, template, climate_zone, prototype_input, model)
+    when 'SmallOffice'
+      return PrototypeBuilding::SmallOffice.custom_swh_tweaks(building_type, template, climate_zone, prototype_input, model)
+    when 'MediumOffice'
+      return PrototypeBuilding::MediumOffice.custom_swh_tweaks(building_type, template, climate_zone, prototype_input, model)
+    when 'LargeOffice'
+      return PrototypeBuilding::LargeOffice.custom_swh_tweaks(building_type, template, climate_zone, prototype_input, model)
+    when 'SmallHotel'
+      return PrototypeBuilding::SmallHotel.custom_swh_tweaks(building_type, template, climate_zone, prototype_input, model)
+    when 'LargeHotel'
+      return PrototypeBuilding::LargeHotel.custom_swh_tweaks(building_type, template, climate_zone, prototype_input, model)
+    when 'Warehouse'
+      return PrototypeBuilding::Warehouse.custom_swh_tweaks(building_type, template, climate_zone, prototype_input, model)
+    when 'RetailStandalone'
+      return PrototypeBuilding::RetailStandalone.custom_swh_tweaks(building_type, template, climate_zone, prototype_input, model)
+    when 'RetailStripmall'
+      return PrototypeBuilding::RetailStripmall.custom_swh_tweaks(building_type, template, climate_zone, prototype_input, model)
+    when 'QuickServiceRestaurant'
+      return PrototypeBuilding::QuickServiceRestaurant.custom_swh_tweaks(building_type, template, climate_zone, prototype_input, model)
+    when 'FullServiceRestaurant'
+      return PrototypeBuilding::FullServiceRestaurant.custom_swh_tweaks(building_type, template, climate_zone, prototype_input, model)
+    when 'Hospital'
+      return PrototypeBuilding::Hospital.custom_swh_tweaks(building_type, template, climate_zone, prototype_input, model)
+    when 'Outpatient'
+      return PrototypeBuilding::Outpatient.custom_swh_tweaks(building_type, template, climate_zone, prototype_input, model)
+    when 'MidriseApartment'
+      return PrototypeBuilding::MidriseApartment.custom_swh_tweaks(building_type, template, climate_zone, prototype_input, model)
+    when 'HighriseApartment'
+      return PrototypeBuilding::HighriseApartment.custom_swh_tweaks(building_type, template, climate_zone, prototype_input, model)
+    else
+      OpenStudio.logFree(OpenStudio::Error, 'openstudio.model.Model.custom_swh_tweaks', "Building Type = #{building_type} not recognized")
+      return false
+    end
+  end
+end

--- a/openstudio-standards/lib/openstudio-standards/prototypes/Prototype.large_office.rb
+++ b/openstudio-standards/lib/openstudio-standards/prototypes/Prototype.large_office.rb
@@ -1,6 +1,8 @@
-# Extend the class to add Medium Office specific stuff
-class OpenStudio::Model::Model
-  def define_space_type_map(building_type, template, climate_zone)
+
+# Modules for building-type specific methods
+module PrototypeBuilding
+module LargeOffice
+  def self.define_space_type_map(building_type, template, climate_zone)
     case template
     when 'DOE Ref Pre-1980', 'DOE Ref 1980-2004'
       space_type_map = {
@@ -36,7 +38,7 @@ class OpenStudio::Model::Model
     return space_type_map
   end
 
-  def define_hvac_system_map(building_type, template, climate_zone)
+  def self.define_hvac_system_map(building_type, template, climate_zone)
     case template
     when 'DOE Ref Pre-1980', 'DOE Ref 1980-2004'
       system_to_space_map = [
@@ -145,7 +147,7 @@ class OpenStudio::Model::Model
     return system_to_space_map
   end
 
-  def define_space_multiplier
+  def self.define_space_multiplier
     # This map define the multipliers for spaces with multipliers not equals to 1
     space_multiplier_map = {
       'DataCenter_mid_ZN_6' => 10,
@@ -159,14 +161,14 @@ class OpenStudio::Model::Model
     return space_multiplier_map
   end
 
-  def custom_hvac_tweaks(building_type, template, climate_zone, prototype_input)
+  def self.custom_hvac_tweaks(building_type, template, climate_zone, prototype_input, model)
     system_to_space_map = define_hvac_system_map(building_type, template, climate_zone)
 
     system_to_space_map.each do |system|
       # find all zones associated with these spaces
       thermal_zones = []
       system['space_names'].each do |space_name|
-        space = getSpaceByName(space_name)
+        space = model.getSpaceByName(space_name)
         if space.empty?
           OpenStudio.logFree(OpenStudio::Error, 'openstudio.model.Model', "No space called #{space_name} was found in the model")
           return false
@@ -182,7 +184,7 @@ class OpenStudio::Model::Model
 
       return_plenum = nil
       unless system['return_plenum'].nil?
-        return_plenum_space = getSpaceByName(system['return_plenum'])
+        return_plenum_space = model.getSpaceByName(system['return_plenum'])
         if return_plenum_space.empty?
           OpenStudio.logFree(OpenStudio::Error, 'openstudio.model.Model', "No space called #{system['return_plenum']} was found in the model")
           return false
@@ -200,18 +202,19 @@ class OpenStudio::Model::Model
     return true
   end
 
-  def update_waterheater_loss_coefficient(template)
+  def self.update_waterheater_loss_coefficient(template, model)
     case template
     when '90.1-2004', '90.1-2007', '90.1-2010', '90.1-2013', 'NECB 2011'
-      getWaterHeaterMixeds.sort.each do |water_heater|
+      model.getWaterHeaterMixeds.sort.each do |water_heater|
         water_heater.setOffCycleLossCoefficienttoAmbientTemperature(11.25413987)
         water_heater.setOnCycleLossCoefficienttoAmbientTemperature(11.25413987)
       end
     end
   end
 
-  def custom_swh_tweaks(building_type, template, climate_zone, prototype_input)
-    update_waterheater_loss_coefficient(template)
+  def self.custom_swh_tweaks(building_type, template, climate_zone, prototype_input, model)
+    PrototypeBuilding::LargeOffice.update_waterheater_loss_coefficient(template, model)
     return true
   end
+end
 end

--- a/openstudio-standards/lib/openstudio-standards/prototypes/Prototype.medium_office.rb
+++ b/openstudio-standards/lib/openstudio-standards/prototypes/Prototype.medium_office.rb
@@ -1,7 +1,8 @@
 
-# Extend the class to add Medium Office specific stuff
-class OpenStudio::Model::Model
-  def define_space_type_map(building_type, template, climate_zone)
+# Modules for building-type specific methods
+module PrototypeBuilding
+module MediumOffice
+  def self.define_space_type_map(building_type, template, climate_zone)
     space_type_map = nil
     space_type_map = case template
     when 'NECB 2011'
@@ -18,7 +19,7 @@ class OpenStudio::Model::Model
     return space_type_map
   end
 
-  def define_hvac_system_map(building_type, template, climate_zone)
+  def self.define_hvac_system_map(building_type, template, climate_zone)
     system_to_space_map = case template
     when 'DOE Ref Pre-1980'
       [
@@ -54,12 +55,12 @@ class OpenStudio::Model::Model
     return system_to_space_map
   end
 
-  def custom_hvac_tweaks(building_type, template, climate_zone, prototype_input)
+  def self.custom_hvac_tweaks(building_type, template, climate_zone, prototype_input, model)
     OpenStudio.logFree(OpenStudio::Info, 'openstudio.model.Model', 'Started building type specific adjustments')
 
-    getSpaces.each do |space|
+    model.getSpaces.each do |space|
       if space.name.get.to_s == 'Core_bottom'
-        add_elevator(template,
+        model.add_elevator(template,
                      space,
                      prototype_input['number_of_elevators'],
                      prototype_input['elevator_type'],
@@ -75,19 +76,20 @@ class OpenStudio::Model::Model
     return true
   end # add hvac
 
-  def update_waterheater_loss_coefficient(template)
+  def self.update_waterheater_loss_coefficient(template, model)
     case template
     when '90.1-2004', '90.1-2007', '90.1-2010', '90.1-2013', 'NECB 2011'
-      getWaterHeaterMixeds.sort.each do |water_heater|
+      model.getWaterHeaterMixeds.sort.each do |water_heater|
         water_heater.setOffCycleLossCoefficienttoAmbientTemperature(7.561562668)
         water_heater.setOnCycleLossCoefficienttoAmbientTemperature(7.561562668)
       end
     end
   end
 
-  def custom_swh_tweaks(building_type, template, climate_zone, prototype_input)
-    update_waterheater_loss_coefficient(template)
+  def self.custom_swh_tweaks(building_type, template, climate_zone, prototype_input, model)
+    PrototypeBuilding::MediumOffice.update_waterheater_loss_coefficient(template, model)
 
     return true
   end
+end
 end

--- a/openstudio-standards/lib/openstudio-standards/prototypes/Prototype.primary_school.rb
+++ b/openstudio-standards/lib/openstudio-standards/prototypes/Prototype.primary_school.rb
@@ -1,7 +1,8 @@
 
-# Extend the class to add Secondary School specific stuff
-class OpenStudio::Model::Model
-  def define_space_type_map(building_type, template, climate_zone)
+# Modules for building-type specific methods
+module PrototypeBuilding
+module PrimarySchool
+  def self.define_space_type_map(building_type, template, climate_zone)
     space_type_map = nil
     case template
     when 'NECB 2011'
@@ -35,89 +36,9 @@ class OpenStudio::Model::Model
     return space_type_map
   end
 
-  def define_hvac_system_map(building_type, template, climate_zone)
+  def self.define_hvac_system_map(building_type, template, climate_zone)
     system_to_space_map = nil
 
-    # case template
-    # when 'DOE Ref Pre-1980', 'DOE Ref 1980-2004'
-    # system_to_space_map = [
-    # {
-    # 'type' => 'PVAV',
-    # 'name' => 'PVAV_POD_1',
-    # 'space_names' =>
-    # [
-    # 'Corner_Class_1_Pod_1_ZN_1_FLR_1',
-    # 'Mult_Class_1_Pod_1_ZN_1_FLR_1',
-    # 'Corridor_Pod_1_ZN_1_FLR_1',
-    # 'Corner_Class_2_Pod_1_ZN_1_FLR_1',
-    # 'Mult_Class_2_Pod_1_ZN_1_FLR_1',
-    # 'Corner_Class_1_Pod_2_ZN_1_FLR_1'
-    # ]
-    # },
-    # {
-    # 'type' => 'PVAV',
-    # 'name' => 'PVAV_POD_2',
-    # 'space_names' =>
-    # [
-    # 'Mult_Class_1_Pod_2_ZN_1_FLR_1',
-    # 'Corridor_Pod_2_ZN_1_FLR_1',
-    # 'Corner_Class_2_Pod_2_ZN_1_FLR_1',
-    # 'Mult_Class_2_Pod_2_ZN_1_FLR_1'
-    # ]
-    # },
-    # {
-    # 'type' => 'PVAV',
-    # 'name' => 'PVAV_POD_3',
-    # 'space_names' =>
-    # [
-    # 'Corner_Class_1_Pod_3_ZN_1_FLR_1',
-    # 'Mult_Class_1_Pod_3_ZN_1_FLR_1',
-    # 'Corridor_Pod_3_ZN_1_FLR_1',
-    # 'Corner_Class_2_Pod_3_ZN_1_FLR_1',
-    # 'Mult_Class_2_Pod_3_ZN_1_FLR_1'
-    # ]
-    # },
-    # {
-    # 'type' => 'PVAV',
-    # 'name' => 'PVAV_OTHER',
-    # 'space_names' =>
-    # [
-    # 'Computer_Class_ZN_1_FLR_1',
-    # 'Main_Corridor_ZN_1_FLR_1',
-    # 'Lobby_ZN_1_FLR_1',
-    # 'Mech_ZN_1_FLR_1',
-    # 'Bath_ZN_1_FLR_1',
-    # 'Offices_ZN_1_FLR_1',
-    # 'Library_Media_Center_ZN_1_FLR_1'
-    # ]
-    # },
-    # {
-    # 'type' => 'PSZ-AC',
-    # 'name' => 'PSZ-AC_1-6',
-    # 'space_names' =>
-    # [
-    # 'Kitchen_ZN_1_FLR_1'
-    # ]
-    # },
-    # {
-    # 'type' => 'PSZ-AC',
-    # 'name' => 'PSZ-AC_2-5',
-    # 'space_names' =>
-    # [
-    # 'Gym_ZN_1_FLR_1'
-    # ]
-    # },
-    # {
-    # 'type' => 'PSZ-AC',
-    # 'name' => 'PSZ-AC_2-7',
-    # 'space_names' =>
-    # [
-    # 'Cafeteria_ZN_1_FLR_1'
-    # ]
-    # }
-    # ]
-
-    # when '90.1-2004', '90.1-2007', '90.1-2010', '90.1-2013'
     system_to_space_map = [
       {
         'type' => 'PVAV',
@@ -229,16 +150,15 @@ class OpenStudio::Model::Model
       }
     ]
 
-    # end
-
     return system_to_space_map
   end
 
-  def custom_hvac_tweaks(building_type, template, climate_zone, prototype_input)
+  def self.custom_hvac_tweaks(building_type, template, climate_zone, prototype_input, model)
     return true
   end
 
-  def custom_swh_tweaks(building_type, template, climate_zone, prototype_input)
+  def self.custom_swh_tweaks(building_type, template, climate_zone, prototype_input, model)
     return true
   end
+end
 end

--- a/openstudio-standards/lib/openstudio-standards/prototypes/Prototype.quick_service_restaurant.rb
+++ b/openstudio-standards/lib/openstudio-standards/prototypes/Prototype.quick_service_restaurant.rb
@@ -1,7 +1,8 @@
 
-# Extend the class to add Medium Office specific stuff
-class OpenStudio::Model::Model
-  def define_space_type_map(building_type, template, climate_zone)
+# Modules for building-type specific methods
+module PrototypeBuilding
+module QuickServiceRestaurant
+  def self.define_space_type_map(building_type, template, climate_zone)
     space_type_map = nil
     case template
     when 'DOE Ref Pre-1980'
@@ -26,7 +27,7 @@ class OpenStudio::Model::Model
     return space_type_map
   end
 
-  def define_hvac_system_map(building_type, template, climate_zone)
+  def self.define_hvac_system_map(building_type, template, climate_zone)
     case template
     when 'DOE Ref Pre-1980', 'DOE Ref 1980-2004'
       system_to_space_map = [
@@ -309,75 +310,75 @@ class OpenStudio::Model::Model
     return system_to_space_map
   end
 
-  def custom_hvac_tweaks(building_type, template, climate_zone, prototype_input)
+  def self.custom_hvac_tweaks(building_type, template, climate_zone, prototype_input, model)
     OpenStudio.logFree(OpenStudio::Info, 'openstudio.model.Model', 'Started building type specific adjustments')
 
     # add extra equipment for kitchen
-    add_extra_equip_kitchen(template)
+    PrototypeBuilding::QuickServiceRestaurant.add_extra_equip_kitchen(template, model)
     # add extra infiltration for dining room door and attic
-    add_door_infiltration(template, climate_zone)
+    PrototypeBuilding::QuickServiceRestaurant.add_door_infiltration(template, climate_zone, model)
     # add zone_mixing between kitchen and dining
-    add_zone_mixing(template)
+    PrototypeBuilding::QuickServiceRestaurant.add_zone_mixing(template, model)
     # Update Sizing Zone
-    update_sizing_zone(template)
+    PrototypeBuilding::QuickServiceRestaurant.update_sizing_zone(template, model)
     # adjust the cooling setpoint
-    adjust_clg_setpoint(template, climate_zone)
+    PrototypeBuilding::QuickServiceRestaurant.adjust_clg_setpoint(template, climate_zone, model)
     # reset the design OA of kitchen
-    reset_kitchen_oa(template)
+    PrototypeBuilding::QuickServiceRestaurant.reset_kitchen_oa(template, model)
 
     OpenStudio.logFree(OpenStudio::Info, 'openstudio.model.Model', 'Finished building type specific adjustments')
 
     return true
   end
 
-  def add_door_infiltration(template, climate_zone)
+  def self.add_door_infiltration(template, climate_zone, model)
     # add extra infiltration for dining room door and attic (there is no attic in 'DOE Ref Pre-1980')
     unless template == 'DOE Ref 1980-2004' || template == 'DOE Ref Pre-1980'
-      dining_space = getSpaceByName('Dining').get
-      attic_space = getSpaceByName('Attic').get
-      infiltration_diningdoor = OpenStudio::Model::SpaceInfiltrationDesignFlowRate.new(self)
-      infiltration_attic = OpenStudio::Model::SpaceInfiltrationDesignFlowRate.new(self)
+      dining_space = model.getSpaceByName('Dining').get
+      attic_space = model.getSpaceByName('Attic').get
+      infiltration_diningdoor = OpenStudio::Model::SpaceInfiltrationDesignFlowRate.new(model)
+      infiltration_attic = OpenStudio::Model::SpaceInfiltrationDesignFlowRate.new(model)
       infiltration_diningdoor.setName('Dining door Infiltration')
       infiltration_per_zone_diningdoor = 0
       infiltration_per_zone_attic = 0.0729
       if template == '90.1-2004'
         infiltration_per_zone_diningdoor = 0.902834611
-        infiltration_diningdoor.setSchedule(add_schedule('RestaurantFastFood DOOR_INFIL_SCH'))
+        infiltration_diningdoor.setSchedule(model.add_schedule('RestaurantFastFood DOOR_INFIL_SCH'))
       elsif template == '90.1-2007'
         case climate_zone
         when 'ASHRAE 169-2006-1A', 'ASHRAE 169-2006-2A', 'ASHRAE 169-2006-2B', 'ASHRAE 169-2006-3A', 'ASHRAE 169-2006-3B',
             'ASHRAE 169-2006-3C', 'ASHRAE 169-2006-4A', 'ASHRAE 169-2006-4B', 'ASHRAE 169-2006-4C'
           infiltration_per_zone_diningdoor = 0.902834611
-          infiltration_diningdoor.setSchedule(add_schedule('RestaurantFastFood DOOR_INFIL_SCH'))
+          infiltration_diningdoor.setSchedule(model.add_schedule('RestaurantFastFood DOOR_INFIL_SCH'))
         else
           infiltration_per_zone_diningdoor = 0.583798439
-          infiltration_diningdoor.setSchedule(add_schedule('RestaurantFastFood VESTIBULE_DOOR_INFIL_SCH'))
+          infiltration_diningdoor.setSchedule(model.add_schedule('RestaurantFastFood VESTIBULE_DOOR_INFIL_SCH'))
         end
       elsif template == '90.1-2010' || template == '90.1-2013'
         case climate_zone
         when 'ASHRAE 169-2006-1A', 'ASHRAE 169-2006-2A', 'ASHRAE 169-2006-2B', 'ASHRAE 169-2006-3A', 'ASHRAE 169-2006-3B', 'ASHRAE 169-2006-3C'
           infiltration_per_zone_diningdoor = 0.902834611
-          infiltration_diningdoor.setSchedule(add_schedule('RestaurantFastFood DOOR_INFIL_SCH'))
+          infiltration_diningdoor.setSchedule(model.add_schedule('RestaurantFastFood DOOR_INFIL_SCH'))
         else
           infiltration_per_zone_diningdoor = 0.583798439
-          infiltration_diningdoor.setSchedule(add_schedule('RestaurantFastFood VESTIBULE_DOOR_INFIL_SCH'))
+          infiltration_diningdoor.setSchedule(model.add_schedule('RestaurantFastFood VESTIBULE_DOOR_INFIL_SCH'))
         end
       end
       infiltration_diningdoor.setDesignFlowRate(infiltration_per_zone_diningdoor)
       infiltration_diningdoor.setSpace(dining_space)
       infiltration_attic.setDesignFlowRate(infiltration_per_zone_attic)
-      infiltration_attic.setSchedule(add_schedule('Always On'))
+      infiltration_attic.setSchedule(model.add_schedule('Always On'))
       infiltration_attic.setSpace(attic_space)
     end
   end
 
   # add extra equipment for kitchen
-  def add_extra_equip_kitchen(template)
-    kitchen_space = getSpaceByName('Kitchen')
+  def self.add_extra_equip_kitchen(template, model)
+    kitchen_space = model.getSpaceByName('Kitchen')
     kitchen_space = kitchen_space.get
     kitchen_space_type = kitchen_space.spaceType.get
-    elec_equip_def1 = OpenStudio::Model::ElectricEquipmentDefinition.new(self)
-    elec_equip_def2 = OpenStudio::Model::ElectricEquipmentDefinition.new(self)
+    elec_equip_def1 = OpenStudio::Model::ElectricEquipmentDefinition.new(model)
+    elec_equip_def2 = OpenStudio::Model::ElectricEquipmentDefinition.new(model)
     elec_equip_def1.setName('Kitchen Electric Equipment Definition1')
     elec_equip_def2.setName('Kitchen Electric Equipment Definition2')
     case template
@@ -402,8 +403,8 @@ class OpenStudio::Model::Model
       elec_equip2.setName('Kitchen_Reach-in-Refrigerator')
       elec_equip1.setSpaceType(kitchen_space_type)
       elec_equip2.setSpaceType(kitchen_space_type)
-      elec_equip1.setSchedule(add_schedule('RestaurantFastFood ALWAYS_ON'))
-      elec_equip2.setSchedule(add_schedule('RestaurantFastFood ALWAYS_ON'))
+      elec_equip1.setSchedule(model.add_schedule('RestaurantFastFood ALWAYS_ON'))
+      elec_equip2.setSchedule(model.add_schedule('RestaurantFastFood ALWAYS_ON'))
     when 'DOE Ref Pre-1980', 'DOE Ref 1980-2004'
       elec_equip_def1.setDesignLevel(577)
       elec_equip_def1.setFractionLatent(0)
@@ -413,42 +414,42 @@ class OpenStudio::Model::Model
       elec_equip1 = OpenStudio::Model::ElectricEquipment.new(elec_equip_def1)
       elec_equip1.setName('Kitchen_ExhFan_Equip')
       elec_equip1.setSpaceType(kitchen_space_type)
-      elec_equip1.setSchedule(add_schedule('RestaurantFastFood Kitchen_Exhaust_SCH'))
+      elec_equip1.setSchedule(model.add_schedule('RestaurantFastFood Kitchen_Exhaust_SCH'))
     end
   end
 
-  def update_sizing_zone(template)
+  def self.update_sizing_zone(template, model)
     case template
     when '90.1-2007', '90.1-2010', '90.1-2013'
-      zone_sizing = getSpaceByName('Dining').get.thermalZone.get.sizingZone
+      zone_sizing = model.getSpaceByName('Dining').get.thermalZone.get.sizingZone
       zone_sizing.setCoolingDesignAirFlowMethod('DesignDayWithLimit')
       zone_sizing.setCoolingMinimumAirFlowperZoneFloorArea(0.003581176)
-      zone_sizing = getSpaceByName('Kitchen').get.thermalZone.get.sizingZone
+      zone_sizing = model.getSpaceByName('Kitchen').get.thermalZone.get.sizingZone
       zone_sizing.setCoolingDesignAirFlowMethod('DesignDayWithLimit')
       zone_sizing.setCoolingMinimumAirFlowperZoneFloorArea(0)
     when '90.1-2004'
-      zone_sizing = getSpaceByName('Dining').get.thermalZone.get.sizingZone
+      zone_sizing = model.getSpaceByName('Dining').get.thermalZone.get.sizingZone
       zone_sizing.setCoolingDesignAirFlowMethod('DesignDayWithLimit')
       zone_sizing.setCoolingMinimumAirFlowperZoneFloorArea(0.007111554)
-      zone_sizing = getSpaceByName('Kitchen').get.thermalZone.get.sizingZone
+      zone_sizing = model.getSpaceByName('Kitchen').get.thermalZone.get.sizingZone
       zone_sizing.setCoolingDesignAirFlowMethod('DesignDayWithLimit')
       zone_sizing.setCoolingMinimumAirFlowperZoneFloorArea(0)
     end
   end
 
-  def adjust_clg_setpoint(template, climate_zone)
+  def self.adjust_clg_setpoint(template, climate_zone, model)
     ['Dining', 'Kitchen'].each do |space_name|
-      space_type_name = getSpaceByName(space_name).get.spaceType.get.name.get
+      space_type_name = model.getSpaceByName(space_name).get.spaceType.get.name.get
       thermostat_name = space_type_name + ' Thermostat'
-      thermostat = getThermostatSetpointDualSetpointByName(thermostat_name).get
+      thermostat = model.getThermostatSetpointDualSetpointByName(thermostat_name).get
       case template
       when '90.1-2004', '90.1-2007', '90.1-2010'
         if climate_zone == 'ASHRAE 169-2006-2B' || climate_zone == 'ASHRAE 169-2006-1B' || climate_zone == 'ASHRAE 169-2006-3B'
           case space_name
           when 'Dining'
-            thermostat.setCoolingSetpointTemperatureSchedule(add_schedule('RestaurantFastFood CLGSETP_SCH_NO_OPTIMUM'))
+            thermostat.setCoolingSetpointTemperatureSchedule(model.add_schedule('RestaurantFastFood CLGSETP_SCH_NO_OPTIMUM'))
           when 'Kitchen'
-            thermostat.setCoolingSetpointTemperatureSchedule(add_schedule('RestaurantFastFood CLGSETP_KITCHEN_SCH_NO_OPTIMUM'))
+            thermostat.setCoolingSetpointTemperatureSchedule(model.add_schedule('RestaurantFastFood CLGSETP_KITCHEN_SCH_NO_OPTIMUM'))
           end
         end
       end
@@ -458,8 +459,8 @@ class OpenStudio::Model::Model
   # In order to provide sufficient OSA to replace exhaust flow through kitchen hoods (3,300 cfm),
   # modeled OSA to kitchen is different from OSA determined based on ASHRAE  62.1.
   # It takes into account the available OSA in dining as transfer air.
-  def reset_kitchen_oa(template)
-    space_kitchen = getSpaceByName('Kitchen').get
+  def self.reset_kitchen_oa(template, model)
+    space_kitchen = model.getSpaceByName('Kitchen').get
     ventilation = space_kitchen.designSpecificationOutdoorAir.get
     ventilation.setOutdoorAirFlowperPerson(0)
     ventilation.setOutdoorAirFlowperFloorArea(0)
@@ -471,10 +472,10 @@ class OpenStudio::Model::Model
     end
   end
 
-  def update_exhaust_fan_efficiency(template)
+  def self.update_exhaust_fan_efficiency(template, model)
     case template
     when '90.1-2004', '90.1-2007', '90.1-2010', '90.1-2013'
-      getFanZoneExhausts.sort.each do |exhaust_fan|
+      model.getFanZoneExhausts.sort.each do |exhaust_fan|
         fan_name = exhaust_fan.name.to_s
         if fan_name.include? 'Dining'
           exhaust_fan.setFanEfficiency(1)
@@ -482,21 +483,21 @@ class OpenStudio::Model::Model
         end
       end
     when 'DOE Ref Pre-1980', 'DOE Ref 1980-2004'
-      getFanZoneExhausts.sort.each do |exhaust_fan|
+      model.getFanZoneExhausts.sort.each do |exhaust_fan|
         exhaust_fan.setFanEfficiency(1)
         exhaust_fan.setPressureRise(0.000001)
       end
     end
   end
 
-  def add_zone_mixing(template)
+  def self.add_zone_mixing(template, model)
     # add zone_mixing between kitchen and dining
-    space_kitchen = getSpaceByName('Kitchen').get
+    space_kitchen = model.getSpaceByName('Kitchen').get
     zone_kitchen = space_kitchen.thermalZone.get
-    space_dining = getSpaceByName('Dining').get
+    space_dining = model.getSpaceByName('Dining').get
     zone_dining = space_dining.thermalZone.get
     zone_mixing_kitchen = OpenStudio::Model::ZoneMixing.new(zone_kitchen)
-    zone_mixing_kitchen.setSchedule(add_schedule('RestaurantFastFood Hours_of_operation'))
+    zone_mixing_kitchen.setSchedule(model.add_schedule('RestaurantFastFood Hours_of_operation'))
     case template
     when 'DOE Ref Pre-1980', 'DOE Ref 1980-2004'
       zone_mixing_kitchen.setDesignFlowRate(0.834532374)
@@ -509,19 +510,20 @@ class OpenStudio::Model::Model
     zone_mixing_kitchen.setDeltaTemperature(0)
   end
 
-  def update_waterheater_loss_coefficient(template)
+  def self.update_waterheater_loss_coefficient(template, model)
     case template
     when '90.1-2004', '90.1-2007', '90.1-2010', '90.1-2013', 'NECB 2011'
-      getWaterHeaterMixeds.sort.each do |water_heater|
+      model.getWaterHeaterMixeds.sort.each do |water_heater|
         water_heater.setOffCycleLossCoefficienttoAmbientTemperature(7.561562668)
         water_heater.setOnCycleLossCoefficienttoAmbientTemperature(7.561562668)
       end
     end
   end
 
-  def custom_swh_tweaks(building_type, template, climate_zone, prototype_input)
-    update_waterheater_loss_coefficient(template)
+  def self.custom_swh_tweaks(building_type, template, climate_zone, prototype_input, model)
+    PrototypeBuilding::QuickServiceRestaurant.update_waterheater_loss_coefficient(template, model)
 
     return true
   end
+end
 end

--- a/openstudio-standards/lib/openstudio-standards/prototypes/Prototype.secondary_school.rb
+++ b/openstudio-standards/lib/openstudio-standards/prototypes/Prototype.secondary_school.rb
@@ -1,7 +1,8 @@
 
-# Extend the class to add Secondary School specific stuff
-class OpenStudio::Model::Model
-  def define_space_type_map(building_type, template, climate_zone)
+# Modules for building-type specific methods
+module PrototypeBuilding
+module SecondarySchool
+  def self.define_space_type_map(building_type, template, climate_zone)
     space_type_map = nil
 
     case template
@@ -54,7 +55,7 @@ class OpenStudio::Model::Model
     return space_type_map
   end
 
-  def define_hvac_system_map(building_type, template, climate_zone)
+  def self.define_hvac_system_map(building_type, template, climate_zone)
     system_to_space_map = nil
 
     case template
@@ -337,12 +338,12 @@ class OpenStudio::Model::Model
     return system_to_space_map
   end
 
-  def custom_hvac_tweaks(building_type, template, climate_zone, prototype_input)
+  def self.custom_hvac_tweaks(building_type, template, climate_zone, prototype_input, model)
     OpenStudio.logFree(OpenStudio::Info, 'openstudio.model.Model', 'Started building type specific adjustments')
 
-    getSpaces.each do |space|
+    model.getSpaces.each do |space|
       if space.name.get.to_s == 'Mech_ZN_1_FLR_1'
-        add_elevator(template,
+        model.add_elevator(template,
                      space,
                      prototype_input['number_of_elevators'],
                      prototype_input['elevator_type'],
@@ -358,7 +359,8 @@ class OpenStudio::Model::Model
     return true
   end
 
-  def custom_swh_tweaks(building_type, template, climate_zone, prototype_input)
+  def self.custom_swh_tweaks(building_type, template, climate_zone, prototype_input, model)
     return true
   end
+end
 end

--- a/openstudio-standards/lib/openstudio-standards/prototypes/Prototype.small_office.rb
+++ b/openstudio-standards/lib/openstudio-standards/prototypes/Prototype.small_office.rb
@@ -1,7 +1,8 @@
 
 # Extend the class to add Small Office specific stuff
-class OpenStudio::Model::Model
-  def define_space_type_map(building_type, template, climate_zone)
+module PrototypeBuilding
+module SmallOffice
+  def self.define_space_type_map(building_type, template, climate_zone)
     space_type_map = nil
 
     space_type_map = case template
@@ -20,7 +21,7 @@ class OpenStudio::Model::Model
     return space_type_map
   end
 
-  def define_hvac_system_map(building_type, template, climate_zone)
+  def self.define_hvac_system_map(building_type, template, climate_zone)
     system_to_space_map = [
       {
         'type' => 'PSZ-AC',
@@ -67,11 +68,12 @@ class OpenStudio::Model::Model
     return system_to_space_map
   end
 
-  def custom_hvac_tweaks(building_type, template, climate_zone, prototype_input)
+  def self.custom_hvac_tweaks(building_type, template, climate_zone, prototype_input, model)
     return true
   end
 
-  def custom_swh_tweaks(building_type, template, climate_zone, prototype_input)
+  def self.custom_swh_tweaks(building_type, template, climate_zone, prototype_input, model)
     return true
   end
+end
 end

--- a/openstudio-standards/lib/openstudio-standards/prototypes/Prototype.warehouse.rb
+++ b/openstudio-standards/lib/openstudio-standards/prototypes/Prototype.warehouse.rb
@@ -1,7 +1,8 @@
 
-# Extend the class to add Medium Office specific stuff
-class OpenStudio::Model::Model
-  def define_space_type_map(building_type, template, climate_zone)
+# Modules for building-type specific methods
+module PrototypeBuilding
+module Warehouse
+  def self.define_space_type_map(building_type, template, climate_zone)
     space_type_map = nil
 
     space_type_map = case template
@@ -23,7 +24,7 @@ class OpenStudio::Model::Model
     return space_type_map
   end
 
-  def define_hvac_system_map(building_type, template, climate_zone)
+  def self.define_hvac_system_map(building_type, template, climate_zone)
     case template
     when 'DOE Ref Pre-1980', 'DOE Ref 1980-2004'
       system_to_space_map = [
@@ -90,23 +91,24 @@ class OpenStudio::Model::Model
     return system_to_space_map
   end
 
-  def custom_hvac_tweaks(building_type, template, climate_zone, prototype_input)
+  def self.custom_hvac_tweaks(building_type, template, climate_zone, prototype_input, model)
     return true
   end
 
-  def update_waterheater_loss_coefficient(template)
+  def self.update_waterheater_loss_coefficient(template, model)
     case template
     when '90.1-2004', '90.1-2007', '90.1-2010', '90.1-2013', 'NECB 2011'
-      getWaterHeaterMixeds.sort.each do |water_heater|
+      model.getWaterHeaterMixeds.sort.each do |water_heater|
         water_heater.setOffCycleLossCoefficienttoAmbientTemperature(0.798542707)
         water_heater.setOnCycleLossCoefficienttoAmbientTemperature(0.798542707)
       end
     end
   end
 
-  def custom_swh_tweaks(building_type, template, climate_zone, prototype_input)
-    update_waterheater_loss_coefficient(template)
+  def self.custom_swh_tweaks(building_type, template, climate_zone, prototype_input, model)
+    PrototypeBuilding::Warehouse.update_waterheater_loss_coefficient(template, model)
 
     return true
   end
+end
 end

--- a/openstudio-standards/test/bin/docker-run-2.sh
+++ b/openstudio-standards/test/bin/docker-run-2.sh
@@ -5,3 +5,26 @@ export CIRCLECI=true
 export PATH="$HOME/.rbenv/bin:$PATH"
 eval "$(rbenv init -)"
 
+# Install the openstudio-standards gem
+cd /openstudio-standards/openstudio-standards
+bundle install
+
+# Run a specific set of tests on each node.
+# Test groups are defined in the Rakefile.
+# Each group must have a total runtime less
+# than 2 hrs.
+case $CIRCLE_NODE_INDEX in
+  0)
+    rake test:gem_group_4
+    ;;
+  1)
+    rake test:gem_group_5
+    ;;
+  2)
+    rake test:gem_group_6
+    ;;
+  3)
+    rake test:gem_group_7
+    ;;
+  *)
+esac

--- a/openstudio-standards/test/bin/docker-run-2.sh
+++ b/openstudio-standards/test/bin/docker-run-2.sh
@@ -5,26 +5,3 @@ export CIRCLECI=true
 export PATH="$HOME/.rbenv/bin:$PATH"
 eval "$(rbenv init -)"
 
-# Install the openstudio-standards gem
-cd /openstudio-standards/openstudio-standards
-bundle install
-
-# Run a specific set of tests on each node.
-# Test groups are defined in the Rakefile.
-# Each group must have a total runtime less
-# than 2 hrs.
-case $CIRCLE_NODE_INDEX in
-  0)
-    rake test:gem_group_4
-    ;;
-  1)
-    rake test:gem_group_5
-    ;;
-  2)
-    rake test:gem_group_6
-    ;;
-  3)
-    rake test:gem_group_7
-    ;;
-  *)
-esac

--- a/openstudio-standards/test/bin/docker-run.sh
+++ b/openstudio-standards/test/bin/docker-run.sh
@@ -15,7 +15,6 @@ bundle install
 # than 2 hrs.
 case $CIRCLE_NODE_INDEX in
   0)
-    rake test:measures
     rake test:gem_group_0
     ;;
   1)
@@ -29,19 +28,3 @@ case $CIRCLE_NODE_INDEX in
     ;;
   *)
 esac
-    
-# Loop through the test files and run
-# every nth test, where n is determined
-# by the total number of CI nodes and
-# the index of this particular node.
-# Note: this command is running
-# ON EACH NODE.
-# i=0
-# files=()
-# for testfile in $(find test/ -name "test_*.rb" | sort); do
-  # if [ $(($i % $CIRCLE_NODE_TOTAL)) -eq $CIRCLE_NODE_INDEX ]
-  # then
-    # ruby $testfile
-  # fi
-  # ((i=i+1))
-# done

--- a/openstudio-standards/test/bin/docker-run.sh
+++ b/openstudio-standards/test/bin/docker-run.sh
@@ -16,16 +16,16 @@ bundle install
 case $CIRCLE_NODE_INDEX in
   0)
     rake test:measures
-    rake test:gem_nrel_group_3
+    rake test:gem_group_0
     ;;
   1)
-    rake test:gem_nrel_group_3
+    rake test:gem_group_1
     ;;
   2)
-    rake test:gem_nrel_group_3
+    rake test:gem_group_2
     ;;
   3)
-    rake test:gem_nrel_group_3
+    rake test:gem_group_3
     ;;
   *)
 esac

--- a/openstudio-standards/test/bin/docker-run.sh
+++ b/openstudio-standards/test/bin/docker-run.sh
@@ -16,16 +16,16 @@ bundle install
 case $CIRCLE_NODE_INDEX in
   0)
     rake test:measures
-    rake test:gem_group_0
+    rake test:gem_nrel_group_3
     ;;
   1)
-    rake test:gem_group_1
+    rake test:gem_nrel_group_3
     ;;
   2)
-    rake test:gem_group_2
+    rake test:gem_nrel_group_3
     ;;
   3)
-    rake test:gem_group_3
+    rake test:gem_nrel_group_3
     ;;
   *)
 esac

--- a/openstudio-standards/test/test_find_ashrae_hot_water_demand.rb
+++ b/openstudio-standards/test/test_find_ashrae_hot_water_demand.rb
@@ -1,6 +1,6 @@
 require_relative 'minitest_helper'
 
-class TestFindSpaceTypeStandardsData < Minitest::Test
+class TestFindASHRAEHotWaterDemand < Minitest::Test
 
   def test_find_ashrae_hot_water_demand
 

--- a/openstudio-standards/test/test_find_construction_properties_data.rb
+++ b/openstudio-standards/test/test_find_construction_properties_data.rb
@@ -1,6 +1,6 @@
 require_relative 'minitest_helper'
 
-class TestFindSpaceTypeStandardsData < Minitest::Test
+class TestFindConstructionPropertiesData < Minitest::Test
 
   def test_find_construction_properties_data
 

--- a/openstudio-standards/test/test_primary_school.rb
+++ b/openstudio-standards/test/test_primary_school.rb
@@ -6,9 +6,8 @@ $LOAD_PATH.unshift File.expand_path('../../../../openstudio-standards/lib', __FI
 class TestPrimarySchool < CreateDOEPrototypeBuildingTest
 
   building_types = ['PrimarySchool']
-  
-  templates = ['DOE Ref Pre-1980']
-  climate_zones = ['ASHRAE 169-2006-2A']
+  templates = ['DOE Ref Pre-1980','DOE Ref 1980-2004', '90.1-2010']
+  climate_zones = ['ASHRAE 169-2006-2A','ASHRAE 169-2006-3B','ASHRAE 169-2006-4A','ASHRAE 169-2006-5A']
 
   # not used for ASHRAE/DOE archetypes, but required for call
   epw_files = ['USA_FL_Miami.Intl.AP.722020_TMY3.epw']

--- a/openstudio-standards/test/test_small_office.rb
+++ b/openstudio-standards/test/test_small_office.rb
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift File.expand_path('../../../../openstudio-standards/lib', __FI
 
 class TestSmallOffice < CreateDOEPrototypeBuildingTest
   
-  building_types = ['SmallOffice','RetailStandalone']
+  building_types = ['SmallOffice']
   templates = ['DOE Ref Pre-1980','DOE Ref 1980-2004','90.1-2010']
   climate_zones = ['ASHRAE 169-2006-2A','ASHRAE 169-2006-3B','ASHRAE 169-2006-4A','ASHRAE 169-2006-5A']
   

--- a/openstudio-standards/test/test_small_office.rb
+++ b/openstudio-standards/test/test_small_office.rb
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift File.expand_path('../../../../openstudio-standards/lib', __FI
 
 class TestSmallOffice < CreateDOEPrototypeBuildingTest
   
-  building_types = ['SmallOffice']
+  building_types = ['SmallOffice','RetailStandalone']
   templates = ['DOE Ref Pre-1980','DOE Ref 1980-2004','90.1-2010']
   climate_zones = ['ASHRAE 169-2006-2A','ASHRAE 169-2006-3B','ASHRAE 169-2006-4A','ASHRAE 169-2006-5A']
   


### PR DESCRIPTION
@phylroy With the changes on this branch I fixed the issue where you had to split the NECB tests out separately.  This issue was being caused by was dynamically reloading building-type specific files.  By moving these into separate modules, this problem is avoided.  However, one thing I noticed is making the NECB tests separate was preventing the reporting from happening for the gem_nrel_group_3 tests because they were being overwritten by the NECB test results.  As s result, I put the NECB tests back into the gem_group_3 directly.  Could you check out this build and let me know if this will work for you?

https://circleci.com/gh/NREL/openstudio-standards/611#tests/containers/0
