### PR TITLE
update rubocop style location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@
 
 # Rubocop output
 /.rubocop
-/.rubocop-https*
+/.rubocop-http*
 
 # Doc generation output
 /.yardoc

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,7 +13,7 @@ AllCops:
     - 'lib/openstudio-standards/prototypes/common/do_not_edit_metaclasses.rb'
 
 inherit_from:
-  - https://raw.githubusercontent.com/NREL/OpenStudio-resources/develop/styles/rubocop.yml
+  - http://s3.amazonaws.com/openstudio-resources/styles/rubocop.yml
 
 # =============== OpenStudio Standards Specific ===========
 # Ignore file name convention; choices based on OpenStudio C++ class names


### PR DESCRIPTION
@asparke2 -- this should be an easy merge. We are moving the rubocop syntax to S3. No longer needs https to download.