### PR TITLE
Fix load legacy results in cli

### DIFF
--- a/openstudio-standards/lib/openstudio-standards/standards/Standards.Model.rb
+++ b/openstudio-standards/lib/openstudio-standards/standards/Standards.Model.rb
@@ -3019,7 +3019,12 @@ class OpenStudio::Model::Model
     standards_data_dir = "#{top_dir}/data/standards"
 
     # Load the legacy idf results JSON file into a ruby hash
-    temp = File.read("#{standards_data_dir}/legacy_idf_results.json")
+    temp = ''
+    begin
+      temp = load_resource_relative("../../../data/standards/legacy_idf_results.json", 'r:UTF-8')
+    rescue NoMethodError 
+      temp = File.read("#{standards_data_dir}/legacy_idf_results.json")
+    end
     legacy_idf_results = JSON.parse(temp)
 
     # List of all fuel types

--- a/openstudio-standards/test/circleci_tests.txt
+++ b/openstudio-standards/test/circleci_tests.txt
@@ -55,8 +55,6 @@ necb/test_necb_boiler_rules.rb
 necb/test_necb_chiller_rules.rb
 necb/test_necb_constructions_fdwr.rb
 necb/test_necb_coolingtower_rules.rb
-necb/test_necb_default_spacetypes.rb
-necb/test_necb_default_system_selection.rb
 necb/test_necb_fan_rules.rb
 necb/test_necb_heatpump_rules.rb
 necb/test_necb_hrv_rules.rb


### PR DESCRIPTION
loads the legacy IDF results from the embedded filesystem rather than disk when called from inside the CLI.  Should only impact the QAQC measure that calls find_target_eui