### PR TITLE
[Nrcan tasks 126 & 127] Arrange tests run on CircleCI based on the locally generated timing data

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     working_directory: ~/openstudio-standards
     docker:
       - image: canmet/docker-openstudio:2.4.3
-    parallelism: 6
+    parallelism: 7
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,10 @@ jobs:
           name: Summarize test times
           command: |
             bundle exec rake test:times
+      - run:
+          name: Copy test result Timings
+          command: |
+            cp -R test/reports timing/
       - store_test_results:
           path: test/reports/
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,10 @@ jobs:
           name: Summarize test times
           command: |
             bundle exec rake test:times
+      - run:
+          name: Print test XML
+          command: |
+            bundle exec rake test:print_times
       - store_test_results:
           path: test/reports/
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     working_directory: ~/openstudio-standards
     docker:
       - image: canmet/docker-openstudio:2.4.3
-    parallelism: 7
+    parallelism: 6
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
           name: Parallelize Tests
           command: |
             >node_tests.txt
-            echo "circleci tests split --index=$CIRCLE_NODE_INDEX test/helpers/ci_test_helper/$CIRCLE_NODE_INDEX.txt > node_tests.txt" | bash
+            echo "cat test/helpers/ci_test_helper/$CIRCLE_NODE_INDEX.txt > node_tests.txt" | bash
             cat node_tests.txt
       - run:
           name: Run tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
           name: Parallelize Tests
           command: |
             >node_tests.txt
-            echo "cat test/helpers/ci_test_helper/$CIRCLE_NODE_INDEX.txt
+            echo "cat test/helpers/ci_test_helper/$CIRCLE_NODE_INDEX.txt"
             echo "cat test/helpers/ci_test_helper/$CIRCLE_NODE_INDEX.txt > node_tests.txt" | bash
             cat node_tests.txt
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,7 @@ jobs:
           name: Parallelize Tests
           command: |
             >node_tests.txt
+            echo "cat test/helpers/ci_test_helper/$CIRCLE_NODE_INDEX.txt
             echo "cat test/helpers/ci_test_helper/$CIRCLE_NODE_INDEX.txt > node_tests.txt" | bash
             cat node_tests.txt
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
           name: Parallelize Tests
           command: |
             >node_tests.txt
-            circleci tests split --split-by=timings --timings-type=classname test/circleci_tests.txt > node_tests.txt
+            circleci tests split --index=$CIRCLE_NODE_INDEX test/helpers/ci_test_helper/$CIRCLE_NODE_INDEX.txt > node_tests.txt
             cat node_tests.txt
       - run:
           name: Run tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,10 +29,6 @@ jobs:
           name: Summarize test times
           command: |
             bundle exec rake test:times
-      - run:
-          name: Print test XML
-          command: |
-            bundle exec rake test:print_times
       - store_test_results:
           path: test/reports/
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
           name: Parallelize Tests
           command: |
             >node_tests.txt
-            circleci tests split --split-by=timings test/circleci_tests.txt > node_tests.txt
+            circleci tests split --split-by=timings --timings-type=classname test/circleci_tests.txt > node_tests.txt
             cat node_tests.txt
       - run:
           name: Run tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
           name: Parallelize Tests
           command: |
             >node_tests.txt
-            circleci tests split --index=$CIRCLE_NODE_INDEX test/helpers/ci_test_helper/$CIRCLE_NODE_INDEX.txt > node_tests.txt
+            echo "circleci tests split --index=$CIRCLE_NODE_INDEX test/helpers/ci_test_helper/$CIRCLE_NODE_INDEX.txt > node_tests.txt" | bash
             cat node_tests.txt
       - run:
           name: Run tests

--- a/Rakefile
+++ b/Rakefile
@@ -26,20 +26,18 @@ namespace :test do
   end
 
 
-  desc 'Run All CircleCI tests'
+  desc 'Run All CircleCI tests locally'
   Rake::TestTask.new('local-circ-all-tests') do |t|
-    file_list = FileList.new('test/helpers/ci_test_generator.rb', 'test/test_run_all_test_locally.rb')
+    file_list = FileList.new('test/test_run_all_test_locally.rb')
     t.libs << 'test'
     t.test_files = file_list
     t.verbose = false
   end
 
   desc 'Generate CircleCI test files'
-  Rake::TestTask.new('gen-circ-files') do |t|
-    file_list = FileList.new('test/helpers/ci_test_generator.rb')
-    t.libs << 'test'
-    t.test_files = file_list
-    t.verbose = false
+  task :'gen-circ-files' do
+    require_relative './test/helpers/ci_test_generator'
+    CITestGenerator::generate(local_run: false)
   end
 
 

--- a/Rakefile
+++ b/Rakefile
@@ -156,6 +156,14 @@ namespace :test do
       end
     end
 
+    desc 'Print the test timing'
+    task 'print_times' do |t|
+      Dir['test/reports/*.xml'].each do |xml|
+        puts File.read(xml)
+        puts '='*30
+      end
+    end
+
   end
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -139,6 +139,7 @@ namespace :test do
       File.open("#{Dir.pwd}/timing/test_by_file.html", 'w') do |html|
         html.puts '<table><tr><th>File Name</th><th>Time (min)</th></tr>'
         files_to_times.each do |f, time_s|
+          puts "[#{time_s}]\t\t#{f}"
           s = (time_s / 60).round(1) # convert time from sec to min
           html.puts "<tr><td>#{f}</td><td>#{s}</td></tr>"
         end
@@ -149,18 +150,11 @@ namespace :test do
       File.open("#{Dir.pwd}/timing/test_by_name.html", 'w') do |html|
         html.puts '<table><tr><th>Test Name</th><th>Time (min)</th></tr>'
         tests_to_times.each do |f, time_s|
+          puts "[#{time_s}]\t\t#{f}"
           s = (time_s / 60).round(1) # convert time from sec to min
           html.puts "<tr><td>#{f}</td><td>#{s}</td></tr>"
         end
         html.puts '</table>'
-      end
-    end
-
-    desc 'Print the test timing'
-    task 'print_times' do |t|
-      Dir['test/reports/*.xml'].each do |xml|
-        puts File.read(xml)
-        puts '='*30
       end
     end
 

--- a/test/helpers/ci_test_generator.rb
+++ b/test/helpers/ci_test_generator.rb
@@ -1757,7 +1757,7 @@ end
     }
 
     # puts JSON.pretty_generate(timings)
-    procs = File.read(File.join(File.dirname(__FILE__), '..', '..' , '.circleci', 'config.yml')).match(/(?<=parallelism:\s)(\d*)/).to_s.to_i
+    procs = ENV['CIRCLE_NODE_TOTAL'] || File.read(File.join(File.dirname(__FILE__), '..', '..' , '.circleci', 'config.yml')).match(/(?<=parallelism:\s)(\d*)/).to_s.to_i
     sorted_timings = LPT.new(timings , procs).lpt_algorithm()[0]
 
     sorted_timings.each_with_index {|files,i|
@@ -1785,7 +1785,7 @@ end
     generate_hvac_sys7_files()
     generate_doe_building_test_files()
     write_file_path_to_ci_tests_txt(local_run)
-    sort_files_by_timing(local_run)
+    sort_files_by_timing(local_run) # unless local_run
   end
 end
 

--- a/test/helpers/ci_test_generator.rb
+++ b/test/helpers/ci_test_generator.rb
@@ -1,78 +1,67 @@
 require 'fileutils'
+module CITestGenerator
 
-def file_out_dir
-  File.absolute_path(File.join(__FILE__,"..","..","ci_test_files"))
-end
+  @@ci_test_path = File.absolute_path(File.join(__FILE__, "..", "..", "circleci_tests.txt"))
+  @@local_ci_test_path = File.absolute_path(File.join(__FILE__, "..", "..", "local_circleci_tests.txt"))
 
-def doe_dir
-  File.absolute_path(File.join(__FILE__,"..","..","doe_prototype"))
-end
+  def self.file_out_dir
+    File.absolute_path(File.join(__FILE__,"..","..","ci_test_files"))
+  end
 
-def cleanup_output_folders
-  dirname = File.join(file_out_dir(), 'output')
-  if File.directory?(dirname)
-    puts "Removing hvac output directory : [#{dirname}]"
-    FileUtils.rm_r(dirname)
+  def self.doe_dir
+    File.absolute_path(File.join(__FILE__,"..","..","doe_prototype"))
   end
-  necb_out_dirname = File.absolute_path(File.join(__FILE__,"..","..","necb", 'output'))
-  if File.directory?(necb_out_dirname)
-    puts "Removing necb output directory : [#{necb_out_dirname}]"
-    FileUtils.rm_r(necb_out_dirname)
-  end
-  nrel_out_dirname = File.absolute_path(File.join(__FILE__,"..","..","..", 'output'))
-  if File.directory?(nrel_out_dirname)
-    puts "Removing nrel output directory : [#{nrel_out_dirname}]"
-    FileUtils.rm_r(nrel_out_dirname)
-  end
-  if File.directory?(file_out_dir())
-    puts "Removing and recreating ci_test_files directory : [#{file_out_dir()}]"
-    FileUtils.rm_r(file_out_dir())
-  end
-  FileUtils.mkdir_p(file_out_dir())
-end
 
-# copied and modified from https://github.com/rubyworks/facets/blob/master/lib/core/facets/string/snakecase.rb
-class String
-  def snek
-    #gsub(/::/, '/').
-    gsub(/([A-Z]+)([A-Z][a-z])/,'\1_\2').
-        gsub(/([a-z\d])([A-Z])/,'\1_\2').
-        tr('-', '_').
-        gsub(/\s/, '_').
-        gsub(/__+/, '_').
-        gsub(/#+/, '').
-        gsub(/\"/, '').
-        downcase
+  def self.cleanup_output_folders
+    dirname = File.join(file_out_dir(), 'output')
+    if File.directory?(dirname)
+      puts "Removing hvac output directory : [#{dirname}]"
+      FileUtils.rm_r(dirname)
+    end
+    necb_out_dirname = File.absolute_path(File.join(__FILE__,"..","..","necb", 'output'))
+    if File.directory?(necb_out_dirname)
+      puts "Removing necb output directory : [#{necb_out_dirname}]"
+      FileUtils.rm_r(necb_out_dirname)
+    end
+    nrel_out_dirname = File.absolute_path(File.join(__FILE__,"..","..","..", 'output'))
+    if File.directory?(nrel_out_dirname)
+      puts "Removing nrel output directory : [#{nrel_out_dirname}]"
+      FileUtils.rm_r(nrel_out_dirname)
+    end
+    if File.directory?(file_out_dir())
+      puts "Removing and recreating ci_test_files directory : [#{file_out_dir()}]"
+      FileUtils.rm_r(file_out_dir())
+    end
+    FileUtils.mkdir_p(file_out_dir())
   end
-end
 
-def generate_ci_bldg_test_files
-  templates = ['NECB2011', 'NECB2015']
-  building_types = [
-      "FullServiceRestaurant",
-      "HighriseApartment",
-      "Hospital",
-      "LargeHotel",
-      "LargeOffice",
-      "MediumOffice",
-      "MidriseApartment",
-      "Outpatient",
-      "PrimarySchool",
-      "QuickServiceRestaurant",
-      "RetailStandalone",
-      "RetailStripmall",
-      "SecondarySchool",
-      "SmallHotel",
-      "SmallOffice",
-      "Warehouse"
-  ]
-  fuel_types = ['gas', 'electric']
-  out_dir = file_out_dir()
-  templates.each {|template|
-    building_types.each {|building_type|
-      fuel_types.each {|fuel_type|
-        filename = File.join(out_dir,"test_necb_bldg_#{building_type}_#{template}_#{fuel_type}.rb")
-        file_string =%Q{
+  def self.generate_ci_bldg_test_files
+    templates = ['NECB2011', 'NECB2015']
+    building_types = [
+        "FullServiceRestaurant",
+        "HighriseApartment",
+        "Hospital",
+        "LargeHotel",
+        "LargeOffice",
+        "MediumOffice",
+        "MidriseApartment",
+        "Outpatient",
+        "PrimarySchool",
+        "QuickServiceRestaurant",
+        "RetailStandalone",
+        "RetailStripmall",
+        "SecondarySchool",
+        "SmallHotel",
+        "SmallOffice",
+        "Warehouse"
+    ]
+    fuel_types = ['gas', 'electric']
+    out_dir = file_out_dir()
+    templates.each {|template|
+      building_types.each {|building_type|
+        fuel_types.each {|fuel_type|
+          filename = File.join(out_dir,"test_necb_bldg_#{building_type}_#{template}_#{fuel_type}.rb")
+          file_string =%Q{
 require_relative '../helpers/minitest_helper'
 require_relative '../helpers/create_doe_prototype_helper'
 require_relative '../helpers/compare_models_helper'
@@ -92,23 +81,28 @@ class Test_#{building_type}_#{template}_#{fuel_type} < NECBRegressionHelper
   end
 end
 }
-        File.open(filename, 'w') { |file| file.write(file_string) }
+          File.open(filename, 'w') { |file| file.write(file_string) }
+        }
       }
     }
-  }
-end
+  end
 
-def write_file_path_to_ci_tests_txt
-  circleci_tests_txt_path = File.absolute_path(File.join(__FILE__, "..", "..", "circleci_tests.txt"))
-  #puts circleci_tests_txt_path
+  def self.write_file_path_to_ci_tests_txt(local_run)
+    circleci_tests_txt_path = @@ci_test_path
 
-  # get the content of circleci_tests.txt file
-  files = IO.readlines(circleci_tests_txt_path)
-  new_file_content = files.clone
+    if local_run
+      FileUtils.copy(@@ci_test_path, @@local_ci_test_path)
+      circleci_tests_txt_path = @@local_ci_test_path
+    end
+    #puts circleci_tests_txt_path
 
-  # remove lines which contains the test_necb_bldg_*.rb
-  files.each_with_index {|line, i|
-    if  line.include?("necb/test_necb_bldg_") or \
+    # get the content of circleci_tests.txt file
+    files = IO.readlines(circleci_tests_txt_path)
+    new_file_content = files.clone
+
+    # remove lines which contains the test_necb_bldg_*.rb
+    files.each_with_index {|line, i|
+      if  line.include?("necb/test_necb_bldg_") or \
         line.include?("necb/test_necb_hvac") or \
         line.include?("doe_prototype/test_add_hvac_systems") or \
         line.include?("doe_prototype/test_full_service_restaurant.rb") or \
@@ -130,63 +124,63 @@ def write_file_path_to_ci_tests_txt
         line.include?("doe_prototype/test_warehouse.rb") or \
         line.include?("ci_test_files/") # remove all previously written ci_test_files
 
-      new_file_content = new_file_content - [files[i]]
-    end
-  }
-
-  # overwrite circleci_tests.txt without the test_necb_bldg_*.rb lines
-  File.open(circleci_tests_txt_path, 'w') { |f|
-    new_file_content.each {|line|
-      f.puts line
+        new_file_content = new_file_content - [files[i]]
+      end
     }
-  }
 
-  # add the new nrcan files generated by this script to the circleci_tests.txt
-  File.open(circleci_tests_txt_path, 'a') { |f|
-    files_path = File.expand_path(File.join(__FILE__,"..","..","ci_test_files", "test_necb_*.rb"))
-    puts files_path
-    Dir[files_path].sort.each {|path|
-      f.puts(path.to_s.gsub(/^.+(openstudio-standards\/test\/)/,''))
+    # overwrite circleci_tests.txt without the test_necb_bldg_*.rb lines
+    File.open(circleci_tests_txt_path, 'w') { |f|
+      new_file_content.each {|line|
+        f.puts line
+      }
     }
-  }
 
-  # add the new doe files generated by this script to the circleci_tests.txt
-  File.open(circleci_tests_txt_path, 'a') { |f|
-    files_path = File.expand_path(File.join(__FILE__,"..","..","ci_test_files", "doe_test*.rb"))
-    puts files_path
-    Dir[files_path].sort.each {|path|
-      f.puts(path.to_s.gsub(/^.+(openstudio-standards\/test\/)/,''))
+    # add the new nrcan files generated by this script to the circleci_tests.txt
+    File.open(circleci_tests_txt_path, 'a') { |f|
+      files_path = File.expand_path(File.join(__FILE__,"..","..","ci_test_files", "test_necb_*.rb"))
+      puts files_path
+      Dir[files_path].sort.each {|path|
+        f.puts(path.to_s.gsub(/^.+(openstudio-standards\/test\/)/,''))
+      }
     }
-  }
-end
 
-def copy_model_files_for_hvac_tests
-  out_dir = file_out_dir()
-  model_dir = File.join(out_dir, 'models')
-  FileUtils.mkpath(model_dir)
-  FileUtils.copy_entry( File.absolute_path(File.join(__dir__, "..", "necb", "models")), model_dir)
-end
+    # add the new doe files generated by this script to the circleci_tests.txt
+    File.open(circleci_tests_txt_path, 'a') { |f|
+      files_path = File.expand_path(File.join(__FILE__,"..","..","ci_test_files", "doe_test*.rb"))
+      puts files_path
+      Dir[files_path].sort.each {|path|
+        f.puts(path.to_s.gsub(/^.+(openstudio-standards\/test\/)/,''))
+      }
+    }
+  end
 
-def copy_doe_model_files_for_hvac_tests
-  model_dir = File.join(file_out_dir(), 'models')
-  FileUtils.mkpath(model_dir)
-  FileUtils.copy_entry( File.absolute_path(File.join(doe_dir(), "models")), model_dir)
-end
+  def self.copy_model_files_for_hvac_tests
+    out_dir = file_out_dir()
+    model_dir = File.join(out_dir, 'models')
+    FileUtils.mkpath(model_dir)
+    FileUtils.copy_entry( File.absolute_path(File.join(__dir__, "..", "necb", "models")), model_dir)
+  end
 
-def generate_hvac_sys1_files
+  def self.copy_doe_model_files_for_hvac_tests
+    model_dir = File.join(file_out_dir(), 'models')
+    FileUtils.mkpath(model_dir)
+    FileUtils.copy_entry( File.absolute_path(File.join(doe_dir(), "models")), model_dir)
+  end
 
-  boiler_fueltypes = ["NaturalGas", "Electricity", "FuelOil#2"]
-  mau_types = [true, false]
-  mau_heating_coil_types = ["Hot Water", "Electric"]
-  baseboard_types = ["Hot Water", "Electric"]
+  def self.generate_hvac_sys1_files
 
-  boiler_fueltypes.each {|boiler_fueltype|
-    mau_types.each {|mau_type|
-      mau_heating_coil_types.each {|mau_heating_coil_type|
-        baseboard_types.each {|baseboard_type|
-        filename = File.join(file_out_dir(),"test_necb_hvac_system_1-#{boiler_fueltype.snek}-#{mau_type.to_s.snek}-#{mau_heating_coil_type.snek}-#{baseboard_type.snek}.rb")
-        puts filename
-        file_string = %q{
+    boiler_fueltypes = ["NaturalGas", "Electricity", "FuelOil#2"]
+    mau_types = [true, false]
+    mau_heating_coil_types = ["Hot Water", "Electric"]
+    baseboard_types = ["Hot Water", "Electric"]
+
+    boiler_fueltypes.each {|boiler_fueltype|
+      mau_types.each {|mau_type|
+        mau_heating_coil_types.each {|mau_heating_coil_type|
+          baseboard_types.each {|baseboard_type|
+            filename = File.join(file_out_dir(),"test_necb_hvac_system_1-#{boiler_fueltype.snek}-#{mau_type.to_s.snek}-#{mau_heating_coil_type.snek}-#{baseboard_type.snek}.rb")
+            puts filename
+            file_string = %q{
 require_relative '../helpers/minitest_helper'
 require_relative '../helpers/create_doe_prototype_helper'
 
@@ -337,34 +331,34 @@ class NECB_HVAC_System_1_Test < MiniTest::Test
     end
 end}
 
-        file_string['$(boiler_fueltypes)'] = boiler_fueltype
-        file_string['$(mau_types)'] = mau_type.to_s
-        file_string['$(mau_heating_coil_types)'] = mau_heating_coil_type
-        file_string['$(baseboard_types)'] = baseboard_type
+            file_string['$(boiler_fueltypes)'] = boiler_fueltype
+            file_string['$(mau_types)'] = mau_type.to_s
+            file_string['$(mau_heating_coil_types)'] = mau_heating_coil_type
+            file_string['$(baseboard_types)'] = baseboard_type
 
-        file_string['$(boiler_fueltypes_snake)'] = boiler_fueltype.to_s.snek
-        file_string['$(mau_types_snake)'] = mau_type.to_s.snek
-        file_string['$(mau_heating_coil_types_snake)'] = mau_heating_coil_type.to_s.snek
-        file_string['$(baseboard_types_snake)'] = baseboard_type.to_s.snek
+            file_string['$(boiler_fueltypes_snake)'] = boiler_fueltype.to_s.snek
+            file_string['$(mau_types_snake)'] = mau_type.to_s.snek
+            file_string['$(mau_heating_coil_types_snake)'] = mau_heating_coil_type.to_s.snek
+            file_string['$(baseboard_types_snake)'] = baseboard_type.to_s.snek
 
-        File.open(filename, 'w') { |file| file.write(file_string) }
+            File.open(filename, 'w') { |file| file.write(file_string) }
+          }
         }
       }
     }
-  }
 
-end
+  end
 
-def generate_hvac_sys2_files
-  boiler_fueltypes = ["NaturalGas", "Electricity", "FuelOil#2",]
-  chiller_types = ["Scroll", "Centrifugal", "Rotary Screw", "Reciprocating"]
-  mua_cooling_types = ["Hydronic", "DX"]
-  boiler_fueltypes.each {|boiler_fueltype|
-    chiller_types.each {|chiller_type|
-      mua_cooling_types.each {|mua_cooling_type|
-        filename = File.join(file_out_dir(),"test_necb_hvac_system_2_#{boiler_fueltype.snek}-#{chiller_type.to_s.snek}-#{mua_cooling_type.snek}.rb")
-        puts filename
-        file_string = %q{require_relative '../helpers/minitest_helper'
+  def self.generate_hvac_sys2_files
+    boiler_fueltypes = ["NaturalGas", "Electricity", "FuelOil#2",]
+    chiller_types = ["Scroll", "Centrifugal", "Rotary Screw", "Reciprocating"]
+    mua_cooling_types = ["Hydronic", "DX"]
+    boiler_fueltypes.each {|boiler_fueltype|
+      chiller_types.each {|chiller_type|
+        mua_cooling_types.each {|mua_cooling_type|
+          filename = File.join(file_out_dir(),"test_necb_hvac_system_2_#{boiler_fueltype.snek}-#{chiller_type.to_s.snek}-#{mua_cooling_type.snek}.rb")
+          puts filename
+          file_string = %q{require_relative '../helpers/minitest_helper'
 require_relative '../helpers/create_doe_prototype_helper'
 
 
@@ -470,32 +464,32 @@ class NECB_HVAC_System_2_Test < MiniTest::Test
   end
 end
 }
-        file_string['$(boiler_fueltype)'] = boiler_fueltype
-        file_string['$(chiller_type)'] = chiller_type.to_s
-        file_string['$(mua_cooling_type)'] = mua_cooling_type
+          file_string['$(boiler_fueltype)'] = boiler_fueltype
+          file_string['$(chiller_type)'] = chiller_type.to_s
+          file_string['$(mua_cooling_type)'] = mua_cooling_type
 
-        file_string['$(boiler_fueltypes_snake)'] = boiler_fueltype.to_s.snek
-        file_string['$(chiller_types_snake)'] = chiller_type.to_s.snek
-        file_string['$(mua_cooling_types_snake)'] = mua_cooling_type.to_s.snek
+          file_string['$(boiler_fueltypes_snake)'] = boiler_fueltype.to_s.snek
+          file_string['$(chiller_types_snake)'] = chiller_type.to_s.snek
+          file_string['$(mua_cooling_types_snake)'] = mua_cooling_type.to_s.snek
 
-        File.open(filename, 'w') { |file| file.write(file_string) }
+          File.open(filename, 'w') { |file| file.write(file_string) }
+        }
       }
     }
-  }
 
-end
+  end
 
-def generate_hvac_sys3_files
-  boiler_fueltypes = ["NaturalGas", "Electricity", "FuelOil#2"]
-  baseboard_types = ["Hot Water", "Electric"]
-  heating_coil_types_sys3 = ["Electric", "Gas", "DX"]
+  def self.generate_hvac_sys3_files
+    boiler_fueltypes = ["NaturalGas", "Electricity", "FuelOil#2"]
+    baseboard_types = ["Hot Water", "Electric"]
+    heating_coil_types_sys3 = ["Electric", "Gas", "DX"]
 
-  boiler_fueltypes.each {|boiler_fueltype|
-    baseboard_types.each {|baseboard_type|
-      heating_coil_types_sys3.each {|heating_coil_type|
-        filename = File.join(file_out_dir(),"test_necb_hvac_system_3_#{boiler_fueltype.snek}-#{baseboard_type.to_s.snek}-#{heating_coil_type.snek}.rb")
-        puts filename
-        file_string = %q{
+    boiler_fueltypes.each {|boiler_fueltype|
+      baseboard_types.each {|baseboard_type|
+        heating_coil_types_sys3.each {|heating_coil_type|
+          filename = File.join(file_out_dir(),"test_necb_hvac_system_3_#{boiler_fueltype.snek}-#{baseboard_type.to_s.snek}-#{heating_coil_type.snek}.rb")
+          puts filename
+          file_string = %q{
 require_relative '../helpers/minitest_helper'
 require_relative '../helpers/create_doe_prototype_helper'
 
@@ -602,33 +596,33 @@ class NECB_HVAC_System_3_Test < MiniTest::Test
   end
 end
 }
-        file_string['$(boiler_fueltype)'] = boiler_fueltype
-        file_string['$(baseboard_type)'] = baseboard_type.to_s
-        file_string['$(heating_coil_type)'] = heating_coil_type
+          file_string['$(boiler_fueltype)'] = boiler_fueltype
+          file_string['$(baseboard_type)'] = baseboard_type.to_s
+          file_string['$(heating_coil_type)'] = heating_coil_type
 
-        file_string['$(boiler_fueltypes_snake)'] = boiler_fueltype.to_s.snek
-        file_string['$(baseboard_types_snake)'] = baseboard_type.to_s.snek
-        file_string['$(heating_coil_type_snake)'] = heating_coil_type.to_s.snek
+          file_string['$(boiler_fueltypes_snake)'] = boiler_fueltype.to_s.snek
+          file_string['$(baseboard_types_snake)'] = baseboard_type.to_s.snek
+          file_string['$(heating_coil_type_snake)'] = heating_coil_type.to_s.snek
 
-        File.open(filename, 'w') { |file| file.write(file_string) }
+          File.open(filename, 'w') { |file| file.write(file_string) }
+        }
       }
     }
-  }
 
-end
+  end
 
-def generate_hvac_sys4_files
-  boiler_fueltypes = ["NaturalGas", "Electricity", "FuelOil#2",]
-  baseboard_types = ["Hot Water", "Electric"]
-  heating_coil_types_sys4 = ["Electric", "Gas"]
+  def self.generate_hvac_sys4_files
+    boiler_fueltypes = ["NaturalGas", "Electricity", "FuelOil#2",]
+    baseboard_types = ["Hot Water", "Electric"]
+    heating_coil_types_sys4 = ["Electric", "Gas"]
 
-  boiler_fueltypes.each {|boiler_fueltype|
-    baseboard_types.each {|baseboard_type|
-      heating_coil_types_sys4.each {|heating_coil_type|
-        filename = File.join(file_out_dir(),"test_necb_hvac_system_4_#{boiler_fueltype.snek}-#{baseboard_type.to_s.snek}-#{heating_coil_type.snek}.rb")
-        puts filename
+    boiler_fueltypes.each {|boiler_fueltype|
+      baseboard_types.each {|baseboard_type|
+        heating_coil_types_sys4.each {|heating_coil_type|
+          filename = File.join(file_out_dir(),"test_necb_hvac_system_4_#{boiler_fueltype.snek}-#{baseboard_type.to_s.snek}-#{heating_coil_type.snek}.rb")
+          puts filename
 
-        file_string = %q{require_relative '../helpers/minitest_helper'
+          file_string = %q{require_relative '../helpers/minitest_helper'
 require_relative '../helpers/create_doe_prototype_helper'
 
 
@@ -735,31 +729,31 @@ class NECB_HVAC_System_4_Test < MiniTest::Test
   end
 end
 }
-        file_string['$(boiler_fueltype)'] = boiler_fueltype
-        file_string['$(baseboard_type)'] = baseboard_type.to_s
-        file_string['$(heating_coil_type)'] = heating_coil_type
+          file_string['$(boiler_fueltype)'] = boiler_fueltype
+          file_string['$(baseboard_type)'] = baseboard_type.to_s
+          file_string['$(heating_coil_type)'] = heating_coil_type
 
-        file_string['$(boiler_fueltypes_snake)'] = boiler_fueltype.to_s.snek
-        file_string['$(baseboard_types_snake)'] = baseboard_type.to_s.snek
-        file_string['$(heating_coil_type_snake)'] = heating_coil_type.to_s.snek
+          file_string['$(boiler_fueltypes_snake)'] = boiler_fueltype.to_s.snek
+          file_string['$(baseboard_types_snake)'] = baseboard_type.to_s.snek
+          file_string['$(heating_coil_type_snake)'] = heating_coil_type.to_s.snek
 
-        File.open(filename, 'w') { |file| file.write(file_string) }
+          File.open(filename, 'w') { |file| file.write(file_string) }
+        }
       }
     }
-  }
 
-end
+  end
 
-def generate_hvac_sys5_files
-  boiler_fueltypes = ["NaturalGas", "Electricity", "FuelOil#2",]
-  chiller_types = ["Scroll", "Centrifugal", "Rotary Screw", "Reciprocating"]
-  mua_cooling_types = ["DX", "Hydronic"]
-  boiler_fueltypes.each {|boiler_fueltype|
-    chiller_types.each {|chiller_type|
-      mua_cooling_types.each {|mua_cooling_type|
-        filename = File.join(file_out_dir(),"test_necb_hvac_system_5_#{boiler_fueltype.snek}-#{chiller_type.to_s.snek}-#{mua_cooling_type.snek}.rb")
-        puts filename
-        file_string = %q{
+  def self.generate_hvac_sys5_files
+    boiler_fueltypes = ["NaturalGas", "Electricity", "FuelOil#2",]
+    chiller_types = ["Scroll", "Centrifugal", "Rotary Screw", "Reciprocating"]
+    mua_cooling_types = ["DX", "Hydronic"]
+    boiler_fueltypes.each {|boiler_fueltype|
+      chiller_types.each {|chiller_type|
+        mua_cooling_types.each {|mua_cooling_type|
+          filename = File.join(file_out_dir(),"test_necb_hvac_system_5_#{boiler_fueltype.snek}-#{chiller_type.to_s.snek}-#{mua_cooling_type.snek}.rb")
+          puts filename
+          file_string = %q{
 require_relative '../helpers/minitest_helper'
 require_relative '../helpers/create_doe_prototype_helper'
 
@@ -869,36 +863,36 @@ class NECB_HVAC_System_5_Test < MiniTest::Test
 
 end
 }
-        file_string['$(boiler_fueltype)'] = boiler_fueltype
-        file_string['$(chiller_type)'] = chiller_type.to_s
-        file_string['$(mua_cooling_type)'] = mua_cooling_type
+          file_string['$(boiler_fueltype)'] = boiler_fueltype
+          file_string['$(chiller_type)'] = chiller_type.to_s
+          file_string['$(mua_cooling_type)'] = mua_cooling_type
 
-        file_string['$(boiler_fueltypes_snake)'] = boiler_fueltype.to_s.snek
-        file_string['$(chiller_types_snake)'] = chiller_type.to_s.snek
-        file_string['$(mua_cooling_types_snake)'] = mua_cooling_type.to_s.snek
+          file_string['$(boiler_fueltypes_snake)'] = boiler_fueltype.to_s.snek
+          file_string['$(chiller_types_snake)'] = chiller_type.to_s.snek
+          file_string['$(mua_cooling_types_snake)'] = mua_cooling_type.to_s.snek
 
-        File.open(filename, 'w') { |file| file.write(file_string) }
+          File.open(filename, 'w') { |file| file.write(file_string) }
+        }
       }
     }
-  }
 
-end
+  end
 
-def generate_hvac_sys6_files
-  boiler_fueltypes = ["NaturalGas", "Electricity", "FuelOil#2",]
-  baseboard_types = ["Hot Water", "Electric"]
-  chiller_types = ["Scroll"] #,"Centrifugal","Rotary Screw","Reciprocating"] are not working.
-  heating_coil_types_sys6 = ["Electric", "Hot Water"]
-  fan_types = ["AF_or_BI_rdg_fancurve", "AF_or_BI_inletvanes", "fc_inletvanes", "var_speed_drive"]
+  def self.generate_hvac_sys6_files
+    boiler_fueltypes = ["NaturalGas", "Electricity", "FuelOil#2",]
+    baseboard_types = ["Hot Water", "Electric"]
+    chiller_types = ["Scroll"] #,"Centrifugal","Rotary Screw","Reciprocating"] are not working.
+    heating_coil_types_sys6 = ["Electric", "Hot Water"]
+    fan_types = ["AF_or_BI_rdg_fancurve", "AF_or_BI_inletvanes", "fc_inletvanes", "var_speed_drive"]
 
-  boiler_fueltypes.each {|boiler_fueltype|
-    baseboard_types.each {|baseboard_type|
-      chiller_types.each {|chiller_type|
-        heating_coil_types_sys6.each {|heating_coil_type|
-          fan_types.each {|fan_type|
-            filename = File.join(file_out_dir(),"test_necb_hvac_system_6_#{boiler_fueltype.snek}-#{baseboard_type.snek}-#{chiller_type.to_s.snek}-#{heating_coil_type.snek}-#{fan_type.to_s.snek}.rb")
-            puts filename
-            file_string = %q{
+    boiler_fueltypes.each {|boiler_fueltype|
+      baseboard_types.each {|baseboard_type|
+        chiller_types.each {|chiller_type|
+          heating_coil_types_sys6.each {|heating_coil_type|
+            fan_types.each {|fan_type|
+              filename = File.join(file_out_dir(),"test_necb_hvac_system_6_#{boiler_fueltype.snek}-#{baseboard_type.snek}-#{chiller_type.to_s.snek}-#{heating_coil_type.snek}-#{fan_type.to_s.snek}.rb")
+              puts filename
+              file_string = %q{
 require_relative '../helpers/minitest_helper'
 require_relative '../helpers/create_doe_prototype_helper'
 
@@ -1013,36 +1007,36 @@ class NECB_HVAC_System_6_Test < MiniTest::Test
   end
 end
 }
-            file_string['$(boiler_fueltype)'] = boiler_fueltype
-            file_string['$(baseboard_type)'] = baseboard_type
-            file_string['$(chiller_type)'] = chiller_type
-            file_string['$(heating_coil_type)'] = heating_coil_type
-            file_string['$(fan_type)'] = fan_type
+              file_string['$(boiler_fueltype)'] = boiler_fueltype
+              file_string['$(baseboard_type)'] = baseboard_type
+              file_string['$(chiller_type)'] = chiller_type
+              file_string['$(heating_coil_type)'] = heating_coil_type
+              file_string['$(fan_type)'] = fan_type
 
-            file_string['$(boiler_fueltype_snake)'] = boiler_fueltype.to_s.snek
-            file_string['$(baseboard_type_snake)'] = baseboard_type.to_s.snek
-            file_string['$(chiller_type_snake)'] = chiller_type.to_s.snek
-            file_string['$(heating_coil_type_snake)'] = heating_coil_type.to_s.snek
-            file_string['$(fan_type_snake)'] = fan_type.to_s.snek
+              file_string['$(boiler_fueltype_snake)'] = boiler_fueltype.to_s.snek
+              file_string['$(baseboard_type_snake)'] = baseboard_type.to_s.snek
+              file_string['$(chiller_type_snake)'] = chiller_type.to_s.snek
+              file_string['$(heating_coil_type_snake)'] = heating_coil_type.to_s.snek
+              file_string['$(fan_type_snake)'] = fan_type.to_s.snek
 
-            File.open(filename, 'w') { |file| file.write(file_string) }
+              File.open(filename, 'w') { |file| file.write(file_string) }
+            }
           }
         }
       }
     }
-  }
-end
+  end
 
-def generate_hvac_sys7_files
-  boiler_fueltypes = ["NaturalGas", "Electricity", "FuelOil#2"]
-  chiller_types = ["Scroll", "Centrifugal", "Rotary Screw", "Reciprocating"]
-  mua_cooling_types = ["Hydronic", "DX"]
-  boiler_fueltypes.each {|boiler_fueltype|
-    chiller_types.each {|chiller_type|
-      mua_cooling_types.each {|mua_cooling_type|
-        filename = File.join(file_out_dir(),"test_necb_hvac_system_7_#{boiler_fueltype.snek}-#{chiller_type.to_s.snek}-#{mua_cooling_type.snek}.rb")
-        puts filename
-        file_string = %q{
+  def self.generate_hvac_sys7_files
+    boiler_fueltypes = ["NaturalGas", "Electricity", "FuelOil#2"]
+    chiller_types = ["Scroll", "Centrifugal", "Rotary Screw", "Reciprocating"]
+    mua_cooling_types = ["Hydronic", "DX"]
+    boiler_fueltypes.each {|boiler_fueltype|
+      chiller_types.each {|chiller_type|
+        mua_cooling_types.each {|mua_cooling_type|
+          filename = File.join(file_out_dir(),"test_necb_hvac_system_7_#{boiler_fueltype.snek}-#{chiller_type.to_s.snek}-#{mua_cooling_type.snek}.rb")
+          puts filename
+          file_string = %q{
 require_relative '../helpers/minitest_helper'
 require_relative '../helpers/create_doe_prototype_helper'
 
@@ -1146,103 +1140,103 @@ class NECB_HVAC_System_7_Test < MiniTest::Test
   end
 end
 }
-        file_string['$(boiler_fueltype)'] = boiler_fueltype
-        file_string['$(chiller_type)'] = chiller_type.to_s
-        file_string['$(mua_cooling_type)'] = mua_cooling_type
+          file_string['$(boiler_fueltype)'] = boiler_fueltype
+          file_string['$(chiller_type)'] = chiller_type.to_s
+          file_string['$(mua_cooling_type)'] = mua_cooling_type
 
-        file_string['$(boiler_fueltypes_snake)'] = boiler_fueltype.to_s.snek
-        file_string['$(chiller_types_snake)'] = chiller_type.to_s.snek
-        file_string['$(mua_cooling_types_snake)'] = mua_cooling_type.to_s.snek
+          file_string['$(boiler_fueltypes_snake)'] = boiler_fueltype.to_s.snek
+          file_string['$(chiller_types_snake)'] = chiller_type.to_s.snek
+          file_string['$(mua_cooling_types_snake)'] = mua_cooling_type.to_s.snek
 
-        File.open(filename, 'w') { |file| file.write(file_string) }
+          File.open(filename, 'w') { |file| file.write(file_string) }
+        }
       }
     }
-  }
 
-end
+  end
 
-def generate_doe_hvac_files
+  def self.generate_doe_hvac_files
 
-  hvac_systems = [
-    ## Forced Air ##
+    hvac_systems = [
+        ## Forced Air ##
 
-    # Gas, Electric, forced air
-    ['PTAC', 'NaturalGas', nil, 'Electricity'],
-    ['PSZ-AC', 'NaturalGas', nil, 'Electricity'],
-    # ['PVAV Reheat', 'NaturalGas', 'NaturalGas', 'Electricity'], # Disable this; failure due to bug in E+ 8.8 w/ VAV terminal min airflow sizing
-    ['VAV Reheat', 'NaturalGas', 'NaturalGas', 'Electricity'],
+        # Gas, Electric, forced air
+        ['PTAC', 'NaturalGas', nil, 'Electricity'],
+        ['PSZ-AC', 'NaturalGas', nil, 'Electricity'],
+        # ['PVAV Reheat', 'NaturalGas', 'NaturalGas', 'Electricity'], # Disable this; failure due to bug in E+ 8.8 w/ VAV terminal min airflow sizing
+        ['VAV Reheat', 'NaturalGas', 'NaturalGas', 'Electricity'],
 
-    # Electric, Electric, forced air
-    ['PTHP', 'Electricity', nil, 'Electricity'],
-    ['PSZ-HP', 'Electricity', nil, 'Electricity'],
-    ['PVAV PFP Boxes', 'Electricity', 'Electricity', 'Electricity'],
-    ['VAV PFP Boxes', 'Electricity', 'Electricity', 'Electricity'],
+        # Electric, Electric, forced air
+        ['PTHP', 'Electricity', nil, 'Electricity'],
+        ['PSZ-HP', 'Electricity', nil, 'Electricity'],
+        ['PVAV PFP Boxes', 'Electricity', 'Electricity', 'Electricity'],
+        ['VAV PFP Boxes', 'Electricity', 'Electricity', 'Electricity'],
 
-    # District Hot Water, Electric, forced air
-    ['PTAC', 'DistrictHeating', nil, 'Electricity'],
-    # ['PVAV Reheat', 'DistrictHeating', 'DistrictHeating', 'Electricity'], # Disable this; failure due to bug in E+ 8.8 w/ VAV terminal min airflow sizing
-    ['VAV Reheat', 'DistrictHeating', 'DistrictHeating', 'Electricity'],
+        # District Hot Water, Electric, forced air
+        ['PTAC', 'DistrictHeating', nil, 'Electricity'],
+        # ['PVAV Reheat', 'DistrictHeating', 'DistrictHeating', 'Electricity'], # Disable this; failure due to bug in E+ 8.8 w/ VAV terminal min airflow sizing
+        ['VAV Reheat', 'DistrictHeating', 'DistrictHeating', 'Electricity'],
 
-    # Ambient Loop, Ambient Loop, forced air
-    # ['PVAV Reheat', 'HeatPump', 'HeatPump', 'HeatPump'],
-    # ['VAV Reheat', 'HeatPump', 'HeatPump', 'HeatPump'],
+        # Ambient Loop, Ambient Loop, forced air
+        # ['PVAV Reheat', 'HeatPump', 'HeatPump', 'HeatPump'],
+        # ['VAV Reheat', 'HeatPump', 'HeatPump', 'HeatPump'],
 
-    # Gas, District Chilled Water, forced air
-    ['PSZ-AC', 'NaturalGas', nil, 'DistrictCooling'],
-    ['PVAV Reheat', 'NaturalGas', 'NaturalGas', 'DistrictCooling'],
-    ['VAV Reheat', 'NaturalGas', 'NaturalGas', 'DistrictCooling'],
+        # Gas, District Chilled Water, forced air
+        ['PSZ-AC', 'NaturalGas', nil, 'DistrictCooling'],
+        ['PVAV Reheat', 'NaturalGas', 'NaturalGas', 'DistrictCooling'],
+        ['VAV Reheat', 'NaturalGas', 'NaturalGas', 'DistrictCooling'],
 
-    # Electric, District Chilled Water, forced air
-    ['PSZ-AC', 'Electricity', nil, 'DistrictCooling'],
-    ['PVAV Reheat', 'Electricity', 'Electricity', 'DistrictCooling'],
-    ['VAV Reheat', 'Electricity', 'Electricity', 'DistrictCooling'],
+        # Electric, District Chilled Water, forced air
+        ['PSZ-AC', 'Electricity', nil, 'DistrictCooling'],
+        ['PVAV Reheat', 'Electricity', 'Electricity', 'DistrictCooling'],
+        ['VAV Reheat', 'Electricity', 'Electricity', 'DistrictCooling'],
 
-    # District Hot Water, District Chilled Water, forced air
-    ['PVAV Reheat', 'DistrictHeating', 'DistrictHeating', 'DistrictCooling'],
-    ['VAV Reheat', 'DistrictHeating', 'DistrictHeating', 'DistrictCooling'],
+        # District Hot Water, District Chilled Water, forced air
+        ['PVAV Reheat', 'DistrictHeating', 'DistrictHeating', 'DistrictCooling'],
+        ['VAV Reheat', 'DistrictHeating', 'DistrictHeating', 'DistrictCooling'],
 
-    ## Hydronic ##
+        ## Hydronic ##
 
-    # Gas, Electric, hydronic
-    ['Fan Coil with DOAS', 'NaturalGas', nil, 'Electricity'],
-    ['Water Source Heat Pumps with DOAS', 'NaturalGas', nil, 'Electricity'],
-    ['Fan Coil with DOAS', 'NaturalGas', 'NaturalGas', 'Electricity'],
+        # Gas, Electric, hydronic
+        ['Fan Coil with DOAS', 'NaturalGas', nil, 'Electricity'],
+        ['Water Source Heat Pumps with DOAS', 'NaturalGas', nil, 'Electricity'],
+        ['Fan Coil with DOAS', 'NaturalGas', 'NaturalGas', 'Electricity'],
 
-    # Electric, Electric, hydronic
-    ['Ground Source Heat Pumps with ERVs', 'Electricity', nil, 'Electricity'],
-    ['Ground Source Heat Pumps with DOAS', 'Electricity', nil, 'Electricity'],
-    ['Ground Source Heat Pumps with DOAS', 'Electricity', 'Electricity', 'Electricity'],
+        # Electric, Electric, hydronic
+        ['Ground Source Heat Pumps with ERVs', 'Electricity', nil, 'Electricity'],
+        ['Ground Source Heat Pumps with DOAS', 'Electricity', nil, 'Electricity'],
+        ['Ground Source Heat Pumps with DOAS', 'Electricity', 'Electricity', 'Electricity'],
 
-    # District Hot Water, Electric, hydronic
-    ['Fan Coil with DOAS', 'DistrictHeating', nil, 'Electricity'],
-    ['Water Source Heat Pumps with DOAS', 'DistrictHeating', 'DistrictHeating', 'Electricity'],
-    ['Fan Coil with DOAS', 'DistrictHeating', 'DistrictHeating', 'Electricity'],
+        # District Hot Water, Electric, hydronic
+        ['Fan Coil with DOAS', 'DistrictHeating', nil, 'Electricity'],
+        ['Water Source Heat Pumps with DOAS', 'DistrictHeating', 'DistrictHeating', 'Electricity'],
+        ['Fan Coil with DOAS', 'DistrictHeating', 'DistrictHeating', 'Electricity'],
 
-    # Ambient Loop, Ambient Loop, hydronic
-    ['Water Source Heat Pumps with ERVs', 'HeatPump', nil, 'HeatPump'],
-    ['Water Source Heat Pumps with DOAS', 'HeatPump', nil, 'HeatPump'],
-    ['Water Source Heat Pumps with DOAS', 'HeatPump', 'HeatPump', 'HeatPump'],
+        # Ambient Loop, Ambient Loop, hydronic
+        ['Water Source Heat Pumps with ERVs', 'HeatPump', nil, 'HeatPump'],
+        ['Water Source Heat Pumps with DOAS', 'HeatPump', nil, 'HeatPump'],
+        ['Water Source Heat Pumps with DOAS', 'HeatPump', 'HeatPump', 'HeatPump'],
 
-    # Gas, District Chilled Water, hydronic
-    ['Fan Coil with DOAS', 'NaturalGas', nil, 'DistrictCooling'],
-    ['Fan Coil with DOAS', 'NaturalGas', 'NaturalGas', 'DistrictCooling'],
+        # Gas, District Chilled Water, hydronic
+        ['Fan Coil with DOAS', 'NaturalGas', nil, 'DistrictCooling'],
+        ['Fan Coil with DOAS', 'NaturalGas', 'NaturalGas', 'DistrictCooling'],
 
-    # Electric, District Chilled Water, hydronic
-    ['Fan Coil with ERVs', 'Electricity', nil, 'DistrictCooling'],
-    ['Fan Coil with DOAS', 'Electricity', 'Electricity', 'DistrictCooling'],
+        # Electric, District Chilled Water, hydronic
+        ['Fan Coil with ERVs', 'Electricity', nil, 'DistrictCooling'],
+        ['Fan Coil with DOAS', 'Electricity', 'Electricity', 'DistrictCooling'],
 
-    # District Hot Water, District Chilled Water, hydronic
-    ['Fan Coil with ERVs', 'DistrictHeating', nil, 'DistrictCooling'],
-    ['Fan Coil with DOAS', 'DistrictHeating', nil, 'DistrictCooling'],
-    ['Fan Coil with DOAS', 'DistrictHeating', 'DistrictHeating', 'DistrictCooling']
-  ]
+        # District Hot Water, District Chilled Water, hydronic
+        ['Fan Coil with ERVs', 'DistrictHeating', nil, 'DistrictCooling'],
+        ['Fan Coil with DOAS', 'DistrictHeating', nil, 'DistrictCooling'],
+        ['Fan Coil with DOAS', 'DistrictHeating', 'DistrictHeating', 'DistrictCooling']
+    ]
 
-  hvac_systems.each {|hvac_system|
-    # puts hvac_system.inspect
-    filename = File.join(file_out_dir(),"doe_test_add_hvac_systems_#{hvac_system[0].snek}-#{hvac_system[1].to_s.snek}-#{hvac_system[2].inspect.snek}-#{hvac_system[3].snek}.rb")
-    puts filename
-    classname = "doe_test_add_HVAC_systems_#{hvac_system[0].snek}-#{hvac_system[1].to_s.snek}-#{hvac_system[2].inspect.snek}-#{hvac_system[3].snek}".snek.split('_').collect(&:capitalize).join
-    file_string = %q{
+    hvac_systems.each {|hvac_system|
+      # puts hvac_system.inspect
+      filename = File.join(file_out_dir(),"doe_test_add_hvac_systems_#{hvac_system[0].snek}-#{hvac_system[1].to_s.snek}-#{hvac_system[2].inspect.snek}-#{hvac_system[3].snek}.rb")
+      puts filename
+      classname = "doe_test_add_HVAC_systems_#{hvac_system[0].snek}-#{hvac_system[1].to_s.snek}-#{hvac_system[2].inspect.snek}-#{hvac_system[3].snek}".snek.split('_').collect(&:capitalize).join
+      file_string = %q{
 require_relative '../helpers/minitest_helper'
 
 class $(classname) < Minitest::Test
@@ -1326,80 +1320,80 @@ class $(classname) < Minitest::Test
   end
 end
 }
-    file_string["$(classname)"] = classname
-    file_string["$(hvac_system)"] = hvac_system.inspect
-    file_string["$(0)"] = hvac_system[0].inspect.snek
-    file_string["$(1)"] = hvac_system[1].inspect.snek
-    file_string["$(2)"] = hvac_system[2].inspect.snek
-    file_string["$(3)"] = hvac_system[3].inspect.snek
+      file_string["$(classname)"] = classname
+      file_string["$(hvac_system)"] = hvac_system.inspect
+      file_string["$(0)"] = hvac_system[0].inspect.snek
+      file_string["$(1)"] = hvac_system[1].inspect.snek
+      file_string["$(2)"] = hvac_system[2].inspect.snek
+      file_string["$(3)"] = hvac_system[3].inspect.snek
 
-    File.open(filename, 'w') { |file| file.write(file_string) }
-  }
+      File.open(filename, 'w') { |file| file.write(file_string) }
+    }
 
-end
+  end
 
-def generate_doe_building_test_files
-  building_types ={
-    'FullServiceRestaurant' =>  {'templates'     => ['DOE Ref Pre-1980','DOE Ref 1980-2004','90.1-2010'],
-                                 'climate_zones' => ['ASHRAE 169-2006-2A','ASHRAE 169-2006-3B','ASHRAE 169-2006-4A','ASHRAE 169-2006-5A']
-                                },
-    'HighriseApartment'     =>  {'templates'     => ['90.1-2004','90.1-2007','90.1-2010','90.1-2013'],
-                                 'climate_zones' => ['ASHRAE 169-2006-2A']
-                                },
-    'Hospital'              =>  {'templates'     => ['DOE Ref Pre-1980','DOE Ref 1980-2004','90.1-2004','90.1-2007','90.1-2010','90.1-2013'],
-                                'climate_zones'  => ['ASHRAE 169-2006-2A','ASHRAE 169-2006-3B','ASHRAE 169-2006-4A','ASHRAE 169-2006-5A']
-                                },
-    'LargeHotel'            =>  {'templates'     => ['DOE Ref Pre-1980','DOE Ref 1980-2004','90.1-2010'],
-                                 'climate_zones' => ['ASHRAE 169-2006-2A','ASHRAE 169-2006-3B','ASHRAE 169-2006-4A','ASHRAE 169-2006-5A']
-                                },
-    'LargeOffice'           =>  {'templates'     => ['DOE Ref Pre-1980','DOE Ref 1980-2004','90.1-2010'],
-                                 'climate_zones' => ['ASHRAE 169-2006-2A','ASHRAE 169-2006-3B','ASHRAE 169-2006-4A','ASHRAE 169-2006-5A']
-                                },
-    'MediumOffice'          =>  {'templates'     => ['DOE Ref Pre-1980','DOE Ref 1980-2004','90.1-2010'],
-                                 'climate_zones' => ['ASHRAE 169-2006-2A','ASHRAE 169-2006-3B','ASHRAE 169-2006-4A','ASHRAE 169-2006-5A']
-                                },
-    'MidriseApartment'      =>  {'templates'     => ['DOE Ref Pre-1980','DOE Ref 1980-2004','90.1-2010'],
-                                 'climate_zones' => ['ASHRAE 169-2006-2A','ASHRAE 169-2006-3B','ASHRAE 169-2006-4A','ASHRAE 169-2006-5A']
-                                },
-    'Outpatient'            =>  {'templates'     => ['DOE Ref 1980-2004', 'DOE Ref Pre-1980', '90.1-2010'],
-                                 'climate_zones' => ['ASHRAE 169-2006-2A','ASHRAE 169-2006-3B','ASHRAE 169-2006-4A','ASHRAE 169-2006-5A']
-                                },
-    'PrimarySchool'         =>  {'templates'     => ['DOE Ref Pre-1980','DOE Ref 1980-2004', '90.1-2010'],
-                                 'climate_zones' => ['ASHRAE 169-2006-2A','ASHRAE 169-2006-3B','ASHRAE 169-2006-4A','ASHRAE 169-2006-5A']
-                                },
-    'QuickServiceRestaurant'=>  {'templates'     => ['DOE Ref Pre-1980','DOE Ref 1980-2004','90.1-2010'],
-                                 'climate_zones' => ['ASHRAE 169-2006-2A','ASHRAE 169-2006-3B','ASHRAE 169-2006-4A','ASHRAE 169-2006-5A']
-                                },
-    'RetailStandalone'      =>  {'templates'     => ['DOE Ref Pre-1980','DOE Ref 1980-2004','90.1-2010'],
-                                 'climate_zones' => ['ASHRAE 169-2006-2A','ASHRAE 169-2006-3B','ASHRAE 169-2006-4A','ASHRAE 169-2006-5A']
-                                },
-    'SecondarySchool'       =>  {'templates'     => ['DOE Ref Pre-1980','DOE Ref 1980-2004', '90.1-2010'],
-                                 'climate_zones' => ['ASHRAE 169-2006-2A','ASHRAE 169-2006-3B','ASHRAE 169-2006-4A','ASHRAE 169-2006-5A']
-                                },
-    'SmallHotel'            =>  {'templates'     => ['DOE Ref Pre-1980','DOE Ref 1980-2004','90.1-2010'],
-                                 'climate_zones' => ['ASHRAE 169-2006-2A','ASHRAE 169-2006-3B','ASHRAE 169-2006-4A','ASHRAE 169-2006-5A']
-                                },
-    'SmallOffice'           =>  {'templates'     => ['DOE Ref Pre-1980','DOE Ref 1980-2004','90.1-2010'],
-                                 'climate_zones' => ['ASHRAE 169-2006-2A','ASHRAE 169-2006-3B','ASHRAE 169-2006-4A','ASHRAE 169-2006-5A']
-                                },
-    'RetailStripmall'       =>  {'templates'     => ['DOE Ref Pre-1980','DOE Ref 1980-2004','90.1-2010'],
-                                 'climate_zones' => ['ASHRAE 169-2006-2A','ASHRAE 169-2006-3B','ASHRAE 169-2006-4A','ASHRAE 169-2006-5A']
-                                },
-    'SuperMarket'           =>  {'templates'     => ['DOE Ref Pre-1980','DOE Ref 1980-2004','90.1-2004','90.1-2007','90.1-2010','90.1-2013'],
-                                 'climate_zones' => ['ASHRAE 169-2006-2A','ASHRAE 169-2006-3B','ASHRAE 169-2006-4A','ASHRAE 169-2006-5A']
-                                },
-    'Warehouse'             =>  {'templates'     => ['DOE Ref Pre-1980','DOE Ref 1980-2004','90.1-2010'],
-                                 'climate_zones' => ['ASHRAE 169-2006-2A','ASHRAE 169-2006-3B','ASHRAE 169-2006-4A','ASHRAE 169-2006-5A']
-                                }
-  }
+  def self.generate_doe_building_test_files
+    building_types ={
+        'FullServiceRestaurant' =>  {'templates'     => ['DOE Ref Pre-1980','DOE Ref 1980-2004','90.1-2010'],
+                                     'climate_zones' => ['ASHRAE 169-2006-2A','ASHRAE 169-2006-3B','ASHRAE 169-2006-4A','ASHRAE 169-2006-5A']
+        },
+        'HighriseApartment'     =>  {'templates'     => ['90.1-2004','90.1-2007','90.1-2010','90.1-2013'],
+                                     'climate_zones' => ['ASHRAE 169-2006-2A']
+        },
+        'Hospital'              =>  {'templates'     => ['DOE Ref Pre-1980','DOE Ref 1980-2004','90.1-2004','90.1-2007','90.1-2010','90.1-2013'],
+                                     'climate_zones'  => ['ASHRAE 169-2006-2A','ASHRAE 169-2006-3B','ASHRAE 169-2006-4A','ASHRAE 169-2006-5A']
+        },
+        'LargeHotel'            =>  {'templates'     => ['DOE Ref Pre-1980','DOE Ref 1980-2004','90.1-2010'],
+                                     'climate_zones' => ['ASHRAE 169-2006-2A','ASHRAE 169-2006-3B','ASHRAE 169-2006-4A','ASHRAE 169-2006-5A']
+        },
+        'LargeOffice'           =>  {'templates'     => ['DOE Ref Pre-1980','DOE Ref 1980-2004','90.1-2010'],
+                                     'climate_zones' => ['ASHRAE 169-2006-2A','ASHRAE 169-2006-3B','ASHRAE 169-2006-4A','ASHRAE 169-2006-5A']
+        },
+        'MediumOffice'          =>  {'templates'     => ['DOE Ref Pre-1980','DOE Ref 1980-2004','90.1-2010'],
+                                     'climate_zones' => ['ASHRAE 169-2006-2A','ASHRAE 169-2006-3B','ASHRAE 169-2006-4A','ASHRAE 169-2006-5A']
+        },
+        'MidriseApartment'      =>  {'templates'     => ['DOE Ref Pre-1980','DOE Ref 1980-2004','90.1-2010'],
+                                     'climate_zones' => ['ASHRAE 169-2006-2A','ASHRAE 169-2006-3B','ASHRAE 169-2006-4A','ASHRAE 169-2006-5A']
+        },
+        'Outpatient'            =>  {'templates'     => ['DOE Ref 1980-2004', 'DOE Ref Pre-1980', '90.1-2010'],
+                                     'climate_zones' => ['ASHRAE 169-2006-2A','ASHRAE 169-2006-3B','ASHRAE 169-2006-4A','ASHRAE 169-2006-5A']
+        },
+        'PrimarySchool'         =>  {'templates'     => ['DOE Ref Pre-1980','DOE Ref 1980-2004', '90.1-2010'],
+                                     'climate_zones' => ['ASHRAE 169-2006-2A','ASHRAE 169-2006-3B','ASHRAE 169-2006-4A','ASHRAE 169-2006-5A']
+        },
+        'QuickServiceRestaurant'=>  {'templates'     => ['DOE Ref Pre-1980','DOE Ref 1980-2004','90.1-2010'],
+                                     'climate_zones' => ['ASHRAE 169-2006-2A','ASHRAE 169-2006-3B','ASHRAE 169-2006-4A','ASHRAE 169-2006-5A']
+        },
+        'RetailStandalone'      =>  {'templates'     => ['DOE Ref Pre-1980','DOE Ref 1980-2004','90.1-2010'],
+                                     'climate_zones' => ['ASHRAE 169-2006-2A','ASHRAE 169-2006-3B','ASHRAE 169-2006-4A','ASHRAE 169-2006-5A']
+        },
+        'SecondarySchool'       =>  {'templates'     => ['DOE Ref Pre-1980','DOE Ref 1980-2004', '90.1-2010'],
+                                     'climate_zones' => ['ASHRAE 169-2006-2A','ASHRAE 169-2006-3B','ASHRAE 169-2006-4A','ASHRAE 169-2006-5A']
+        },
+        'SmallHotel'            =>  {'templates'     => ['DOE Ref Pre-1980','DOE Ref 1980-2004','90.1-2010'],
+                                     'climate_zones' => ['ASHRAE 169-2006-2A','ASHRAE 169-2006-3B','ASHRAE 169-2006-4A','ASHRAE 169-2006-5A']
+        },
+        'SmallOffice'           =>  {'templates'     => ['DOE Ref Pre-1980','DOE Ref 1980-2004','90.1-2010'],
+                                     'climate_zones' => ['ASHRAE 169-2006-2A','ASHRAE 169-2006-3B','ASHRAE 169-2006-4A','ASHRAE 169-2006-5A']
+        },
+        'RetailStripmall'       =>  {'templates'     => ['DOE Ref Pre-1980','DOE Ref 1980-2004','90.1-2010'],
+                                     'climate_zones' => ['ASHRAE 169-2006-2A','ASHRAE 169-2006-3B','ASHRAE 169-2006-4A','ASHRAE 169-2006-5A']
+        },
+        'SuperMarket'           =>  {'templates'     => ['DOE Ref Pre-1980','DOE Ref 1980-2004','90.1-2004','90.1-2007','90.1-2010','90.1-2013'],
+                                     'climate_zones' => ['ASHRAE 169-2006-2A','ASHRAE 169-2006-3B','ASHRAE 169-2006-4A','ASHRAE 169-2006-5A']
+        },
+        'Warehouse'             =>  {'templates'     => ['DOE Ref Pre-1980','DOE Ref 1980-2004','90.1-2010'],
+                                     'climate_zones' => ['ASHRAE 169-2006-2A','ASHRAE 169-2006-3B','ASHRAE 169-2006-4A','ASHRAE 169-2006-5A']
+        }
+    }
 
-  building_types.keys.sort.each {|building_type|
-    building_types[building_type]['templates'].each {|template|
-      building_types[building_type]['climate_zones'].each {|climate_zone|
-        filename = File.join(file_out_dir(),"doe_test_bldg_#{building_type.snek}-#{template.snek}-#{climate_zone.to_s.snek}.rb")
-        puts filename
-        method_name = "test_#{building_type}-#{template}-#{climate_zone}".gsub(' ','_').gsub('-','_').gsub('.','_')
-        file_string = %q{
+    building_types.keys.sort.each {|building_type|
+      building_types[building_type]['templates'].each {|template|
+        building_types[building_type]['climate_zones'].each {|climate_zone|
+          filename = File.join(file_out_dir(),"doe_test_bldg_#{building_type.snek}-#{template.snek}-#{climate_zone.to_s.snek}.rb")
+          puts filename
+          method_name = "test_#{building_type}-#{template}-#{climate_zone}".gsub(' ','_').gsub('-','_').gsub('.','_')
+          file_string = %q{
 require_relative '../helpers/minitest_helper'
 require_relative '../helpers/create_doe_prototype_helper'
 
@@ -1733,61 +1727,79 @@ class Test$(building_type) < CreateDOEPrototypeBuildingTest
 
 end
 }
-        file_string.gsub!('$(method_name)',"#{method_name}")
-        file_string.gsub!('$(building_type)',"#{building_type}")
-        file_string.gsub!('$(template)',"#{template}")
-        file_string.gsub!('$(climate_zone)',"#{climate_zone}")
+          file_string.gsub!('$(method_name)',"#{method_name}")
+          file_string.gsub!('$(building_type)',"#{building_type}")
+          file_string.gsub!('$(template)',"#{template}")
+          file_string.gsub!('$(climate_zone)',"#{climate_zone}")
 
-        File.open(filename, 'w') { |file| file.write(file_string) }
+          File.open(filename, 'w') { |file| file.write(file_string) }
+        }
       }
     }
-  }
 
-end
+  end
 
-
-def sort_files_by_timing
-  require_relative 'ci_test_helper/lpt'
-  ci_test_path = File.absolute_path(File.join(__FILE__, "..", "..", "circleci_tests.txt"))
-
-  timings = JSON.parse(File.read(File.join(File.dirname(__FILE__), 'ci_test_helper', 'timings.json')))
-  existing_ci_tests = File.read(ci_test_path).split("\n")
-  #p existing_ci_tests
-  existing_ci_tests.each {|test_file|
-    next if timings.key?(test_file)
-    next unless test_file.include?('.rb')
-    timings[test_file] = {}
-    puts "Setting default time of 240s for #{test_file} to timings"
-    timings[test_file]['total'] = 240 # set default of 240s if test file is not part of the timings file
-  }
-
-  # puts JSON.pretty_generate(timings)
-  procs = File.read(File.join(File.dirname(__FILE__), '..', '..' , '.circleci', 'config.yml')).match(/(?<=parallelism:\s)(\d*)/).to_s.to_i
-  sorted_timings = LPT.new(timings , procs).lpt_algorithm()[0]
-
-  sorted_timings.each_with_index {|files,i|
-    File.open(File.join(File.dirname(__FILE__), 'ci_test_helper' ,"#{i}.txt"), "w") do |f|
-      f.puts(files)
+  def self.sort_files_by_timing(local_run)
+    require_relative 'ci_test_helper/lpt'
+    ci_test_path = @@ci_test_path
+    if local_run
+      ci_test_path = @@local_ci_test_path
     end
-  }
-  if !!(ENV['CIRCLE_BRANCH'] =~ /nrcan/i)
-    puts "CIRCLE_BRANCH: #{ENV['CIRCLE_BRANCH']}"
+    timings = JSON.parse(File.read(File.join(File.dirname(__FILE__), 'ci_test_helper', 'timings.json')))
+    existing_ci_tests = File.read(ci_test_path).split("\n")
+    #p existing_ci_tests
+    existing_ci_tests.each {|test_file|
+      next if timings.key?(test_file)
+      next unless test_file.include?('.rb')
+      timings[test_file] = {}
+      puts "Setting default time of 240s for #{test_file} to timings"
+      timings[test_file]['total'] = 240 # set default of 240s if test file is not part of the timings file
+    }
+
+    # puts JSON.pretty_generate(timings)
+    procs = File.read(File.join(File.dirname(__FILE__), '..', '..' , '.circleci', 'config.yml')).match(/(?<=parallelism:\s)(\d*)/).to_s.to_i
+    sorted_timings = LPT.new(timings , procs).lpt_algorithm()[0]
+
+    sorted_timings.each_with_index {|files,i|
+      File.open(File.join(File.dirname(__FILE__), 'ci_test_helper' ,"#{i}.txt"), "w") do |f|
+        f.puts(files)
+      end
+    }
+    if !!(ENV['CIRCLE_BRANCH'] =~ /nrcan/i)
+      puts "CIRCLE_BRANCH: #{ENV['CIRCLE_BRANCH']}"
+    end
+  end
+
+  def self.generate(local_run = false)
+    cleanup_output_folders()
+    copy_doe_model_files_for_hvac_tests()
+    generate_doe_hvac_files()
+    generate_ci_bldg_test_files()
+    copy_model_files_for_hvac_tests()
+    generate_hvac_sys1_files()
+    generate_hvac_sys2_files()
+    generate_hvac_sys3_files()
+    generate_hvac_sys4_files()
+# generate_hvac_sys5_files() # known failure
+    generate_hvac_sys6_files()
+    generate_hvac_sys7_files()
+    generate_doe_building_test_files()
+    write_file_path_to_ci_tests_txt(local_run)
+    sort_files_by_timing(local_run)
   end
 end
 
-
-cleanup_output_folders()
-copy_doe_model_files_for_hvac_tests()
-generate_doe_hvac_files()
-generate_ci_bldg_test_files()
-copy_model_files_for_hvac_tests()
-generate_hvac_sys1_files()
-generate_hvac_sys2_files()
-generate_hvac_sys3_files()
-generate_hvac_sys4_files()
-# generate_hvac_sys5_files() # known failure
-generate_hvac_sys6_files()
-generate_hvac_sys7_files()
-generate_doe_building_test_files()
-write_file_path_to_ci_tests_txt()
-sort_files_by_timing()
+# copied and modified from https://github.com/rubyworks/facets/blob/master/lib/core/facets/string/snakecase.rb
+class String
+  def snek
+    #gsub(/::/, '/').
+    gsub(/([A-Z]+)([A-Z][a-z])/,'\1_\2').
+        gsub(/([a-z\d])([A-Z])/,'\1_\2').
+        tr('-', '_').
+        gsub(/\s/, '_').
+        gsub(/__+/, '_').
+        gsub(/#+/, '').
+        gsub(/\"/, '').
+        downcase
+  end
+end

--- a/test/helpers/ci_test_generator.rb
+++ b/test/helpers/ci_test_generator.rb
@@ -1396,41 +1396,26 @@ def generate_doe_building_test_files
       building_types[building_type]['climate_zones'].each {|climate_zone|
         filename = File.join(file_out_dir(),"doe_test_bldg_#{building_type.snek}-#{template.snek}-#{climate_zone.to_s.snek}.rb")
         puts filename
+        method_name = "test_#{building_type}-#{template}-#{climate_zone}".gsub(' ','_').gsub('-','_').gsub('.','_')
         file_string = %q{
 require_relative '../helpers/minitest_helper'
 require_relative '../helpers/create_doe_prototype_helper'
 
-
-
 class Test$(building_type) < CreateDOEPrototypeBuildingTest
 
-  building_types = ['$(building_type)']
+  def $(method_name)()
+    building_type = '$(building_type)'
+    template = '$(template)'
+    climate_zone = '$(climate_zone)'
 
-  templates = ['$(template)']
-  climate_zones = ['$(climate_zone)']
-  # templates = ['DOE Ref 1980-2004', 'DOE Ref Pre-1980', '90.1-2007', '90.1-2010', '90.1-2013', '90.1-2004']
-  # climate_zones = ['ASHRAE 169-2006-1A', 'ASHRAE 169-2006-2A','ASHRAE 169-2006-2B',
-                   # 'ASHRAE 169-2006-3A', 'ASHRAE 169-2006-3B', 'ASHRAE 169-2006-3C', 'ASHRAE 169-2006-4A',
-                   # 'ASHRAE 169-2006-4B', 'ASHRAE 169-2006-4C', 'ASHRAE 169-2006-5A', 'ASHRAE 169-2006-5B',
-                   # 'ASHRAE 169-2006-6A', 'ASHRAE 169-2006-6B', 'ASHRAE 169-2006-7A', 'ASHRAE 169-2006-8A']
+    # not used for ASHRAE/DOE archetypes, but required for call
+    epw_file = 'USA_FL_Miami.Intl.AP.722020_TMY3.epw'
 
-  # not used for ASHRAE/DOE archetypes, but required for call
-  epw_files = ['USA_FL_Miami.Intl.AP.722020_TMY3.epw']
+    create_models = true
+    run_models = false
+    compare_results = false
 
-  create_models = true
-  run_models = false
-  compare_results = false
-
-  debug = false
-
-  def CreateDOEPrototypeBuildingTest.create_building(building_type,
-      template,
-      climate_zone,
-      epw_file,
-      create_models,
-      run_models,
-      compare_results,
-      debug )
+    debug = false
 
     method_name = nil
     case template
@@ -1442,315 +1427,311 @@ class Test$(building_type) < CreateDOEPrototypeBuildingTest
         method_name = "test_#{building_type}-#{template}-#{climate_zone}".gsub(' ','_')
     end
 
+    # Start time
+    start_time = Time.new
 
-    define_method(method_name) do
+    # Reset the log for this test
+    reset_log
 
-      # Start time
-      start_time = Time.new
+    # Paths for this test run
 
-      # Reset the log for this test
-      reset_log
-
-      # Paths for this test run
-
-      model_name = nil
-      case template
-        when 'NECB2011'
-          model_name = "#{building_type}-#{template}-#{climate_zone}-#{epw_file}"
-        else
-          model_name = "#{building_type}-#{template}-#{climate_zone}"
-      end
+    model_name = nil
+    case template
+      when 'NECB2011'
+        model_name = "#{building_type}-#{template}-#{climate_zone}-#{epw_file}"
+      else
+        model_name = "#{building_type}-#{template}-#{climate_zone}"
+    end
 
 
-      run_dir = "#{@test_dir}/#{model_name}"
-      if !Dir.exists?(run_dir)
-        Dir.mkdir(run_dir)
-      end
-      full_sim_dir = "#{run_dir}/AnnualRun"
-      idf_path_string = "#{run_dir}/#{model_name}.idf"
-      idf_path = OpenStudio::Path.new(idf_path_string)
-      osm_path_string = "#{run_dir}/final.osm"
-      output_path = OpenStudio::Path.new(run_dir)
+    run_dir = "#{@test_dir}/#{model_name}"
+    if !Dir.exists?(run_dir)
+      Dir.mkdir(run_dir)
+    end
+    full_sim_dir = "#{run_dir}/AnnualRun"
+    idf_path_string = "#{run_dir}/#{model_name}.idf"
+    idf_path = OpenStudio::Path.new(idf_path_string)
+    osm_path_string = "#{run_dir}/final.osm"
+    output_path = OpenStudio::Path.new(run_dir)
 
-      model = nil
+    model = nil
 
-      # Create the model, if requested
-      if create_models
-        prototype_creator = Standard.build("#{template}_#{building_type}")
-        model = prototype_creator.model_create_prototype_model(climate_zone, epw_file, run_dir)
-        @current_model = model
-        puts model.class
-        output_variable_array =
-            [
-                "Facility Total Electric Demand Power",
-                "Water Heater Gas Rate",
-                "Plant Supply Side Heating Demand Rate",
-                "Heating Coil Gas Rate",
-                "Cooling Coil Electric Power",
-                "Boiler Gas Rate",
-                "Heating Coil Air Heating Rate",
-                "Heating Coil Electric Power",
-                "Cooling Coil Total Cooling Rate",
-                "Water Heater Heating Rate",
-                "Zone Air Temperature",
-                "Water Heater Electric Power",
-                "Chiller Electric Power",
-                "Chiller Electric Energy",
-                "Cooling Tower Heat Transfer Rate",
-                "Cooling Tower Fan Electric Power",
-                "Cooling Tower Fan Electric Energy"
-            ]
-        BTAP::Reports::set_output_variables(model,"Hourly", output_variable_array)
+    # Create the model, if requested
+    if create_models
+      prototype_creator = Standard.build("#{template}_#{building_type}")
+      model = prototype_creator.model_create_prototype_model(climate_zone, epw_file, run_dir)
+      @current_model = model
+      puts model.class
+      output_variable_array =
+          [
+              "Facility Total Electric Demand Power",
+              "Water Heater Gas Rate",
+              "Plant Supply Side Heating Demand Rate",
+              "Heating Coil Gas Rate",
+              "Cooling Coil Electric Power",
+              "Boiler Gas Rate",
+              "Heating Coil Air Heating Rate",
+              "Heating Coil Electric Power",
+              "Cooling Coil Total Cooling Rate",
+              "Water Heater Heating Rate",
+              "Zone Air Temperature",
+              "Water Heater Electric Power",
+              "Chiller Electric Power",
+              "Chiller Electric Energy",
+              "Cooling Tower Heat Transfer Rate",
+              "Cooling Tower Fan Electric Power",
+              "Cooling Tower Fan Electric Energy"
+          ]
+      BTAP::Reports::set_output_variables(model,"Hourly", output_variable_array)
 
-        # Convert the model to energyplus idf
+      # Convert the model to energyplus idf
+      forward_translator = OpenStudio::EnergyPlus::ForwardTranslator.new
+      idf = forward_translator.translateModel(model)
+      idf.save(idf_path,true)
+
+    end
+
+    # TO DO: call add_output routine (btap)
+
+
+
+    # Run the simulation, if requested
+    if run_models
+
+      # Delete previous run directories if they exist
+      FileUtils.rm_rf(full_sim_dir)
+
+      # Load the model from disk if not already in memory
+      if model.nil?
+        model = standard.safe_load_model(osm_path_string)
         forward_translator = OpenStudio::EnergyPlus::ForwardTranslator.new
         idf = forward_translator.translateModel(model)
         idf.save(idf_path,true)
-
       end
 
-      # TO DO: call add_output routine (btap)
-
-
-
-      # Run the simulation, if requested
-      if run_models
-
-        # Delete previous run directories if they exist
-        FileUtils.rm_rf(full_sim_dir)
-
-        # Load the model from disk if not already in memory
-        if model.nil?
-          model = standard.safe_load_model(osm_path_string)
-          forward_translator = OpenStudio::EnergyPlus::ForwardTranslator.new
-          idf = forward_translator.translateModel(model)
-          idf.save(idf_path,true)
-        end
-
-        # Run the annual simulation
-        standard = Standard.build("#{template}")
-        standard.model_run_simulation_and_log_errors(model, full_sim_dir)
-
-      end
-
-
-
-      # Compare the results against the legacy idf files if requested
-      if compare_results
-
-        acceptable_error_percentage = 0 # Max % error for any end use/fuel type combo
-
-        # Load the legacy idf results JSON file into a ruby hash
-        temp = File.read("#{Dir.pwd}/data/legacy_idf_results.json")
-        legacy_idf_results = JSON.parse(temp)
-
-        # List of all fuel types
-        fuel_types = ['Electricity', 'Natural Gas', 'Additional Fuel', 'District Cooling', 'District Heating', 'Water']
-
-        # List of all end uses
-        end_uses = ['Heating', 'Cooling', 'Interior Lighting', 'Exterior Lighting', 'Interior Equipment', 'Exterior Equipment', 'Fans', 'Pumps', 'Heat Rejection','Humidification', 'Heat Recovery', 'Water Systems', 'Refrigeration', 'Generators']
-
-        sql_path_string = "#{@test_dir}/#{model_name}/AnnualRun/EnergyPlus/eplusout.sql"
-        sql_path = OpenStudio::Path.new(sql_path_string)
-        sql_path_string_2 = "#{@test_dir}/#{model_name}/AnnualRun/run/eplusout.sql"
-        sql_path_2 = OpenStudio::Path.new(sql_path_string_2)
-        sql = nil
-        if OpenStudio.exists(sql_path)
-          sql = OpenStudio::SqlFile.new(sql_path)
-        elsif OpenStudio.exists(sql_path_2)
-          sql = OpenStudio::SqlFile.new(sql_path_2)
-        else
-          OpenStudio::logFree(OpenStudio::Error, 'openstudio.model.Model', "Could not find sql file, could not compare results.")
-        end
-
-        # Create a hash of hashes to store the results from each file
-        results_hash = Hash.new{|h,k| h[k]=Hash.new(&h.default_proc) }
-
-        # Get the osm values for all fuel type/end use pairs
-        # and compare to the legacy idf results
-        csv_rows = []
-        total_legacy_energy_val = 0
-        total_osm_energy_val = 0
-        total_legacy_water_val = 0
-        total_osm_water_val = 0
-        total_cumulative_energy_err = 0
-        total_cumulative_water_err = 0
-        fuel_types.each do |fuel_type|
-          end_uses.each do |end_use|
-            next if end_use == 'Exterior Equipment'
-            # Get the legacy results number
-            legacy_val = legacy_idf_results.dig(building_type, template, climate_zone, fuel_type, end_use)
-            # Combine the exterior lighting and exterior equipment
-            if end_use == 'Exterior Lighting'
-              legacy_exterior_equipment = legacy_idf_results.dig(building_type, template, climate_zone, fuel_type, 'Exterior Equipment')
-              unless legacy_exterior_equipment.nil?
-                legacy_val += legacy_exterior_equipment
-              end
-            end
-
-            if legacy_val.nil?
-              OpenStudio::logFree(OpenStudio::Error, 'openstudio.model.Model', "#{fuel_type} #{end_use} legacy idf value not found")
-              legacy_val = 0
-              next
-            end
-
-            # Add the energy to the total
-            if fuel_type == 'Water'
-              total_legacy_water_val += legacy_val
-            else
-              total_legacy_energy_val += legacy_val
-            end
-
-            # Select the correct units based on fuel type
-            units = 'GJ'
-            if fuel_type == 'Water'
-              units = 'm3'
-            end
-
-            # End use breakdown query
-            energy_query = "SELECT Value FROM TabularDataWithStrings WHERE (ReportName='AnnualBuildingUtilityPerformanceSummary') AND (ReportForString='Entire Facility') AND (TableName='End Uses') AND (ColumnName='#{fuel_type}') AND (RowName = '#{end_use}') AND (Units='#{units}')"
-
-            # Get the end use value
-            osm_val = sql.execAndReturnFirstDouble(energy_query)
-            if osm_val.is_initialized
-              osm_val = osm_val.get
-            else
-              OpenStudio::logFree(OpenStudio::Error, 'openstudio.model.Model', "No sql value found for #{fuel_type}-#{end_use}")
-              osm_val = 0
-            end
-
-            # Combine the exterior lighting and exterior equipment
-            if end_use == 'Exterior Lighting'
-              # End use breakdown query
-              energy_query = "SELECT Value FROM TabularDataWithStrings WHERE (ReportName='AnnualBuildingUtilityPerformanceSummary') AND (ReportForString='Entire Facility') AND (TableName='End Uses') AND (ColumnName='#{fuel_type}') AND (RowName = 'Exterior Equipment') AND (Units='#{units}')"
-
-              # Get the end use value
-              osm_val_2 = sql.execAndReturnFirstDouble(energy_query)
-              if osm_val_2.is_initialized
-                osm_val_2 = osm_val_2.get
-              else
-                OpenStudio::logFree(OpenStudio::Warn, 'openstudio.model.Model', "No sql value found for #{fuel_type}-Exterior Equipment.")
-                osm_val_2 = 0
-              end
-              osm_val += osm_val_2
-            end
-
-            # Add the energy to the total
-            if fuel_type == 'Water'
-              total_osm_water_val += osm_val
-            else
-              total_osm_energy_val += osm_val
-            end
-
-            # Add the absolute error to the total
-            abs_err = (legacy_val-osm_val).abs
-
-            if fuel_type == 'Water'
-              total_cumulative_water_err += abs_err
-            else
-              total_cumulative_energy_err += abs_err
-            end
-
-            # Calculate the error and check if less than
-            # acceptable_error_percentage
-            percent_error = nil
-            write_to_file = false
-            if osm_val > 0 && legacy_val > 0
-              percent_error = ((osm_val - legacy_val)/legacy_val) * 100
-              if percent_error.abs >= acceptable_error_percentage
-                OpenStudio::logFree(OpenStudio::Info, 'openstudio.model.Model', "#{fuel_type}-#{end_use} Error = #{percent_error.round}% (#{osm_val}, #{legacy_val})")
-                write_to_file = true
-              end
-            elsif osm_val > 0 && legacy_val.abs < 1e-6
-              # The osm has a fuel/end use that the legacy idf does not
-              percent_error = 9999
-              OpenStudio::logFree(OpenStudio::Info, 'openstudio.model.Model', "#{fuel_type}-#{end_use} Error = osm has extra fuel/end use that legacy idf does not (#{osm_val})")
-              write_to_file = true
-            elsif osm_val.abs < 1e-6 && legacy_val > 0
-              # The osm has a fuel/end use that the legacy idf does not
-              percent_error = 9999
-              OpenStudio::logFree(OpenStudio::Info, 'openstudio.model.Model', "#{fuel_type}-#{end_use} Error = osm is missing a fuel/end use that legacy idf has (#{legacy_val})")
-              write_to_file = true
-            else
-              # Both osm and legacy are == 0 for this fuel/end use, no error
-              percent_error = 0
-            end
-
-            # ALWAYS OUTPUT THE VALUES
-            write_to_file = true
-            if write_to_file
-              csv_rows << "#{building_type},#{template},#{climate_zone},#{fuel_type},#{end_use},#{legacy_val.round(2)},#{osm_val.round(2)},#{percent_error.round},#{abs_err.round}"
-            end
-
-          end # Next end use
-        end # Next fuel type
-
-        # Calculate the overall energy error
-        total_percent_error = nil
-        if total_osm_energy_val > 0 && total_legacy_energy_val > 0
-          # If both
-          total_percent_error = ((total_osm_energy_val - total_legacy_energy_val)/total_legacy_energy_val) * 100
-          OpenStudio::logFree(OpenStudio::Info, 'openstudio.model.Model', "Total Energy Error = #{total_percent_error.round}%")
-        elsif total_osm_energy_val > 0 && total_legacy_energy_val == 0
-          # The osm has a fuel/end use that the legacy idf does not
-          total_percent_error = 9999
-          OpenStudio::logFree(OpenStudio::Info, 'openstudio.model.Model', "Total Energy Error = osm has extra fuel/end use that legacy idf does not (#{total_osm_energy_val})")
-        elsif total_osm_energy_val == 0 && total_legacy_energy_val > 0
-          # The osm has a fuel/end use that the legacy idf does not
-          total_percent_error = 9999
-          OpenStudio::logFree(OpenStudio::Info, 'openstudio.model.Model', "Total Energy Error = osm is missing a fuel/end use that legacy idf has (#{total_legacy_energy_val})")
-        else
-          # Both osm and legacy are == 0 for, no error
-          total_percent_error = 0
-          OpenStudio::logFree(OpenStudio::Info, 'openstudio.model.Model', "Total Energy Error = both idf and osm don't use any energy.")
-        end
-
-        tot_abs_energy_err = ((total_osm_energy_val - total_legacy_energy_val)/total_legacy_energy_val) * 100
-        tot_cumulative_energy_err = (total_cumulative_energy_err/total_legacy_energy_val) * 100
-
-        if tot_cumulative_energy_err.abs > 20
-          OpenStudio::logFree(OpenStudio::Warn, 'openstudio.model.Model', "Total Energy cumulative error = #{tot_cumulative_energy_err.round}%.")
-        end
-
-        csv_rows << "#{building_type},#{template},#{climate_zone},Total Energy,Total Energy,#{total_legacy_energy_val.round(2)},#{total_osm_energy_val.round(2)},#{total_percent_error.round},#{tot_abs_energy_err.round},#{tot_cumulative_energy_err.round}"
-
-        # Append the comparison results
-        File.open(@results_csv_file, 'a') do |file|
-          csv_rows.each do |csv_row|
-            file.puts csv_row
-          end
-        end
-
-      end
-
-      # Calculate run time
-      run_time = Time.new - start_time
-
-      # Report out errors
-      log_file_path = "#{run_dir}/openstudio-standards.log"
-      messages = log_messages_to_file(log_file_path, debug)
-      errors = get_logs(OpenStudio::Error)
-
-      # Copy errors to combined log file
-      File.open(@combined_results_log, 'a') do |file|
-        file.puts "*** #{model_name}, Time: #{run_time.round} sec ***"
-        messages.each do |message|
-          file.puts message
-        end
-      end
-
-      # Assert if there were any errors
-      assert(errors.size == 0, errors)
+      # Run the annual simulation
+      standard = Standard.build("#{template}")
+      standard.model_run_simulation_and_log_errors(model, full_sim_dir)
 
     end
+
+
+
+    # Compare the results against the legacy idf files if requested
+    if compare_results
+
+      acceptable_error_percentage = 0 # Max % error for any end use/fuel type combo
+
+      # Load the legacy idf results JSON file into a ruby hash
+      temp = File.read("#{Dir.pwd}/data/legacy_idf_results.json")
+      legacy_idf_results = JSON.parse(temp)
+
+      # List of all fuel types
+      fuel_types = ['Electricity', 'Natural Gas', 'Additional Fuel', 'District Cooling', 'District Heating', 'Water']
+
+      # List of all end uses
+      end_uses = ['Heating', 'Cooling', 'Interior Lighting', 'Exterior Lighting', 'Interior Equipment', 'Exterior Equipment', 'Fans', 'Pumps', 'Heat Rejection','Humidification', 'Heat Recovery', 'Water Systems', 'Refrigeration', 'Generators']
+
+      sql_path_string = "#{@test_dir}/#{model_name}/AnnualRun/EnergyPlus/eplusout.sql"
+      sql_path = OpenStudio::Path.new(sql_path_string)
+      sql_path_string_2 = "#{@test_dir}/#{model_name}/AnnualRun/run/eplusout.sql"
+      sql_path_2 = OpenStudio::Path.new(sql_path_string_2)
+      sql = nil
+      if OpenStudio.exists(sql_path)
+        sql = OpenStudio::SqlFile.new(sql_path)
+      elsif OpenStudio.exists(sql_path_2)
+        sql = OpenStudio::SqlFile.new(sql_path_2)
+      else
+        OpenStudio::logFree(OpenStudio::Error, 'openstudio.model.Model', "Could not find sql file, could not compare results.")
+      end
+
+      # Create a hash of hashes to store the results from each file
+      results_hash = Hash.new{|h,k| h[k]=Hash.new(&h.default_proc) }
+
+      # Get the osm values for all fuel type/end use pairs
+      # and compare to the legacy idf results
+      csv_rows = []
+      total_legacy_energy_val = 0
+      total_osm_energy_val = 0
+      total_legacy_water_val = 0
+      total_osm_water_val = 0
+      total_cumulative_energy_err = 0
+      total_cumulative_water_err = 0
+      fuel_types.each do |fuel_type|
+        end_uses.each do |end_use|
+          next if end_use == 'Exterior Equipment'
+          # Get the legacy results number
+          legacy_val = legacy_idf_results.dig(building_type, template, climate_zone, fuel_type, end_use)
+          # Combine the exterior lighting and exterior equipment
+          if end_use == 'Exterior Lighting'
+            legacy_exterior_equipment = legacy_idf_results.dig(building_type, template, climate_zone, fuel_type, 'Exterior Equipment')
+            unless legacy_exterior_equipment.nil?
+              legacy_val += legacy_exterior_equipment
+            end
+          end
+
+          if legacy_val.nil?
+            OpenStudio::logFree(OpenStudio::Error, 'openstudio.model.Model', "#{fuel_type} #{end_use} legacy idf value not found")
+            legacy_val = 0
+            next
+          end
+
+          # Add the energy to the total
+          if fuel_type == 'Water'
+            total_legacy_water_val += legacy_val
+          else
+            total_legacy_energy_val += legacy_val
+          end
+
+          # Select the correct units based on fuel type
+          units = 'GJ'
+          if fuel_type == 'Water'
+            units = 'm3'
+          end
+
+          # End use breakdown query
+          energy_query = "SELECT Value FROM TabularDataWithStrings WHERE (ReportName='AnnualBuildingUtilityPerformanceSummary') AND (ReportForString='Entire Facility') AND (TableName='End Uses') AND (ColumnName='#{fuel_type}') AND (RowName = '#{end_use}') AND (Units='#{units}')"
+
+          # Get the end use value
+          osm_val = sql.execAndReturnFirstDouble(energy_query)
+          if osm_val.is_initialized
+            osm_val = osm_val.get
+          else
+            OpenStudio::logFree(OpenStudio::Error, 'openstudio.model.Model', "No sql value found for #{fuel_type}-#{end_use}")
+            osm_val = 0
+          end
+
+          # Combine the exterior lighting and exterior equipment
+          if end_use == 'Exterior Lighting'
+            # End use breakdown query
+            energy_query = "SELECT Value FROM TabularDataWithStrings WHERE (ReportName='AnnualBuildingUtilityPerformanceSummary') AND (ReportForString='Entire Facility') AND (TableName='End Uses') AND (ColumnName='#{fuel_type}') AND (RowName = 'Exterior Equipment') AND (Units='#{units}')"
+
+            # Get the end use value
+            osm_val_2 = sql.execAndReturnFirstDouble(energy_query)
+            if osm_val_2.is_initialized
+              osm_val_2 = osm_val_2.get
+            else
+              OpenStudio::logFree(OpenStudio::Warn, 'openstudio.model.Model', "No sql value found for #{fuel_type}-Exterior Equipment.")
+              osm_val_2 = 0
+            end
+            osm_val += osm_val_2
+          end
+
+          # Add the energy to the total
+          if fuel_type == 'Water'
+            total_osm_water_val += osm_val
+          else
+            total_osm_energy_val += osm_val
+          end
+
+          # Add the absolute error to the total
+          abs_err = (legacy_val-osm_val).abs
+
+          if fuel_type == 'Water'
+            total_cumulative_water_err += abs_err
+          else
+            total_cumulative_energy_err += abs_err
+          end
+
+          # Calculate the error and check if less than
+          # acceptable_error_percentage
+          percent_error = nil
+          write_to_file = false
+          if osm_val > 0 && legacy_val > 0
+            percent_error = ((osm_val - legacy_val)/legacy_val) * 100
+            if percent_error.abs >= acceptable_error_percentage
+              OpenStudio::logFree(OpenStudio::Info, 'openstudio.model.Model', "#{fuel_type}-#{end_use} Error = #{percent_error.round}% (#{osm_val}, #{legacy_val})")
+              write_to_file = true
+            end
+          elsif osm_val > 0 && legacy_val.abs < 1e-6
+            # The osm has a fuel/end use that the legacy idf does not
+            percent_error = 9999
+            OpenStudio::logFree(OpenStudio::Info, 'openstudio.model.Model', "#{fuel_type}-#{end_use} Error = osm has extra fuel/end use that legacy idf does not (#{osm_val})")
+            write_to_file = true
+          elsif osm_val.abs < 1e-6 && legacy_val > 0
+            # The osm has a fuel/end use that the legacy idf does not
+            percent_error = 9999
+            OpenStudio::logFree(OpenStudio::Info, 'openstudio.model.Model', "#{fuel_type}-#{end_use} Error = osm is missing a fuel/end use that legacy idf has (#{legacy_val})")
+            write_to_file = true
+          else
+            # Both osm and legacy are == 0 for this fuel/end use, no error
+            percent_error = 0
+          end
+
+          # ALWAYS OUTPUT THE VALUES
+          write_to_file = true
+          if write_to_file
+            csv_rows << "#{building_type},#{template},#{climate_zone},#{fuel_type},#{end_use},#{legacy_val.round(2)},#{osm_val.round(2)},#{percent_error.round},#{abs_err.round}"
+          end
+
+        end # Next end use
+      end # Next fuel type
+
+      # Calculate the overall energy error
+      total_percent_error = nil
+      if total_osm_energy_val > 0 && total_legacy_energy_val > 0
+        # If both
+        total_percent_error = ((total_osm_energy_val - total_legacy_energy_val)/total_legacy_energy_val) * 100
+        OpenStudio::logFree(OpenStudio::Info, 'openstudio.model.Model', "Total Energy Error = #{total_percent_error.round}%")
+      elsif total_osm_energy_val > 0 && total_legacy_energy_val == 0
+        # The osm has a fuel/end use that the legacy idf does not
+        total_percent_error = 9999
+        OpenStudio::logFree(OpenStudio::Info, 'openstudio.model.Model', "Total Energy Error = osm has extra fuel/end use that legacy idf does not (#{total_osm_energy_val})")
+      elsif total_osm_energy_val == 0 && total_legacy_energy_val > 0
+        # The osm has a fuel/end use that the legacy idf does not
+        total_percent_error = 9999
+        OpenStudio::logFree(OpenStudio::Info, 'openstudio.model.Model', "Total Energy Error = osm is missing a fuel/end use that legacy idf has (#{total_legacy_energy_val})")
+      else
+        # Both osm and legacy are == 0 for, no error
+        total_percent_error = 0
+        OpenStudio::logFree(OpenStudio::Info, 'openstudio.model.Model', "Total Energy Error = both idf and osm don't use any energy.")
+      end
+
+      tot_abs_energy_err = ((total_osm_energy_val - total_legacy_energy_val)/total_legacy_energy_val) * 100
+      tot_cumulative_energy_err = (total_cumulative_energy_err/total_legacy_energy_val) * 100
+
+      if tot_cumulative_energy_err.abs > 20
+        OpenStudio::logFree(OpenStudio::Warn, 'openstudio.model.Model', "Total Energy cumulative error = #{tot_cumulative_energy_err.round}%.")
+      end
+
+      csv_rows << "#{building_type},#{template},#{climate_zone},Total Energy,Total Energy,#{total_legacy_energy_val.round(2)},#{total_osm_energy_val.round(2)},#{total_percent_error.round},#{tot_abs_energy_err.round},#{tot_cumulative_energy_err.round}"
+
+      # Append the comparison results
+      File.open(@results_csv_file, 'a') do |file|
+        csv_rows.each do |csv_row|
+          file.puts csv_row
+        end
+      end
+
+    end
+
+    # Calculate run time
+    run_time = Time.new - start_time
+
+    # Report out errors
+    log_file_path = "#{run_dir}/openstudio-standards.log"
+    messages = log_messages_to_file(log_file_path, debug)
+    errors = get_logs(OpenStudio::Error)
+
+    # Copy errors to combined log file
+    File.open(@combined_results_log, 'a') do |file|
+      file.puts "*** #{model_name}, Time: #{run_time.round} sec ***"
+      messages.each do |message|
+        file.puts message
+      end
+    end
+
+    # Assert if there were any errors
+    assert(errors.size == 0, errors)
   end
 
-  Test$(building_type).create_run_model_tests(building_types, templates, climate_zones, epw_files, create_models, run_models, compare_results, debug)
+  # TestFullServiceRestaurant.create_run_model_tests(building_types, templates, climate_zones, epw_files, create_models, run_models, compare_results, debug)
 
-  # Test$(building_type).compare_test_results(building_types, templates, climate_zones, file_ext="")
+  # TestFullServiceRestaurant.compare_test_results(building_types, templates, climate_zones, file_ext="")
 
 end
 }
+        file_string.gsub!('$(method_name)',"#{method_name}")
         file_string.gsub!('$(building_type)',"#{building_type}")
         file_string.gsub!('$(template)',"#{template}")
         file_string.gsub!('$(climate_zone)',"#{climate_zone}")

--- a/test/helpers/ci_test_generator.rb
+++ b/test/helpers/ci_test_generator.rb
@@ -1241,13 +1241,14 @@ def generate_doe_hvac_files
     # puts hvac_system.inspect
     filename = File.join(file_out_dir(),"doe_test_add_hvac_systems_#{hvac_system[0].snek}-#{hvac_system[1].to_s.snek}-#{hvac_system[2].inspect.snek}-#{hvac_system[3].snek}.rb")
     puts filename
+    classname = "doe_test_add_HVAC_systems_#{hvac_system[0].snek}-#{hvac_system[1].to_s.snek}-#{hvac_system[2].inspect.snek}-#{hvac_system[3].snek}".snek.split('_').collect(&:capitalize).join
     file_string = %q{
 require_relative '../helpers/minitest_helper'
 
-class TestAddHVACSystems < Minitest::Test
+class $(classname) < Minitest::Test
 
   def test_add_hvac_systems_$(0)_$(1)_$(2)_$(3)
-
+    assert(true)
     # Make the output directory if it doesn't exist
     output_dir = File.expand_path('output', File.dirname(__FILE__))
     FileUtils.mkdir output_dir unless Dir.exist? output_dir
@@ -1325,6 +1326,7 @@ class TestAddHVACSystems < Minitest::Test
   end
 end
 }
+    file_string["$(classname)"] = classname
     file_string["$(hvac_system)"] = hvac_system.inspect
     file_string["$(0)"] = hvac_system[0].inspect.snek
     file_string["$(1)"] = hvac_system[1].inspect.snek

--- a/test/helpers/ci_test_helper/lpt.rb
+++ b/test/helpers/ci_test_helper/lpt.rb
@@ -1,39 +1,52 @@
 require 'json'
+# Largest Processing Time algorithm
+# https://en.wikipedia.org/wiki/Multiprocessor_scheduling#Algorithms
+
+# similar solution https://github.com/sanathkumarbs/longest-processing-time-algorithm-lpt/blob/master/lpt.py
 class LPT
+  # Jobs hash format. The key is the line from the circleCi text file
+  # total is the number of seconds to run the job specified by the key
+  # any other keys are not used
+  # {
+  #   "ci_test_files/doe_test_bldg_large_hotel-90.1_2010-ashrae_169_2006_2_a.rb": {
+  #       "total": 44
+  #   },
+  #       "ci_test_files/doe_test_add_hvac_systems_vav_reheat-natural_gas-natural_gas-electricity.rb": {
+  #       "total": 99
+  #   },
+  #   .........
+  # }
+  # procs: Integer i.e. Number of cpus
   def initialize(jobs,procs)
     @jobs = jobs
     @processors = procs
   end
 
   def run()
-    scheduled_jobs, loads = lpt_algorithm()
-    return [scheduled_jobs, loads]
+    scheduled_jobs, loads = lpt_algorithm() # runs the algorithn
+    return [scheduled_jobs, loads] # returns the results
   end
 
   def lpt_algorithm
+    # sort jobs from large to small
     sorted_jobs = @jobs.sort_by {|_key, value| value['total']}.reverse
-
     # puts JSON.pretty_generate(sorted_jobs)
 
-    loads = []
-    scheduled_jobs = []
+    loads = [] # stores an array of total times per each cpu
+    scheduled_jobs = [] # # stores an array of jobs per each cpu
 
     for i in 1..@processors do
-      loads << 0
-      scheduled_jobs << []
+      loads << 0 # set default loads to 0
+      scheduled_jobs << [] # set default jobs for each processor as an empty array
     end
 
     sorted_jobs.each {|file_name, timing|
-      load =  timing['total']
-      minloadproc_indx = minloadproc(loads)
-      scheduled_jobs[minloadproc_indx] << file_name
-      loads[minloadproc_indx] += load
+      load =  timing['total'] # stores the total time it takes for each job to complete
+      minloadproc_indx = loads.each_with_index.min[1] # gets the processor with the minimum load
+      scheduled_jobs[minloadproc_indx] << file_name # adds the current job to the processor with minimum load
+      loads[minloadproc_indx] += load # adds the load of the job to the cpu with the lowest load
     }
 
     return [scheduled_jobs, loads]
-  end
-
-  def minloadproc(loads)
-    return loads.each_with_index.min[1] # return index of minimum load
   end
 end

--- a/test/helpers/ci_test_helper/lpt.rb
+++ b/test/helpers/ci_test_helper/lpt.rb
@@ -1,0 +1,39 @@
+require 'json'
+class LPT
+  def initialize(jobs,procs)
+    @jobs = jobs
+    @processors = procs
+  end
+
+  def run()
+    scheduled_jobs, loads = lpt_algorithm()
+    return [scheduled_jobs, loads]
+  end
+
+  def lpt_algorithm
+    sorted_jobs = @jobs.sort_by {|_key, value| value['total']}.reverse
+
+    # puts JSON.pretty_generate(sorted_jobs)
+
+    loads = []
+    scheduled_jobs = []
+
+    for i in 1..@processors do
+      loads << 0
+      scheduled_jobs << []
+    end
+
+    sorted_jobs.each {|file_name, timing|
+      load =  timing['total']
+      minloadproc_indx = minloadproc(loads)
+      scheduled_jobs[minloadproc_indx] << file_name
+      loads[minloadproc_indx] += load
+    }
+
+    return [scheduled_jobs, loads]
+  end
+
+  def minloadproc(loads)
+    return loads.each_with_index.min[1] # return index of minimum load
+  end
+end

--- a/test/helpers/ci_test_helper/timings.json
+++ b/test/helpers/ci_test_helper/timings.json
@@ -1,0 +1,2572 @@
+{
+  "ci_test_files/test_necb_bldg_SecondarySchool_NECB2015_electric.rb": {
+    "start": 1534425866,
+    "end": 1534426185,
+    "total": 319
+  },
+  "ci_test_files/test_necb_hvac_system_6_fuel_oil2-electric-scroll-hot_water-fc_inletvanes.rb": {
+    "start": 1534425866,
+    "end": 1534425940,
+    "total": 74
+  },
+  "ci_test_files/doe_test_bldg_large_hotel-90.1_2010-ashrae_169_2006_2_a.rb": {
+    "start": 1534425866,
+    "end": 1534425910,
+    "total": 44
+  },
+  "ci_test_files/doe_test_add_hvac_systems_vav_reheat-natural_gas-natural_gas-electricity.rb": {
+    "start": 1534425866,
+    "end": 1534425965,
+    "total": 99
+  },
+  "ci_test_files/test_necb_hvac_system_6_fuel_oil2-hot_water-scroll-hot_water-af_or_bi_inletvanes.rb": {
+    "start": 1534425866,
+    "end": 1534425942,
+    "total": 76
+  },
+  "ci_test_files/test_necb_hvac_system_2_natural_gas-scroll-hydronic.rb": {
+    "start": 1534425866,
+    "end": 1534425957,
+    "total": 91
+  },
+  "ci_test_files/test_necb_hvac_system_3_natural_gas-electric-electric.rb": {
+    "start": 1534425866,
+    "end": 1534425935,
+    "total": 69
+  },
+  "ci_test_files/doe_test_bldg_outpatient-doe_ref_1980_2004-ashrae_169_2006_5_a.rb": {
+    "start": 1534425866,
+    "end": 1534425953,
+    "total": 87
+  },
+  "ci_test_files/test_necb_bldg_HighriseApartment_NECB2015_gas.rb": {
+    "start": 1534425866,
+    "end": 1534426089,
+    "total": 223
+  },
+  "ci_test_files/test_necb_hvac_system_1-fuel_oil2-false-hot_water-electric.rb": {
+    "start": 1534425866,
+    "end": 1534425926,
+    "total": 60
+  },
+  "ci_test_files/test_necb_hvac_system_4_electricity-hot_water-gas.rb": {
+    "start": 1534425866,
+    "end": 1534425941,
+    "total": 75
+  },
+  "ci_test_files/test_necb_bldg_HighriseApartment_NECB2011_gas.rb": {
+    "start": 1534425866,
+    "end": 1534426019,
+    "total": 153
+  },
+  "ci_test_files/doe_test_bldg_hospital-90.1_2004-ashrae_169_2006_2_a.rb": {
+    "start": 1534425866,
+    "end": 1534425929,
+    "total": 63
+  },
+  "90_1_prm/test_create_performance_rating_method_baseline_bldg_3.rb": {
+    "start": 1534425866,
+    "end": 1534425910,
+    "total": 44
+  },
+  "ci_test_files/doe_test_bldg_large_office-doe_ref_1980_2004-ashrae_169_2006_2_a.rb": {
+    "start": 1534425866,
+    "end": 1534425899,
+    "total": 33
+  },
+  "ci_test_files/doe_test_add_hvac_systems_water_source_heat_pumps_with_doas-district_heating-district_heating-electricity.rb": {
+    "start": 1534425866,
+    "end": 1534426074,
+    "total": 208
+  },
+  "ci_test_files/doe_test_bldg_full_service_restaurant-doe_ref_1980_2004-ashrae_169_2006_5_a.rb": {
+    "start": 1534425866,
+    "end": 1534425894,
+    "total": 28
+  },
+  "ci_test_files/test_necb_bldg_PrimarySchool_NECB2015_electric.rb": {
+    "start": 1534425866,
+    "end": 1534426024,
+    "total": 158
+  },
+  "ci_test_files/doe_test_bldg_warehouse-doe_ref_pre_1980-ashrae_169_2006_3_b.rb": {
+    "start": 1534425866,
+    "end": 1534425895,
+    "total": 29
+  },
+  "ci_test_files/test_necb_hvac_system_2_fuel_oil2-reciprocating-hydronic.rb": {
+    "start": 1534425866,
+    "end": 1534425958,
+    "total": 92
+  },
+  "ci_test_files/doe_test_bldg_super_market-90.1_2013-ashrae_169_2006_3_b.rb": {
+    "start": 1534425866,
+    "end": 1534425909,
+    "total": 43
+  },
+  "ci_test_files/test_necb_bldg_FullServiceRestaurant_NECB2011_gas.rb": {
+    "start": 1534425866,
+    "end": 1534425914,
+    "total": 48
+  },
+  "ci_test_files/doe_test_bldg_secondary_school-doe_ref_1980_2004-ashrae_169_2006_4_a.rb": {
+    "start": 1534425866,
+    "end": 1534425920,
+    "total": 54
+  },
+  "ci_test_files/doe_test_bldg_large_hotel-doe_ref_1980_2004-ashrae_169_2006_4_a.rb": {
+    "start": 1534425866,
+    "end": 1534425911,
+    "total": 45
+  },
+  "ci_test_files/doe_test_bldg_super_market-90.1_2004-ashrae_169_2006_5_a.rb": {
+    "start": 1534425867,
+    "end": 1534425910,
+    "total": 43
+  },
+  "ci_test_files/doe_test_bldg_small_hotel-90.1_2010-ashrae_169_2006_3_b.rb": {
+    "start": 1534425867,
+    "end": 1534425932,
+    "total": 65
+  },
+  "necb/test_necb_airloop_sizing_parameters.rb": {
+    "start": 1534425867,
+    "end": 1534425930,
+    "total": 63
+  },
+  "ci_test_files/doe_test_bldg_small_hotel-doe_ref_1980_2004-ashrae_169_2006_2_a.rb": {
+    "start": 1534425867,
+    "end": 1534425941,
+    "total": 74
+  },
+  "ci_test_files/doe_test_bldg_warehouse-doe_ref_1980_2004-ashrae_169_2006_4_a.rb": {
+    "start": 1534425867,
+    "end": 1534425896,
+    "total": 29
+  },
+  "ci_test_files/doe_test_bldg_large_office-90.1_2010-ashrae_169_2006_4_a.rb": {
+    "start": 1534425867,
+    "end": 1534425913,
+    "total": 46
+  },
+  "ci_test_files/test_necb_hvac_system_1-electricity-true-electric-electric.rb": {
+    "start": 1534425867,
+    "end": 1534425932,
+    "total": 65
+  },
+  "ci_test_files/doe_test_bldg_retail_standalone-doe_ref_1980_2004-ashrae_169_2006_5_a.rb": {
+    "start": 1534425867,
+    "end": 1534425896,
+    "total": 29
+  },
+  "ci_test_files/test_necb_hvac_system_6_fuel_oil2-hot_water-scroll-hot_water-var_speed_drive.rb": {
+    "start": 1534425894,
+    "end": 1534425968,
+    "total": 74
+  },
+  "ci_test_files/test_necb_hvac_system_6_electricity-hot_water-scroll-electric-var_speed_drive.rb": {
+    "start": 1534425895,
+    "end": 1534425965,
+    "total": 70
+  },
+  "ci_test_files/test_necb_bldg_LargeOffice_NECB2015_gas.rb": {
+    "start": 1534425896,
+    "end": 1534425995,
+    "total": 99
+  },
+  "ci_test_files/test_necb_bldg_SmallHotel_NECB2011_electric.rb": {
+    "start": 1534425896,
+    "end": 1534426043,
+    "total": 147
+  },
+  "ci_test_files/test_necb_hvac_system_6_electricity-hot_water-scroll-hot_water-af_or_bi_inletvanes.rb": {
+    "start": 1534425899,
+    "end": 1534425973,
+    "total": 74
+  },
+  "ci_test_files/doe_test_bldg_secondary_school-90.1_2010-ashrae_169_2006_3_b.rb": {
+    "start": 1534425909,
+    "end": 1534425974,
+    "total": 65
+  },
+  "ci_test_files/doe_test_bldg_quick_service_restaurant-90.1_2010-ashrae_169_2006_5_a.rb": {
+    "start": 1534425910,
+    "end": 1534425938,
+    "total": 28
+  },
+  "ci_test_files/doe_test_add_hvac_systems_water_source_heat_pumps_with_er_vs-heat_pump-nil-heat_pump.rb": {
+    "start": 1534425910,
+    "end": 1534426017,
+    "total": 107
+  },
+  "ci_test_files/doe_test_bldg_small_office-doe_ref_pre_1980-ashrae_169_2006_2_a.rb": {
+    "start": 1534425910,
+    "end": 1534425938,
+    "total": 28
+  },
+  "ci_test_files/test_necb_bldg_SecondarySchool_NECB2011_gas.rb": {
+    "start": 1534425911,
+    "end": 1534426196,
+    "total": 285
+  },
+  "necb/test_necb_constructions_fdwr.rb": {
+    "start": 1534425913,
+    "end": 1534425937,
+    "total": 24
+  },
+  "ci_test_files/doe_test_bldg_secondary_school-90.1_2010-ashrae_169_2006_4_a.rb": {
+    "start": 1534425914,
+    "end": 1534425985,
+    "total": 71
+  },
+  "90_1_general/test_find_space_type_standards_data.rb": {
+    "start": 1534425920,
+    "end": 1534425924,
+    "total": 4
+  },
+  "ci_test_files/doe_test_bldg_full_service_restaurant-90.1_2010-ashrae_169_2006_2_a.rb": {
+    "start": 1534425924,
+    "end": 1534425952,
+    "total": 28
+  },
+  "ci_test_files/test_necb_hvac_system_3_electricity-electric-electric.rb": {
+    "start": 1534425926,
+    "end": 1534425992,
+    "total": 66
+  },
+  "ci_test_files/test_necb_hvac_system_1-fuel_oil2-true-hot_water-electric.rb": {
+    "start": 1534425929,
+    "end": 1534425994,
+    "total": 65
+  },
+  "ci_test_files/doe_test_bldg_small_office-doe_ref_pre_1980-ashrae_169_2006_3_b.rb": {
+    "start": 1534425930,
+    "end": 1534425958,
+    "total": 28
+  },
+  "ci_test_files/doe_test_bldg_small_office-doe_ref_pre_1980-ashrae_169_2006_4_a.rb": {
+    "start": 1534425932,
+    "end": 1534425959,
+    "total": 27
+  },
+  "ci_test_files/test_necb_bldg_RetailStandalone_NECB2011_gas.rb": {
+    "start": 1534425932,
+    "end": 1534425982,
+    "total": 50
+  },
+  "ci_test_files/test_necb_bldg_SmallOffice_NECB2011_gas.rb": {
+    "start": 1534425935,
+    "end": 1534425984,
+    "total": 49
+  },
+  "ci_test_files/doe_test_bldg_large_hotel-90.1_2010-ashrae_169_2006_4_a.rb": {
+    "start": 1534425937,
+    "end": 1534425979,
+    "total": 42
+  },
+  "ci_test_files/test_necb_hvac_system_6_fuel_oil2-hot_water-scroll-electric-fc_inletvanes.rb": {
+    "start": 1534425938,
+    "end": 1534426007,
+    "total": 69
+  },
+  "necb/test_necb_qaqc_single.rb": {
+    "start": 1534425938,
+    "end": 1534426042,
+    "total": 104
+  },
+  "90_1_prm/test_create_performance_rating_method_baseline_bldg_2.rb": {
+    "start": 1534425940,
+    "end": 1534425946,
+    "total": 6
+  },
+  "ci_test_files/test_necb_hvac_system_4_electricity-electric-gas.rb": {
+    "start": 1534425941,
+    "end": 1534426008,
+    "total": 67
+  },
+  "ci_test_files/doe_test_bldg_small_hotel-90.1_2010-ashrae_169_2006_2_a.rb": {
+    "start": 1534425941,
+    "end": 1534426002,
+    "total": 61
+  },
+  "ci_test_files/test_necb_hvac_system_4_fuel_oil2-hot_water-gas.rb": {
+    "start": 1534425942,
+    "end": 1534426013,
+    "total": 71
+  },
+  "ci_test_files/doe_test_bldg_retail_stripmall-doe_ref_pre_1980-ashrae_169_2006_3_b.rb": {
+    "start": 1534425946,
+    "end": 1534425975,
+    "total": 29
+  },
+  "ci_test_files/doe_test_bldg_retail_stripmall-90.1_2010-ashrae_169_2006_4_a.rb": {
+    "start": 1534425952,
+    "end": 1534425987,
+    "total": 35
+  },
+  "ci_test_files/doe_test_bldg_small_hotel-doe_ref_1980_2004-ashrae_169_2006_5_a.rb": {
+    "start": 1534425953,
+    "end": 1534426024,
+    "total": 71
+  },
+  "ci_test_files/test_necb_hvac_system_7_natural_gas-scroll-dx.rb": {
+    "start": 1534425957,
+    "end": 1534426045,
+    "total": 88
+  },
+  "necb/test_necb_loop_rules.rb": {
+    "start": 1534425958,
+    "end": 1534426048,
+    "total": 90
+  },
+  "ci_test_files/test_necb_bldg_LargeOffice_NECB2011_gas.rb": {
+    "start": 1534425958,
+    "end": 1534426025,
+    "total": 67
+  },
+  "ci_test_files/test_necb_hvac_system_6_natural_gas-hot_water-scroll-hot_water-var_speed_drive.rb": {
+    "start": 1534425959,
+    "end": 1534426032,
+    "total": 73
+  },
+  "doe_prototype/test_add_exterior_lights.rb": {
+    "start": 1534425965,
+    "end": 1534426001,
+    "total": 36
+  },
+  "ci_test_files/test_necb_hvac_system_6_fuel_oil2-electric-scroll-electric-af_or_bi_inletvanes.rb": {
+    "start": 1534425965,
+    "end": 1534426031,
+    "total": 66
+  },
+  "ci_test_files/test_necb_hvac_system_2_natural_gas-rotary_screw-dx.rb": {
+    "start": 1534425968,
+    "end": 1534426056,
+    "total": 88
+  },
+  "90_1_prm/test_create_performance_rating_method_baseline_bldg_9.rb": {
+    "start": 1534425973,
+    "end": 1534425995,
+    "total": 22
+  },
+  "ci_test_files/test_necb_bldg_MidriseApartment_NECB2015_gas.rb": {
+    "start": 1534425974,
+    "end": 1534426066,
+    "total": 92
+  },
+  "ci_test_files/test_necb_hvac_system_3_fuel_oil2-electric-gas.rb": {
+    "start": 1534425975,
+    "end": 1534426042,
+    "total": 67
+  },
+  "ci_test_files/doe_test_bldg_super_market-doe_ref_1980_2004-ashrae_169_2006_5_a.rb": {
+    "start": 1534425979,
+    "end": 1534426020,
+    "total": 41
+  },
+  "ci_test_files/doe_test_add_hvac_systems_ptac-district_heating-nil-electricity.rb": {
+    "start": 1534425982,
+    "end": 1534426041,
+    "total": 59
+  },
+  "ci_test_files/test_necb_hvac_system_2_electricity-scroll-hydronic.rb": {
+    "start": 1534425984,
+    "end": 1534426074,
+    "total": 90
+  },
+  "ci_test_files/doe_test_bldg_medium_office-doe_ref_pre_1980-ashrae_169_2006_3_b.rb": {
+    "start": 1534425985,
+    "end": 1534426020,
+    "total": 35
+  },
+  "ci_test_files/doe_test_bldg_outpatient-doe_ref_1980_2004-ashrae_169_2006_2_a.rb": {
+    "start": 1534425987,
+    "end": 1534426067,
+    "total": 80
+  },
+  "ci_test_files/doe_test_add_hvac_systems_water_source_heat_pumps_with_doas-heat_pump-heat_pump-heat_pump.rb": {
+    "start": 1534425992,
+    "end": 1534426210,
+    "total": 218
+  },
+  "ci_test_files/doe_test_bldg_small_office-doe_ref_pre_1980-ashrae_169_2006_5_a.rb": {
+    "start": 1534425994,
+    "end": 1534426021,
+    "total": 27
+  },
+  "ci_test_files/test_necb_hvac_system_7_natural_gas-reciprocating-hydronic.rb": {
+    "start": 1534425995,
+    "end": 1534426084,
+    "total": 89
+  },
+  "ci_test_files/doe_test_bldg_super_market-doe_ref_1980_2004-ashrae_169_2006_2_a.rb": {
+    "start": 1534425995,
+    "end": 1534426035,
+    "total": 40
+  },
+  "ci_test_files/doe_test_bldg_small_office-90.1_2010-ashrae_169_2006_4_a.rb": {
+    "start": 1534426001,
+    "end": 1534426029,
+    "total": 28
+  },
+  "ci_test_files/test_necb_hvac_system_4_fuel_oil2-electric-gas.rb": {
+    "start": 1534426002,
+    "end": 1534426069,
+    "total": 67
+  },
+  "ci_test_files/doe_test_bldg_hospital-90.1_2010-ashrae_169_2006_4_a.rb": {
+    "start": 1534426007,
+    "end": 1534426067,
+    "total": 60
+  },
+  "ci_test_files/test_necb_hvac_system_7_electricity-centrifugal-dx.rb": {
+    "start": 1534426008,
+    "end": 1534426097,
+    "total": 89
+  },
+  "ci_test_files/doe_test_bldg_outpatient-90.1_2010-ashrae_169_2006_3_b.rb": {
+    "start": 1534426013,
+    "end": 1534426107,
+    "total": 94
+  },
+  "ci_test_files/test_necb_hvac_system_7_fuel_oil2-reciprocating-hydronic.rb": {
+    "start": 1534426017,
+    "end": 1534426106,
+    "total": 89
+  },
+  "ci_test_files/test_necb_bldg_SecondarySchool_NECB2015_gas.rb": {
+    "start": 1534426019,
+    "end": 1534426369,
+    "total": 350
+  },
+  "ci_test_files/doe_test_bldg_retail_standalone-doe_ref_1980_2004-ashrae_169_2006_2_a.rb": {
+    "start": 1534426020,
+    "end": 1534426047,
+    "total": 27
+  },
+  "ci_test_files/test_necb_bldg_LargeHotel_NECB2011_gas.rb": {
+    "start": 1534426020,
+    "end": 1534426109,
+    "total": 89
+  },
+  "ci_test_files/test_necb_hvac_system_2_electricity-reciprocating-dx.rb": {
+    "start": 1534426021,
+    "end": 1534426109,
+    "total": 88
+  },
+  "ci_test_files/test_necb_bldg_SmallHotel_NECB2015_gas.rb": {
+    "start": 1534426024,
+    "end": 1534426233,
+    "total": 209
+  },
+  "ci_test_files/test_necb_hvac_system_1-electricity-false-electric-hot_water.rb": {
+    "start": 1534426024,
+    "end": 1534426086,
+    "total": 62
+  },
+  "ci_test_files/test_necb_hvac_system_6_natural_gas-electric-scroll-hot_water-af_or_bi_inletvanes.rb": {
+    "start": 1534426025,
+    "end": 1534426096,
+    "total": 71
+  },
+  "ci_test_files/doe_test_bldg_hospital-90.1_2007-ashrae_169_2006_5_a.rb": {
+    "start": 1534426029,
+    "end": 1534426152,
+    "total": 123
+  },
+  "ci_test_files/test_necb_hvac_system_6_natural_gas-electric-scroll-hot_water-var_speed_drive.rb": {
+    "start": 1534426031,
+    "end": 1534426103,
+    "total": 72
+  },
+  "ci_test_files/doe_test_bldg_retail_standalone-doe_ref_pre_1980-ashrae_169_2006_4_a.rb": {
+    "start": 1534426032,
+    "end": 1534426058,
+    "total": 26
+  },
+  "ci_test_files/doe_test_bldg_warehouse-doe_ref_1980_2004-ashrae_169_2006_3_b.rb": {
+    "start": 1534426035,
+    "end": 1534426062,
+    "total": 27
+  },
+  "ci_test_files/doe_test_bldg_super_market-doe_ref_pre_1980-ashrae_169_2006_5_a.rb": {
+    "start": 1534426041,
+    "end": 1534426081,
+    "total": 40
+  },
+  "ci_test_files/doe_test_add_hvac_systems_vav_reheat-natural_gas-natural_gas-district_cooling.rb": {
+    "start": 1534426042,
+    "end": 1534426107,
+    "total": 65
+  },
+  "ci_test_files/test_necb_hvac_system_7_fuel_oil2-scroll-dx.rb": {
+    "start": 1534426042,
+    "end": 1534426131,
+    "total": 89
+  },
+  "ci_test_files/doe_test_bldg_retail_standalone-90.1_2010-ashrae_169_2006_4_a.rb": {
+    "start": 1534426043,
+    "end": 1534426071,
+    "total": 28
+  },
+  "ci_test_files/doe_test_bldg_full_service_restaurant-doe_ref_1980_2004-ashrae_169_2006_3_b.rb": {
+    "start": 1534426045,
+    "end": 1534426072,
+    "total": 27
+  },
+  "ci_test_files/doe_test_bldg_quick_service_restaurant-doe_ref_pre_1980-ashrae_169_2006_5_a.rb": {
+    "start": 1534426047,
+    "end": 1534426074,
+    "total": 27
+  },
+  "ci_test_files/test_necb_hvac_system_6_fuel_oil2-electric-scroll-hot_water-af_or_bi_inletvanes.rb": {
+    "start": 1534426048,
+    "end": 1534426118,
+    "total": 70
+  },
+  "ci_test_files/doe_test_add_hvac_systems_pvav_reheat-electricity-electricity-district_cooling.rb": {
+    "start": 1534426056,
+    "end": 1534426111,
+    "total": 55
+  },
+  "ci_test_files/doe_test_bldg_retail_stripmall-doe_ref_1980_2004-ashrae_169_2006_4_a.rb": {
+    "start": 1534426058,
+    "end": 1534426087,
+    "total": 29
+  },
+  "ci_test_files/test_necb_hvac_system_3_natural_gas-electric-gas.rb": {
+    "start": 1534426062,
+    "end": 1534426129,
+    "total": 67
+  },
+  "ci_test_files/doe_test_add_hvac_systems_fan_coil_with_doas-natural_gas-natural_gas-district_cooling.rb": {
+    "start": 1534426066,
+    "end": 1534426179,
+    "total": 113
+  },
+  "ci_test_files/test_necb_hvac_system_4_natural_gas-electric-gas.rb": {
+    "start": 1534426067,
+    "end": 1534426136,
+    "total": 69
+  },
+  "ci_test_files/doe_test_bldg_large_hotel-doe_ref_1980_2004-ashrae_169_2006_3_b.rb": {
+    "start": 1534426067,
+    "end": 1534426108,
+    "total": 41
+  },
+  "ci_test_files/doe_test_bldg_hospital-90.1_2013-ashrae_169_2006_3_b.rb": {
+    "start": 1534426069,
+    "end": 1534426134,
+    "total": 65
+  },
+  "ci_test_files/doe_test_add_hvac_systems_fan_coil_with_doas-district_heating-nil-district_cooling.rb": {
+    "start": 1534426071,
+    "end": 1534426183,
+    "total": 112
+  },
+  "ci_test_files/doe_test_bldg_primary_school-doe_ref_pre_1980-ashrae_169_2006_2_a.rb": {
+    "start": 1534426072,
+    "end": 1534426111,
+    "total": 39
+  },
+  "ci_test_files/doe_test_add_hvac_systems_pvav_pfp_boxes-electricity-electricity-electricity.rb": {
+    "start": 1534426074,
+    "end": 1534426137,
+    "total": 63
+  },
+  "ci_test_files/test_necb_hvac_system_6_natural_gas-hot_water-scroll-hot_water-af_or_bi_inletvanes.rb": {
+    "start": 1534426074,
+    "end": 1534426147,
+    "total": 73
+  },
+  "ci_test_files/doe_test_bldg_hospital-doe_ref_pre_1980-ashrae_169_2006_3_b.rb": {
+    "start": 1534426074,
+    "end": 1534426153,
+    "total": 79
+  },
+  "ci_test_files/test_necb_hvac_system_2_natural_gas-centrifugal-dx.rb": {
+    "start": 1534426081,
+    "end": 1534426170,
+    "total": 89
+  },
+  "ci_test_files/test_necb_bldg_QuickServiceRestaurant_NECB2015_electric.rb": {
+    "start": 1534426084,
+    "end": 1534426148,
+    "total": 64
+  },
+  "ci_test_files/test_necb_bldg_RetailStripmall_NECB2011_electric.rb": {
+    "start": 1534426086,
+    "end": 1534426147,
+    "total": 61
+  },
+  "ci_test_files/test_necb_hvac_system_6_natural_gas-electric-scroll-electric-af_or_bi_rdg_fancurve.rb": {
+    "start": 1534426087,
+    "end": 1534426154,
+    "total": 67
+  },
+  "ci_test_files/doe_test_bldg_primary_school-90.1_2010-ashrae_169_2006_4_a.rb": {
+    "start": 1534426089,
+    "end": 1534426130,
+    "total": 41
+  },
+  "ci_test_files/doe_test_bldg_warehouse-90.1_2010-ashrae_169_2006_3_b.rb": {
+    "start": 1534426096,
+    "end": 1534426125,
+    "total": 29
+  },
+  "ci_test_files/test_necb_bldg_RetailStripmall_NECB2015_gas.rb": {
+    "start": 1534426097,
+    "end": 1534426183,
+    "total": 86
+  },
+  "ci_test_files/doe_test_bldg_super_market-doe_ref_pre_1980-ashrae_169_2006_4_a.rb": {
+    "start": 1534426103,
+    "end": 1534426144,
+    "total": 41
+  },
+  "ci_test_files/doe_test_bldg_super_market-90.1_2010-ashrae_169_2006_4_a.rb": {
+    "start": 1534426106,
+    "end": 1534426147,
+    "total": 41
+  },
+  "doe_prototype/test_add_elevators.rb": {
+    "start": 1534426107,
+    "end": 1534426158,
+    "total": 51
+  },
+  "ci_test_files/doe_test_bldg_retail_stripmall-doe_ref_1980_2004-ashrae_169_2006_3_b.rb": {
+    "start": 1534426107,
+    "end": 1534426138,
+    "total": 31
+  },
+  "ci_test_files/test_necb_hvac_system_2_electricity-centrifugal-dx.rb": {
+    "start": 1534426108,
+    "end": 1534426197,
+    "total": 89
+  },
+  "ci_test_files/doe_test_bldg_retail_standalone-doe_ref_1980_2004-ashrae_169_2006_4_a.rb": {
+    "start": 1534426109,
+    "end": 1534426136,
+    "total": 27
+  },
+  "ci_test_files/doe_test_bldg_outpatient-doe_ref_1980_2004-ashrae_169_2006_3_b.rb": {
+    "start": 1534426109,
+    "end": 1534426190,
+    "total": 81
+  },
+  "ci_test_files/test_necb_hvac_system_1-natural_gas-true-hot_water-hot_water.rb": {
+    "start": 1534426111,
+    "end": 1534426178,
+    "total": 67
+  },
+  "ci_test_files/doe_test_bldg_super_market-90.1_2004-ashrae_169_2006_3_b.rb": {
+    "start": 1534426111,
+    "end": 1534426152,
+    "total": 41
+  },
+  "ci_test_files/test_necb_hvac_system_6_fuel_oil2-electric-scroll-electric-fc_inletvanes.rb": {
+    "start": 1534426118,
+    "end": 1534426184,
+    "total": 66
+  },
+  "ci_test_files/doe_test_bldg_medium_office-doe_ref_1980_2004-ashrae_169_2006_4_a.rb": {
+    "start": 1534426125,
+    "end": 1534426156,
+    "total": 31
+  },
+  "ci_test_files/doe_test_bldg_hospital-90.1_2004-ashrae_169_2006_5_a.rb": {
+    "start": 1534426129,
+    "end": 1534426189,
+    "total": 60
+  },
+  "ci_test_files/doe_test_bldg_large_hotel-doe_ref_pre_1980-ashrae_169_2006_4_a.rb": {
+    "start": 1534426130,
+    "end": 1534426173,
+    "total": 43
+  },
+  "ci_test_files/doe_test_bldg_primary_school-doe_ref_1980_2004-ashrae_169_2006_2_a.rb": {
+    "start": 1534426131,
+    "end": 1534426168,
+    "total": 37
+  },
+  "ci_test_files/doe_test_bldg_hospital-90.1_2010-ashrae_169_2006_2_a.rb": {
+    "start": 1534426134,
+    "end": 1534426196,
+    "total": 62
+  },
+  "ci_test_files/test_necb_hvac_system_2_natural_gas-rotary_screw-hydronic.rb": {
+    "start": 1534426136,
+    "end": 1534426225,
+    "total": 89
+  },
+  "ci_test_files/test_necb_bldg_MediumOffice_NECB2011_gas.rb": {
+    "start": 1534426136,
+    "end": 1534426196,
+    "total": 60
+  },
+  "ci_test_files/test_necb_bldg_RetailStripmall_NECB2011_gas.rb": {
+    "start": 1534426137,
+    "end": 1534426199,
+    "total": 62
+  },
+  "ci_test_files/doe_test_add_hvac_systems_fan_coil_with_doas-natural_gas-natural_gas-electricity.rb": {
+    "start": 1534426138,
+    "end": 1534426258,
+    "total": 120
+  },
+  "ci_test_files/test_necb_hvac_system_6_electricity-hot_water-scroll-electric-af_or_bi_rdg_fancurve.rb": {
+    "start": 1534426144,
+    "end": 1534426214,
+    "total": 70
+  },
+  "ci_test_files/test_necb_hvac_system_4_natural_gas-electric-electric.rb": {
+    "start": 1534426147,
+    "end": 1534426215,
+    "total": 68
+  },
+  "ci_test_files/test_necb_hvac_system_7_electricity-reciprocating-hydronic.rb": {
+    "start": 1534426147,
+    "end": 1534426236,
+    "total": 89
+  },
+  "ci_test_files/doe_test_bldg_secondary_school-doe_ref_1980_2004-ashrae_169_2006_5_a.rb": {
+    "start": 1534426147,
+    "end": 1534426198,
+    "total": 51
+  },
+  "ci_test_files/doe_test_bldg_full_service_restaurant-90.1_2010-ashrae_169_2006_5_a.rb": {
+    "start": 1534426148,
+    "end": 1534426175,
+    "total": 27
+  },
+  "ci_test_files/doe_test_bldg_primary_school-90.1_2010-ashrae_169_2006_5_a.rb": {
+    "start": 1534426152,
+    "end": 1534426195,
+    "total": 43
+  },
+  "ci_test_files/test_necb_hvac_system_1-fuel_oil2-true-hot_water-hot_water.rb": {
+    "start": 1534426152,
+    "end": 1534426218,
+    "total": 66
+  },
+  "ci_test_files/test_necb_hvac_system_6_natural_gas-hot_water-scroll-electric-fc_inletvanes.rb": {
+    "start": 1534426153,
+    "end": 1534426223,
+    "total": 70
+  },
+  "ci_test_files/doe_test_add_hvac_systems_ptac-natural_gas-nil-electricity.rb": {
+    "start": 1534426154,
+    "end": 1534426214,
+    "total": 60
+  },
+  "ci_test_files/doe_test_add_hvac_systems_psz_hp-electricity-nil-electricity.rb": {
+    "start": 1534426156,
+    "end": 1534426216,
+    "total": 60
+  },
+  "ci_test_files/test_necb_hvac_system_7_fuel_oil2-reciprocating-dx.rb": {
+    "start": 1534426158,
+    "end": 1534426247,
+    "total": 89
+  },
+  "ci_test_files/doe_test_add_hvac_systems_fan_coil_with_er_vs-electricity-nil-district_cooling.rb": {
+    "start": 1534426168,
+    "end": 1534426264,
+    "total": 96
+  },
+  "ci_test_files/doe_test_bldg_midrise_apartment-doe_ref_1980_2004-ashrae_169_2006_4_a.rb": {
+    "start": 1534426170,
+    "end": 1534426214,
+    "total": 44
+  },
+  "necb/test_necb_schedules.rb": {
+    "start": 1534426173,
+    "end": 1534426264,
+    "total": 91
+  },
+  "necb/test_necb_weather.rb": {
+    "start": 1534426175,
+    "end": 1534426205,
+    "total": 30
+  },
+  "ci_test_files/doe_test_bldg_hospital-90.1_2013-ashrae_169_2006_4_a.rb": {
+    "start": 1534426178,
+    "end": 1534426246,
+    "total": 68
+  },
+  "ci_test_files/test_necb_hvac_system_2_fuel_oil2-rotary_screw-dx.rb": {
+    "start": 1534426179,
+    "end": 1534426267,
+    "total": 88
+  },
+  "ci_test_files/test_necb_bldg_SmallOffice_NECB2015_gas.rb": {
+    "start": 1534426183,
+    "end": 1534426253,
+    "total": 70
+  },
+  "ci_test_files/doe_test_bldg_hospital-doe_ref_1980_2004-ashrae_169_2006_5_a.rb": {
+    "start": 1534426183,
+    "end": 1534426243,
+    "total": 60
+  },
+  "ci_test_files/doe_test_add_hvac_systems_psz_ac-natural_gas-nil-district_cooling.rb": {
+    "start": 1534426184,
+    "end": 1534426245,
+    "total": 61
+  },
+  "ci_test_files/doe_test_bldg_warehouse-doe_ref_1980_2004-ashrae_169_2006_2_a.rb": {
+    "start": 1534426185,
+    "end": 1534426213,
+    "total": 28
+  },
+  "ci_test_files/doe_test_bldg_warehouse-90.1_2010-ashrae_169_2006_4_a.rb": {
+    "start": 1534426189,
+    "end": 1534426218,
+    "total": 29
+  },
+  "ci_test_files/doe_test_bldg_quick_service_restaurant-doe_ref_1980_2004-ashrae_169_2006_2_a.rb": {
+    "start": 1534426190,
+    "end": 1534426218,
+    "total": 28
+  },
+  "ci_test_files/doe_test_bldg_super_market-doe_ref_pre_1980-ashrae_169_2006_2_a.rb": {
+    "start": 1534426195,
+    "end": 1534426235,
+    "total": 40
+  },
+  "ci_test_files/doe_test_bldg_outpatient-90.1_2010-ashrae_169_2006_5_a.rb": {
+    "start": 1534426196,
+    "end": 1534426288,
+    "total": 92
+  },
+  "ci_test_files/doe_test_bldg_medium_office-doe_ref_1980_2004-ashrae_169_2006_3_b.rb": {
+    "start": 1534426196,
+    "end": 1534426228,
+    "total": 32
+  },
+  "necb/test_necb_waterheater_rules.rb": {
+    "start": 1534426196,
+    "end": 1534426343,
+    "total": 147
+  },
+  "ci_test_files/test_necb_hvac_system_2_fuel_oil2-centrifugal-dx.rb": {
+    "start": 1534426197,
+    "end": 1534426285,
+    "total": 88
+  },
+  "ci_test_files/doe_test_bldg_medium_office-doe_ref_pre_1980-ashrae_169_2006_4_a.rb": {
+    "start": 1534426198,
+    "end": 1534426234,
+    "total": 36
+  },
+  "ci_test_files/test_necb_hvac_system_2_electricity-scroll-dx.rb": {
+    "start": 1534426199,
+    "end": 1534426288,
+    "total": 89
+  },
+  "ci_test_files/doe_test_bldg_medium_office-doe_ref_pre_1980-ashrae_169_2006_5_a.rb": {
+    "start": 1534426205,
+    "end": 1534426239,
+    "total": 34
+  },
+  "ci_test_files/doe_test_bldg_large_hotel-doe_ref_pre_1980-ashrae_169_2006_3_b.rb": {
+    "start": 1534426210,
+    "end": 1534426251,
+    "total": 41
+  },
+  "ci_test_files/test_necb_hvac_system_6_natural_gas-hot_water-scroll-hot_water-fc_inletvanes.rb": {
+    "start": 1534426213,
+    "end": 1534426284,
+    "total": 71
+  },
+  "ci_test_files/doe_test_bldg_small_office-90.1_2010-ashrae_169_2006_3_b.rb": {
+    "start": 1534426214,
+    "end": 1534426242,
+    "total": 28
+  },
+  "ci_test_files/test_necb_hvac_system_7_natural_gas-rotary_screw-hydronic.rb": {
+    "start": 1534426214,
+    "end": 1534426304,
+    "total": 90
+  },
+  "ci_test_files/test_necb_hvac_system_6_electricity-electric-scroll-hot_water-af_or_bi_inletvanes.rb": {
+    "start": 1534426214,
+    "end": 1534426285,
+    "total": 71
+  },
+  "ci_test_files/doe_test_bldg_midrise_apartment-90.1_2010-ashrae_169_2006_4_a.rb": {
+    "start": 1534426215,
+    "end": 1534426258,
+    "total": 43
+  },
+  "ci_test_files/doe_test_add_hvac_systems_fan_coil_with_doas-natural_gas-nil-district_cooling.rb": {
+    "start": 1534426216,
+    "end": 1534426329,
+    "total": 113
+  },
+  "ci_test_files/test_necb_hvac_system_1-natural_gas-true-electric-hot_water.rb": {
+    "start": 1534426218,
+    "end": 1534426283,
+    "total": 65
+  },
+  "ci_test_files/test_necb_bldg_PrimarySchool_NECB2011_electric.rb": {
+    "start": 1534426218,
+    "end": 1534426338,
+    "total": 120
+  },
+  "necb/test_necb_shw.rb": {
+    "start": 1534426218,
+    "end": 1534426418,
+    "total": 200
+  },
+  "ci_test_files/doe_test_bldg_super_market-doe_ref_pre_1980-ashrae_169_2006_3_b.rb": {
+    "start": 1534426223,
+    "end": 1534426263,
+    "total": 40
+  },
+  "ci_test_files/test_necb_hvac_system_2_electricity-reciprocating-hydronic.rb": {
+    "start": 1534426225,
+    "end": 1534426313,
+    "total": 88
+  },
+  "ci_test_files/doe_test_bldg_retail_standalone-90.1_2010-ashrae_169_2006_3_b.rb": {
+    "start": 1534426228,
+    "end": 1534426256,
+    "total": 28
+  },
+  "ci_test_files/test_necb_hvac_system_6_natural_gas-hot_water-scroll-electric-af_or_bi_inletvanes.rb": {
+    "start": 1534426233,
+    "end": 1534426303,
+    "total": 70
+  },
+  "ci_test_files/doe_test_bldg_hospital-90.1_2013-ashrae_169_2006_5_a.rb": {
+    "start": 1534426234,
+    "end": 1534426300,
+    "total": 66
+  },
+  "ci_test_files/doe_test_bldg_midrise_apartment-doe_ref_pre_1980-ashrae_169_2006_3_b.rb": {
+    "start": 1534426235,
+    "end": 1534426278,
+    "total": 43
+  },
+  "ci_test_files/doe_test_bldg_retail_stripmall-doe_ref_pre_1980-ashrae_169_2006_4_a.rb": {
+    "start": 1534426236,
+    "end": 1534426265,
+    "total": 29
+  },
+  "ci_test_files/test_necb_hvac_system_3_natural_gas-electric-dx.rb": {
+    "start": 1534426239,
+    "end": 1534426306,
+    "total": 67
+  },
+  "ci_test_files/doe_test_bldg_midrise_apartment-doe_ref_1980_2004-ashrae_169_2006_3_b.rb": {
+    "start": 1534426242,
+    "end": 1534426285,
+    "total": 43
+  },
+  "90_1_general/test_chiller_electric_eir.rb": {
+    "start": 1534426243,
+    "end": 1534426247,
+    "total": 4
+  },
+  "ci_test_files/doe_test_bldg_hospital-90.1_2007-ashrae_169_2006_4_a.rb": {
+    "start": 1534426245,
+    "end": 1534426309,
+    "total": 64
+  },
+  "ci_test_files/doe_test_bldg_full_service_restaurant-doe_ref_pre_1980-ashrae_169_2006_2_a.rb": {
+    "start": 1534426246,
+    "end": 1534426272,
+    "total": 26
+  },
+  "ci_test_files/doe_test_bldg_midrise_apartment-90.1_2010-ashrae_169_2006_2_a.rb": {
+    "start": 1534426247,
+    "end": 1534426290,
+    "total": 43
+  },
+  "ci_test_files/doe_test_add_hvac_systems_ground_source_heat_pumps_with_er_vs-electricity-nil-electricity.rb": {
+    "start": 1534426247,
+    "end": 1534426347,
+    "total": 100
+  },
+  "ci_test_files/test_necb_bldg_MediumOffice_NECB2015_gas.rb": {
+    "start": 1534426251,
+    "end": 1534426341,
+    "total": 90
+  },
+  "ci_test_files/test_necb_hvac_system_6_fuel_oil2-hot_water-scroll-hot_water-af_or_bi_rdg_fancurve.rb": {
+    "start": 1534426253,
+    "end": 1534426325,
+    "total": 72
+  },
+  "ci_test_files/doe_test_bldg_medium_office-90.1_2010-ashrae_169_2006_4_a.rb": {
+    "start": 1534426256,
+    "end": 1534426288,
+    "total": 32
+  },
+  "ci_test_files/test_necb_hvac_system_7_natural_gas-centrifugal-dx.rb": {
+    "start": 1534426258,
+    "end": 1534426347,
+    "total": 89
+  },
+  "ci_test_files/test_necb_hvac_system_7_natural_gas-reciprocating-dx.rb": {
+    "start": 1534426258,
+    "end": 1534426346,
+    "total": 88
+  },
+  "ci_test_files/doe_test_bldg_outpatient-doe_ref_pre_1980-ashrae_169_2006_3_b.rb": {
+    "start": 1534426263,
+    "end": 1534426345,
+    "total": 82
+  },
+  "ci_test_files/doe_test_bldg_large_hotel-doe_ref_1980_2004-ashrae_169_2006_5_a.rb": {
+    "start": 1534426264,
+    "end": 1534426307,
+    "total": 43
+  },
+  "ci_test_files/test_necb_hvac_system_6_electricity-electric-scroll-hot_water-af_or_bi_rdg_fancurve.rb": {
+    "start": 1534426264,
+    "end": 1534426334,
+    "total": 70
+  },
+  "ci_test_files/doe_test_bldg_medium_office-doe_ref_pre_1980-ashrae_169_2006_2_a.rb": {
+    "start": 1534426265,
+    "end": 1534426301,
+    "total": 36
+  },
+  "ci_test_files/doe_test_bldg_hospital-90.1_2013-ashrae_169_2006_2_a.rb": {
+    "start": 1534426267,
+    "end": 1534426329,
+    "total": 62
+  },
+  "ci_test_files/test_necb_hvac_system_7_electricity-rotary_screw-dx.rb": {
+    "start": 1534426272,
+    "end": 1534426360,
+    "total": 88
+  },
+  "90_1_prm/test_create_performance_rating_method_baseline_bldg_12.rb": {
+    "start": 1534426278,
+    "end": 1534426388,
+    "total": 110
+  },
+  "ci_test_files/test_necb_bldg_Outpatient_NECB2011_electric.rb": {
+    "start": 1534426283,
+    "end": 1534426631,
+    "total": 348
+  },
+  "ci_test_files/doe_test_bldg_hospital-doe_ref_1980_2004-ashrae_169_2006_3_b.rb": {
+    "start": 1534426284,
+    "end": 1534426345,
+    "total": 61
+  },
+  "ci_test_files/test_necb_bldg_Warehouse_NECB2015_electric.rb": {
+    "start": 1534426285,
+    "end": 1534426355,
+    "total": 70
+  },
+  "ci_test_files/doe_test_bldg_super_market-90.1_2013-ashrae_169_2006_2_a.rb": {
+    "start": 1534426285,
+    "end": 1534426326,
+    "total": 41
+  },
+  "ci_test_files/doe_test_bldg_primary_school-90.1_2010-ashrae_169_2006_3_b.rb": {
+    "start": 1534426285,
+    "end": 1534426327,
+    "total": 42
+  },
+  "ci_test_files/doe_test_add_hvac_systems_fan_coil_with_doas-district_heating-district_heating-district_cooling.rb": {
+    "start": 1534426288,
+    "end": 1534426403,
+    "total": 115
+  },
+  "ci_test_files/doe_test_bldg_secondary_school-doe_ref_pre_1980-ashrae_169_2006_2_a.rb": {
+    "start": 1534426288,
+    "end": 1534426337,
+    "total": 49
+  },
+  "ci_test_files/doe_test_bldg_retail_stripmall-doe_ref_pre_1980-ashrae_169_2006_2_a.rb": {
+    "start": 1534426288,
+    "end": 1534426318,
+    "total": 30
+  },
+  "ci_test_files/test_necb_bldg_RetailStandalone_NECB2015_gas.rb": {
+    "start": 1534426290,
+    "end": 1534426362,
+    "total": 72
+  },
+  "90_1_general/test_find_target_eui_by_end_use.rb": {
+    "start": 1534426300,
+    "end": 1534426304,
+    "total": 4
+  },
+  "ci_test_files/doe_test_bldg_large_office-doe_ref_1980_2004-ashrae_169_2006_4_a.rb": {
+    "start": 1534426301,
+    "end": 1534426333,
+    "total": 32
+  },
+  "ci_test_files/doe_test_bldg_full_service_restaurant-doe_ref_pre_1980-ashrae_169_2006_5_a.rb": {
+    "start": 1534426303,
+    "end": 1534426330,
+    "total": 27
+  },
+  "ci_test_files/test_necb_hvac_system_2_natural_gas-centrifugal-hydronic.rb": {
+    "start": 1534426304,
+    "end": 1534426393,
+    "total": 89
+  },
+  "ci_test_files/doe_test_bldg_large_office-doe_ref_pre_1980-ashrae_169_2006_3_b.rb": {
+    "start": 1534426304,
+    "end": 1534426337,
+    "total": 33
+  },
+  "ci_test_files/doe_test_bldg_retail_standalone-doe_ref_1980_2004-ashrae_169_2006_3_b.rb": {
+    "start": 1534426306,
+    "end": 1534426332,
+    "total": 26
+  },
+  "ci_test_files/test_necb_hvac_system_6_natural_gas-electric-scroll-electric-fc_inletvanes.rb": {
+    "start": 1534426307,
+    "end": 1534426373,
+    "total": 66
+  },
+  "ci_test_files/test_necb_hvac_system_7_electricity-centrifugal-hydronic.rb": {
+    "start": 1534426309,
+    "end": 1534426398,
+    "total": 89
+  },
+  "ci_test_files/doe_test_bldg_hospital-doe_ref_pre_1980-ashrae_169_2006_5_a.rb": {
+    "start": 1534426313,
+    "end": 1534426372,
+    "total": 59
+  },
+  "ci_test_files/doe_test_bldg_outpatient-90.1_2010-ashrae_169_2006_2_a.rb": {
+    "start": 1534426318,
+    "end": 1534426412,
+    "total": 94
+  },
+  "ci_test_files/test_necb_hvac_system_3_electricity-hot_water-electric.rb": {
+    "start": 1534426325,
+    "end": 1534426396,
+    "total": 71
+  },
+  "necb/test_necb_boiler_rules.rb": {
+    "start": 1534426326,
+    "end": 1534426813,
+    "total": 487
+  },
+  "ci_test_files/doe_test_bldg_hospital-90.1_2007-ashrae_169_2006_3_b.rb": {
+    "start": 1534426327,
+    "end": 1534426388,
+    "total": 61
+  },
+  "ci_test_files/test_necb_hvac_system_3_natural_gas-hot_water-electric.rb": {
+    "start": 1534426329,
+    "end": 1534426402,
+    "total": 73
+  },
+  "ci_test_files/test_necb_hvac_system_6_fuel_oil2-electric-scroll-electric-af_or_bi_rdg_fancurve.rb": {
+    "start": 1534426329,
+    "end": 1534426396,
+    "total": 67
+  },
+  "ci_test_files/test_necb_hvac_system_6_electricity-electric-scroll-hot_water-fc_inletvanes.rb": {
+    "start": 1534426330,
+    "end": 1534426401,
+    "total": 71
+  },
+  "ci_test_files/doe_test_bldg_small_hotel-doe_ref_pre_1980-ashrae_169_2006_3_b.rb": {
+    "start": 1534426332,
+    "end": 1534426401,
+    "total": 69
+  },
+  "ci_test_files/test_necb_bldg_RetailStandalone_NECB2011_electric.rb": {
+    "start": 1534426333,
+    "end": 1534426382,
+    "total": 49
+  },
+  "necb/test_remove_duplicate_materials_and_constructions.rb": {
+    "start": 1534426334,
+    "end": 1534426342,
+    "total": 8
+  },
+  "90_1_prm/test_create_performance_rating_method_baseline_bldg_11.rb": {
+    "start": 1534426337,
+    "end": 1534426656,
+    "total": 319
+  },
+  "ci_test_files/doe_test_bldg_secondary_school-doe_ref_1980_2004-ashrae_169_2006_3_b.rb": {
+    "start": 1534426337,
+    "end": 1534426394,
+    "total": 57
+  },
+  "ci_test_files/test_necb_bldg_SmallHotel_NECB2011_gas.rb": {
+    "start": 1534426338,
+    "end": 1534426486,
+    "total": 148
+  },
+  "ci_test_files/doe_test_bldg_large_office-doe_ref_1980_2004-ashrae_169_2006_3_b.rb": {
+    "start": 1534426341,
+    "end": 1534426373,
+    "total": 32
+  },
+  "necb/test_necb_chiller_rules.rb": {
+    "start": 1534426342,
+    "end": 1534427123,
+    "total": 781
+  },
+  "ci_test_files/test_necb_hvac_system_3_electricity-electric-dx.rb": {
+    "start": 1534426343,
+    "end": 1534426409,
+    "total": 66
+  },
+  "ci_test_files/doe_test_bldg_small_office-doe_ref_1980_2004-ashrae_169_2006_3_b.rb": {
+    "start": 1534426345,
+    "end": 1534426372,
+    "total": 27
+  },
+  "ci_test_files/doe_test_bldg_midrise_apartment-doe_ref_pre_1980-ashrae_169_2006_2_a.rb": {
+    "start": 1534426345,
+    "end": 1534426388,
+    "total": 43
+  },
+  "ci_test_files/doe_test_add_hvac_systems_pvav_reheat-district_heating-district_heating-district_cooling.rb": {
+    "start": 1534426346,
+    "end": 1534426411,
+    "total": 65
+  },
+  "ci_test_files/doe_test_bldg_large_hotel-90.1_2010-ashrae_169_2006_3_b.rb": {
+    "start": 1534426347,
+    "end": 1534426389,
+    "total": 42
+  },
+  "ci_test_files/test_necb_bldg_Warehouse_NECB2011_electric.rb": {
+    "start": 1534426347,
+    "end": 1534426396,
+    "total": 49
+  },
+  "ci_test_files/test_necb_hvac_system_7_fuel_oil2-rotary_screw-dx.rb": {
+    "start": 1534426355,
+    "end": 1534426443,
+    "total": 88
+  },
+  "doe_prototype/test_space_type_hash.rb": {
+    "start": 1534426360,
+    "end": 1534426368,
+    "total": 8
+  },
+  "ci_test_files/doe_test_bldg_hospital-90.1_2010-ashrae_169_2006_3_b.rb": {
+    "start": 1534426362,
+    "end": 1534426424,
+    "total": 62
+  },
+  "ci_test_files/doe_test_add_hvac_systems_ground_source_heat_pumps_with_doas-electricity-electricity-electricity.rb": {
+    "start": 1534426368,
+    "end": 1534426543,
+    "total": 175
+  },
+  "ci_test_files/doe_test_bldg_small_office-doe_ref_1980_2004-ashrae_169_2006_5_a.rb": {
+    "start": 1534426369,
+    "end": 1534426397,
+    "total": 28
+  },
+  "ci_test_files/test_necb_bldg_Outpatient_NECB2011_gas.rb": {
+    "start": 1534426372,
+    "end": 1534426751,
+    "total": 379
+  },
+  "necb/test_necb_fan_rules.rb": {
+    "start": 1534426372,
+    "end": 1534426482,
+    "total": 110
+  },
+  "ci_test_files/test_necb_hvac_system_6_natural_gas-electric-scroll-hot_water-fc_inletvanes.rb": {
+    "start": 1534426373,
+    "end": 1534426444,
+    "total": 71
+  },
+  "90_1_general/test_find_construction_properties_data.rb": {
+    "start": 1534426373,
+    "end": 1534426380,
+    "total": 7
+  },
+  "ci_test_files/test_necb_hvac_system_7_natural_gas-scroll-hydronic.rb": {
+    "start": 1534426380,
+    "end": 1534426470,
+    "total": 90
+  },
+  "ci_test_files/test_necb_bldg_HighriseApartment_NECB2015_electric.rb": {
+    "start": 1534426382,
+    "end": 1534426584,
+    "total": 202
+  },
+  "ci_test_files/test_necb_hvac_system_2_fuel_oil2-reciprocating-dx.rb": {
+    "start": 1534426388,
+    "end": 1534426474,
+    "total": 86
+  },
+  "necb/test_necb_heatpump_rules.rb": {
+    "start": 1534426388,
+    "end": 1534426612,
+    "total": 224
+  },
+  "ci_test_files/test_necb_hvac_system_2_electricity-rotary_screw-hydronic.rb": {
+    "start": 1534426388,
+    "end": 1534426477,
+    "total": 89
+  },
+  "ci_test_files/test_necb_hvac_system_2_fuel_oil2-rotary_screw-hydronic.rb": {
+    "start": 1534426389,
+    "end": 1534426478,
+    "total": 89
+  },
+  "90_1_prm/test_create_performance_rating_method_baseline_building.rb": {
+    "start": 1534426393,
+    "end": 1534426404,
+    "total": 11
+  },
+  "ci_test_files/doe_test_bldg_large_hotel-doe_ref_pre_1980-ashrae_169_2006_5_a.rb": {
+    "start": 1534426394,
+    "end": 1534426439,
+    "total": 45
+  },
+  "ci_test_files/doe_test_bldg_small_hotel-90.1_2010-ashrae_169_2006_4_a.rb": {
+    "start": 1534426396,
+    "end": 1534426458,
+    "total": 62
+  },
+  "ci_test_files/doe_test_add_hvac_systems_ground_source_heat_pumps_with_doas-electricity-nil-electricity.rb": {
+    "start": 1534426396,
+    "end": 1534426572,
+    "total": 176
+  },
+  "ci_test_files/test_necb_hvac_system_6_natural_gas-hot_water-scroll-electric-var_speed_drive.rb": {
+    "start": 1534426396,
+    "end": 1534426465,
+    "total": 69
+  },
+  "ci_test_files/doe_test_bldg_retail_standalone-doe_ref_pre_1980-ashrae_169_2006_3_b.rb": {
+    "start": 1534426397,
+    "end": 1534426423,
+    "total": 26
+  },
+  "ci_test_files/doe_test_bldg_small_office-90.1_2010-ashrae_169_2006_2_a.rb": {
+    "start": 1534426398,
+    "end": 1534426427,
+    "total": 29
+  },
+  "ci_test_files/doe_test_bldg_super_market-90.1_2004-ashrae_169_2006_4_a.rb": {
+    "start": 1534426401,
+    "end": 1534426441,
+    "total": 40
+  },
+  "ci_test_files/doe_test_bldg_medium_office-90.1_2010-ashrae_169_2006_5_a.rb": {
+    "start": 1534426401,
+    "end": 1534426433,
+    "total": 32
+  },
+  "ci_test_files/test_necb_hvac_system_3_fuel_oil2-hot_water-electric.rb": {
+    "start": 1534426402,
+    "end": 1534426473,
+    "total": 71
+  },
+  "ci_test_files/test_necb_hvac_system_7_fuel_oil2-centrifugal-dx.rb": {
+    "start": 1534426403,
+    "end": 1534426491,
+    "total": 88
+  },
+  "ci_test_files/test_necb_hvac_system_6_fuel_oil2-hot_water-scroll-electric-af_or_bi_rdg_fancurve.rb": {
+    "start": 1534426404,
+    "end": 1534426474,
+    "total": 70
+  },
+  "ci_test_files/doe_test_bldg_midrise_apartment-90.1_2010-ashrae_169_2006_5_a.rb": {
+    "start": 1534426409,
+    "end": 1534426453,
+    "total": 44
+  },
+  "ci_test_files/doe_test_bldg_primary_school-doe_ref_pre_1980-ashrae_169_2006_5_a.rb": {
+    "start": 1534426411,
+    "end": 1534426450,
+    "total": 39
+  },
+  "ci_test_files/test_necb_hvac_system_6_electricity-hot_water-scroll-hot_water-af_or_bi_rdg_fancurve.rb": {
+    "start": 1534426412,
+    "end": 1534426484,
+    "total": 72
+  },
+  "ci_test_files/test_necb_bldg_FullServiceRestaurant_NECB2015_gas.rb": {
+    "start": 1534426418,
+    "end": 1534426482,
+    "total": 64
+  },
+  "ci_test_files/test_necb_hvac_system_1-electricity-true-electric-hot_water.rb": {
+    "start": 1534426423,
+    "end": 1534426489,
+    "total": 66
+  },
+  "ci_test_files/doe_test_bldg_retail_stripmall-doe_ref_pre_1980-ashrae_169_2006_5_a.rb": {
+    "start": 1534426424,
+    "end": 1534426453,
+    "total": 29
+  },
+  "ci_test_files/doe_test_add_hvac_systems_fan_coil_with_doas-district_heating-nil-electricity.rb": {
+    "start": 1534426427,
+    "end": 1534426544,
+    "total": 117
+  },
+  "ci_test_files/doe_test_bldg_super_market-90.1_2007-ashrae_169_2006_2_a.rb": {
+    "start": 1534426433,
+    "end": 1534426473,
+    "total": 40
+  },
+  "ci_test_files/doe_test_bldg_super_market-90.1_2010-ashrae_169_2006_2_a.rb": {
+    "start": 1534426439,
+    "end": 1534426481,
+    "total": 42
+  },
+  "ci_test_files/test_necb_hvac_system_7_fuel_oil2-rotary_screw-hydronic.rb": {
+    "start": 1534426441,
+    "end": 1534426529,
+    "total": 88
+  },
+  "ci_test_files/test_necb_hvac_system_6_electricity-electric-scroll-hot_water-var_speed_drive.rb": {
+    "start": 1534426443,
+    "end": 1534426514,
+    "total": 71
+  },
+  "ci_test_files/test_necb_bldg_LargeHotel_NECB2015_gas.rb": {
+    "start": 1534426444,
+    "end": 1534426563,
+    "total": 119
+  },
+  "ci_test_files/test_necb_hvac_system_1-fuel_oil2-false-hot_water-hot_water.rb": {
+    "start": 1534426450,
+    "end": 1534426512,
+    "total": 62
+  },
+  "ci_test_files/test_necb_hvac_system_3_fuel_oil2-hot_water-dx.rb": {
+    "start": 1534426453,
+    "end": 1534426522,
+    "total": 69
+  },
+  "ci_test_files/doe_test_bldg_warehouse-90.1_2010-ashrae_169_2006_2_a.rb": {
+    "start": 1534426453,
+    "end": 1534426482,
+    "total": 29
+  },
+  "ci_test_files/test_necb_hvac_system_6_electricity-electric-scroll-electric-af_or_bi_rdg_fancurve.rb": {
+    "start": 1534426458,
+    "end": 1534426524,
+    "total": 66
+  },
+  "ci_test_files/doe_test_add_hvac_systems_pthp-electricity-nil-electricity.rb": {
+    "start": 1534426465,
+    "end": 1534426517,
+    "total": 52
+  },
+  "ci_test_files/doe_test_bldg_quick_service_restaurant-doe_ref_1980_2004-ashrae_169_2006_5_a.rb": {
+    "start": 1534426470,
+    "end": 1534426497,
+    "total": 27
+  },
+  "ci_test_files/test_necb_hvac_system_4_natural_gas-hot_water-electric.rb": {
+    "start": 1534426473,
+    "end": 1534426544,
+    "total": 71
+  },
+  "ci_test_files/doe_test_bldg_full_service_restaurant-90.1_2010-ashrae_169_2006_4_a.rb": {
+    "start": 1534426473,
+    "end": 1534426501,
+    "total": 28
+  },
+  "ci_test_files/doe_test_add_hvac_systems_vav_pfp_boxes-electricity-electricity-electricity.rb": {
+    "start": 1534426474,
+    "end": 1534426562,
+    "total": 88
+  },
+  "90_1_prm/test_create_performance_rating_method_baseline_bldg_13.rb": {
+    "start": 1534426474,
+    "end": 1534426524,
+    "total": 50
+  },
+  "ci_test_files/test_necb_bldg_SmallHotel_NECB2015_electric.rb": {
+    "start": 1534426477,
+    "end": 1534426696,
+    "total": 219
+  },
+  "ci_test_files/test_necb_hvac_system_7_electricity-scroll-hydronic.rb": {
+    "start": 1534426478,
+    "end": 1534426568,
+    "total": 90
+  },
+  "ci_test_files/test_necb_bldg_LargeOffice_NECB2015_electric.rb": {
+    "start": 1534426481,
+    "end": 1534426572,
+    "total": 91
+  },
+  "ci_test_files/test_necb_bldg_RetailStandalone_NECB2015_electric.rb": {
+    "start": 1534426482,
+    "end": 1534426552,
+    "total": 70
+  },
+  "ci_test_files/doe_test_bldg_small_office-doe_ref_1980_2004-ashrae_169_2006_4_a.rb": {
+    "start": 1534426482,
+    "end": 1534426510,
+    "total": 28
+  },
+  "ci_test_files/doe_test_bldg_retail_stripmall-90.1_2010-ashrae_169_2006_2_a.rb": {
+    "start": 1534426482,
+    "end": 1534426517,
+    "total": 35
+  },
+  "ci_test_files/test_necb_bldg_Outpatient_NECB2015_electric.rb": {
+    "start": 1534426484,
+    "end": 1534426984,
+    "total": 500
+  },
+  "ci_test_files/test_necb_hvac_system_1-electricity-true-hot_water-electric.rb": {
+    "start": 1534426486,
+    "end": 1534426551,
+    "total": 65
+  },
+  "ci_test_files/test_necb_bldg_SmallOffice_NECB2011_electric.rb": {
+    "start": 1534426489,
+    "end": 1534426538,
+    "total": 49
+  },
+  "ci_test_files/doe_test_bldg_outpatient-doe_ref_pre_1980-ashrae_169_2006_5_a.rb": {
+    "start": 1534426491,
+    "end": 1534426574,
+    "total": 83
+  },
+  "ci_test_files/test_necb_bldg_SmallOffice_NECB2015_electric.rb": {
+    "start": 1534426497,
+    "end": 1534426565,
+    "total": 68
+  },
+  "ci_test_files/test_necb_bldg_MidriseApartment_NECB2011_electric.rb": {
+    "start": 1534426501,
+    "end": 1534426561,
+    "total": 60
+  },
+  "ci_test_files/doe_test_bldg_small_hotel-doe_ref_1980_2004-ashrae_169_2006_4_a.rb": {
+    "start": 1534426510,
+    "end": 1534426581,
+    "total": 71
+  },
+  "ci_test_files/doe_test_bldg_medium_office-90.1_2010-ashrae_169_2006_3_b.rb": {
+    "start": 1534426512,
+    "end": 1534426544,
+    "total": 32
+  },
+  "ci_test_files/doe_test_bldg_small_hotel-doe_ref_pre_1980-ashrae_169_2006_5_a.rb": {
+    "start": 1534426514,
+    "end": 1534426582,
+    "total": 68
+  },
+  "ci_test_files/test_necb_hvac_system_2_natural_gas-scroll-dx.rb": {
+    "start": 1534426517,
+    "end": 1534426604,
+    "total": 87
+  },
+  "ci_test_files/test_necb_bldg_LargeHotel_NECB2015_electric.rb": {
+    "start": 1534426517,
+    "end": 1534426634,
+    "total": 117
+  },
+  "ci_test_files/doe_test_bldg_outpatient-doe_ref_pre_1980-ashrae_169_2006_4_a.rb": {
+    "start": 1534426522,
+    "end": 1534426602,
+    "total": 80
+  },
+  "ci_test_files/test_necb_bldg_HighriseApartment_NECB2011_electric.rb": {
+    "start": 1534426524,
+    "end": 1534426663,
+    "total": 139
+  },
+  "90_1_prm/test_create_performance_rating_method_baseline_bldg_4.rb": {
+    "start": 1534426524,
+    "end": 1534426529,
+    "total": 5
+  },
+  "ci_test_files/test_necb_hvac_system_7_electricity-reciprocating-dx.rb": {
+    "start": 1534426529,
+    "end": 1534426617,
+    "total": 88
+  },
+  "ci_test_files/test_necb_hvac_system_6_electricity-hot_water-scroll-hot_water-fc_inletvanes.rb": {
+    "start": 1534426529,
+    "end": 1534426602,
+    "total": 73
+  },
+  "ci_test_files/test_necb_hvac_system_1-fuel_oil2-false-electric-hot_water.rb": {
+    "start": 1534426538,
+    "end": 1534426600,
+    "total": 62
+  },
+  "ci_test_files/test_necb_hvac_system_6_natural_gas-hot_water-scroll-hot_water-af_or_bi_rdg_fancurve.rb": {
+    "start": 1534426543,
+    "end": 1534426616,
+    "total": 73
+  },
+  "ci_test_files/test_necb_hvac_system_1-fuel_oil2-false-electric-electric.rb": {
+    "start": 1534426544,
+    "end": 1534426601,
+    "total": 57
+  },
+  "ci_test_files/doe_test_add_hvac_systems_fan_coil_with_doas-district_heating-district_heating-electricity.rb": {
+    "start": 1534426544,
+    "end": 1534426660,
+    "total": 116
+  },
+  "ci_test_files/test_necb_hvac_system_1-electricity-false-hot_water-electric.rb": {
+    "start": 1534426544,
+    "end": 1534426602,
+    "total": 58
+  },
+  "ci_test_files/doe_test_bldg_hospital-90.1_2010-ashrae_169_2006_5_a.rb": {
+    "start": 1534426551,
+    "end": 1534426619,
+    "total": 68
+  },
+  "ci_test_files/doe_test_bldg_outpatient-doe_ref_1980_2004-ashrae_169_2006_4_a.rb": {
+    "start": 1534426552,
+    "end": 1534426635,
+    "total": 83
+  },
+  "ci_test_files/doe_test_bldg_retail_standalone-doe_ref_pre_1980-ashrae_169_2006_2_a.rb": {
+    "start": 1534426561,
+    "end": 1534426588,
+    "total": 27
+  },
+  "ci_test_files/doe_test_add_hvac_systems_water_source_heat_pumps_with_doas-natural_gas-nil-electricity.rb": {
+    "start": 1534426562,
+    "end": 1534426736,
+    "total": 174
+  },
+  "ci_test_files/doe_test_bldg_warehouse-doe_ref_pre_1980-ashrae_169_2006_2_a.rb": {
+    "start": 1534426563,
+    "end": 1534426591,
+    "total": 28
+  },
+  "ci_test_files/doe_test_bldg_warehouse-doe_ref_pre_1980-ashrae_169_2006_5_a.rb": {
+    "start": 1534426565,
+    "end": 1534426593,
+    "total": 28
+  },
+  "necb/test_necb_coolingtower_rules.rb": {
+    "start": 1534426568,
+    "end": 1534426899,
+    "total": 331
+  },
+  "ci_test_files/doe_test_bldg_warehouse-90.1_2010-ashrae_169_2006_5_a.rb": {
+    "start": 1534426572,
+    "end": 1534426600,
+    "total": 28
+  },
+  "ci_test_files/doe_test_bldg_super_market-90.1_2007-ashrae_169_2006_3_b.rb": {
+    "start": 1534426572,
+    "end": 1534426613,
+    "total": 41
+  },
+  "ci_test_files/doe_test_bldg_highrise_apartment-90.1_2010-ashrae_169_2006_2_a.rb": {
+    "start": 1534426574,
+    "end": 1534426867,
+    "total": 293
+  },
+  "ci_test_files/test_necb_bldg_QuickServiceRestaurant_NECB2011_electric.rb": {
+    "start": 1534426581,
+    "end": 1534426625,
+    "total": 44
+  },
+  "ci_test_files/test_necb_bldg_FullServiceRestaurant_NECB2011_electric.rb": {
+    "start": 1534426582,
+    "end": 1534426626,
+    "total": 44
+  },
+  "ci_test_files/doe_test_bldg_secondary_school-90.1_2010-ashrae_169_2006_2_a.rb": {
+    "start": 1534426584,
+    "end": 1534426645,
+    "total": 61
+  },
+  "ci_test_files/test_necb_hvac_system_3_natural_gas-hot_water-gas.rb": {
+    "start": 1534426588,
+    "end": 1534426660,
+    "total": 72
+  },
+  "ci_test_files/test_necb_bldg_QuickServiceRestaurant_NECB2015_gas.rb": {
+    "start": 1534426591,
+    "end": 1534426655,
+    "total": 64
+  },
+  "ci_test_files/doe_test_bldg_outpatient-doe_ref_pre_1980-ashrae_169_2006_2_a.rb": {
+    "start": 1534426593,
+    "end": 1534426675,
+    "total": 82
+  },
+  "ci_test_files/test_necb_bldg_LargeHotel_NECB2011_electric.rb": {
+    "start": 1534426600,
+    "end": 1534426691,
+    "total": 91
+  },
+  "ci_test_files/doe_test_add_hvac_systems_fan_coil_with_doas-electricity-electricity-district_cooling.rb": {
+    "start": 1534426600,
+    "end": 1534426712,
+    "total": 112
+  },
+  "ci_test_files/doe_test_bldg_large_office-doe_ref_pre_1980-ashrae_169_2006_4_a.rb": {
+    "start": 1534426601,
+    "end": 1534426634,
+    "total": 33
+  },
+  "ci_test_files/doe_test_bldg_hospital-doe_ref_1980_2004-ashrae_169_2006_2_a.rb": {
+    "start": 1534426602,
+    "end": 1534426660,
+    "total": 58
+  },
+  "ci_test_files/test_necb_hvac_system_1-electricity-true-hot_water-hot_water.rb": {
+    "start": 1534426602,
+    "end": 1534426669,
+    "total": 67
+  },
+  "ci_test_files/doe_test_add_hvac_systems_fan_coil_with_doas-natural_gas-nil-electricity.rb": {
+    "start": 1534426602,
+    "end": 1534426722,
+    "total": 120
+  },
+  "ci_test_files/doe_test_bldg_super_market-90.1_2010-ashrae_169_2006_3_b.rb": {
+    "start": 1534426604,
+    "end": 1534426645,
+    "total": 41
+  },
+  "ci_test_files/doe_test_bldg_large_office-90.1_2010-ashrae_169_2006_3_b.rb": {
+    "start": 1534426612,
+    "end": 1534426656,
+    "total": 44
+  },
+  "ci_test_files/doe_test_bldg_full_service_restaurant-doe_ref_1980_2004-ashrae_169_2006_4_a.rb": {
+    "start": 1534426613,
+    "end": 1534426640,
+    "total": 27
+  },
+  "ci_test_files/test_necb_hvac_system_3_natural_gas-hot_water-dx.rb": {
+    "start": 1534426616,
+    "end": 1534426685,
+    "total": 69
+  },
+  "ci_test_files/test_necb_hvac_system_6_natural_gas-electric-scroll-hot_water-af_or_bi_rdg_fancurve.rb": {
+    "start": 1534426617,
+    "end": 1534426688,
+    "total": 71
+  },
+  "doe_prototype/test_effective_num_stories.rb": {
+    "start": 1534426619,
+    "end": 1534426630,
+    "total": 11
+  },
+  "ci_test_files/test_necb_hvac_system_7_natural_gas-centrifugal-hydronic.rb": {
+    "start": 1534426625,
+    "end": 1534426715,
+    "total": 90
+  },
+  "ci_test_files/doe_test_bldg_hospital-doe_ref_1980_2004-ashrae_169_2006_4_a.rb": {
+    "start": 1534426626,
+    "end": 1534426688,
+    "total": 62
+  },
+  "ci_test_files/doe_test_bldg_hospital-90.1_2007-ashrae_169_2006_2_a.rb": {
+    "start": 1534426630,
+    "end": 1534426689,
+    "total": 59
+  },
+  "ci_test_files/doe_test_bldg_retail_stripmall-90.1_2010-ashrae_169_2006_5_a.rb": {
+    "start": 1534426631,
+    "end": 1534426666,
+    "total": 35
+  },
+  "ci_test_files/doe_test_bldg_highrise_apartment-90.1_2013-ashrae_169_2006_2_a.rb": {
+    "start": 1534426634,
+    "end": 1534426944,
+    "total": 310
+  },
+  "ci_test_files/doe_test_bldg_medium_office-doe_ref_1980_2004-ashrae_169_2006_2_a.rb": {
+    "start": 1534426634,
+    "end": 1534426665,
+    "total": 31
+  },
+  "ci_test_files/doe_test_bldg_super_market-doe_ref_1980_2004-ashrae_169_2006_4_a.rb": {
+    "start": 1534426635,
+    "end": 1534426676,
+    "total": 41
+  },
+  "90_1_prm/test_create_performance_rating_method_baseline_bldg_5.rb": {
+    "start": 1534426640,
+    "end": 1534426688,
+    "total": 48
+  },
+  "necb/test_necb_default_spacetypes.rb": {
+    "start": 1534426645,
+    "end": 1534426727,
+    "total": 82
+  },
+  "ci_test_files/doe_test_bldg_quick_service_restaurant-90.1_2010-ashrae_169_2006_2_a.rb": {
+    "start": 1534426645,
+    "end": 1534426673,
+    "total": 28
+  },
+  "ci_test_files/doe_test_bldg_medium_office-doe_ref_1980_2004-ashrae_169_2006_5_a.rb": {
+    "start": 1534426655,
+    "end": 1534426687,
+    "total": 32
+  },
+  "ci_test_files/test_necb_hvac_system_2_electricity-centrifugal-hydronic.rb": {
+    "start": 1534426656,
+    "end": 1534426747,
+    "total": 91
+  },
+  "ci_test_files/doe_test_bldg_hospital-90.1_2004-ashrae_169_2006_4_a.rb": {
+    "start": 1534426656,
+    "end": 1534426719,
+    "total": 63
+  },
+  "ci_test_files/test_necb_hvac_system_3_electricity-electric-gas.rb": {
+    "start": 1534426660,
+    "end": 1534426727,
+    "total": 67
+  },
+  "ci_test_files/test_necb_bldg_LargeOffice_NECB2011_electric.rb": {
+    "start": 1534426660,
+    "end": 1534426723,
+    "total": 63
+  },
+  "ci_test_files/doe_test_bldg_secondary_school-doe_ref_pre_1980-ashrae_169_2006_5_a.rb": {
+    "start": 1534426660,
+    "end": 1534426710,
+    "total": 50
+  },
+  "ci_test_files/test_necb_hvac_system_1-natural_gas-false-hot_water-hot_water.rb": {
+    "start": 1534426663,
+    "end": 1534426725,
+    "total": 62
+  },
+  "ci_test_files/doe_test_bldg_secondary_school-doe_ref_1980_2004-ashrae_169_2006_2_a.rb": {
+    "start": 1534426665,
+    "end": 1534426715,
+    "total": 50
+  },
+  "90_1_general/test_get_building_climate_zone_and_building_type.rb": {
+    "start": 1534426666,
+    "end": 1534426671,
+    "total": 5
+  },
+  "ci_test_files/doe_test_bldg_secondary_school-90.1_2010-ashrae_169_2006_5_a.rb": {
+    "start": 1534426669,
+    "end": 1534426792,
+    "total": 123
+  },
+  "ci_test_files/test_necb_bldg_Outpatient_NECB2015_gas.rb": {
+    "start": 1534426671,
+    "end": 1534427228,
+    "total": 557
+  },
+  "ci_test_files/doe_test_bldg_full_service_restaurant-doe_ref_pre_1980-ashrae_169_2006_3_b.rb": {
+    "start": 1534426673,
+    "end": 1534426700,
+    "total": 27
+  },
+  "ci_test_files/test_necb_hvac_system_6_electricity-hot_water-scroll-electric-af_or_bi_inletvanes.rb": {
+    "start": 1534426675,
+    "end": 1534426745,
+    "total": 70
+  },
+  "ci_test_files/test_necb_hvac_system_3_fuel_oil2-electric-electric.rb": {
+    "start": 1534426676,
+    "end": 1534426743,
+    "total": 67
+  },
+  "ci_test_files/test_necb_hvac_system_6_fuel_oil2-hot_water-scroll-electric-af_or_bi_inletvanes.rb": {
+    "start": 1534426685,
+    "end": 1534426756,
+    "total": 71
+  },
+  "ci_test_files/doe_test_bldg_midrise_apartment-doe_ref_pre_1980-ashrae_169_2006_4_a.rb": {
+    "start": 1534426687,
+    "end": 1534426731,
+    "total": 44
+  },
+  "ci_test_files/doe_test_bldg_quick_service_restaurant-doe_ref_1980_2004-ashrae_169_2006_4_a.rb": {
+    "start": 1534426688,
+    "end": 1534426715,
+    "total": 27
+  },
+  "90_1_prm/test_create_performance_rating_method_baseline_bldg_10.rb": {
+    "start": 1534426688,
+    "end": 1534426731,
+    "total": 43
+  },
+  "ci_test_files/test_necb_bldg_RetailStripmall_NECB2015_electric.rb": {
+    "start": 1534426688,
+    "end": 1534426773,
+    "total": 85
+  },
+  "ci_test_files/doe_test_bldg_midrise_apartment-90.1_2010-ashrae_169_2006_3_b.rb": {
+    "start": 1534426689,
+    "end": 1534426733,
+    "total": 44
+  },
+  "ci_test_files/test_necb_hvac_system_6_electricity-electric-scroll-electric-var_speed_drive.rb": {
+    "start": 1534426691,
+    "end": 1534426758,
+    "total": 67
+  },
+  "ci_test_files/doe_test_bldg_small_office-doe_ref_1980_2004-ashrae_169_2006_2_a.rb": {
+    "start": 1534426696,
+    "end": 1534426724,
+    "total": 28
+  },
+  "ci_test_files/doe_test_bldg_full_service_restaurant-90.1_2010-ashrae_169_2006_3_b.rb": {
+    "start": 1534426700,
+    "end": 1534426728,
+    "total": 28
+  },
+  "ci_test_files/doe_test_bldg_small_office-90.1_2010-ashrae_169_2006_5_a.rb": {
+    "start": 1534426710,
+    "end": 1534426740,
+    "total": 30
+  },
+  "ci_test_files/test_necb_hvac_system_3_electricity-hot_water-gas.rb": {
+    "start": 1534426712,
+    "end": 1534426786,
+    "total": 74
+  },
+  "ci_test_files/test_necb_hvac_system_3_electricity-hot_water-dx.rb": {
+    "start": 1534426715,
+    "end": 1534426786,
+    "total": 71
+  },
+  "ci_test_files/doe_test_bldg_retail_stripmall-doe_ref_1980_2004-ashrae_169_2006_5_a.rb": {
+    "start": 1534426715,
+    "end": 1534426745,
+    "total": 30
+  },
+  "ci_test_files/test_necb_hvac_system_3_fuel_oil2-electric-dx.rb": {
+    "start": 1534426715,
+    "end": 1534426781,
+    "total": 66
+  },
+  "ci_test_files/test_necb_hvac_system_6_fuel_oil2-electric-scroll-hot_water-af_or_bi_rdg_fancurve.rb": {
+    "start": 1534426719,
+    "end": 1534426792,
+    "total": 73
+  },
+  "ci_test_files/test_necb_hvac_system_2_fuel_oil2-scroll-dx.rb": {
+    "start": 1534426722,
+    "end": 1534426812,
+    "total": 90
+  },
+  "ci_test_files/test_necb_hvac_system_6_natural_gas-electric-scroll-electric-af_or_bi_inletvanes.rb": {
+    "start": 1534426723,
+    "end": 1534426791,
+    "total": 68
+  },
+  "ci_test_files/doe_test_add_hvac_systems_fan_coil_with_er_vs-district_heating-nil-district_cooling.rb": {
+    "start": 1534426724,
+    "end": 1534426824,
+    "total": 100
+  },
+  "ci_test_files/test_necb_hvac_system_4_natural_gas-hot_water-gas.rb": {
+    "start": 1534426725,
+    "end": 1534426798,
+    "total": 73
+  },
+  "ci_test_files/doe_test_bldg_large_hotel-doe_ref_1980_2004-ashrae_169_2006_2_a.rb": {
+    "start": 1534426727,
+    "end": 1534426767,
+    "total": 40
+  },
+  "ci_test_files/doe_test_bldg_super_market-90.1_2013-ashrae_169_2006_5_a.rb": {
+    "start": 1534426727,
+    "end": 1534426771,
+    "total": 44
+  },
+  "necb/test_necb_unitary_rules.rb": {
+    "start": 1534426728,
+    "end": 1534427342,
+    "total": 614
+  },
+  "ci_test_files/doe_test_bldg_retail_standalone-90.1_2010-ashrae_169_2006_2_a.rb": {
+    "start": 1534426731,
+    "end": 1534426760,
+    "total": 29
+  },
+  "90_1_general/test_coil_dx.rb": {
+    "start": 1534426731,
+    "end": 1534426739,
+    "total": 8
+  },
+  "ci_test_files/doe_test_bldg_quick_service_restaurant-doe_ref_pre_1980-ashrae_169_2006_3_b.rb": {
+    "start": 1534426733,
+    "end": 1534426760,
+    "total": 27
+  },
+  "ci_test_files/test_necb_hvac_system_6_fuel_oil2-hot_water-scroll-electric-var_speed_drive.rb": {
+    "start": 1534426736,
+    "end": 1534426809,
+    "total": 73
+  },
+  "ci_test_files/test_necb_bldg_Hospital_NECB2015_electric.rb": {
+    "start": 1534426739,
+    "end": 1534427123,
+    "total": 384
+  },
+  "ci_test_files/doe_test_bldg_full_service_restaurant-doe_ref_pre_1980-ashrae_169_2006_4_a.rb": {
+    "start": 1534426740,
+    "end": 1534426767,
+    "total": 27
+  },
+  "ci_test_files/doe_test_bldg_primary_school-doe_ref_1980_2004-ashrae_169_2006_5_a.rb": {
+    "start": 1534426743,
+    "end": 1534426783,
+    "total": 40
+  },
+  "ci_test_files/test_necb_hvac_system_1-natural_gas-true-electric-electric.rb": {
+    "start": 1534426745,
+    "end": 1534426808,
+    "total": 63
+  },
+  "ci_test_files/doe_test_add_hvac_systems_vav_reheat-district_heating-district_heating-electricity.rb": {
+    "start": 1534426745,
+    "end": 1534426838,
+    "total": 93
+  },
+  "ci_test_files/doe_test_bldg_quick_service_restaurant-doe_ref_pre_1980-ashrae_169_2006_2_a.rb": {
+    "start": 1534426747,
+    "end": 1534426774,
+    "total": 27
+  },
+  "ci_test_files/test_necb_bldg_QuickServiceRestaurant_NECB2011_gas.rb": {
+    "start": 1534426751,
+    "end": 1534426797,
+    "total": 46
+  },
+  "ci_test_files/doe_test_bldg_full_service_restaurant-doe_ref_1980_2004-ashrae_169_2006_2_a.rb": {
+    "start": 1534426756,
+    "end": 1534426783,
+    "total": 27
+  },
+  "ci_test_files/doe_test_bldg_retail_standalone-doe_ref_pre_1980-ashrae_169_2006_5_a.rb": {
+    "start": 1534426758,
+    "end": 1534426785,
+    "total": 27
+  },
+  "ci_test_files/test_necb_hvac_system_1-natural_gas-false-hot_water-electric.rb": {
+    "start": 1534426760,
+    "end": 1534426819,
+    "total": 59
+  },
+  "ci_test_files/test_necb_hvac_system_2_natural_gas-reciprocating-hydronic.rb": {
+    "start": 1534426760,
+    "end": 1534426852,
+    "total": 92
+  },
+  "ci_test_files/test_necb_hvac_system_7_fuel_oil2-centrifugal-hydronic.rb": {
+    "start": 1534426767,
+    "end": 1534426857,
+    "total": 90
+  },
+  "ci_test_files/test_necb_hvac_system_1-natural_gas-false-electric-hot_water.rb": {
+    "start": 1534426767,
+    "end": 1534426831,
+    "total": 64
+  },
+  "ci_test_files/test_necb_hvac_system_6_fuel_oil2-hot_water-scroll-hot_water-fc_inletvanes.rb": {
+    "start": 1534426771,
+    "end": 1534426846,
+    "total": 75
+  },
+  "ci_test_files/test_necb_bldg_PrimarySchool_NECB2011_gas.rb": {
+    "start": 1534426773,
+    "end": 1534426903,
+    "total": 130
+  },
+  "ci_test_files/doe_test_bldg_primary_school-doe_ref_1980_2004-ashrae_169_2006_3_b.rb": {
+    "start": 1534426774,
+    "end": 1534426813,
+    "total": 39
+  },
+  "ci_test_files/test_necb_hvac_system_7_electricity-rotary_screw-hydronic.rb": {
+    "start": 1534426781,
+    "end": 1534426874,
+    "total": 93
+  },
+  "ci_test_files/doe_test_bldg_super_market-90.1_2007-ashrae_169_2006_4_a.rb": {
+    "start": 1534426783,
+    "end": 1534426824,
+    "total": 41
+  },
+  "ci_test_files/doe_test_bldg_super_market-90.1_2010-ashrae_169_2006_5_a.rb": {
+    "start": 1534426783,
+    "end": 1534426826,
+    "total": 43
+  },
+  "ci_test_files/doe_test_bldg_midrise_apartment-doe_ref_pre_1980-ashrae_169_2006_5_a.rb": {
+    "start": 1534426785,
+    "end": 1534426829,
+    "total": 44
+  },
+  "ci_test_files/doe_test_bldg_midrise_apartment-doe_ref_1980_2004-ashrae_169_2006_5_a.rb": {
+    "start": 1534426786,
+    "end": 1534426831,
+    "total": 45
+  },
+  "ci_test_files/doe_test_bldg_warehouse-doe_ref_1980_2004-ashrae_169_2006_5_a.rb": {
+    "start": 1534426786,
+    "end": 1534426813,
+    "total": 27
+  },
+  "ci_test_files/test_necb_bldg_Warehouse_NECB2015_gas.rb": {
+    "start": 1534426791,
+    "end": 1534426862,
+    "total": 71
+  },
+  "ci_test_files/test_necb_hvac_system_1-electricity-false-hot_water-hot_water.rb": {
+    "start": 1534426792,
+    "end": 1534426855,
+    "total": 63
+  },
+  "ci_test_files/doe_test_bldg_highrise_apartment-90.1_2007-ashrae_169_2006_2_a.rb": {
+    "start": 1534426792,
+    "end": 1534427082,
+    "total": 290
+  },
+  "ci_test_files/doe_test_bldg_quick_service_restaurant-90.1_2010-ashrae_169_2006_4_a.rb": {
+    "start": 1534426797,
+    "end": 1534426824,
+    "total": 27
+  },
+  "doe_prototype/test_add_swh.rb": {
+    "start": 1534426798,
+    "end": 1534426833,
+    "total": 35
+  },
+  "ci_test_files/doe_test_bldg_primary_school-doe_ref_pre_1980-ashrae_169_2006_3_b.rb": {
+    "start": 1534426808,
+    "end": 1534426847,
+    "total": 39
+  },
+  "necb/test_necb_default_system_selection.rb": {
+    "start": 1534426809,
+    "end": 1534427163,
+    "total": 354
+  },
+  "ci_test_files/test_necb_bldg_Hospital_NECB2011_electric.rb": {
+    "start": 1534426812,
+    "end": 1534427108,
+    "total": 296
+  },
+  "ci_test_files/test_necb_hvac_system_4_electricity-hot_water-electric.rb": {
+    "start": 1534426813,
+    "end": 1534426887,
+    "total": 74
+  },
+  "ci_test_files/test_necb_hvac_system_6_electricity-electric-scroll-electric-fc_inletvanes.rb": {
+    "start": 1534426813,
+    "end": 1534426880,
+    "total": 67
+  },
+  "ci_test_files/test_necb_bldg_MediumOffice_NECB2015_electric.rb": {
+    "start": 1534426813,
+    "end": 1534426896,
+    "total": 83
+  },
+  "necb/test_necb_hrv_rules.rb": {
+    "start": 1534426819,
+    "end": 1534426851,
+    "total": 32
+  },
+  "ci_test_files/doe_test_add_hvac_systems_vav_reheat-district_heating-district_heating-district_cooling.rb": {
+    "start": 1534426824,
+    "end": 1534426890,
+    "total": 66
+  },
+  "ci_test_files/doe_test_bldg_secondary_school-doe_ref_pre_1980-ashrae_169_2006_4_a.rb": {
+    "start": 1534426824,
+    "end": 1534426873,
+    "total": 49
+  },
+  "ci_test_files/doe_test_bldg_hospital-90.1_2004-ashrae_169_2006_3_b.rb": {
+    "start": 1534426824,
+    "end": 1534426887,
+    "total": 63
+  },
+  "ci_test_files/test_necb_hvac_system_2_fuel_oil2-centrifugal-hydronic.rb": {
+    "start": 1534426826,
+    "end": 1534426919,
+    "total": 93
+  },
+  "ci_test_files/test_necb_hvac_system_1-electricity-false-electric-electric.rb": {
+    "start": 1534426829,
+    "end": 1534426888,
+    "total": 59
+  },
+  "ci_test_files/doe_test_bldg_hospital-doe_ref_pre_1980-ashrae_169_2006_2_a.rb": {
+    "start": 1534426831,
+    "end": 1534426891,
+    "total": 60
+  },
+  "ci_test_files/test_necb_hvac_system_6_electricity-hot_water-scroll-hot_water-var_speed_drive.rb": {
+    "start": 1534426831,
+    "end": 1534426907,
+    "total": 76
+  },
+  "ci_test_files/test_necb_bldg_Warehouse_NECB2011_gas.rb": {
+    "start": 1534426833,
+    "end": 1534426882,
+    "total": 49
+  },
+  "ci_test_files/doe_test_bldg_small_hotel-90.1_2010-ashrae_169_2006_5_a.rb": {
+    "start": 1534426838,
+    "end": 1534426901,
+    "total": 63
+  },
+  "ci_test_files/test_necb_hvac_system_6_fuel_oil2-electric-scroll-electric-var_speed_drive.rb": {
+    "start": 1534426846,
+    "end": 1534426913,
+    "total": 67
+  },
+  "doe_prototype/test_add_exhaust.rb": {
+    "start": 1534426847,
+    "end": 1534426883,
+    "total": 36
+  },
+  "ci_test_files/doe_test_add_hvac_systems_psz_ac-natural_gas-nil-electricity.rb": {
+    "start": 1534426851,
+    "end": 1534426909,
+    "total": 58
+  },
+  "ci_test_files/test_necb_bldg_MidriseApartment_NECB2015_electric.rb": {
+    "start": 1534426852,
+    "end": 1534426942,
+    "total": 90
+  },
+  "ci_test_files/test_necb_bldg_FullServiceRestaurant_NECB2015_electric.rb": {
+    "start": 1534426855,
+    "end": 1534426920,
+    "total": 65
+  },
+  "ci_test_files/test_necb_hvac_system_1-fuel_oil2-true-electric-hot_water.rb": {
+    "start": 1534426857,
+    "end": 1534426924,
+    "total": 67
+  },
+  "ci_test_files/doe_test_bldg_large_office-90.1_2010-ashrae_169_2006_2_a.rb": {
+    "start": 1534426862,
+    "end": 1534426904,
+    "total": 42
+  },
+  "ci_test_files/doe_test_bldg_primary_school-doe_ref_1980_2004-ashrae_169_2006_4_a.rb": {
+    "start": 1534426867,
+    "end": 1534426907,
+    "total": 40
+  },
+  "ci_test_files/doe_test_bldg_large_office-doe_ref_pre_1980-ashrae_169_2006_2_a.rb": {
+    "start": 1534426873,
+    "end": 1534426908,
+    "total": 35
+  },
+  "ci_test_files/test_necb_hvac_system_7_natural_gas-rotary_screw-dx.rb": {
+    "start": 1534426874,
+    "end": 1534426966,
+    "total": 92
+  },
+  "ci_test_files/doe_test_bldg_small_hotel-doe_ref_pre_1980-ashrae_169_2006_4_a.rb": {
+    "start": 1534426880,
+    "end": 1534426950,
+    "total": 70
+  },
+  "ci_test_files/test_necb_hvac_system_4_fuel_oil2-electric-electric.rb": {
+    "start": 1534426882,
+    "end": 1534426951,
+    "total": 69
+  },
+  "ci_test_files/test_necb_hvac_system_7_electricity-scroll-dx.rb": {
+    "start": 1534426883,
+    "end": 1534426975,
+    "total": 92
+  },
+  "ci_test_files/doe_test_bldg_small_hotel-doe_ref_1980_2004-ashrae_169_2006_3_b.rb": {
+    "start": 1534426887,
+    "end": 1534426962,
+    "total": 75
+  },
+  "ci_test_files/test_necb_hvac_system_1-natural_gas-false-electric-electric.rb": {
+    "start": 1534426887,
+    "end": 1534426946,
+    "total": 59
+  },
+  "ci_test_files/test_necb_hvac_system_6_electricity-hot_water-scroll-electric-fc_inletvanes.rb": {
+    "start": 1534426888,
+    "end": 1534426959,
+    "total": 71
+  },
+  "ci_test_files/doe_test_bldg_super_market-doe_ref_1980_2004-ashrae_169_2006_3_b.rb": {
+    "start": 1534426890,
+    "end": 1534426931,
+    "total": 41
+  },
+  "ci_test_files/test_necb_hvac_system_1-fuel_oil2-true-electric-electric.rb": {
+    "start": 1534426891,
+    "end": 1534426955,
+    "total": 64
+  },
+  "ci_test_files/doe_test_bldg_highrise_apartment-90.1_2004-ashrae_169_2006_2_a.rb": {
+    "start": 1534426896,
+    "end": 1534427182,
+    "total": 286
+  },
+  "ci_test_files/doe_test_bldg_super_market-90.1_2013-ashrae_169_2006_4_a.rb": {
+    "start": 1534426899,
+    "end": 1534426944,
+    "total": 45
+  },
+  "ci_test_files/doe_test_bldg_primary_school-doe_ref_pre_1980-ashrae_169_2006_4_a.rb": {
+    "start": 1534426901,
+    "end": 1534426940,
+    "total": 39
+  },
+  "ci_test_files/test_necb_bldg_MidriseApartment_NECB2011_gas.rb": {
+    "start": 1534426903,
+    "end": 1534426968,
+    "total": 65
+  },
+  "90_1_prm/test_create_performance_rating_method_baseline_bldg_7.rb": {
+    "start": 1534426904,
+    "end": 1534426916,
+    "total": 12
+  },
+  "ci_test_files/doe_test_bldg_large_hotel-90.1_2010-ashrae_169_2006_5_a.rb": {
+    "start": 1534426907,
+    "end": 1534426952,
+    "total": 45
+  },
+  "ci_test_files/test_necb_bldg_PrimarySchool_NECB2015_gas.rb": {
+    "start": 1534426907,
+    "end": 1534427071,
+    "total": 164
+  },
+  "ci_test_files/doe_test_bldg_warehouse-doe_ref_pre_1980-ashrae_169_2006_4_a.rb": {
+    "start": 1534426908,
+    "end": 1534426935,
+    "total": 27
+  },
+  "ci_test_files/test_necb_hvac_system_3_fuel_oil2-hot_water-gas.rb": {
+    "start": 1534426909,
+    "end": 1534426983,
+    "total": 74
+  },
+  "ci_test_files/doe_test_bldg_retail_stripmall-90.1_2010-ashrae_169_2006_3_b.rb": {
+    "start": 1534426913,
+    "end": 1534426949,
+    "total": 36
+  },
+  "ci_test_files/test_necb_hvac_system_6_natural_gas-electric-scroll-electric-var_speed_drive.rb": {
+    "start": 1534426916,
+    "end": 1534426985,
+    "total": 69
+  },
+  "ci_test_files/doe_test_bldg_large_office-90.1_2010-ashrae_169_2006_5_a.rb": {
+    "start": 1534426919,
+    "end": 1534426969,
+    "total": 50
+  },
+  "ci_test_files/test_necb_bldg_MediumOffice_NECB2011_electric.rb": {
+    "start": 1534426920,
+    "end": 1534426978,
+    "total": 58
+  },
+  "90_1_general/test_boiler_hot_water.rb": {
+    "start": 1534426924,
+    "end": 1534426929,
+    "total": 5
+  },
+  "ci_test_files/doe_test_bldg_primary_school-90.1_2010-ashrae_169_2006_2_a.rb": {
+    "start": 1534426929,
+    "end": 1534426972,
+    "total": 43
+  },
+  "ci_test_files/test_necb_hvac_system_7_fuel_oil2-scroll-hydronic.rb": {
+    "start": 1534426931,
+    "end": 1534427023,
+    "total": 92
+  },
+  "ci_test_files/doe_test_bldg_retail_stripmall-doe_ref_1980_2004-ashrae_169_2006_2_a.rb": {
+    "start": 1534426935,
+    "end": 1534426965,
+    "total": 30
+  },
+  "ci_test_files/doe_test_bldg_super_market-90.1_2007-ashrae_169_2006_5_a.rb": {
+    "start": 1534426940,
+    "end": 1534426982,
+    "total": 42
+  },
+  "ci_test_files/doe_test_add_hvac_systems_pvav_reheat-natural_gas-natural_gas-district_cooling.rb": {
+    "start": 1534426942,
+    "end": 1534427008,
+    "total": 66
+  },
+  "ci_test_files/doe_test_bldg_secondary_school-doe_ref_pre_1980-ashrae_169_2006_3_b.rb": {
+    "start": 1534426944,
+    "end": 1534426995,
+    "total": 51
+  },
+  "ci_test_files/test_necb_bldg_Hospital_NECB2011_gas.rb": {
+    "start": 1534426944,
+    "end": 1534427251,
+    "total": 307
+  },
+  "ci_test_files/doe_test_bldg_outpatient-90.1_2010-ashrae_169_2006_4_a.rb": {
+    "start": 1534426946,
+    "end": 1534427042,
+    "total": 96
+  },
+  "ci_test_files/test_necb_hvac_system_6_electricity-electric-scroll-electric-af_or_bi_inletvanes.rb": {
+    "start": 1534426949,
+    "end": 1534427016,
+    "total": 67
+  },
+  "ci_test_files/test_necb_bldg_Hospital_NECB2015_gas.rb": {
+    "start": 1534426950,
+    "end": 1534427358,
+    "total": 408
+  },
+  "ci_test_files/doe_test_bldg_medium_office-90.1_2010-ashrae_169_2006_2_a.rb": {
+    "start": 1534426951,
+    "end": 1534426982,
+    "total": 31
+  },
+  "ci_test_files/test_necb_bldg_SecondarySchool_NECB2011_electric.rb": {
+    "start": 1534426952,
+    "end": 1534427205,
+    "total": 253
+  },
+  "ci_test_files/test_necb_hvac_system_4_electricity-electric-electric.rb": {
+    "start": 1534426955,
+    "end": 1534427024,
+    "total": 69
+  },
+  "ci_test_files/doe_test_add_hvac_systems_vav_reheat-electricity-electricity-district_cooling.rb": {
+    "start": 1534426959,
+    "end": 1534427021,
+    "total": 62
+  },
+  "ci_test_files/doe_test_bldg_large_office-doe_ref_pre_1980-ashrae_169_2006_5_a.rb": {
+    "start": 1534426962,
+    "end": 1534426997,
+    "total": 35
+  },
+  "ci_test_files/test_necb_hvac_system_2_fuel_oil2-scroll-hydronic.rb": {
+    "start": 1534426965,
+    "end": 1534427058,
+    "total": 93
+  },
+  "ci_test_files/doe_test_bldg_midrise_apartment-doe_ref_1980_2004-ashrae_169_2006_2_a.rb": {
+    "start": 1534426966,
+    "end": 1534427011,
+    "total": 45
+  },
+  "ci_test_files/doe_test_add_hvac_systems_psz_ac-electricity-nil-district_cooling.rb": {
+    "start": 1534426968,
+    "end": 1534427033,
+    "total": 65
+  },
+  "ci_test_files/doe_test_add_hvac_systems_water_source_heat_pumps_with_doas-heat_pump-nil-heat_pump.rb": {
+    "start": 1534426969,
+    "end": 1534427184,
+    "total": 215
+  },
+  "ci_test_files/doe_test_bldg_quick_service_restaurant-doe_ref_1980_2004-ashrae_169_2006_3_b.rb": {
+    "start": 1534426972,
+    "end": 1534426999,
+    "total": 27
+  },
+  "ci_test_files/doe_test_bldg_quick_service_restaurant-90.1_2010-ashrae_169_2006_3_b.rb": {
+    "start": 1534426975,
+    "end": 1534427003,
+    "total": 28
+  },
+  "ci_test_files/test_necb_hvac_system_6_fuel_oil2-electric-scroll-hot_water-var_speed_drive.rb": {
+    "start": 1534426978,
+    "end": 1534427051,
+    "total": 73
+  },
+  "ci_test_files/doe_test_bldg_large_hotel-doe_ref_pre_1980-ashrae_169_2006_2_a.rb": {
+    "start": 1534426982,
+    "end": 1534427023,
+    "total": 41
+  },
+  "ci_test_files/test_necb_hvac_system_2_natural_gas-reciprocating-dx.rb": {
+    "start": 1534426982,
+    "end": 1534427072,
+    "total": 90
+  },
+  "ci_test_files/test_necb_hvac_system_6_natural_gas-hot_water-scroll-electric-af_or_bi_rdg_fancurve.rb": {
+    "start": 1534426983,
+    "end": 1534427053,
+    "total": 70
+  },
+  "ci_test_files/doe_test_bldg_quick_service_restaurant-doe_ref_pre_1980-ashrae_169_2006_4_a.rb": {
+    "start": 1534426984,
+    "end": 1534427012,
+    "total": 28
+  },
+  "ci_test_files/doe_test_bldg_super_market-90.1_2004-ashrae_169_2006_2_a.rb": {
+    "start": 1534426985,
+    "end": 1534427026,
+    "total": 41
+  },
+  "90_1_general/test_find_target_eui.rb": {
+    "start": 1534426995,
+    "end": 1534427000,
+    "total": 5
+  },
+  "ci_test_files/test_necb_hvac_system_1-natural_gas-true-hot_water-electric.rb": {
+    "start": 1534426997,
+    "end": 1534427063,
+    "total": 66
+  },
+  "ci_test_files/doe_test_bldg_large_office-doe_ref_1980_2004-ashrae_169_2006_5_a.rb": {
+    "start": 1534426999,
+    "end": 1534427034,
+    "total": 35
+  },
+  "ci_test_files/doe_test_bldg_small_hotel-doe_ref_pre_1980-ashrae_169_2006_2_a.rb": {
+    "start": 1534427000,
+    "end": 1534427070,
+    "total": 70
+  },
+  "necb/test_necb_pumppower_rules.rb": {
+    "start": 1534427003,
+    "end": 1534427060,
+    "total": 57
+  },
+  "ci_test_files/doe_test_bldg_retail_standalone-90.1_2010-ashrae_169_2006_5_a.rb": {
+    "start": 1534427008,
+    "end": 1534427037,
+    "total": 29
+  },
+  "ci_test_files/test_necb_hvac_system_2_electricity-rotary_screw-dx.rb": {
+    "start": 1534427011,
+    "end": 1534427099,
+    "total": 88
+  },
+  "ci_test_files/doe_test_bldg_hospital-doe_ref_pre_1980-ashrae_169_2006_4_a.rb": {
+    "start": 1534427012,
+    "end": 1534427072,
+    "total": 60
+  },
+  "ci_test_files/test_necb_hvac_system_4_fuel_oil2-hot_water-electric.rb": {
+    "start": 1534427016,
+    "end": 1534427087,
+    "total": 71
+  }
+}

--- a/test/test_run_all_test_locally.rb
+++ b/test/test_run_all_test_locally.rb
@@ -4,7 +4,7 @@ require 'fileutils'
 require 'parallel'
 require 'open3'
 
-TestListFile = File.join(File.dirname(__FILE__), 'circleci_tests.txt')
+TestListFile = File.join(File.dirname(__FILE__), 'local_circleci_tests.txt')
 TestOutputFolder = File.join(File.dirname(__FILE__), 'local_test_output')
 ProcessorsUsed = ( Parallel.processor_count * 2 / 3 ).floor
 

--- a/test/test_run_all_test_locally.rb
+++ b/test/test_run_all_test_locally.rb
@@ -58,6 +58,9 @@ end
 
 class RunAllTests< Minitest::Test
   def test_all()
+    require_relative './helpers/ci_test_generator'
+    CITestGenerator::generate(true)
+
     @full_file_list = nil
     FileUtils.rm_rf(TestOutputFolder)
     FileUtils.mkpath(TestOutputFolder)
@@ -75,9 +78,16 @@ class RunAllTests< Minitest::Test
 
     puts "Running #{@full_file_list.size} tests suites in parallel using #{ProcessorsUsed} of available cpus."
     puts "To increase or decrease the ProcessorsUsed, please edit the test/test_run_all_locally.rb file."
+    timings_json = Hash.new()
     Parallel.each(@full_file_list, in_threads: (ProcessorsUsed), progress: "Progress :" ) do |test_file|
+      file_name = File.basename(test_file, '.rb')
+      timings_json[test_file.to_s] = {}
+      timings_json[test_file.to_s]['start'] = Time.now.to_i
       write_results(Open3.capture3('bundle', 'exec', "ruby '#{test_file}'"), test_file)
+      timings_json[test_file.to_s]['end'] = Time.now.to_i
+      timings_json[test_file.to_s]['total'] =timings_json[test_file.to_s]['end'] - timings_json[test_file.to_s]['start']
     end
+    File.open(File.join(File.dirname(__FILE__), 'helpers', 'ci_test_helper', 'timings.json'), 'w') { |file| file.puts(JSON.pretty_generate(timings_json))}
   end
 
 end

--- a/test/test_run_all_test_locally.rb
+++ b/test/test_run_all_test_locally.rb
@@ -80,12 +80,12 @@ class RunAllTests< Minitest::Test
     puts "To increase or decrease the ProcessorsUsed, please edit the test/test_run_all_locally.rb file."
     timings_json = Hash.new()
     Parallel.each(@full_file_list, in_threads: (ProcessorsUsed), progress: "Progress :" ) do |test_file|
-      file_name = File.basename(test_file, '.rb')
-      timings_json[test_file.to_s] = {}
-      timings_json[test_file.to_s]['start'] = Time.now.to_i
+      file_name = test_file.gsub(/^.+(openstudio-standards\/test\/)/,'')
+      timings_json[file_name.to_s] = {}
+      timings_json[file_name.to_s]['start'] = Time.now.to_i
       write_results(Open3.capture3('bundle', 'exec', "ruby '#{test_file}'"), test_file)
-      timings_json[test_file.to_s]['end'] = Time.now.to_i
-      timings_json[test_file.to_s]['total'] =timings_json[test_file.to_s]['end'] - timings_json[test_file.to_s]['start']
+      timings_json[file_name.to_s]['end'] = Time.now.to_i
+      timings_json[file_name.to_s]['total'] =timings_json[file_name.to_s]['end'] - timings_json[file_name.to_s]['start']
     end
     File.open(File.join(File.dirname(__FILE__), 'helpers', 'ci_test_helper', 'timings.json'), 'w') { |file| file.puts(JSON.pretty_generate(timings_json))}
   end


### PR DESCRIPTION
Related to 
https://github.com/canmet-energy/btap_tasks/issues/126 (Investigate faulty timing data reported for CircleCI)
and  https://github.com/canmet-energy/btap_tasks/issues/127 (For local testing, modify test such that circelci_tests.txt file does not get modified)

Using the `Largest Processing Time algorithm` order the test files based on the timing data generated by running `bundle exec rake test:local-circ-all-tests`

Also while running `bundle exec rake test:local-circ-all-tests`, it does not overwrite the circleci_test.txt file