### PR TITLE
DOE prototypes minor geometry fixes

### DIFF
--- a/data/geometry/ASHRAELargeOffice.osm
+++ b/data/geometry/ASHRAELargeOffice.osm
@@ -319,7 +319,7 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  -7.21911419532262e-16,                  !- X Origin {m}
+  0,                                      !- X Origin {m}
   44.165,                                 !- Y Origin {m}
   43.5952,                                !- Z Origin {m}
   {f4d26ab6-6069-4f95-a4bb-2505ee54b65c}, !- Building Story Name
@@ -733,7 +733,7 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  -7.21911419532262e-16,                  !- X Origin {m}
+  0,                                      !- X Origin {m}
   0,                                      !- Y Origin {m}
   43.5952,                                !- Z Origin {m}
   {f4d26ab6-6069-4f95-a4bb-2505ee54b65c}, !- Building Story Name
@@ -830,7 +830,7 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  -7.21911419532262e-16,                  !- X Origin {m}
+  0,                                      !- X Origin {m}
   0,                                      !- Y Origin {m}
   46.3392,                                !- Z Origin {m}
   ,                                       !- Building Story Name
@@ -997,7 +997,7 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  -7.21911419532262e-16,                  !- X Origin {m}
+  0,                                      !- X Origin {m}
   0,                                      !- Y Origin {m}
   43.5952,                                !- Z Origin {m}
   {f4d26ab6-6069-4f95-a4bb-2505ee54b65c}, !- Building Story Name
@@ -1642,8 +1642,8 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  73.1072, 4.08374768133815e-015, 2.744,  !- X,Y,Z Vertex 1 {m}
-  73.1072, 4.08374768133815e-015, 0,      !- X,Y,Z Vertex 2 {m}
+  73.1072, 0, 2.744,                      !- X,Y,Z Vertex 1 {m}
+  73.1072, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   68.534, 4.5732, 0,                      !- X,Y,Z Vertex 3 {m}
   68.534, 4.5732, 2.744;                  !- X,Y,Z Vertex 4 {m}
 
@@ -1795,8 +1795,8 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  4.083703031917e-015, 4.5731, 2.744,     !- X,Y,Z Vertex 1 {m}
-  4.083703031917e-015, 4.5731, 0,         !- X,Y,Z Vertex 2 {m}
+  0, 4.5731, 2.744,                       !- X,Y,Z Vertex 1 {m}
+  0, 4.5731, 0,                           !- X,Y,Z Vertex 2 {m}
   4.5732, 0, 0,                           !- X,Y,Z Vertex 3 {m}
   4.5732, 0, 2.744;                       !- X,Y,Z Vertex 4 {m}
 
@@ -1974,8 +1974,8 @@ OS:Surface,
   ,                                       !- Number of Vertices
   4.5732, 44.165, 2.744,                  !- X,Y,Z Vertex 1 {m}
   4.5732, 44.165, 0,                      !- X,Y,Z Vertex 2 {m}
-  4.08370303191701e-015, 48.7381, 0,      !- X,Y,Z Vertex 3 {m}
-  4.08370303191701e-015, 48.7381, 2.744;  !- X,Y,Z Vertex 4 {m}
+  0, 48.7381, 0,                          !- X,Y,Z Vertex 3 {m}
+  0, 48.7381, 2.744;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {391dc8f1-8a29-442c-b115-ef910343caeb}, !- Handle
@@ -2057,8 +2057,8 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -2.55231439494813e-016, 4.5731, 2.744,  !- X,Y,Z Vertex 1 {m}
-  -2.55231439494813e-016, 4.5731, 0,      !- X,Y,Z Vertex 2 {m}
+  0, 4.5731, 2.744,                       !- X,Y,Z Vertex 1 {m}
+  0, 4.5731, 0,                           !- X,Y,Z Vertex 2 {m}
   4.5732, 0, 0,                           !- X,Y,Z Vertex 3 {m}
   4.5732, 0, 2.744;                       !- X,Y,Z Vertex 4 {m}
 
@@ -2074,8 +2074,8 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -2.55231439494813e-016, 4.5731, 2.744,  !- X,Y,Z Vertex 1 {m}
-  -2.55231439494813e-016, 4.5731, 0,      !- X,Y,Z Vertex 2 {m}
+  0, 4.5731, 2.744,                       !- X,Y,Z Vertex 1 {m}
+  0, 4.5731, 0,                           !- X,Y,Z Vertex 2 {m}
   4.5732, 0, 0,                           !- X,Y,Z Vertex 3 {m}
   4.5732, 0, 2.744;                       !- X,Y,Z Vertex 4 {m}
 
@@ -2125,10 +2125,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  2.55234230083634e-016, 4.5732, 2.744,   !- X,Y,Z Vertex 1 {m}
-  2.55234230083634e-016, 4.5732, 0,       !- X,Y,Z Vertex 2 {m}
-  4.5732, 2.55234230083634e-016, 0,       !- X,Y,Z Vertex 3 {m}
-  4.5732, 2.55234230083634e-016, 2.744;   !- X,Y,Z Vertex 4 {m}
+  0, 4.5732, 2.744,                       !- X,Y,Z Vertex 1 {m}
+  0, 4.5732, 0,                           !- X,Y,Z Vertex 2 {m}
+  4.5732, 0, 0,                           !- X,Y,Z Vertex 3 {m}
+  4.5732, 0, 2.744;                       !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {3a8bc761-afcd-446c-955c-8e3f0810fe12}, !- Handle
@@ -2312,8 +2312,8 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   0,                                      !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -3.33066907387547e-016, 0, 2.744,       !- X,Y,Z Vertex 1 {m}
-  -3.33066907387547e-016, 0, 0,           !- X,Y,Z Vertex 2 {m}
+  0, 0, 2.744,                            !- X,Y,Z Vertex 1 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
   0.9144, 0, 0,                           !- X,Y,Z Vertex 3 {m}
   0.9144, 0, 2.744;                       !- X,Y,Z Vertex 4 {m}
 
@@ -2479,8 +2479,8 @@ OS:Surface,
   ,                                       !- Number of Vertices
   0.9144, 39.5918, 2.744,                 !- X,Y,Z Vertex 1 {m}
   0.9144, 39.5918, 0,                     !- X,Y,Z Vertex 2 {m}
-  -3.33066907387547e-016, 39.5918, 0,     !- X,Y,Z Vertex 3 {m}
-  -3.33066907387547e-016, 39.5918, 2.744; !- X,Y,Z Vertex 4 {m}
+  0, 39.5918, 0,                          !- X,Y,Z Vertex 3 {m}
+  0, 39.5918, 2.744;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {561780d0-96ef-47fb-b60d-7ddaed864176}, !- Handle
@@ -2632,8 +2632,8 @@ OS:Surface,
   ,                                       !- Number of Vertices
   4.5732, 44.165, 2.744,                  !- X,Y,Z Vertex 1 {m}
   4.5732, 44.165, 0,                      !- X,Y,Z Vertex 2 {m}
-  8.16740606383402e-015, 48.7381, 0,      !- X,Y,Z Vertex 3 {m}
-  8.16740606383402e-015, 48.7381, 2.744;  !- X,Y,Z Vertex 4 {m}
+  0, 48.7381, 0,                          !- X,Y,Z Vertex 3 {m}
+  0, 48.7381, 2.744;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {3ca4f15a-47d9-4a55-88ea-98e1de03d901}, !- Handle
@@ -2834,10 +2834,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  5.10468460167268e-016, 4.5732, 2.744,   !- X,Y,Z Vertex 1 {m}
-  5.10468460167268e-016, 4.5732, 0,       !- X,Y,Z Vertex 2 {m}
-  4.5732, 4.08374768133815e-015, 0,       !- X,Y,Z Vertex 3 {m}
-  4.5732, 4.08374768133815e-015, 2.744;   !- X,Y,Z Vertex 4 {m}
+  0, 4.5732, 2.744,                       !- X,Y,Z Vertex 1 {m}
+  0, 4.5732, 0,                           !- X,Y,Z Vertex 2 {m}
+  4.5732, 0, 0,                           !- X,Y,Z Vertex 3 {m}
+  4.5732, 0, 2.744;                       !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {c721c59d-459a-4ccb-8759-6f4a63ce20c6}, !- Handle
@@ -3072,10 +3072,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  2.55234230083634e-016, 4.5732, 2.744,   !- X,Y,Z Vertex 1 {m}
-  2.55234230083634e-016, 4.5732, 0,       !- X,Y,Z Vertex 2 {m}
-  4.5732, 2.55234230083634e-016, 0,       !- X,Y,Z Vertex 3 {m}
-  4.5732, 2.55234230083634e-016, 2.744;   !- X,Y,Z Vertex 4 {m}
+  0, 4.5732, 2.744,                       !- X,Y,Z Vertex 1 {m}
+  0, 4.5732, 0,                           !- X,Y,Z Vertex 2 {m}
+  4.5732, 0, 0,                           !- X,Y,Z Vertex 3 {m}
+  4.5732, 0, 2.744;                       !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {814b60dc-836e-421b-99c0-f8a854e3e4e5}, !- Handle
@@ -3210,8 +3210,8 @@ OS:Surface,
   ,                                       !- Number of Vertices
   0.9144, 39.5918, 0,                     !- X,Y,Z Vertex 1 {m}
   0.9144, 0, 0,                           !- X,Y,Z Vertex 2 {m}
-  -3.33066907387547e-016, 0, 0,           !- X,Y,Z Vertex 3 {m}
-  -3.33066907387547e-016, 39.5918, 0;     !- X,Y,Z Vertex 4 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
+  0, 39.5918, 0;                          !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {2b4012bf-b312-44ff-8dd0-16e5aff0039b}, !- Handle
@@ -3329,8 +3329,8 @@ OS:Surface,
   ,                                       !- Number of Vertices
   4.5732, 44.165, 2.744,                  !- X,Y,Z Vertex 1 {m}
   4.5732, 44.165, 0,                      !- X,Y,Z Vertex 2 {m}
-  4.08370303191701e-015, 48.7381, 0,      !- X,Y,Z Vertex 3 {m}
-  4.08370303191701e-015, 48.7381, 2.744;  !- X,Y,Z Vertex 4 {m}
+  0, 48.7381, 0,                          !- X,Y,Z Vertex 3 {m}
+  0, 48.7381, 2.744;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {b531b2fe-9de1-4032-9f51-f0c2e2f54078}, !- Handle
@@ -3344,10 +3344,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   0,                                      !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -3.33066907387547e-016, 39.5918, 2.744, !- X,Y,Z Vertex 1 {m}
-  -3.33066907387547e-016, 39.5918, 0,     !- X,Y,Z Vertex 2 {m}
-  -3.33066907387547e-016, 0, 0,           !- X,Y,Z Vertex 3 {m}
-  -3.33066907387547e-016, 0, 2.744;       !- X,Y,Z Vertex 4 {m}
+  0, 39.5918, 2.744,                      !- X,Y,Z Vertex 1 {m}
+  0, 39.5918, 0,                          !- X,Y,Z Vertex 2 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
+  0, 0, 2.744;                            !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {2b4a080c-6c41-4063-838c-6a7e4b99f33e}, !- Handle
@@ -3361,8 +3361,8 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  73.1072, 4.08374768133815e-015, 2.744,  !- X,Y,Z Vertex 1 {m}
-  73.1072, 4.08374768133815e-015, 0,      !- X,Y,Z Vertex 2 {m}
+  73.1072, 0, 2.744,                      !- X,Y,Z Vertex 1 {m}
+  73.1072, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   68.534, 4.5732, 0,                      !- X,Y,Z Vertex 3 {m}
   68.534, 4.5732, 2.744;                  !- X,Y,Z Vertex 4 {m}
 
@@ -3397,8 +3397,8 @@ OS:Surface,
   ,                                       !- Number of Vertices
   0.9144, 0, 2.744,                       !- X,Y,Z Vertex 1 {m}
   0.9144, 39.5918, 2.744,                 !- X,Y,Z Vertex 2 {m}
-  -3.33066907387547e-016, 39.5918, 2.744, !- X,Y,Z Vertex 3 {m}
-  -3.33066907387547e-016, 0, 2.744;       !- X,Y,Z Vertex 4 {m}
+  0, 39.5918, 2.744,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 2.744;                            !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {75c88fd3-ebc1-4c31-8d28-9e805fc36558}, !- Handle
@@ -3582,8 +3582,8 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  73.1072, 4.08374768133815e-015, 2.744,  !- X,Y,Z Vertex 1 {m}
-  73.1072, 4.08374768133815e-015, 0,      !- X,Y,Z Vertex 2 {m}
+  73.1072, 0, 2.744,                      !- X,Y,Z Vertex 1 {m}
+  73.1072, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   68.534, 4.5732, 0,                      !- X,Y,Z Vertex 3 {m}
   68.534, 4.5732, 2.744;                  !- X,Y,Z Vertex 4 {m}
 

--- a/data/geometry/ASHRAESmallOffice.osm
+++ b/data/geometry/ASHRAESmallOffice.osm
@@ -473,8 +473,8 @@ OS:Surface,
   ,                                       !- Number of Vertices
   22.69, 5, 3.05,                         !- X,Y,Z Vertex 1 {m}
   22.69, 5, 0,                            !- X,Y,Z Vertex 2 {m}
-  27.69, 2.04187384066908e-015, 0,        !- X,Y,Z Vertex 3 {m}
-  27.69, 2.04187384066908e-015, 3.05;     !- X,Y,Z Vertex 4 {m}
+  27.69, 0, 0,                            !- X,Y,Z Vertex 3 {m}
+  27.69, 0, 3.05;                         !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {63b30273-21d2-4b1d-bd16-9edb06da8514}, !- Handle
@@ -1105,8 +1105,8 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  27.69, 2.04187384066908e-015, 3.05,     !- X,Y,Z Vertex 1 {m}
-  27.69, 2.04187384066908e-015, 0,        !- X,Y,Z Vertex 2 {m}
+  27.69, 0, 3.05,                         !- X,Y,Z Vertex 1 {m}
+  27.69, 0, 0,                            !- X,Y,Z Vertex 2 {m}
   22.69, 5, 0,                            !- X,Y,Z Vertex 3 {m}
   22.69, 5, 3.05;                         !- X,Y,Z Vertex 4 {m}
 

--- a/data/geometry/DOERefLargeOffice.osm
+++ b/data/geometry/DOERefLargeOffice.osm
@@ -379,8 +379,8 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  0.04,                                   !- Y Origin {m}
-  0.2,                                    !- Z Origin {m}
+  0,                                      !- Y Origin {m}
+  0,                                      !- Z Origin {m}
   {896e190c-e48f-4d78-9f1a-de88136d19ed}, !- Building Story Name
   {7e09e11e-3069-48f9-a48f-ee8e73b96eb9}, !- Thermal Zone Name
   Yes,                                    !- Part of Total Floor Area
@@ -899,8 +899,8 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  4.08370303191701e-015, 48.7381, 22.56,  !- X,Y,Z Vertex 1 {m}
-  4.08370303191701e-015, 48.7381, 19.816, !- X,Y,Z Vertex 2 {m}
+  0, 48.7381, 22.56,                      !- X,Y,Z Vertex 1 {m}
+  0, 48.7381, 19.816,                     !- X,Y,Z Vertex 2 {m}
   4.5732, 44.165, 19.816,                 !- X,Y,Z Vertex 3 {m}
   4.5732, 44.165, 22.56;                  !- X,Y,Z Vertex 4 {m}
 
@@ -952,8 +952,8 @@ OS:Surface,
   ,                                       !- Number of Vertices
   68.534, 4.5732, 2.744,                  !- X,Y,Z Vertex 1 {m}
   68.534, 4.5732, 0,                      !- X,Y,Z Vertex 2 {m}
-  73.1072, 4.08374768133815e-015, 0,      !- X,Y,Z Vertex 3 {m}
-  73.1072, 4.08374768133815e-015, 2.744;  !- X,Y,Z Vertex 4 {m}
+  73.1072, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  73.1072, 0, 2.744;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {54802686-5cac-400a-a5e6-1fc69945699a}, !- Handle
@@ -1020,8 +1020,8 @@ OS:Surface,
   ,                                       !- Number of Vertices
   4.5732, 44.165, 2.744,                  !- X,Y,Z Vertex 1 {m}
   4.5732, 44.165, 0,                      !- X,Y,Z Vertex 2 {m}
-  4.08370303191701e-015, 48.7381, 0,      !- X,Y,Z Vertex 3 {m}
-  4.08370303191701e-015, 48.7381, 2.744;  !- X,Y,Z Vertex 4 {m}
+  0, 48.7381, 0,                          !- X,Y,Z Vertex 3 {m}
+  0, 48.7381, 2.744;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {1b4aa364-cf54-4248-b2ef-142e2b7d02d0}, !- Handle
@@ -1103,8 +1103,8 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  73.1072, 4.08374768133815e-015, 22.56,  !- X,Y,Z Vertex 1 {m}
-  73.1072, 4.08374768133815e-015, 19.816, !- X,Y,Z Vertex 2 {m}
+  73.1072, 0, 22.56,                      !- X,Y,Z Vertex 1 {m}
+  73.1072, 0, 19.816,                     !- X,Y,Z Vertex 2 {m}
   68.534, 4.5732, 19.816,                 !- X,Y,Z Vertex 3 {m}
   68.534, 4.5732, 22.56;                  !- X,Y,Z Vertex 4 {m}
 
@@ -1212,8 +1212,8 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  8.16740606383402e-015, 48.7381, 46.3392, !- X,Y,Z Vertex 1 {m}
-  8.16740606383402e-015, 48.7381, 43.5952, !- X,Y,Z Vertex 2 {m}
+  0, 48.7381, 46.3392,                    !- X,Y,Z Vertex 1 {m}
+  0, 48.7381, 43.5952,                    !- X,Y,Z Vertex 2 {m}
   4.5732, 44.165, 43.5952,                !- X,Y,Z Vertex 3 {m}
   4.5732, 44.165, 46.3392;                !- X,Y,Z Vertex 4 {m}
 
@@ -1606,8 +1606,8 @@ OS:Surface,
   ,                                       !- Number of Vertices
   4.5732, 44.165, 46.3392,                !- X,Y,Z Vertex 1 {m}
   4.5732, 44.165, 43.5952,                !- X,Y,Z Vertex 2 {m}
-  4.08370303191701e-015, 48.7381, 43.5952, !- X,Y,Z Vertex 3 {m}
-  4.08370303191701e-015, 48.7381, 46.3392; !- X,Y,Z Vertex 4 {m}
+  0, 48.7381, 43.5952,                    !- X,Y,Z Vertex 3 {m}
+  0, 48.7381, 46.3392;                    !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {dc89c14d-552b-4420-8358-b94aa51ecd4c}, !- Handle
@@ -1706,8 +1706,8 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  4.08370303191701e-015, 48.7381, 2.744,  !- X,Y,Z Vertex 1 {m}
-  4.08370303191701e-015, 48.7381, 0,      !- X,Y,Z Vertex 2 {m}
+  0, 48.7381, 2.744,                      !- X,Y,Z Vertex 1 {m}
+  0, 48.7381, 0,                          !- X,Y,Z Vertex 2 {m}
   4.5732, 44.165, 0,                      !- X,Y,Z Vertex 3 {m}
   4.5732, 44.165, 2.744;                  !- X,Y,Z Vertex 4 {m}
 
@@ -1854,8 +1854,8 @@ OS:Surface,
   ,                                       !- Number of Vertices
   4.5732, 44.165, 22.56,                  !- X,Y,Z Vertex 1 {m}
   4.5732, 44.165, 19.816,                 !- X,Y,Z Vertex 2 {m}
-  4.08370303191701e-015, 48.7381, 19.816, !- X,Y,Z Vertex 3 {m}
-  4.08370303191701e-015, 48.7381, 22.56;  !- X,Y,Z Vertex 4 {m}
+  0, 48.7381, 19.816,                     !- X,Y,Z Vertex 3 {m}
+  0, 48.7381, 22.56;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {a934c512-5d43-42c2-b796-68f9d2f6c3f3}, !- Handle
@@ -1971,8 +1971,8 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  73.1072, 4.08374768133815e-015, 46.3392, !- X,Y,Z Vertex 1 {m}
-  73.1072, 4.08374768133815e-015, 43.5952, !- X,Y,Z Vertex 2 {m}
+  73.1072, 0, 46.3392,                    !- X,Y,Z Vertex 1 {m}
+  73.1072, 0, 43.5952,                    !- X,Y,Z Vertex 2 {m}
   68.534, 4.5732, 43.5952,                !- X,Y,Z Vertex 3 {m}
   68.534, 4.5732, 46.3392;                !- X,Y,Z Vertex 4 {m}
 
@@ -2283,8 +2283,8 @@ OS:Surface,
   ,                                       !- Number of Vertices
   68.534, 4.5732, 46.3392,                !- X,Y,Z Vertex 1 {m}
   68.534, 4.5732, 43.5952,                !- X,Y,Z Vertex 2 {m}
-  73.1072, 4.08374768133815e-015, 43.5952, !- X,Y,Z Vertex 3 {m}
-  73.1072, 4.08374768133815e-015, 46.3392; !- X,Y,Z Vertex 4 {m}
+  73.1072, 0, 43.5952,                    !- X,Y,Z Vertex 3 {m}
+  73.1072, 0, 46.3392;                    !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {23af6e5f-fb7d-4349-ab06-b03d07422e21}, !- Handle
@@ -2655,8 +2655,8 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  73.1072, 4.08374768133815e-015, 2.744,  !- X,Y,Z Vertex 1 {m}
-  73.1072, 4.08374768133815e-015, 0,      !- X,Y,Z Vertex 2 {m}
+  73.1072, 0, 2.744,                      !- X,Y,Z Vertex 1 {m}
+  73.1072, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   68.534, 4.5732, 0,                      !- X,Y,Z Vertex 3 {m}
   68.534, 4.5732, 2.744;                  !- X,Y,Z Vertex 4 {m}
 
@@ -2725,8 +2725,8 @@ OS:Surface,
   ,                                       !- Number of Vertices
   68.534, 4.5732, 22.56,                  !- X,Y,Z Vertex 1 {m}
   68.534, 4.5732, 19.816,                 !- X,Y,Z Vertex 2 {m}
-  73.1072, 4.08374768133815e-015, 19.816, !- X,Y,Z Vertex 3 {m}
-  73.1072, 4.08374768133815e-015, 22.56;  !- X,Y,Z Vertex 4 {m}
+  73.1072, 0, 19.816,                     !- X,Y,Z Vertex 3 {m}
+  73.1072, 0, 22.56;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {358cc6fa-a266-4c77-8a9e-1e289008b5db}, !- Handle

--- a/data/geometry/DOERefSmallHotel.osm
+++ b/data/geometry/DOERefSmallHotel.osm
@@ -8229,8 +8229,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {555201ea-0c0e-4df3-b813-ccc710b8dae6}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {41e119e9-a57b-48f8-b9b7-e04a8c0195d6}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -10881,8 +10881,8 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {cde37d94-0d8f-4be9-b503-792001487e8a}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {e4a49f13-2277-4d20-b5fb-4c587c407f14}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground

--- a/data/geometry/DOERefWarehouse.osm
+++ b/data/geometry/DOERefWarehouse.osm
@@ -31,10 +31,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {4a035398-e49d-42c2-ab5b-4a4c6a2d73f7}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {93ee4c81-2ed9-4b73-9cb5-82f57fdc18c2}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   45.7178, 30.4785, 8.534,                !- X,Y,Z Vertex 1 {m}
@@ -221,10 +221,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {6d122caa-5590-45e8-b46b-87cdc21cf9dd}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {a95cc1df-826b-4ea6-bde3-10fa7dd6f052}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   25.9067, 0, 4.267,                      !- X,Y,Z Vertex 1 {m}
@@ -391,10 +391,10 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   1,                                      !- Multiplier
   ,                                       !- Number of Vertices
-  45.718, 65.0716, 2.1335,                !- X,Y,Z Vertex 1 {m}
-  45.718, 65.0716, 0,                     !- X,Y,Z Vertex 2 {m}
-  45.718, 65.986, 0,                      !- X,Y,Z Vertex 3 {m}
-  45.718, 65.986, 2.1335;                 !- X,Y,Z Vertex 4 {m}
+  45.7178, 65.0716, 2.1335,               !- X,Y,Z Vertex 1 {m}
+  45.7178, 65.0716, 0,                    !- X,Y,Z Vertex 2 {m}
+  45.7178, 65.986, 0,                     !- X,Y,Z Vertex 3 {m}
+  45.7178, 65.986, 2.1335;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {8d78c09b-cfec-413f-95c9-1e0d881493a9}, !- Handle
@@ -446,10 +446,10 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   1,                                      !- Multiplier
   ,                                       !- Number of Vertices
-  45.718, 47.5465, 2.1335,                !- X,Y,Z Vertex 1 {m}
-  45.718, 47.5465, 0,                     !- X,Y,Z Vertex 2 {m}
-  45.718, 48.4608, 0,                     !- X,Y,Z Vertex 3 {m}
-  45.718, 48.4608, 2.1335;                !- X,Y,Z Vertex 4 {m}
+  45.7178, 47.5465, 2.1335,               !- X,Y,Z Vertex 1 {m}
+  45.7178, 47.5465, 0,                    !- X,Y,Z Vertex 2 {m}
+  45.7178, 48.4608, 0,                    !- X,Y,Z Vertex 3 {m}
+  45.7178, 48.4608, 2.1335;               !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {499365cb-98fa-46d1-a4c0-87db5431834b}, !- Handle
@@ -510,10 +510,10 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   1,                                      !- Multiplier
   ,                                       !- Number of Vertices
-  45.718, 82.5968, 2.1335,                !- X,Y,Z Vertex 1 {m}
-  45.718, 82.5968, 0,                     !- X,Y,Z Vertex 2 {m}
-  45.718, 83.5111, 0,                     !- X,Y,Z Vertex 3 {m}
-  45.718, 83.5111, 2.1335;                !- X,Y,Z Vertex 4 {m}
+  45.7178, 82.5968, 2.1335,               !- X,Y,Z Vertex 1 {m}
+  45.7178, 82.5968, 0,                    !- X,Y,Z Vertex 2 {m}
+  45.7178, 83.5111, 0,                    !- X,Y,Z Vertex 3 {m}
+  45.7178, 83.5111, 2.1335;               !- X,Y,Z Vertex 4 {m}
 
 OS:ConvergenceLimits,
   {64f3b173-f852-4d94-b429-3376a587d8c6}, !- Handle
@@ -685,6 +685,57 @@ OS:HeatBalanceAlgorithm,
   200;                                    !- Surface Temperature Upper Limit {C}
 
 OS:Surface,
+  {a95cc1df-826b-4ea6-bde3-10fa7dd6f052}, !- Handle
+  Office_Wall_East Reversed,              !- Name
+  Wall,                                   !- Surface Type
+  ,                                       !- Construction Name
+  {4a035398-e49d-42c2-ab5b-4a4c6a2d73f7}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {c19449a9-e627-4c44-8fb9-899ea884e797}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  25.9067, 9.1435, 4.267,                 !- X,Y,Z Vertex 1 {m}
+  25.9067, 9.1435, 0,                     !- X,Y,Z Vertex 2 {m}
+  25.9067, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  25.9067, 0, 4.267;                      !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {75fd56fb-ce92-4202-9b80-bfe1bfac5f6d}, !- Handle
+  Office_Wall_North Reversed,             !- Name
+  Wall,                                   !- Surface Type
+  ,                                       !- Construction Name
+  {4a035398-e49d-42c2-ab5b-4a4c6a2d73f7}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {c3efc38f-c8b3-488c-9401-98e12bed3ed7}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  0, 9.1435, 4.267,                       !- X,Y,Z Vertex 1 {m}
+  0, 9.1435, 0,                           !- X,Y,Z Vertex 2 {m}
+  25.9067, 9.1435, 0,                     !- X,Y,Z Vertex 3 {m}
+  25.9067, 9.1435, 4.267;                 !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {93ee4c81-2ed9-4b73-9cb5-82f57fdc18c2}, !- Handle
+  FineStorage_Wall_North Reversed,        !- Name
+  Wall,                                   !- Surface Type
+  ,                                       !- Construction Name
+  {5d98aa08-59f2-4a73-bec1-097ed7f67ab3}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {211eccee-9239-49a8-a483-fabf7eb8b269}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  0, 30.4785, 8.534,                      !- X,Y,Z Vertex 1 {m}
+  0, 30.4785, 0,                          !- X,Y,Z Vertex 2 {m}
+  45.7178, 30.4785, 0,                    !- X,Y,Z Vertex 3 {m}
+  45.7178, 30.4785, 8.534;                !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
   {a7567fa3-8961-46b3-97d8-e6b9a19270ff}, !- Handle
   Office_Ceiling,                         !- Name
   RoofCeiling,                            !- Surface Type
@@ -724,10 +775,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {6d122caa-5590-45e8-b46b-87cdc21cf9dd}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {75fd56fb-ce92-4202-9b80-bfe1bfac5f6d}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   25.9067, 9.1435, 4.267,                 !- X,Y,Z Vertex 1 {m}
@@ -764,10 +815,10 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   1,                                      !- Multiplier
   ,                                       !- Number of Vertices
-  45.718, 14.7821, 2.1335,                !- X,Y,Z Vertex 1 {m}
-  45.718, 14.7821, 0,                     !- X,Y,Z Vertex 2 {m}
-  45.718, 15.6964, 0,                     !- X,Y,Z Vertex 3 {m}
-  45.718, 15.6964, 2.1335;                !- X,Y,Z Vertex 4 {m}
+  45.7178, 14.7821, 2.1335,               !- X,Y,Z Vertex 1 {m}
+  45.7178, 14.7821, 0,                    !- X,Y,Z Vertex 2 {m}
+  45.7178, 15.6964, 0,                    !- X,Y,Z Vertex 3 {m}
+  45.7178, 15.6964, 2.1335;               !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {c0fbed24-7688-45b6-9d60-99820c3c010a}, !- Handle
@@ -1226,4 +1277,3 @@ OS:Rendering:Color,
   120,                                    !- Rendering Red Value
   230,                                    !- Rendering Green Value
   199;                                    !- Rendering Blue Value
-


### PR DESCRIPTION
- set origins and vertices to 0 if < 1e-15
- reset basement origin in DOERefLargeOffice so it doesn't overlap with 1st floor
- fixed surface matching for ceiling/attic in DOERefSmallHotel
- add missing walls to DOERefWarehouse