### PR TITLE
Fix invalid variable, catch NaNs when sorting

### DIFF
--- a/lib/openstudio-standards/standards/Standards.Model.rb
+++ b/lib/openstudio-standards/standards/Standards.Model.rb
@@ -1335,7 +1335,11 @@ class Standard
   # with the keys 'zone',
   def model_eliminate_outlier_zones(model, array_of_zones, key_to_inspect, tolerance, field_name, units)
     # Sort the zones by the desired key
-    array_of_zones = array_of_zones.sort_by {|hsh| hsh[key_to_inspect]}
+    begin
+      array_of_zones = array_of_zones.sort_by {|hsh| hsh[key_to_inspect]}
+    rescue ArgumentError => e
+      OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.Model', "Unable to sort array_of_zones by #{key_to_inspect} due to #{e.message}, defaulting to order that was passed")
+    end
 
     # Calculate the area-weighted average
     total = 0.0

--- a/lib/openstudio-standards/standards/Standards.Space.rb
+++ b/lib/openstudio-standards/standards/Standards.Space.rb
@@ -96,7 +96,7 @@ class Standard
 
     # Make sure there is one floor surface
     if floor_surface.nil?
-      OpenStudio.logFree(OpenStudio::Warn, 'openstudio.model.Space', "Could not find a floor in space #{name.get}, cannot determine daylighted areas.")
+      OpenStudio.logFree(OpenStudio::Warn, 'openstudio.model.Space', "Could not find a floor in space #{space.name}, cannot determine daylighted areas.")
       return result
     end
 


### PR DESCRIPTION
Fixes two errors.

1) Variable should be space.name and not name.get.
2) In the `model_eliminate_outlier_zones` method, if the array_of_zones has NaNs in the key_to_inspect, then raised an exception on sort. Cat this exception and simply act on the array_of_zones in the order that was passed. 

Needed for running the gbxml test case here: https://github.com/NREL/openstudio-cli-demo/tree/2.6.0/gbxml_osw
