### PR TITLE
Added clearer error message if AirLoopHVAC serves zero floor area

### DIFF
--- a/openstudio-standards/lib/openstudio-standards/standards/Standards.AirLoopHVAC.rb
+++ b/openstudio-standards/lib/openstudio-standards/standards/Standards.AirLoopHVAC.rb
@@ -342,6 +342,11 @@ class OpenStudio::Model::AirLoopHVAC
 
     # Calculate and report the total area for debugging/testing
     floor_area_served_m2 = floor_area_served
+
+    if floor_area_served_m2 == 0
+      OpenStudio.logFree(OpenStudio::Error,'openstudio.standards.AirLoopHVAC', "AirLoopHVAC #{self.name.to_s} serves zero floor area. Check that it has thermal zones attached to it, and that they have non-zero floor area'.")
+    end
+
     floor_area_served_ft2 = OpenStudio.convert(floor_area_served_m2, 'm^2', 'ft^2').get
     cfm_per_ft2 = dsn_air_flow_cfm / floor_area_served_ft2
     cfm_per_hp = dsn_air_flow_cfm / allowable_fan_bhp


### PR DESCRIPTION
Related to: https://unmethours.com/question/22914/openstudio-baseline-building-measure-error/