### PR TITLE
account for multiplier with internal loads

### DIFF
--- a/lib/openstudio-standards/standards/Standards.Model.rb
+++ b/lib/openstudio-standards/standards/Standards.Model.rb
@@ -1386,8 +1386,8 @@ class Standard
       # Call method recursively if something was eliminated
       array_of_zones = model_eliminate_outlier_zones(model, array_of_zones, key_to_inspect, tolerance, field_name, units)
     else
-      # OpenStudio::logFree(OpenStudio::Debug, 'openstudio.standards.Model', "#{worst.round(1)} - #{avg.round(1)} = #{biggest_delta.round(1)} #{units} < tolerance of #{tolerance} #{units}, stopping elimination process.")
-      OpenStudio.logFree(OpenStudio::Debug, 'openstudio.standards.Model', "#{worst} - #{avg} = #{biggest_delta} #{units} < tolerance of #{tolerance} #{units}, stopping elimination process.")
+      zn_name = array_of_zones[biggest_delta_i]['zone'].name.get.to_s
+      OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.Model', "For zone #{zn_name}, the #{field_name} #{worst.round(2)} #{units} - average #{field_name} #{avg.round(2)} #{units} = #{biggest_delta.round(2)} #{units} < tolerance of #{tolerance} #{units}, stopping elimination process.")
     end
 
     return array_of_zones
@@ -1481,7 +1481,7 @@ class Standard
       area_ft2 = OpenStudio.convert(area_m2, 'm^2', 'ft^2').get
       data['area_ft2'] = area_ft2
       # Get the internal loads
-      int_load_w = thermal_zone_design_internal_load(zone)
+      int_load_w = thermal_zone_design_internal_load(zone) * zone.multiplier
       # Normalize per-area
       int_load_w_per_m2 = int_load_w / area_m2
       int_load_btu_per_ft2 = OpenStudio.convert(int_load_w_per_m2, 'W/m^2', 'Btu/hr*ft^2').get


### PR DESCRIPTION
- account for zone multiplier when calculating zone internal loads
- better log message for model_eliminate_outlier_zones termination