### PR TITLE
Fix/DOE_geometry

### DIFF
--- a/data/geometry/ASHRAE90120042007LargeHotel.osm
+++ b/data/geometry/ASHRAE90120042007LargeHotel.osm
@@ -777,7 +777,7 @@ OS:Surface,
 
 OS:Surface,
   {2c06a457-865a-40b6-838c-9be5a679153d}, !- Handle
-  Corridor_Flr_6_Wall_3_West,             !- Name
+  Corridor_Flr_6_Wall_2_West,             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {8db4d7a3-2488-4c4c-a843-128954346798}, !- Space Name
@@ -794,12 +794,12 @@ OS:Surface,
 
 OS:Surface,
   {b704ad1c-b44a-43cd-827e-1eaaa714ea10}, !- Handle
-  Corridor_Flr_6_Wall_2_West,             !- Name
+  Corridor_Flr_6_Wall_4_West,           !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {8db4d7a3-2488-4c4c-a843-128954346798}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {69429ced-9e9c-443d-a436-abe7c7a09a0a}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -1169,8 +1169,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e7c48afd-fd2f-4b1f-a6ed-bc521183d564}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {e9c34369-94f5-420d-ab69-7989fd4fb122}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -1419,8 +1419,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {4e45dfce-4774-4bb3-87cb-f096a1e6a868}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {cd606390-2ecf-47df-aac8-57774f16ba10}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -1661,8 +1661,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {227b807d-4e11-4183-8a63-1ff910e681e5}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {f167dd56-f99d-4d08-bfe9-cb907e0cc75d}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -1780,8 +1780,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {227b807d-4e11-4183-8a63-1ff910e681e5}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {641a68f5-3b06-483d-b433-b086626f28a6}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -1797,8 +1797,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {4e45dfce-4774-4bb3-87cb-f096a1e6a868}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {f60f499f-48a8-45d0-9e7d-37936e116e03}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -1831,8 +1831,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e7c48afd-fd2f-4b1f-a6ed-bc521183d564}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {cd296b28-2ba3-4052-b306-06b5691b246c}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -2621,8 +2621,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {8db4d7a3-2488-4c4c-a843-128954346798}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {b7b7c8e2-8cd3-4bbe-8cfe-316581e6658e}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -2813,8 +2813,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {227b807d-4e11-4183-8a63-1ff910e681e5}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {c9cac1df-0500-4e93-aca8-168ce98698b8}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -2881,8 +2881,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {227b807d-4e11-4183-8a63-1ff910e681e5}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {c96f4baf-843e-4e6a-96c8-082c31f522fd}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -3075,8 +3075,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c11369de-980c-4379-8814-84c108bfb730}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {de34b478-3803-4e06-a6b0-94fb668f99b0}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -3253,8 +3253,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {8db4d7a3-2488-4c4c-a843-128954346798}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {b43b9c9e-e9ef-499e-8e23-4b0ea2184482}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -3616,8 +3616,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {87113b54-1a70-42f4-8d62-370ab9058660}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {178b8df5-a2db-4b2f-ac66-1390d2d371f4}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -3986,8 +3986,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {8337fdfc-5370-48cb-afdc-4b5fbc87ce0d}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {6b5e0663-fa03-41e1-a0d2-f04d2b656a81}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -4020,8 +4020,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {064876aa-b4ee-47a9-bd4b-88b7fce9181b}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {b704ad1c-b44a-43cd-827e-1eaaa714ea10}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -4050,12 +4050,12 @@ OS:Surface,
 
 OS:Surface,
   {183721a8-2a8e-4e97-af67-33313dfa63c5}, !- Handle
-  Room_1_Flr_6_Wall_East,                 !- Name
+  Room_1_Flr_6_Wall_2_East,               !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {b9b16d75-f08b-472e-8174-dacb52b5ac8d}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {717f2e27-2b9a-429f-92cb-f35ac4c9562b}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -4071,8 +4071,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {8337fdfc-5370-48cb-afdc-4b5fbc87ce0d}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {183721a8-2a8e-4e97-af67-33313dfa63c5}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -5978,14 +5978,14 @@ OS:ZoneHVAC:EquipmentList,
 
 OS:Surface,
   {34e15ad4-259e-4af7-9d47-f9dfb6b78bc5}, !- Handle
-  Surface 1,                              !- Name
+  Corridor_Flr_6_Wall_3_West,           !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {8db4d7a3-2488-4c4c-a843-128954346798}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {ae375c1a-a6f6-4f72-97c7-68988455a7f8}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   4.572, 14.326, 19.2,                    !- X,Y,Z Vertex 1 {m}
@@ -5995,7 +5995,7 @@ OS:Surface,
 
 OS:Surface,
   {412a52da-a12c-4d25-8be6-37fe167cf8d3}, !- Handle
-  Surface 2,                              !- Name
+  Corridor_Flr_3_Wall_4_South,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {227b807d-4e11-4183-8a63-1ff910e681e5}, !- Space Name
@@ -6012,7 +6012,7 @@ OS:Surface,
 
 OS:Surface,
   {507a5052-c6fa-4e80-96ea-d8413460cc49}, !- Handle
-  Surface 3,                              !- Name
+  Corridor_Flr_3_Wall_4_North,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {227b807d-4e11-4183-8a63-1ff910e681e5}, !- Space Name
@@ -6029,7 +6029,7 @@ OS:Surface,
 
 OS:Surface,
   {b561fd0f-55af-433e-86cc-3619d4454fba}, !- Handle
-  Surface 4,                              !- Name
+  Corridor_Flr_6_Wall_3_South,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {8db4d7a3-2488-4c4c-a843-128954346798}, !- Space Name
@@ -6046,14 +6046,14 @@ OS:Surface,
 
 OS:Surface,
   {ae375c1a-a6f6-4f72-97c7-68988455a7f8}, !- Handle
-  Surface 5,                              !- Name
+  Room_1_Flr_6_Wall_1_East,               !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {b9b16d75-f08b-472e-8174-dacb52b5ac8d}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {34e15ad4-259e-4af7-9d47-f9dfb6b78bc5}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   4.572, 9.449, 19.2,                     !- X,Y,Z Vertex 1 {m}
@@ -6063,14 +6063,14 @@ OS:Surface,
 
 OS:Surface,
   {de34b478-3803-4e06-a6b0-94fb668f99b0}, !- Handle
-  Surface 6,                              !- Name
+  Corridor_Flr_6_Wall_5_North,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {8db4d7a3-2488-4c4c-a843-128954346798}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {7d3999f4-b92b-4587-87f6-715a408ad120}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   81.991, 12.497, 19.2,                   !- X,Y,Z Vertex 1 {m}

--- a/data/geometry/ASHRAE9012010LargeHotel.osm
+++ b/data/geometry/ASHRAE9012010LargeHotel.osm
@@ -645,8 +645,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f365e26d-0494-4dfd-9203-71099e3e8c68}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {00b8ec32-d18a-41fe-8531-bdfa6658695d}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -990,8 +990,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {a58732ab-b523-456d-a945-fa52cc6b3532}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {412a52da-a12c-4d25-8be6-37fe167cf8d3}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -1029,8 +1029,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f365e26d-0494-4dfd-9203-71099e3e8c68}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {7f30129d-fb8b-40fd-9a01-760420c0936b}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -1063,8 +1063,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {defe2645-49e9-4f8e-8f41-0b8a7abd3814}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {0cbc40d3-7a9b-4397-aba6-bbe0952305fd}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -1262,8 +1262,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {be32e255-c03d-4203-9525-676749cff26f}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {bf8df7e0-29d4-4009-ad88-7bd3ff1e3ee0}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -1348,7 +1348,7 @@ OS:Surface,
 
 OS:Surface,
   {daa866da-fa92-4d26-94d9-e47bb50f7952}, !- Handle
-  Corridor_Flr_6_Wall_3_West,             !- Name
+  Corridor_Flr_6_Wall_2_West,             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {ba9112c1-578e-4b0e-ad64-9cb0a312e853}, !- Space Name
@@ -1365,12 +1365,12 @@ OS:Surface,
 
 OS:Surface,
   {0210cf11-033b-41f1-856b-3775ef9242f7}, !- Handle
-  Corridor_Flr_6_Wall_2_West,             !- Name
+  Corridor_Flr_6_Wall_3_West,           !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {ba9112c1-578e-4b0e-ad64-9cb0a312e853}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {a387d9d5-0fc7-4c0c-bc62-f2c4d479fafb}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -1386,8 +1386,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {daa3cb58-34c7-4155-8107-81a29224b5c9}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {b561fd0f-55af-433e-86cc-3619d4454fba}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -1471,8 +1471,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f365e26d-0494-4dfd-9203-71099e3e8c68}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {55ca003e-f775-49b1-af68-595a9841a4ef}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -1870,8 +1870,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {4228df96-e6c2-4c61-9dc9-d2a37855c23d}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {86a12737-f004-44c2-a507-c1809d9d2b1a}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -1904,8 +1904,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {5e0f53dd-e503-42b7-828c-26bb581fa71a}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {ae5bfaa3-3b7c-48e3-b52e-78eaef9b9a05}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -2006,8 +2006,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {ba9112c1-578e-4b0e-ad64-9cb0a312e853}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {6408d28a-f069-4fab-bf37-e27aa3eca5a1}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -2516,8 +2516,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {defe2645-49e9-4f8e-8f41-0b8a7abd3814}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {507a5052-c6fa-4e80-96ea-d8413460cc49}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -2750,12 +2750,12 @@ OS:Surface,
 
 OS:Surface,
   {a387d9d5-0fc7-4c0c-bc62-f2c4d479fafb}, !- Handle
-  Room_1_Flr_6_Wall_East,                 !- Name
+  Room_1_Flr_6_Wall_1_East,               !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {addf53a5-5252-4c58-bb60-25979e29a7b0}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {0210cf11-033b-41f1-856b-3775ef9242f7}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -2805,8 +2805,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {4228df96-e6c2-4c61-9dc9-d2a37855c23d}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {2b58aeec-ded3-4b5a-9889-d3b6cbbc0420}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -3492,8 +3492,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f365e26d-0494-4dfd-9203-71099e3e8c68}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {88a59611-2475-4ff4-b35a-3393481416be}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -3539,12 +3539,12 @@ OS:Surface,
 
 OS:Surface,
   {ae5bfaa3-3b7c-48e3-b52e-78eaef9b9a05}, !- Handle
-  Corridor_Flr_6_Wall_4_North,            !- Name
+  Corridor_Flr_6_Wall_5_North,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {ba9112c1-578e-4b0e-ad64-9cb0a312e853}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {069a7773-a926-4ac1-95d4-8ede4714882b}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -3847,8 +3847,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {be32e255-c03d-4203-9525-676749cff26f}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {42c95fc7-48fc-473e-9eb9-35840cdd0e90}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -5978,7 +5978,7 @@ OS:ZoneHVAC:EquipmentList,
 
 OS:Surface,
   {34e15ad4-259e-4af7-9d47-f9dfb6b78bc5}, !- Handle
-  Surface 1,                              !- Name
+  Corridor_Flr_3_Wall_3_South,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f365e26d-0494-4dfd-9203-71099e3e8c68}, !- Space Name
@@ -5995,14 +5995,14 @@ OS:Surface,
 
 OS:Surface,
   {412a52da-a12c-4d25-8be6-37fe167cf8d3}, !- Handle
-  Surface 2,                              !- Name
+  Corridor_Flr_6_Wall_4_North,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {ba9112c1-578e-4b0e-ad64-9cb0a312e853}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {462abc48-a941-4d8d-8754-a7fb87371b15}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   79.553, 12.497, 19.2,                   !- X,Y,Z Vertex 1 {m}
@@ -6012,14 +6012,14 @@ OS:Surface,
 
 OS:Surface,
   {507a5052-c6fa-4e80-96ea-d8413460cc49}, !- Handle
-  Surface 3,                              !- Name
+  Room_1_Flr_6_Wall_2_East,               !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {addf53a5-5252-4c58-bb60-25979e29a7b0}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {926f8d71-4078-457d-9ca2-7a76c9842234}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   4.572, 5.791, 19.2,                     !- X,Y,Z Vertex 1 {m}
@@ -6029,14 +6029,14 @@ OS:Surface,
 
 OS:Surface,
   {b561fd0f-55af-433e-86cc-3619d4454fba}, !- Handle
-  Surface 4,                              !- Name
+  Corridor_Flr_6_Wall_4_West,           !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {ba9112c1-578e-4b0e-ad64-9cb0a312e853}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {1af3098e-1db7-49ff-ac55-49512d364a49}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   4.572, 22.86, 19.2,                     !- X,Y,Z Vertex 1 {m}
@@ -6046,7 +6046,7 @@ OS:Surface,
 
 OS:Surface,
   {ae375c1a-a6f6-4f72-97c7-68988455a7f8}, !- Handle
-  Surface 5,                              !- Name
+  Corridor_Flr_6_Wall_3_South,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {ba9112c1-578e-4b0e-ad64-9cb0a312e853}, !- Space Name
@@ -6063,7 +6063,7 @@ OS:Surface,
 
 OS:Surface,
   {de34b478-3803-4e06-a6b0-94fb668f99b0}, !- Handle
-  Surface 6,                              !- Name
+  Corridor_Flr_3_Wall_4_North,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f365e26d-0494-4dfd-9203-71099e3e8c68}, !- Space Name

--- a/data/geometry/ASHRAE9012010SuperMarket.osm
+++ b/data/geometry/ASHRAE9012010SuperMarket.osm
@@ -48,7 +48,7 @@ OS:Timestep,
 
 OS:Building,
   {e0ce3521-4e53-4eca-8017-2f1c8dec2b50}, !- Handle
-  90.1-2013-SuperMarket,                  !- Name
+  90.1-2010-SuperMarket,                  !- Name
   ,                                       !- Building Sector Type
   ,                                       !- North Axis {deg}
   ,                                       !- Nominal Floor to Floor Height {m}
@@ -168,10 +168,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {9871e5b3-040a-44e4-9df8-f5fa1e1e10af}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {cc30f6ab-6b11-467b-9ac6-f27fa0f61a99}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   23.4807, 4.57199999999984, 4.572,       !- X,Y,Z Vertex 1 {m}
@@ -185,10 +185,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {9871e5b3-040a-44e4-9df8-f5fa1e1e10af}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {ca2f05a1-a2bd-48a2-9153-89c97999e6da}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   1.25873118711682e-017, 4.57199999999984, 4.572, !- X,Y,Z Vertex 1 {m}
@@ -251,10 +251,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {0f799d38-5e12-4224-a2f6-65f846eb1148}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {39c15528-345e-45ac-b158-66756973609d}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   1.06465271808986e-016, 43.8197999999998, 4.572, !- X,Y,Z Vertex 1 {m}
@@ -285,10 +285,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {0f799d38-5e12-4224-a2f6-65f846eb1148}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {45a6d2ff-634c-4124-9381-0a5008ab5137}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   8.19169458172421e-017, 4.57199999999984, 4.572, !- X,Y,Z Vertex 1 {m}
@@ -402,10 +402,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {403f025b-298f-491c-a18a-1bbad23b565c}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {94aaca25-d5ce-45d4-8879-ebafdd3e303d}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   29.5767, 4.57199999999984, 4.572,       !- X,Y,Z Vertex 1 {m}
@@ -536,10 +536,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {27cc4560-6291-4c1f-b14c-c4f5c6d2b6e7}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {83ca7553-a425-4e10-b748-ac025bcea02c}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   53.0574, 4.57199999999984, 4.57199999999999, !- X,Y,Z Vertex 1 {m}
@@ -553,10 +553,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {27cc4560-6291-4c1f-b14c-c4f5c6d2b6e7}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {cbd1d764-f9b9-4bcc-bf58-0cd93bdb6c3c}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   53.0574, 1.82093990566872e-015, 4.57199999999999, !- X,Y,Z Vertex 1 {m}
@@ -670,10 +670,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {027a0cdc-6550-4760-91ae-c3f5379af193}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {05e52492-8e20-42a9-97f4-72c244e07fbd}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   53.0574, 4.57199999999984, 4.572,       !- X,Y,Z Vertex 1 {m}
@@ -770,10 +770,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {0fd60f7d-ee76-49e8-8ff8-533766628f82}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {04c7a1a7-94a7-4401-89e2-84f28f38ad30}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   7.37341704866608e-017, 43.8197999999998, 4.572, !- X,Y,Z Vertex 1 {m}
@@ -787,10 +787,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {0fd60f7d-ee76-49e8-8ff8-533766628f82}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {8dbd9195-13b2-4fec-a680-c9d0e67f8f4c}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   15.9211, 43.8197999999998, 4.572,       !- X,Y,Z Vertex 1 {m}
@@ -804,10 +804,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {0fd60f7d-ee76-49e8-8ff8-533766628f82}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {ae4bd153-24b9-4f2b-8c40-2777d85cc1ae}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   53.0574, 21.1184999999998, 4.572,       !- X,Y,Z Vertex 1 {m}
@@ -821,10 +821,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {0fd60f7d-ee76-49e8-8ff8-533766628f82}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {8bc8cf51-4ddd-4a8a-b0e9-12969a554249}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   29.5767, 4.57199999999984, 4.572,       !- X,Y,Z Vertex 1 {m}
@@ -887,10 +887,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {02a20178-5cec-4076-8aed-244e2d3a36c6}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {9ed1c977-dbf6-43ee-8dca-5e1b1dcad969}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   62.9555, 43.8197999999998, 4.57199999999997, !- X,Y,Z Vertex 1 {m}
@@ -904,10 +904,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {02a20178-5cec-4076-8aed-244e2d3a36c6}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {bb3a51da-60c7-497f-b289-f56f9b0ce096}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   53.0574, 43.8197999999998, 4.57199999999998, !- X,Y,Z Vertex 1 {m}
@@ -987,10 +987,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e49a5709-1d20-4e6a-9a0e-227ee997614f}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {b47087bd-ed4a-4f56-a76e-bdcd8e373a53}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   15.9211, 45.3564999999998, 4.57199999999997, !- X,Y,Z Vertex 1 {m}
@@ -1055,10 +1055,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e49a5709-1d20-4e6a-9a0e-227ee997614f}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {5bbadb78-ba61-4d27-89df-4b57c7867d38}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   53.0574, 43.8197999999998, 4.57199999999999, !- X,Y,Z Vertex 1 {m}
@@ -1104,10 +1104,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d856eb50-0aea-4645-9879-1b42620e7dc0}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {567f0fc0-f34e-49fc-a8eb-0e37671ab03b}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   -12.4919, 45.3564999999998, 4.57199999999992, !- X,Y,Z Vertex 1 {m}
@@ -1138,10 +1138,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d856eb50-0aea-4645-9879-1b42620e7dc0}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {8cd47b03-c056-4b81-aeb1-12e7630c1d02}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   1.06465271808984e-016, 43.8197999999998, 4.57199999999992, !- X,Y,Z Vertex 1 {m}
@@ -1172,10 +1172,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d856eb50-0aea-4645-9879-1b42620e7dc0}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {fc3499fd-4ab8-46c3-babc-d977059d3882}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   15.9211, 43.8197999999998, 4.57199999999992, !- X,Y,Z Vertex 1 {m}
@@ -1272,10 +1272,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f3162082-eda4-4375-8ef5-d49ffc070545}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {f8c699a4-0a9f-4393-80fe-86e47e7847b0}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   15.9211, 45.3564999999998, 4.57199999999997, !- X,Y,Z Vertex 1 {m}
@@ -1289,10 +1289,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f3162082-eda4-4375-8ef5-d49ffc070545}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {40961984-fc31-498e-9f76-19d825533ac1}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   8.42809999999998, 45.3564999999998, 4.57199999999997, !- X,Y,Z Vertex 1 {m}
@@ -1406,10 +1406,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {b39118ad-8025-406a-bd98-a3296de4495f}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {225b9589-d9b4-4e5f-8730-5a4098b03192}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   -0.00147500000000655, 45.3564999999998, 4.57199999999998, !- X,Y,Z Vertex 1 {m}
@@ -1523,10 +1523,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {924465bf-33f6-40f8-b618-98b028c09193}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {5199c356-0c9b-462b-815e-8e39e1c50346}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   -6.24670000000001, 45.3564999999998, 4.57199999999998, !- X,Y,Z Vertex 1 {m}
@@ -1606,10 +1606,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {7ea97877-f957-4cb1-abcf-6afbcfc66d5e}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {0baee146-05eb-43fb-88ac-227dc1eb002a}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   -12.4919, 45.3564999999998, 4.57199999999998, !- X,Y,Z Vertex 1 {m}
@@ -1757,10 +1757,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {37d6525f-e4c5-4606-bcf6-d3716d739007}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {00e7a68f-4d45-4211-a43f-ad3099780eda}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   -16.2338, 45.3564999999998, 4.57199999999998, !- X,Y,Z Vertex 1 {m}
@@ -1774,10 +1774,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e49a5709-1d20-4e6a-9a0e-227ee997614f}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {8a28a781-590c-4c1c-b3c0-8cc99d8a24df}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   15.9211, 43.8197999999998, 4.57199999999999, !- X,Y,Z Vertex 1 {m}
@@ -1791,10 +1791,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e49a5709-1d20-4e6a-9a0e-227ee997614f}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {d4b047d6-8c26-4f9d-8e04-542d97518490}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   15.9211, 52.7954999999998, 4.57199999999999, !- X,Y,Z Vertex 1 {m}
@@ -1808,10 +1808,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d856eb50-0aea-4645-9879-1b42620e7dc0}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {3e7a79c5-ba48-4346-9fcd-41743c54ca21}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   8.42809999999998, 45.3564999999998, 4.57199999999997, !- X,Y,Z Vertex 1 {m}
@@ -1825,10 +1825,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d856eb50-0aea-4645-9879-1b42620e7dc0}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {ac0ce12f-188b-4571-9afa-1b8a94e4a842}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   -6.24670000000001, 45.3564999999998, 4.57199999999998, !- X,Y,Z Vertex 1 {m}
@@ -1842,10 +1842,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d856eb50-0aea-4645-9879-1b42620e7dc0}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {efcc3f09-ccd9-4e3d-8daf-d600378b6bed}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   15.9211, 45.3564999999998, 4.57199999999991, !- X,Y,Z Vertex 1 {m}
@@ -1859,10 +1859,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d856eb50-0aea-4645-9879-1b42620e7dc0}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {6b50ef9f-eb3b-4f5f-bccb-c4ac9e48b600}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   -0.00147500000000655, 45.3564999999998, 4.57199999999992, !- X,Y,Z Vertex 1 {m}
@@ -1876,10 +1876,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d856eb50-0aea-4645-9879-1b42620e7dc0}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {b704588a-eedd-4cb2-a229-24f26120554c}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   -16.2338, 43.8197999999998, 4.57199999999992, !- X,Y,Z Vertex 1 {m}
@@ -1893,10 +1893,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {0fd60f7d-ee76-49e8-8ff8-533766628f82}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {075fe905-f3fb-46fd-beac-c788ce0e4b59}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   23.4807, 4.57199999999984, 4.572,       !- X,Y,Z Vertex 1 {m}
@@ -1910,10 +1910,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {0fd60f7d-ee76-49e8-8ff8-533766628f82}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {8e09faea-b97e-487d-acd0-d8e97fd38ade}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   53.0574, 4.57199999999984, 4.572,       !- X,Y,Z Vertex 1 {m}
@@ -1927,10 +1927,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {0fd60f7d-ee76-49e8-8ff8-533766628f82}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {e1c39006-1ee1-4a56-9416-1453b51240f7}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   53.0574, 43.8197999999998, 4.572,       !- X,Y,Z Vertex 1 {m}
@@ -1944,10 +1944,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {0fd60f7d-ee76-49e8-8ff8-533766628f82}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {8d613320-1876-4a18-9083-6c630fddcd43}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   7.37341704866608e-017, 4.57199999999984, 4.572, !- X,Y,Z Vertex 1 {m}
@@ -1961,10 +1961,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {027a0cdc-6550-4760-91ae-c3f5379af193}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {054641de-6b49-4e29-9178-f658c23cfb41}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   53.0574, 21.1184999999998, 4.572,       !- X,Y,Z Vertex 1 {m}
@@ -1978,10 +1978,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {0f799d38-5e12-4224-a2f6-65f846eb1148}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {b778e4c0-40db-47f0-b31f-5d3d1800674f}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   9.82824964784047e-017, 5.29316363196444e-017, 4.572, !- X,Y,Z Vertex 1 {m}

--- a/data/geometry/ASHRAE9012013Hospital.osm
+++ b/data/geometry/ASHRAE9012013Hospital.osm
@@ -52,10 +52,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {4b0352d7-5b15-44a5-874c-f4c860e83600}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
+  Outdoors,                               !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  NoSun,                                  !- Sun Exposure
-  NoWind,                                 !- Wind Exposure
+  SunExposed,                             !- Sun Exposure
+  WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   65.532, 42.672, 17.0732,                !- X,Y,Z Vertex 1 {m}
@@ -638,8 +638,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {5fa7a66e-65f8-47fe-850f-4aff5015d62b}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {fe2e086f-e1c3-46d3-8a4e-3176da4a96b9}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -655,8 +655,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e9e27262-9df7-40dc-9a36-b9e4a585473e}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {d196909f-e708-424c-8b62-e23fef048807}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -694,8 +694,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {6ad47ab4-cb8c-4b6f-9311-9dc048eb2eda}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {c4401f19-9005-41d6-a222-faa155cf3b10}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -733,8 +733,8 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {8c173263-502d-42ba-a69e-93df43e4d6ca}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {ad242bae-a693-422e-8f2d-435218ff6c70}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -979,8 +979,8 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {e8233850-2c26-457b-b983-e0a87242a5d7}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {a261d29f-e590-443c-b9b2-963577043ae6}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -1018,8 +1018,8 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {013d2c94-7239-4063-ba94-06ba14717adc}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {180f3ef3-222b-4e7f-b133-0d4ed36ecae5}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -1075,8 +1075,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {17ae9a84-1b9c-49a1-8f48-a49619cb8e39}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {d6ca60ce-5dad-4c3e-98bc-9cc81225ac71}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -1215,8 +1215,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {7f22e5a6-e759-445a-84cb-6b454b893756}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {105afa91-3779-4fdb-a60f-7eb9abc56556}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -1271,8 +1271,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e9e27262-9df7-40dc-9a36-b9e4a585473e}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {0614854f-06fb-446e-9f2c-d99714b3ac6b}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -1361,8 +1361,8 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {42cd4d82-e24e-4e11-88d4-f870740fe240}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {89741c59-d0b7-4b54-b9dd-b090e722293c}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -1523,8 +1523,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {fc9bddfe-4ba5-4685-8ab9-4aa035cfc214}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {412a52da-a12c-4d25-8be6-37fe167cf8d3}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -1820,8 +1820,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c8b8007f-d842-489f-b119-fad0f32ca54d}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {d850a3ba-d291-4fbd-bdba-0b03e083d270}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -1993,8 +1993,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {e02691e9-a447-40e1-aa67-039878424ae6}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {535c1521-f95a-4c01-8070-9bdd078da2f2}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -2010,8 +2010,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e0b3f21a-5417-4d6d-9bad-44c2b5fb3717}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {ae375c1a-a6f6-4f72-97c7-68988455a7f8}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -2055,8 +2055,8 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  9.144, 33.582, 12.8049,                 !- X,Y,Z Vertex 1 {m}
-  9.144, 33.582, 8.5366,                  !- X,Y,Z Vertex 2 {m}
+  9.144, 33.528, 12.8049,                 !- X,Y,Z Vertex 1 {m}
+  9.144, 33.528, 8.5366,                  !- X,Y,Z Vertex 2 {m}
   9.144, 10.668, 8.5366,                  !- X,Y,Z Vertex 3 {m}
   9.144, 10.668, 12.8049;                 !- X,Y,Z Vertex 4 {m}
 
@@ -2127,8 +2127,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {aeb14eec-a11c-4495-b283-f98c2eca3dbf}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {8a25afd7-2df1-44cc-92b0-e18a1af635e8}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -2166,8 +2166,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {3a43a92b-6516-45e6-9f37-eb7bf8bccb83}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {da355684-968c-4d14-8f9a-fe93e8dc43a4}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -2279,8 +2279,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3d0a884f-f38a-4024-ba41-a3615b0d597f}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {cc5daf66-ae7d-4362-b67f-5e2dbf8edce6}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -2313,8 +2313,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {0ebf2d87-9a96-4832-a366-f21cea5fd615}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {e5bbcbda-e9f3-421f-ad21-70a134c8eddf}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -2381,8 +2381,8 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {970b3b19-607d-49a6-8d29-1ec76a5b55c6}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {d7e28700-9bb9-4a66-b4e9-e80b64edc423}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -2398,8 +2398,8 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {47d5f6b5-5e98-43ad-8669-c046505a937d}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {a1a5acfa-4f4f-454e-ad2b-5a734513d70a}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -2411,7 +2411,7 @@ OS:Surface,
 
 OS:Surface,
   {2fc319e1-7021-4537-8de4-7748516e5208}, !- Handle
-  Basement_Ceiling,                       !- Name
+  Basement_Ceiling_1,                     !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {8cefc791-4220-41cf-852d-0cd472e915e7}, !- Space Name
@@ -2432,8 +2432,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {970b3b19-607d-49a6-8d29-1ec76a5b55c6}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {0f5129da-3b5a-4c1f-8345-6c0d899b9136}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -2466,8 +2466,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {668fd0fa-a605-4127-8009-961514db81c7}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {f4107467-8586-4570-bd47-61c25e12dad9}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -2561,8 +2561,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e421471b-c574-4e8a-b7a8-245348dd3775}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {7163f711-d161-48b1-9c62-d24ff670b839}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -2578,8 +2578,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {dc66d323-72f5-4969-aebb-d547b4919d13}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {4f081654-d3d2-4dba-adea-41898dc054ab}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -2646,8 +2646,8 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {3d0a884f-f38a-4024-ba41-a3615b0d597f}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {5f90fb4b-00a3-4f7c-9da6-bb0d2f6c8dbd}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -2736,8 +2736,8 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {0b208f03-204c-460e-a229-d14790739b8b}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {da752f69-bdad-4b32-ac33-e2cc3121c7c2}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -2753,8 +2753,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e8233850-2c26-457b-b983-e0a87242a5d7}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {408e3a40-2f14-41c8-9928-575db1e3557c}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -2804,8 +2804,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {dc66d323-72f5-4969-aebb-d547b4919d13}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {cc411283-bef9-439d-a74e-bc4b9b61ff44}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -2821,14 +2821,14 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3a43a92b-6516-45e6-9f37-eb7bf8bccb83}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {24bcd3a9-6470-4ea5-bf35-65bd4e056a6c}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  9.144, 33.582, 12.8049,                 !- X,Y,Z Vertex 1 {m}
-  9.144, 33.582, 8.5366,                  !- X,Y,Z Vertex 2 {m}
+  9.144, 33.528, 12.8049,                 !- X,Y,Z Vertex 1 {m}
+  9.144, 33.528, 8.5366,                  !- X,Y,Z Vertex 2 {m}
   9.144, 42.672, 8.5366,                  !- X,Y,Z Vertex 3 {m}
   9.144, 42.672, 12.8049;                 !- X,Y,Z Vertex 4 {m}
 
@@ -2855,8 +2855,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {16b36206-de28-4cc5-a003-3fd3fdc223f7}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {95de039e-5c85-4126-9b27-cd5b8bbead5b}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -2889,16 +2889,16 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {31390124-80ad-4222-b08a-01be2ad61163}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {a976292f-4ede-486d-87c0-a38da8a2e980}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   9.144, 42.672, 17.0732,                 !- X,Y,Z Vertex 1 {m}
   9.144, 42.672, 12.8049,                 !- X,Y,Z Vertex 2 {m}
-  9.144, 33.582, 12.8049,                 !- X,Y,Z Vertex 3 {m}
-  9.144, 33.582, 17.0732;                 !- X,Y,Z Vertex 4 {m}
+  9.144, 33.528, 12.8049,                 !- X,Y,Z Vertex 3 {m}
+  9.144, 33.528, 17.0732;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {a261d29f-e590-443c-b9b2-963577043ae6}, !- Handle
@@ -2906,8 +2906,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {17ae9a84-1b9c-49a1-8f48-a49619cb8e39}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {a7283700-b96f-4e4a-bf96-8a3847614eec}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -2923,8 +2923,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {2870f103-d956-457d-b911-977241d8c35a}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {87a8cecf-d74c-4115-bcc9-a0322bce880a}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -2957,8 +2957,8 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {e0b3f21a-5417-4d6d-9bad-44c2b5fb3717}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {9b112bf1-35e7-48c7-b4ad-10eb23646c10}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -3014,8 +3014,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {7cce3ac6-5d1d-4960-9e9f-f0d99f44c040}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {ab5dc732-1429-454f-b178-6d7ab8802397}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -3031,8 +3031,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3a43a92b-6516-45e6-9f37-eb7bf8bccb83}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {8100d5a6-c544-40ae-a4b9-73c0a13030eb}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -3056,8 +3056,8 @@ OS:Surface,
   ,                                       !- Number of Vertices
   9.144, 10.668, 17.0732,                 !- X,Y,Z Vertex 1 {m}
   9.144, 10.668, 12.8049,                 !- X,Y,Z Vertex 2 {m}
-  9.144, 33.582, 12.8049,                 !- X,Y,Z Vertex 3 {m}
-  9.144, 33.582, 17.0732;                 !- X,Y,Z Vertex 4 {m}
+  9.144, 33.528, 12.8049,                 !- X,Y,Z Vertex 3 {m}
+  9.144, 33.528, 17.0732;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {b782f2b1-1e64-4013-94e5-41e118efa0ab}, !- Handle
@@ -3082,8 +3082,8 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {7c3f7787-1a2c-4af2-b30d-c5fe68177501}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {70b061cf-e29f-42b2-9040-b3ec1d5081d6}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -3099,10 +3099,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {648db5a6-f0b0-425d-a12c-a9502504cf7a}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
+  Outdoors,                               !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  NoSun,                                  !- Sun Exposure
-  NoWind,                                 !- Wind Exposure
+  SunExposed,                             !- Sun Exposure
+  WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   28.956, 48.768, 8.5366,                 !- X,Y,Z Vertex 1 {m}
@@ -3172,8 +3172,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {6ad47ab4-cb8c-4b6f-9311-9dc048eb2eda}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {321ebd9e-1534-4ef2-ad0f-6b94f572965c}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -3279,8 +3279,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {aeb14eec-a11c-4495-b283-f98c2eca3dbf}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {5d1af081-760d-4073-86fc-554f40c9d098}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -3296,8 +3296,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {47d5f6b5-5e98-43ad-8669-c046505a937d}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {3a399768-0d26-442c-9545-fa8762c0feaa}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -3330,8 +3330,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {ebe6e839-d2fb-4757-8148-ae01cb77f2b7}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {50744263-980a-4528-9751-466442515973}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -3364,8 +3364,8 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {31390124-80ad-4222-b08a-01be2ad61163}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {183a3138-9faa-4755-bcbb-2d6c659f9046}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -3489,8 +3489,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {e8233850-2c26-457b-b983-e0a87242a5d7}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {59f4e05d-6b43-4dd0-a783-a1872de59aa2}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -3557,8 +3557,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {2870f103-d956-457d-b911-977241d8c35a}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {1de7e67f-db3e-4e3a-a755-e1366589446e}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -3608,8 +3608,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {70b3b79a-870d-4657-b97f-0bf50ccd6e7e}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {df001918-25be-4ed1-bce4-e17d08cc1280}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -3676,8 +3676,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {47d5f6b5-5e98-43ad-8669-c046505a937d}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {d083477d-f5f6-4089-9cf1-32e6a9f6476f}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -3693,8 +3693,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {7802b3f6-be28-4f7e-ab11-b2ff579c4766}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {feb3cd91-7b93-4a5e-aa7c-2fbee94841c9}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -3761,8 +3761,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {60897f76-ccc0-4353-9cbd-ce8e06f8207c}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {fd013922-61d4-4254-898d-c5edb2872080}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -3795,8 +3795,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {bc7d28d5-92bd-44ec-8fa2-e6e43ce5010c}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {c3843fc1-61f6-47cc-a580-460f266cc43b}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -3829,8 +3829,8 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {668fd0fa-a605-4127-8009-961514db81c7}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {8f42ab0d-a8b5-4e68-91fd-573be1236742}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -3931,8 +3931,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {75111445-9889-4e0e-bf8b-33e4ad0474cb}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {7808f468-dc70-4ff4-a590-ac5164eec1e0}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -3999,8 +3999,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e421471b-c574-4e8a-b7a8-245348dd3775}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {930f0a63-ef53-4c72-aa79-3180e600ce8b}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -4067,8 +4067,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e9e27262-9df7-40dc-9a36-b9e4a585473e}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {67c22901-cea0-4a8a-8b4c-11b22bdbaff9}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -4084,8 +4084,8 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {7cce3ac6-5d1d-4960-9e9f-f0d99f44c040}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {6080b08a-0606-4e51-bc61-1b4a45829dd2}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -4225,10 +4225,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3a43a92b-6516-45e6-9f37-eb7bf8bccb83}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
+  Outdoors,                               !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  NoSun,                                  !- Sun Exposure
-  NoWind,                                 !- Wind Exposure
+  SunExposed,                             !- Sun Exposure
+  WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   4.572, 48.768, 12.8049,                 !- X,Y,Z Vertex 1 {m}
@@ -4344,8 +4344,8 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {5fa7a66e-65f8-47fe-850f-4aff5015d62b}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {e7f8efab-d31d-41ac-8837-33b965268455}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -4446,8 +4446,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {1c76f8a5-14f0-4ef9-aedd-f22672148afa}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {02cd7f4d-8e39-4d68-bcdc-d9c5f9dab7e1}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -4473,11 +4473,10 @@ OS:Surface,
   28.956, 0, 0,                           !- X,Y,Z Vertex 2 {m}
   21.3415, 0, 0,                          !- X,Y,Z Vertex 3 {m}
   21.3415, 4.572, 0,                      !- X,Y,Z Vertex 4 {m}
-  9.144, 4.572, 0,                        !- X,Y,Z Vertex 5 {m}
-  6.096, 4.572, 0,                        !- X,Y,Z Vertex 6 {m}
-  6.096, 0, 0,                            !- X,Y,Z Vertex 7 {m}
-  0, 0, 0,                                !- X,Y,Z Vertex 8 {m}
-  0, 53.34, 0;                            !- X,Y,Z Vertex 9 {m}
+  6.096, 4.572, 0,                        !- X,Y,Z Vertex 5 {m}
+  6.096, 0, 0,                            !- X,Y,Z Vertex 6 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 7 {m}
+  0, 53.34, 0;                            !- X,Y,Z Vertex 8 {m}
 
 OS:Surface,
   {dacfed6f-6ad3-45b6-a644-8af9444f6f45}, !- Handle
@@ -4485,8 +4484,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {b32db625-e874-459e-ae5c-6213262e2622}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {0a1a9391-a2ac-4f69-b095-21184607c477}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -4553,8 +4552,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {1168441b-e4e6-4d44-a00f-18b75cc06a24}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {f044d43a-09b1-4ef7-ba9a-a3c019bc4caf}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -4587,8 +4586,8 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {bc7d28d5-92bd-44ec-8fa2-e6e43ce5010c}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {e04ef9d0-4d2c-4947-a41d-10e22e657bb2}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -4621,8 +4620,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {bc7d28d5-92bd-44ec-8fa2-e6e43ce5010c}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {a85cd5d7-0061-4546-8ede-2b3366185288}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -4676,8 +4675,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {e0b3f21a-5417-4d6d-9bad-44c2b5fb3717}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {ec1fa491-9b4e-420d-98c2-0c60ef628b7c}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -4710,14 +4709,14 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {4b0352d7-5b15-44a5-874c-f4c860e83600}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {15ff06d9-e3cb-4784-9c9b-bb1b8a14a4ff}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  9.144, 33.582, 17.0732,                 !- X,Y,Z Vertex 1 {m}
-  9.144, 33.582, 12.8049,                 !- X,Y,Z Vertex 2 {m}
+  9.144, 33.528, 17.0732,                 !- X,Y,Z Vertex 1 {m}
+  9.144, 33.528, 12.8049,                 !- X,Y,Z Vertex 2 {m}
   9.144, 42.672, 12.8049,                 !- X,Y,Z Vertex 3 {m}
   9.144, 42.672, 17.0732;                 !- X,Y,Z Vertex 4 {m}
 
@@ -4846,8 +4845,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {432827a6-9676-48d3-9de8-55f3ed327c07}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {55eea7c2-83a9-4e38-8a66-58fb7d0ea97b}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -4863,8 +4862,8 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {d7e311f6-f2c1-47c2-b301-cbba90b6f733}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {0531c0e6-eff2-4166-8878-f8d977783239}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -4931,8 +4930,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {013d2c94-7239-4063-ba94-06ba14717adc}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {f7d1c174-8880-40b1-8a01-4128252bc5ba}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -4990,8 +4989,8 @@ OS:Surface,
   ,                                       !- Number of Vertices
   9.144, 10.668, 12.8049,                 !- X,Y,Z Vertex 1 {m}
   9.144, 10.668, 8.5366,                  !- X,Y,Z Vertex 2 {m}
-  9.144, 33.582, 8.5366,                  !- X,Y,Z Vertex 3 {m}
-  9.144, 33.582, 12.8049;                 !- X,Y,Z Vertex 4 {m}
+  9.144, 33.528, 8.5366,                  !- X,Y,Z Vertex 3 {m}
+  9.144, 33.528, 12.8049;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {eb0262d2-8e7c-4c4a-968d-1650eb5b4d57}, !- Handle
@@ -5033,10 +5032,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {5fa7a66e-65f8-47fe-850f-4aff5015d62b}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
+  Outdoors,                               !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  NoSun,                                  !- Sun Exposure
-  NoWind,                                 !- Wind Exposure
+  SunExposed,                             !- Sun Exposure
+  WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   70.104, 0, 8.5366,                      !- X,Y,Z Vertex 1 {m}
@@ -5050,10 +5049,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3a43a92b-6516-45e6-9f37-eb7bf8bccb83}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
+  Outdoors,                               !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  NoSun,                                  !- Sun Exposure
-  NoWind,                                 !- Wind Exposure
+  SunExposed,                             !- Sun Exposure
+  WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   65.532, 42.672, 12.8049,                !- X,Y,Z Vertex 1 {m}
@@ -5084,10 +5083,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e421471b-c574-4e8a-b7a8-245348dd3775}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
+  Outdoors,                               !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  NoSun,                                  !- Sun Exposure
-  NoWind,                                 !- Wind Exposure
+  SunExposed,                             !- Sun Exposure
+  WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   64.008, 39.624, 4.2683,                 !- X,Y,Z Vertex 1 {m}
@@ -5186,8 +5185,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {b32db625-e874-459e-ae5c-6213262e2622}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {1903696b-25a7-49b1-a8cc-ebf957bee218}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -5254,8 +5253,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {2d4ce43e-14fd-4122-b641-b757121d5aba}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {910a644d-62d5-4bc9-9b07-0c9555e0a6a0}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -5339,8 +5338,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {ccee8f2b-c192-4f18-9407-cda799f28f23}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {a6afa6ba-8312-4b32-b3c3-0f89b074aad4}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -5356,10 +5355,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {4b0352d7-5b15-44a5-874c-f4c860e83600}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
+  Outdoors,                               !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  NoSun,                                  !- Sun Exposure
-  NoWind,                                 !- Wind Exposure
+  SunExposed,                             !- Sun Exposure
+  WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   4.572, 48.768, 17.0732,                 !- X,Y,Z Vertex 1 {m}
@@ -5390,8 +5389,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {2294b9a3-413c-42bf-8af1-ea3aba2f3837}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {d9a758ae-dcd7-4d45-b706-04207108bdd4}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -5424,8 +5423,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {5fa7a66e-65f8-47fe-850f-4aff5015d62b}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {3c18a7bb-601a-4568-888c-3b6527ee2940}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -5526,8 +5525,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {7802b3f6-be28-4f7e-ab11-b2ff579c4766}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {6698567c-510f-4b65-afa5-58a4c50774b9}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -5543,8 +5542,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c8b8007f-d842-489f-b119-fad0f32ca54d}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {09c670f2-9441-44d7-a2bb-34dce17b7748}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -5628,8 +5627,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e8233850-2c26-457b-b983-e0a87242a5d7}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {17a70b6c-8903-4e80-96bd-1960fa8bc233}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -5662,8 +5661,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d2b1807c-c9f4-44c2-8597-3b555b94b37c}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {9b381fb4-9c86-461e-856f-43ca207a6a40}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -5696,8 +5695,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {2294b9a3-413c-42bf-8af1-ea3aba2f3837}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {2b051b4f-5dc8-43d9-8dff-c15a4d4567c8}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -5742,9 +5741,8 @@ OS:Surface,
   70.104, 13.716, 0,                      !- X,Y,Z Vertex 4 {m}
   64.008, 13.716, 0,                      !- X,Y,Z Vertex 5 {m}
   64.008, 4.572, 0,                       !- X,Y,Z Vertex 6 {m}
-  45.72, 4.572, 0,                        !- X,Y,Z Vertex 7 {m}
-  39.624, 4.572, 0,                       !- X,Y,Z Vertex 8 {m}
-  39.624, 48.768, 0;                      !- X,Y,Z Vertex 9 {m}
+  39.624, 4.572, 0,                       !- X,Y,Z Vertex 7 {m}
+  39.624, 48.768, 0;                      !- X,Y,Z Vertex 8 {m}
 
 OS:Surface,
   {42df4b75-1019-42be-bc4d-2ee09b7f435e}, !- Handle
@@ -5769,8 +5767,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {8ec78f13-57f2-4f0e-9746-f05360546e20}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {ce5242ce-fd5f-4765-8667-993660abc344}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -5820,8 +5818,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {0f8481b9-82a8-4c09-8d52-f278649c4c33}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {4f7c7d74-b707-42e0-8016-b122c650983d}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -5854,8 +5852,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {1fd4c829-a755-45de-b877-ff8108b86807}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {a9fd89f8-ff30-4d8b-b749-c8aef4cb2067}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -5871,8 +5869,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {4b0352d7-5b15-44a5-874c-f4c860e83600}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {fb2dd5d4-8d33-41f8-a714-19d3ed1740be}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -5888,8 +5886,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e02691e9-a447-40e1-aa67-039878424ae6}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {dfe8b32d-a617-4cfb-a47e-5cb4e5fda3c2}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -5962,8 +5960,8 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  9.144, 33.582, 17.0732,                 !- X,Y,Z Vertex 1 {m}
-  9.144, 33.582, 12.8049,                 !- X,Y,Z Vertex 2 {m}
+  9.144, 33.528, 17.0732,                 !- X,Y,Z Vertex 1 {m}
+  9.144, 33.528, 12.8049,                 !- X,Y,Z Vertex 2 {m}
   9.144, 10.668, 12.8049,                 !- X,Y,Z Vertex 3 {m}
   9.144, 10.668, 17.0732;                 !- X,Y,Z Vertex 4 {m}
 
@@ -5973,8 +5971,8 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {aeb14eec-a11c-4495-b283-f98c2eca3dbf}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {74928bcc-d6f5-4e09-ab22-149fe06810a7}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -5992,8 +5990,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {42cd4d82-e24e-4e11-88d4-f870740fe240}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {9ac64baf-a3e5-43da-94ea-f686057557fd}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -6009,8 +6007,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {47d5f6b5-5e98-43ad-8669-c046505a937d}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {a2f4aec2-5325-4fea-90b8-6ed5d99e7c0a}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -6043,8 +6041,8 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {16b36206-de28-4cc5-a003-3fd3fdc223f7}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {45c90384-502d-43bb-aac4-52f28bba930e}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -6151,8 +6149,8 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {1c76f8a5-14f0-4ef9-aedd-f22672148afa}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {2412ef37-5701-4282-a20b-f2571ccb5b10}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -6202,8 +6200,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {f4b6e0eb-817b-405c-98f0-c425865851fb}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {b630a08c-bea4-44d4-a20a-0993fe636feb}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -6211,8 +6209,7 @@ OS:Surface,
   39.624, 42.672, 8.5366,                 !- X,Y,Z Vertex 1 {m}
   39.624, 10.668, 8.5366,                 !- X,Y,Z Vertex 2 {m}
   28.956, 10.668, 8.5366,                 !- X,Y,Z Vertex 3 {m}
-  28.956, 19.812, 8.5366,                 !- X,Y,Z Vertex 4 {m}
-  28.956, 42.672, 8.5366;                 !- X,Y,Z Vertex 5 {m}
+  28.956, 42.672, 8.5366;                 !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {d870ae02-c6b9-4cf0-8ba5-38dade2d06b9}, !- Handle
@@ -6288,8 +6285,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0bb10f6e-83ca-443c-bdd6-76ddf2ef5dd5}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {27fcfb48-1e0c-42d6-a359-d3df26e02d48}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -6305,8 +6302,8 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {0ebf2d87-9a96-4832-a366-f21cea5fd615}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {81909e64-bb6b-48a8-8805-33ea6099986a}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -6398,10 +6395,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {b32db625-e874-459e-ae5c-6213262e2622}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
+  Outdoors,                               !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  NoSun,                                  !- Sun Exposure
-  NoWind,                                 !- Wind Exposure
+  SunExposed,                             !- Sun Exposure
+  WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   4.572, 44.196, 8.5366,                  !- X,Y,Z Vertex 1 {m}
@@ -6483,8 +6480,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {7f22e5a6-e759-445a-84cb-6b454b893756}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {aa125bee-678f-4d05-9785-ac1e49b2918e}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -6551,8 +6548,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {0f8481b9-82a8-4c09-8d52-f278649c4c33}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {336ad7d8-eac6-422f-9792-d29f3da28d43}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -6619,16 +6616,16 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {2870f103-d956-457d-b911-977241d8c35a}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {b561fd0f-55af-433e-86cc-3619d4454fba}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  28.956, 42.672, 8.5366,                 !- X,Y,Z Vertex 1 {m}
-  39.624, 42.672, 8.5366,                 !- X,Y,Z Vertex 2 {m}
-  39.624, 53.34, 8.5366,                  !- X,Y,Z Vertex 3 {m}
-  28.956, 53.34, 8.5366;                  !- X,Y,Z Vertex 4 {m}
+  39.624, 42.672, 8.5366,                 !- X,Y,Z Vertex 1 {m}
+  39.624, 53.34, 8.5366,                  !- X,Y,Z Vertex 2 {m}
+  28.956, 53.34, 8.5366,                  !- X,Y,Z Vertex 3 {m}
+  28.956, 42.672, 8.5366;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {b64d3ced-5885-4afc-9b49-969554c8d520}, !- Handle
@@ -6653,8 +6650,8 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {7f22e5a6-e759-445a-84cb-6b454b893756}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {bbe5ef4c-9228-44af-b64a-afac7b888d58}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -6670,8 +6667,8 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {7698b8f9-ce74-4b6b-806d-12cdef049900}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {69c18cae-9d2f-4864-9c57-e3dd9c93faac}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -6704,8 +6701,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {7f22e5a6-e759-445a-84cb-6b454b893756}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {da7d1709-9f24-4cad-aead-c169da645664}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -6721,8 +6718,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {7cce3ac6-5d1d-4960-9e9f-f0d99f44c040}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {dc428305-ab12-4661-b7b1-c7fe4452e5bd}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -6806,8 +6803,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e9e27262-9df7-40dc-9a36-b9e4a585473e}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {6306c332-37b5-4191-a945-60d8db12ae79}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -6857,8 +6854,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {aeb14eec-a11c-4495-b283-f98c2eca3dbf}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {568c28e0-56e4-4e5a-b7f9-e1e737ca82c0}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -6874,8 +6871,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {d2b1807c-c9f4-44c2-8597-3b555b94b37c}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {e05141f5-0506-4551-a154-a78e3f9ae2f5}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -6883,8 +6880,7 @@ OS:Surface,
   70.104, 4.572, 8.5366,                  !- X,Y,Z Vertex 1 {m}
   70.104, 0, 8.5366,                      !- X,Y,Z Vertex 2 {m}
   62.484, 0, 8.5366,                      !- X,Y,Z Vertex 3 {m}
-  62.484, 4.572, 8.5366,                  !- X,Y,Z Vertex 4 {m}
-  65.532, 4.572, 8.5366;                  !- X,Y,Z Vertex 5 {m}
+  62.484, 4.572, 8.5366;                  !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {b843d441-7b16-4de8-94cf-6f2b473bb75d}, !- Handle
@@ -6926,8 +6922,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3a43a92b-6516-45e6-9f37-eb7bf8bccb83}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {f3331ec8-ffff-46f4-bf5e-8fb4f9182175}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -6960,8 +6956,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {6a8c5c6f-369f-4ab1-867d-7f5523a9610f}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {893b5944-e696-48a1-9f14-6a7f84f9bf00}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -7030,16 +7026,16 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f4b6e0eb-817b-405c-98f0-c425865851fb}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {9a8d1b7e-2bf8-4e2a-a412-7fda7f7a0dc4}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   9.144, 42.672, 12.8049,                 !- X,Y,Z Vertex 1 {m}
   9.144, 42.672, 8.5366,                  !- X,Y,Z Vertex 2 {m}
-  9.144, 33.582, 8.5366,                  !- X,Y,Z Vertex 3 {m}
-  9.144, 33.582, 12.8049;                 !- X,Y,Z Vertex 4 {m}
+  9.144, 33.528, 8.5366,                  !- X,Y,Z Vertex 3 {m}
+  9.144, 33.528, 12.8049;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {ec770f09-5270-4b1c-a6c3-cd094f6dabad}, !- Handle
@@ -7047,8 +7043,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {648db5a6-f0b0-425d-a12c-a9502504cf7a}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {559d9ceb-a704-4792-8838-6a6e587138d6}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -7098,8 +7094,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {b32db625-e874-459e-ae5c-6213262e2622}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {566aea66-c1c2-4225-a368-75dd867cfee9}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -7268,8 +7264,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {e9e27262-9df7-40dc-9a36-b9e4a585473e}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {551d1ef7-9c86-44a8-9afc-22e0a9ab1f1a}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -7277,8 +7273,7 @@ OS:Surface,
   39.624, 10.668, 8.5366,                 !- X,Y,Z Vertex 1 {m}
   39.624, 0, 8.5366,                      !- X,Y,Z Vertex 2 {m}
   28.956, 0, 8.5366,                      !- X,Y,Z Vertex 3 {m}
-  28.956, 4.572, 8.5366,                  !- X,Y,Z Vertex 4 {m}
-  28.956, 10.668, 8.5366;                 !- X,Y,Z Vertex 5 {m}
+  28.956, 10.668, 8.5366;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {ae8350b7-ec38-46c6-8acb-8c06e3b6faab}, !- Handle
@@ -7303,8 +7298,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {648db5a6-f0b0-425d-a12c-a9502504cf7a}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {954ccdd2-26e4-4255-963b-d913f6d989e5}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -7320,17 +7315,16 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {4b0352d7-5b15-44a5-874c-f4c860e83600}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {34e15ad4-259e-4af7-9d47-f9dfb6b78bc5}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   65.532, 42.672, 17.0732,                !- X,Y,Z Vertex 1 {m}
   65.532, 48.768, 17.0732,                !- X,Y,Z Vertex 2 {m}
-  44.196, 48.768, 17.0732,                !- X,Y,Z Vertex 3 {m}
-  39.624, 48.768, 17.0732,                !- X,Y,Z Vertex 4 {m}
-  39.624, 42.672, 17.0732;                !- X,Y,Z Vertex 5 {m}
+  39.624, 48.768, 17.0732,                !- X,Y,Z Vertex 3 {m}
+  39.624, 42.672, 17.0732;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {6e4f4a74-187d-4a88-926a-34d8540efa56}, !- Handle
@@ -7372,8 +7366,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {4b0352d7-5b15-44a5-874c-f4c860e83600}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {9db115fe-ad70-4d1e-892f-1edcd327f067}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -7457,8 +7451,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0b208f03-204c-460e-a229-d14790739b8b}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {7bfa6a2b-a70c-4473-bc4d-b5967f24998d}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -7559,8 +7553,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {75111445-9889-4e0e-bf8b-33e4ad0474cb}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {95204fa4-665a-4b00-a779-bff0de5c8d00}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -7576,8 +7570,8 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {fc9bddfe-4ba5-4685-8ab9-4aa035cfc214}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {9133f20c-d88a-4829-a000-fb019b06a3ce}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -7657,12 +7651,12 @@ OS:Surface,
 
 OS:Surface,
   {e96fc82c-6c5b-4af8-a100-419e9d3c075d}, !- Handle
-  Lobby_Records_Flr_1_Ceiling,            !- Name
+  Lobby_Records_Flr_1_Ceiling_7,          !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {ebe6e839-d2fb-4757-8148-ae01cb77f2b7}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {c6f60957-7c7b-4701-869e-309bc5a9c8b8}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -7678,8 +7672,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {0b208f03-204c-460e-a229-d14790739b8b}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {fd48f5e5-33a4-4c32-be55-d8550897f6ee}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -7797,8 +7791,8 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {e421471b-c574-4e8a-b7a8-245348dd3775}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {a6d15c65-3ddb-42e8-bd00-926e749c5bb2}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -7814,8 +7808,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {7c3f7787-1a2c-4af2-b30d-c5fe68177501}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {9dda3cae-4368-4b00-b7c0-c5d8074b8b07}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -7831,8 +7825,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {668fd0fa-a605-4127-8009-961514db81c7}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {13605f1c-0e05-4326-921b-7e624ee89f8e}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -7899,8 +7893,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {7f22e5a6-e759-445a-84cb-6b454b893756}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {c00a9beb-b35b-49fc-bcc6-a995e78f18ba}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -7952,8 +7946,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {648db5a6-f0b0-425d-a12c-a9502504cf7a}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {e96fc82c-6c5b-4af8-a100-419e9d3c075d}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -8054,8 +8048,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {8c173263-502d-42ba-a69e-93df43e4d6ca}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {caf4cc39-e649-4a8e-97d6-92706769731d}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -8122,8 +8116,8 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {e141e567-31a6-4982-92aa-a4d8a75baef0}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {0d4215b1-8595-4963-9141-7c99a30aa72a}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -8190,8 +8184,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {70b3b79a-870d-4657-b97f-0bf50ccd6e7e}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {121140cd-91e6-4cd8-9607-22b0820c02ca}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -8241,8 +8235,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {7802b3f6-be28-4f7e-ab11-b2ff579c4766}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {3f2b4ec2-15be-4a4c-a833-f64fec9a790e}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -8258,8 +8252,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e421471b-c574-4e8a-b7a8-245348dd3775}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {ea8819e9-6cae-4415-8b5d-ad4f793ec62e}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -8275,8 +8269,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0f8481b9-82a8-4c09-8d52-f278649c4c33}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {480b6e18-959a-4136-945d-0d8861aee250}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -8309,8 +8303,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {8c173263-502d-42ba-a69e-93df43e4d6ca}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {c27b97a8-164a-4e15-bfe6-7c60415d80e8}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -8326,8 +8320,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {aeb14eec-a11c-4495-b283-f98c2eca3dbf}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {c09c7b3e-ddce-4c0a-9de6-2affe7be9003}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -8343,8 +8337,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e421471b-c574-4e8a-b7a8-245348dd3775}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {8a4effad-3dbc-4f6d-a435-b77af1ceb8d8}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -8394,8 +8388,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {8ec78f13-57f2-4f0e-9746-f05360546e20}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {f65b4b7f-53b2-4364-a2bf-f11f7762129b}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -8445,8 +8439,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {70b3b79a-870d-4657-b97f-0bf50ccd6e7e}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {d62beb34-0bfd-432f-9b95-7bd4d29a60f7}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -8462,8 +8456,8 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {dd7a92d0-924e-4003-b630-567ab7ab69ab}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {97922924-522a-4635-948a-6783f5aca89c}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -8496,8 +8490,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {5fa7a66e-65f8-47fe-850f-4aff5015d62b}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {f4f214a8-9297-4fdd-b258-0b4f49c38e82}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -8632,17 +8626,16 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {60897f76-ccc0-4353-9cbd-ce8e06f8207c}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {507a5052-c6fa-4e80-96ea-d8413460cc49}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   70.104, 53.34, 8.5366,                  !- X,Y,Z Vertex 1 {m}
   70.104, 48.768, 8.5366,                 !- X,Y,Z Vertex 2 {m}
-  65.532, 48.768, 8.5366,                 !- X,Y,Z Vertex 3 {m}
-  62.484, 48.768, 8.5366,                 !- X,Y,Z Vertex 4 {m}
-  62.484, 53.34, 8.5366;                  !- X,Y,Z Vertex 5 {m}
+  62.484, 48.768, 8.5366,                 !- X,Y,Z Vertex 3 {m}
+  62.484, 53.34, 8.5366;                  !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {e5bbcbda-e9f3-421f-ad21-70a134c8eddf}, !- Handle
@@ -8650,8 +8643,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3d0a884f-f38a-4024-ba41-a3615b0d597f}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {789768d7-4e4d-4e4f-9b7e-713957ac932a}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -8667,8 +8660,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {5fa7a66e-65f8-47fe-850f-4aff5015d62b}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {4c218e21-829e-40f1-b307-b53fc546cefc}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -8684,8 +8677,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {aeb14eec-a11c-4495-b283-f98c2eca3dbf}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {ec770f09-5270-4b1c-a6c3-cd094f6dabad}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -8735,8 +8728,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {7cce3ac6-5d1d-4960-9e9f-f0d99f44c040}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {454cbf73-dfa7-47ba-a828-0828df01b895}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -13419,8 +13412,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0bb10f6e-83ca-443c-bdd6-76ddf2ef5dd5}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {de282c3d-a726-4d05-8a15-925ca4e7d132}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -13428,8 +13421,7 @@ OS:Surface,
   65.532, 48.768, 17.0732,                !- X,Y,Z Vertex 1 {m}
   65.532, 42.672, 17.0732,                !- X,Y,Z Vertex 2 {m}
   39.624, 42.672, 17.0732,                !- X,Y,Z Vertex 3 {m}
-  39.624, 48.768, 17.0732,                !- X,Y,Z Vertex 4 {m}
-  44.196, 48.768, 17.0732;                !- X,Y,Z Vertex 5 {m}
+  39.624, 48.768, 17.0732;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {412a52da-a12c-4d25-8be6-37fe167cf8d3}, !- Handle
@@ -13437,10 +13429,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {4b0352d7-5b15-44a5-874c-f4c860e83600}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {d1cde792-5d5b-4b79-bf30-303541cc52d4}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   65.532, 48.768, 17.0732,                !- X,Y,Z Vertex 1 {m}
@@ -13454,17 +13446,16 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {0b208f03-204c-460e-a229-d14790739b8b}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {104a676f-f42a-42ec-9913-0bd5765a2d70}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   70.104, 48.768, 8.5366,                 !- X,Y,Z Vertex 1 {m}
   70.104, 53.34, 8.5366,                  !- X,Y,Z Vertex 2 {m}
   62.484, 53.34, 8.5366,                  !- X,Y,Z Vertex 3 {m}
-  62.484, 48.768, 8.5366,                 !- X,Y,Z Vertex 4 {m}
-  65.532, 48.768, 8.5366;                 !- X,Y,Z Vertex 5 {m}
+  62.484, 48.768, 8.5366;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {b561fd0f-55af-433e-86cc-3619d4454fba}, !- Handle
@@ -13472,8 +13463,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {3a43a92b-6516-45e6-9f37-eb7bf8bccb83}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {a34060eb-629e-44b9-9bab-9e16f4d1c1d4}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -13489,10 +13480,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {5fa7a66e-65f8-47fe-850f-4aff5015d62b}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {b926dc39-e6df-46a2-8046-049a672f85d2}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   60.96, 41.148, 8.5366,                  !- X,Y,Z Vertex 1 {m}
@@ -13506,10 +13497,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {0b208f03-204c-460e-a229-d14790739b8b}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   70.104, 47.244, 8.5366,                 !- X,Y,Z Vertex 1 {m}
@@ -13523,10 +13514,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {0b208f03-204c-460e-a229-d14790739b8b}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   62.484, 48.768, 8.5366,                 !- X,Y,Z Vertex 1 {m}
@@ -13540,8 +13531,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0b208f03-204c-460e-a229-d14790739b8b}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {8d7d3535-822d-4af4-af50-36d9e3c3a88f}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -13557,7 +13548,7 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0b208f03-204c-460e-a229-d14790739b8b}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
@@ -13574,7 +13565,7 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0b208f03-204c-460e-a229-d14790739b8b}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
@@ -13591,10 +13582,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {e421471b-c574-4e8a-b7a8-245348dd3775}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {6a6e1363-5fc3-4ab3-9556-228d03728c55}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   48.768, 22.86, 4.2683,                  !- X,Y,Z Vertex 1 {m}
@@ -13608,8 +13599,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0bb10f6e-83ca-443c-bdd6-76ddf2ef5dd5}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {5fb01ad6-bcc3-4db8-82f2-601839f41937}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -13625,10 +13616,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {4b0352d7-5b15-44a5-874c-f4c860e83600}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {a77db2c4-8926-4d0e-9568-46de22677065}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   39.624, 42.672, 17.0732,                !- X,Y,Z Vertex 1 {m}
@@ -13644,8 +13635,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0bb10f6e-83ca-443c-bdd6-76ddf2ef5dd5}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {b122dd8a-4220-45dd-9ccc-1e7dbad31d46}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -13661,10 +13652,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {7698b8f9-ce74-4b6b-806d-12cdef049900}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {9b1470be-8962-416f-af66-cc76ba6757a0}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   60.96, 19.812, 17.0732,                 !- X,Y,Z Vertex 1 {m}
@@ -13678,8 +13669,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0bb10f6e-83ca-443c-bdd6-76ddf2ef5dd5}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {4b9655f2-d1be-484c-9f0a-6ef973008a80}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -13695,10 +13686,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {7f22e5a6-e759-445a-84cb-6b454b893756}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {2ecb2394-f5a0-4485-acaf-9040f713ec3f}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   65.532, 4.572, 17.0732,                 !- X,Y,Z Vertex 1 {m}
@@ -13714,7 +13705,7 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0bb10f6e-83ca-443c-bdd6-76ddf2ef5dd5}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
@@ -13731,7 +13722,7 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0bb10f6e-83ca-443c-bdd6-76ddf2ef5dd5}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
@@ -13748,10 +13739,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {0ebf2d87-9a96-4832-a366-f21cea5fd615}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {d783e1e5-26da-45f4-8c0f-ef2fcd399af0}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   6.096, 4.572, 17.0732,                  !- X,Y,Z Vertex 1 {m}
@@ -13765,8 +13756,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {75111445-9889-4e0e-bf8b-33e4ad0474cb}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {5890b7f1-0b9c-4e00-9e5e-98b462edea85}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -13799,17 +13790,16 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {5fa7a66e-65f8-47fe-850f-4aff5015d62b}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {a088dfcb-4ae1-49b1-87dd-c42b51b97f8e}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   60.96, 42.672, 8.5366,                  !- X,Y,Z Vertex 1 {m}
   60.96, 48.768, 8.5366,                  !- X,Y,Z Vertex 2 {m}
   48.768, 48.768, 8.5366,                 !- X,Y,Z Vertex 3 {m}
-  48.768, 47.244, 8.5366,                 !- X,Y,Z Vertex 4 {m}
-  48.768, 42.672, 8.5366;                 !- X,Y,Z Vertex 5 {m}
+  48.768, 42.672, 8.5366;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {35d16a43-528e-4bb0-b366-0307cf03d08b}, !- Handle
@@ -13817,10 +13807,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d2b1807c-c9f4-44c2-8597-3b555b94b37c}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {95f382df-6256-48af-a274-6407639c0883}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   65.532, 4.572, 12.8049,                 !- X,Y,Z Vertex 1 {m}
@@ -13851,10 +13841,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {1168441b-e4e6-4d44-a00f-18b75cc06a24}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {4d33cad5-3e08-4e8e-ba52-86193eec8414}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   39.624, 48.768, 4.2683,                 !- X,Y,Z Vertex 1 {m}
@@ -13864,14 +13854,14 @@ OS:Surface,
 
 OS:Surface,
   {b33dba6b-b3dc-431f-999e-546c9d49159b}, !- Handle
-  Surface 27,                             !- Name
+  Basement_Ceiling_9,                     !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {8cefc791-4220-41cf-852d-0cd472e915e7}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   70.104, 4.572, 0,                       !- X,Y,Z Vertex 1 {m}
@@ -13881,14 +13871,14 @@ OS:Surface,
 
 OS:Surface,
   {07d1efb5-c730-49b2-92e2-6a2db754d803}, !- Handle
-  Surface 28,                             !- Name
+  Basement_Ceiling_3,                     !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {8cefc791-4220-41cf-852d-0cd472e915e7}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   9.144, 0, 0,                            !- X,Y,Z Vertex 1 {m}
@@ -13902,10 +13892,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {1168441b-e4e6-4d44-a00f-18b75cc06a24}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {c77ef648-aa43-4660-b559-2470b4eeec10}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   39.624, 4.572, 4.2683,                  !- X,Y,Z Vertex 1 {m}
@@ -13919,8 +13909,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {5fa7a66e-65f8-47fe-850f-4aff5015d62b}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {3914e10d-e717-4f5f-8bba-657fd562eb2f}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -13932,14 +13922,14 @@ OS:Surface,
 
 OS:Surface,
   {1ba6552c-7435-41e0-a11f-91a17d369f0f}, !- Handle
-  Surface 31,                             !- Name
+  Basement_Ceiling_6,                     !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {8cefc791-4220-41cf-852d-0cd472e915e7}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   45.72, 0, 0,                            !- X,Y,Z Vertex 1 {m}
@@ -13953,10 +13943,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e421471b-c574-4e8a-b7a8-245348dd3775}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   64.008, 9.144, 4.2683,                  !- X,Y,Z Vertex 1 {m}
@@ -13970,10 +13960,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {17ae9a84-1b9c-49a1-8f48-a49619cb8e39}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {8d1abac8-f396-44b2-b345-b854e9ba8614}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   6.096, 4.572, 12.8049,                  !- X,Y,Z Vertex 1 {m}
@@ -13987,10 +13977,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {e8233850-2c26-457b-b983-e0a87242a5d7}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {6a1cc8f6-c49b-42bf-82b2-ce9fb0f1f148}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   9.144, 10.668, 8.5366,                  !- X,Y,Z Vertex 1 {m}
@@ -14017,14 +14007,14 @@ OS:Surface,
 
 OS:Surface,
   {49de8715-0c8d-4155-8d49-022f93ad0fe6}, !- Handle
-  Surface 36,                             !- Name
+  Basement_Ceiling_2,                     !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {8cefc791-4220-41cf-852d-0cd472e915e7}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   28.956, 0, 0,                           !- X,Y,Z Vertex 1 {m}
@@ -14033,9 +14023,8 @@ OS:Surface,
   0, 0, 0,                                !- X,Y,Z Vertex 4 {m}
   6.096, 0, 0,                            !- X,Y,Z Vertex 5 {m}
   6.096, 4.572, 0,                        !- X,Y,Z Vertex 6 {m}
-  9.144, 4.572, 0,                        !- X,Y,Z Vertex 7 {m}
-  21.3415, 4.572, 0,                      !- X,Y,Z Vertex 8 {m}
-  21.3415, 0, 0;                          !- X,Y,Z Vertex 9 {m}
+  21.3415, 4.572, 0,                      !- X,Y,Z Vertex 7 {m}
+  21.3415, 0, 0;                          !- X,Y,Z Vertex 8 {m}
 
 OS:Surface,
   {ed09367e-45b9-4b95-8e1c-d7390d6a5443}, !- Handle
@@ -14043,8 +14032,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {e8233850-2c26-457b-b983-e0a87242a5d7}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {fadb667e-b842-4205-bfc4-16869d1662c8}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -14081,10 +14070,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {1fd4c829-a755-45de-b877-ff8108b86807}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   0, 48.768, 12.8049,                     !- X,Y,Z Vertex 1 {m}
@@ -14115,10 +14104,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3a43a92b-6516-45e6-9f37-eb7bf8bccb83}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {99da29b0-ecf9-4219-b1b2-77c181f7b238}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   65.532, 48.768, 12.8049,                !- X,Y,Z Vertex 1 {m}
@@ -14132,10 +14121,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {7cce3ac6-5d1d-4960-9e9f-f0d99f44c040}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {2157d3c9-b429-40f3-aef5-751c8f567336}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   48.768, 47.244, 8.5366,                 !- X,Y,Z Vertex 1 {m}
@@ -14149,17 +14138,16 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {2870f103-d956-457d-b911-977241d8c35a}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {b674e94a-8db4-4aec-86b1-38cfb4fce66a}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   39.624, 0, 8.5366,                      !- X,Y,Z Vertex 1 {m}
   39.624, 10.668, 8.5366,                 !- X,Y,Z Vertex 2 {m}
   28.956, 10.668, 8.5366,                 !- X,Y,Z Vertex 3 {m}
-  28.956, 4.572, 8.5366,                  !- X,Y,Z Vertex 4 {m}
-  28.956, 0, 8.5366;                      !- X,Y,Z Vertex 5 {m}
+  28.956, 0, 8.5366;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {a1a5acfa-4f4f-454e-ad2b-5a734513d70a}, !- Handle
@@ -14167,8 +14155,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {3a43a92b-6516-45e6-9f37-eb7bf8bccb83}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {b074cb71-fb94-4162-b579-f4b1e2d17787}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -14184,8 +14172,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {3a43a92b-6516-45e6-9f37-eb7bf8bccb83}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {4a93ca53-3812-404b-bacb-6323cf144129}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -14203,10 +14191,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {2870f103-d956-457d-b911-977241d8c35a}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {1db65e93-f31b-4dd3-a095-aeaa0204e60e}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   39.624, 0, 8.5366,                      !- X,Y,Z Vertex 1 {m}
@@ -14220,10 +14208,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {2870f103-d956-457d-b911-977241d8c35a}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {0b531984-10df-44cf-8486-0d7689121893}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   39.624, 47.244, 8.5366,                 !- X,Y,Z Vertex 1 {m}
@@ -14237,10 +14225,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {2870f103-d956-457d-b911-977241d8c35a}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {1c11fa53-d214-44f4-9985-0c989328dc1a}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   28.956, 48.768, 8.5366,                 !- X,Y,Z Vertex 1 {m}
@@ -14254,10 +14242,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {2870f103-d956-457d-b911-977241d8c35a}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {11539731-965f-4e25-968d-efea3a7439dd}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   28.956, 21.3415, 8.5366,                !- X,Y,Z Vertex 1 {m}
@@ -14271,17 +14259,16 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {2870f103-d956-457d-b911-977241d8c35a}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {29966189-c7fb-46c0-a00c-cf24b396e627}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   39.624, 10.668, 8.5366,                 !- X,Y,Z Vertex 1 {m}
   39.624, 42.672, 8.5366,                 !- X,Y,Z Vertex 2 {m}
   28.956, 42.672, 8.5366,                 !- X,Y,Z Vertex 3 {m}
-  28.956, 19.812, 8.5366,                 !- X,Y,Z Vertex 4 {m}
-  28.956, 10.668, 8.5366;                 !- X,Y,Z Vertex 5 {m}
+  28.956, 10.668, 8.5366;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {96f62409-b4bf-4749-acd1-afc5ee334e0e}, !- Handle
@@ -14289,19 +14276,18 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {e9e27262-9df7-40dc-9a36-b9e4a585473e}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {f33b6919-bfe0-4f0c-b26f-e6f926c6a2e3}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   65.532, 16.764, 8.5366,                 !- X,Y,Z Vertex 1 {m}
   65.532, 4.572, 8.5366,                  !- X,Y,Z Vertex 2 {m}
-  44.196, 4.572, 8.5366,                  !- X,Y,Z Vertex 3 {m}
-  39.624, 4.572, 8.5366,                  !- X,Y,Z Vertex 4 {m}
-  39.624, 10.668, 8.5366,                 !- X,Y,Z Vertex 5 {m}
-  60.96, 10.668, 8.5366,                  !- X,Y,Z Vertex 6 {m}
-  60.96, 16.764, 8.5366;                  !- X,Y,Z Vertex 7 {m}
+  39.624, 4.572, 8.5366,                  !- X,Y,Z Vertex 3 {m}
+  39.624, 10.668, 8.5366,                 !- X,Y,Z Vertex 4 {m}
+  60.96, 10.668, 8.5366,                  !- X,Y,Z Vertex 5 {m}
+  60.96, 16.764, 8.5366;                  !- X,Y,Z Vertex 6 {m}
 
 OS:Surface,
   {0aeeafec-bf8f-44e0-8a34-f7210d40505a}, !- Handle
@@ -14309,17 +14295,16 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {e9e27262-9df7-40dc-9a36-b9e4a585473e}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {3224e308-1e8b-47cd-a39c-f7acb7ec22a9}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   28.956, 10.668, 8.5366,                 !- X,Y,Z Vertex 1 {m}
   28.956, 4.572, 8.5366,                  !- X,Y,Z Vertex 2 {m}
-  6.096, 4.572, 8.5366,                   !- X,Y,Z Vertex 3 {m}
-  4.572, 4.572, 8.5366,                   !- X,Y,Z Vertex 4 {m}
-  4.572, 10.668, 8.5366;                  !- X,Y,Z Vertex 5 {m}
+  4.572, 4.572, 8.5366,                   !- X,Y,Z Vertex 3 {m}
+  4.572, 10.668, 8.5366;                  !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {d5e9709c-4d29-495d-a67c-50d56e96896c}, !- Handle
@@ -14327,8 +14312,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {f4b6e0eb-817b-405c-98f0-c425865851fb}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {95118cea-f630-4aa1-8959-0be3b482e32b}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -14344,8 +14329,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {f4b6e0eb-817b-405c-98f0-c425865851fb}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {9c50da0f-5462-4ba7-b29f-786e23f02d5c}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -14363,8 +14348,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {2d4ce43e-14fd-4122-b641-b757121d5aba}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {101de97d-d023-4197-a46d-934a10b1803f}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -14380,10 +14365,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {31390124-80ad-4222-b08a-01be2ad61163}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {0411ebb3-9af3-489e-9871-d57d5b3f4f78}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   39.624, 10.668, 17.0732,                !- X,Y,Z Vertex 1 {m}
@@ -14399,8 +14384,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {2d4ce43e-14fd-4122-b641-b757121d5aba}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {13d8edca-f17b-4a9f-8402-de08ca4175c3}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -14416,8 +14401,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {2d4ce43e-14fd-4122-b641-b757121d5aba}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {8f9ee008-87d1-4be3-8629-11e2ebf9c233}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -14433,8 +14418,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {2d4ce43e-14fd-4122-b641-b757121d5aba}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {617a8237-69b6-4911-afc0-0416a9c98fb2}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -14452,8 +14437,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {2d4ce43e-14fd-4122-b641-b757121d5aba}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {2a8311e7-db40-40b8-8239-77f5c79faae5}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -14469,7 +14454,7 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {2d4ce43e-14fd-4122-b641-b757121d5aba}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
@@ -14486,10 +14471,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {7f22e5a6-e759-445a-84cb-6b454b893756}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {17217052-44a7-45f0-a4a5-29f86bf77b1a}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   39.624, 0, 17.0732,                     !- X,Y,Z Vertex 1 {m}
@@ -14505,7 +14490,7 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {2d4ce43e-14fd-4122-b641-b757121d5aba}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
@@ -14517,32 +14502,15 @@ OS:Surface,
   44.196, 4.572, 17.0732;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {56d9ebe4-0f0b-4971-8274-dc732b649d4b}, !- Handle
-  Surface 64,                             !- Name
-  Wall,                                   !- Surface Type
-  ,                                       !- Construction Name
-  {31390124-80ad-4222-b08a-01be2ad61163}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
-  ,                                       !- View Factor to Ground
-  ,                                       !- Number of Vertices
-  9.144, 33.582, 17.0732,                 !- X,Y,Z Vertex 1 {m}
-  9.144, 33.582, 12.8049,                 !- X,Y,Z Vertex 2 {m}
-  9.144, 33.528, 12.8049,                 !- X,Y,Z Vertex 3 {m}
-  9.144, 33.528, 17.0732;                 !- X,Y,Z Vertex 4 {m}
-
-OS:Surface,
   {feb3cd91-7b93-4a5e-aa7c-2fbee94841c9}, !- Handle
   Surface 65,                             !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {31390124-80ad-4222-b08a-01be2ad61163}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {63efed9b-3ebb-4b0a-a394-be0bcc77d0d0}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   15.24, 33.528, 17.0732,                 !- X,Y,Z Vertex 1 {m}
@@ -14556,8 +14524,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {6a8c5c6f-369f-4ab1-867d-7f5523a9610f}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {3b831813-daa7-4e21-ba35-7ae7358899e1}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -14575,8 +14543,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {7802b3f6-be28-4f7e-ab11-b2ff579c4766}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {ab6d2ab6-f09d-48e4-93d8-053b64214bcc}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -14594,8 +14562,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {7802b3f6-be28-4f7e-ab11-b2ff579c4766}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {c31985c6-696a-4728-8aa7-0fcc9dad2166}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -14611,8 +14579,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {3a43a92b-6516-45e6-9f37-eb7bf8bccb83}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {0ee28c4d-2fff-48bf-89fd-8fbf762777b9}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -14620,8 +14588,7 @@ OS:Surface,
   60.96, 48.768, 8.5366,                  !- X,Y,Z Vertex 1 {m}
   60.96, 42.672, 8.5366,                  !- X,Y,Z Vertex 2 {m}
   48.768, 42.672, 8.5366,                 !- X,Y,Z Vertex 3 {m}
-  48.768, 47.244, 8.5366,                 !- X,Y,Z Vertex 4 {m}
-  48.768, 48.768, 8.5366;                 !- X,Y,Z Vertex 5 {m}
+  48.768, 48.768, 8.5366;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {a6afa6ba-8312-4b32-b3c3-0f89b074aad4}, !- Handle
@@ -14629,10 +14596,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {47d5f6b5-5e98-43ad-8669-c046505a937d}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {dda133d5-d34b-49d8-a529-83269944fe95}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   48.768, 22.86, 8.5366,                  !- X,Y,Z Vertex 1 {m}
@@ -14646,8 +14613,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {3a43a92b-6516-45e6-9f37-eb7bf8bccb83}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {ce525ba1-8b6c-4461-8bbc-16843874a57e}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -14663,8 +14630,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {3a43a92b-6516-45e6-9f37-eb7bf8bccb83}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {a1e8f15f-fd94-4b4c-9a60-7855723dfe6a}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -14680,10 +14647,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {5fa7a66e-65f8-47fe-850f-4aff5015d62b}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   60.96, 48.768, 8.5366,                  !- X,Y,Z Vertex 1 {m}
@@ -14697,10 +14664,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {5fa7a66e-65f8-47fe-850f-4aff5015d62b}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {0cb91d1d-9040-4769-b6f2-94fb3647aced}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   44.196, 0, 8.5366,                      !- X,Y,Z Vertex 1 {m}
@@ -14727,14 +14694,14 @@ OS:Surface,
 
 OS:Surface,
   {038126fd-8d40-49c0-87e2-0858891d0d28}, !- Handle
-  Surface 76,                             !- Name
+  PatRoom4_Flr_3_Wall_South_2,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {60897f76-ccc0-4353-9cbd-ce8e06f8207c}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   65.532, 48.768, 12.8049,                !- X,Y,Z Vertex 1 {m}
@@ -14748,10 +14715,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {7cce3ac6-5d1d-4960-9e9f-f0d99f44c040}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   48.768, 48.768, 8.5366,                 !- X,Y,Z Vertex 1 {m}
@@ -14765,8 +14732,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {3a43a92b-6516-45e6-9f37-eb7bf8bccb83}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {5ebaf1c8-5af5-452e-b8d5-34386d73d882}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -14782,10 +14749,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {aeb14eec-a11c-4495-b283-f98c2eca3dbf}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {13edc9f8-a4ee-490a-8562-610b66c5c1cc}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   15.24, 21.3415, 8.5366,                 !- X,Y,Z Vertex 1 {m}
@@ -14799,10 +14766,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {e0b3f21a-5417-4d6d-9bad-44c2b5fb3717}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {e8ff1da0-fcb7-461f-a6c1-15b27400104d}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   65.532, 41.148, 8.5366,                 !- X,Y,Z Vertex 1 {m}
@@ -14816,10 +14783,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {e8233850-2c26-457b-b983-e0a87242a5d7}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {8802ccb7-7644-405b-bf66-70f8d64141ea}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   28.956, 10.668, 8.5366,                 !- X,Y,Z Vertex 1 {m}
@@ -14830,32 +14797,15 @@ OS:Surface,
   9.144, 10.668, 8.5366;                  !- X,Y,Z Vertex 6 {m}
 
 OS:Surface,
-  {bae7a3f5-d15a-4b0a-b30b-bb02b97a722a}, !- Handle
-  Surface 82,                             !- Name
-  Wall,                                   !- Surface Type
-  ,                                       !- Construction Name
-  {f4b6e0eb-817b-405c-98f0-c425865851fb}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
-  ,                                       !- View Factor to Ground
-  ,                                       !- Number of Vertices
-  9.144, 33.582, 12.8049,                 !- X,Y,Z Vertex 1 {m}
-  9.144, 33.582, 8.5366,                  !- X,Y,Z Vertex 2 {m}
-  9.144, 33.528, 8.5366,                  !- X,Y,Z Vertex 3 {m}
-  9.144, 33.528, 12.8049;                 !- X,Y,Z Vertex 4 {m}
-
-OS:Surface,
   {4f081654-d3d2-4dba-adea-41898dc054ab}, !- Handle
   Surface 83,                             !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {3d0a884f-f38a-4024-ba41-a3615b0d597f}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {3e6a3d3a-6a2a-4cf4-925a-cae531c8555d}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   4.572, 7.622, 17.0732,                  !- X,Y,Z Vertex 1 {m}
@@ -14869,8 +14819,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {75111445-9889-4e0e-bf8b-33e4ad0474cb}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {91f86ee3-c05a-44ac-bee0-a34219e6de08}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -14903,8 +14853,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {dc66d323-72f5-4969-aebb-d547b4919d13}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {4e621ede-a418-4a72-9010-f8bfc8fd1f0f}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -14920,10 +14870,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {42cd4d82-e24e-4e11-88d4-f870740fe240}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   0, 48.768, 17.0732,                     !- X,Y,Z Vertex 1 {m}
@@ -14954,8 +14904,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {e02691e9-a447-40e1-aa67-039878424ae6}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {6e221b4f-3b78-4339-a9b5-208a7fc55974}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -14971,8 +14921,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {432827a6-9676-48d3-9de8-55f3ed327c07}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {3db7e024-2170-425e-8b6c-d81b41ef16e5}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -14990,10 +14940,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {aeb14eec-a11c-4495-b283-f98c2eca3dbf}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {cbe72b1c-c01c-47a9-8751-42bdfeab7763}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   28.956, 21.3415, 8.5366,                !- X,Y,Z Vertex 1 {m}
@@ -15009,10 +14959,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {e8233850-2c26-457b-b983-e0a87242a5d7}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {db58abbf-cf32-422e-9e19-0ec1fb4a2cd9}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   28.956, 19.812, 8.5366,                 !- X,Y,Z Vertex 1 {m}
@@ -15026,10 +14976,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {e8233850-2c26-457b-b983-e0a87242a5d7}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {463cca08-e8ef-4b87-860f-f962ffa9593e}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   4.572, 4.572, 8.5366,                   !- X,Y,Z Vertex 1 {m}
@@ -15043,10 +14993,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {5fa7a66e-65f8-47fe-850f-4aff5015d62b}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {5804467d-b360-438d-a6eb-dee91a910386}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   48.768, 53.34, 8.5366,                  !- X,Y,Z Vertex 1 {m}
@@ -15060,8 +15010,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {ccee8f2b-c192-4f18-9407-cda799f28f23}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {ba0b6826-c03b-462d-851a-fe16dad1d27c}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -15079,10 +15029,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {e421471b-c574-4e8a-b7a8-245348dd3775}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {3b65cbde-616e-4931-a07d-06cee9adee11}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   64.008, 4.572, 4.2683,                  !- X,Y,Z Vertex 1 {m}
@@ -15102,10 +15052,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {4b0352d7-5b15-44a5-874c-f4c860e83600}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {92b944fe-d698-48f6-98ff-783f4764bfd9}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   9.144, 10.668, 17.0732,                 !- X,Y,Z Vertex 1 {m}
@@ -15119,7 +15069,7 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {7802b3f6-be28-4f7e-ab11-b2ff579c4766}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
@@ -15136,10 +15086,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {4b0352d7-5b15-44a5-874c-f4c860e83600}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {3a502aa6-ea26-4ee2-9371-3dd9cfc19268}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   9.144, 45.72, 17.0732,                  !- X,Y,Z Vertex 1 {m}
@@ -15153,8 +15103,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {dc66d323-72f5-4969-aebb-d547b4919d13}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {328cfaee-7c78-4f9b-886a-2fea099225ed}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -15187,7 +15137,7 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {e02691e9-a447-40e1-aa67-039878424ae6}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
@@ -15204,7 +15154,7 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {e02691e9-a447-40e1-aa67-039878424ae6}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
@@ -15234,14 +15184,14 @@ OS:Surface,
 
 OS:Surface,
   {d9f4932c-0144-4f08-9b6c-6acd9bd5a8db}, !- Handle
-  Surface 105,                            !- Name
+  PatRoom4_Flr_4_Wall_South_2,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {fc9bddfe-4ba5-4685-8ab9-4aa035cfc214}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   65.532, 48.768, 17.0732,                !- X,Y,Z Vertex 1 {m}
@@ -15255,10 +15205,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {5fa7a66e-65f8-47fe-850f-4aff5015d62b}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {0f7bbba8-4f31-4675-90ba-e49aaade92ef}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   60.96, 19.812, 8.5366,                  !- X,Y,Z Vertex 1 {m}
@@ -15274,8 +15224,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {5fa7a66e-65f8-47fe-850f-4aff5015d62b}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {cb0b520a-8d39-475d-a422-c8e2c3984eee}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -15291,17 +15241,16 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {5fa7a66e-65f8-47fe-850f-4aff5015d62b}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {fd6f0296-86e9-41d9-8b85-8edd5f8c3c8e}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   70.104, 0, 8.5366,                      !- X,Y,Z Vertex 1 {m}
   70.104, 4.572, 8.5366,                  !- X,Y,Z Vertex 2 {m}
-  65.532, 4.572, 8.5366,                  !- X,Y,Z Vertex 3 {m}
-  62.484, 4.572, 8.5366,                  !- X,Y,Z Vertex 4 {m}
-  62.484, 0, 8.5366;                      !- X,Y,Z Vertex 5 {m}
+  62.484, 4.572, 8.5366,                  !- X,Y,Z Vertex 3 {m}
+  62.484, 0, 8.5366;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {f33b6919-bfe0-4f0c-b26f-e6f926c6a2e3}, !- Handle
@@ -15309,10 +15258,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {5fa7a66e-65f8-47fe-850f-4aff5015d62b}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {96f62409-b4bf-4749-acd1-afc5ee334e0e}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   65.532, 4.572, 8.5366,                  !- X,Y,Z Vertex 1 {m}
@@ -15320,8 +15269,7 @@ OS:Surface,
   60.96, 16.764, 8.5366,                  !- X,Y,Z Vertex 3 {m}
   60.96, 10.668, 8.5366,                  !- X,Y,Z Vertex 4 {m}
   39.624, 10.668, 8.5366,                 !- X,Y,Z Vertex 5 {m}
-  39.624, 4.572, 8.5366,                  !- X,Y,Z Vertex 6 {m}
-  44.196, 4.572, 8.5366;                  !- X,Y,Z Vertex 7 {m}
+  39.624, 4.572, 8.5366;                  !- X,Y,Z Vertex 6 {m}
 
 OS:Surface,
   {bcadfddd-4979-45bd-9665-353edfa4e55e}, !- Handle
@@ -15346,8 +15294,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {5fa7a66e-65f8-47fe-850f-4aff5015d62b}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {4f7dc632-0fb5-4bb6-91d3-69d7946afc91}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -15369,7 +15317,7 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {5fa7a66e-65f8-47fe-850f-4aff5015d62b}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
@@ -15386,7 +15334,7 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {5fa7a66e-65f8-47fe-850f-4aff5015d62b}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
@@ -15403,7 +15351,7 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {5fa7a66e-65f8-47fe-850f-4aff5015d62b}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
@@ -15420,10 +15368,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {e421471b-c574-4e8a-b7a8-245348dd3775}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {22832320-2ed0-477e-b344-8094cfb6d28c}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   64.008, 41.148, 4.2683,                 !- X,Y,Z Vertex 1 {m}
@@ -15437,17 +15385,16 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {e421471b-c574-4e8a-b7a8-245348dd3775}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {60201699-f7b9-44a5-bfa3-a8d27cc696d7}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   48.768, 47.244, 4.2683,                 !- X,Y,Z Vertex 1 {m}
   48.768, 48.768, 4.2683,                 !- X,Y,Z Vertex 2 {m}
-  45.72, 48.768, 4.2683,                  !- X,Y,Z Vertex 3 {m}
-  39.624, 48.768, 4.2683,                 !- X,Y,Z Vertex 4 {m}
-  39.624, 47.244, 4.2683;                 !- X,Y,Z Vertex 5 {m}
+  39.624, 48.768, 4.2683,                 !- X,Y,Z Vertex 3 {m}
+  39.624, 47.244, 4.2683;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {7744bd5d-b704-41bf-916d-7a598d03cf17}, !- Handle
@@ -15455,10 +15402,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {5fa7a66e-65f8-47fe-850f-4aff5015d62b}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   62.484, 0, 8.5366,                      !- X,Y,Z Vertex 1 {m}
@@ -15472,10 +15419,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {5fa7a66e-65f8-47fe-850f-4aff5015d62b}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {d5e9709c-4d29-495d-a67c-50d56e96896c}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   60.96, 10.668, 8.5366,                  !- X,Y,Z Vertex 1 {m}
@@ -15489,10 +15436,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {5fa7a66e-65f8-47fe-850f-4aff5015d62b}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   70.104, 8.992, 8.5366,                  !- X,Y,Z Vertex 1 {m}
@@ -15506,8 +15453,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {e9e27262-9df7-40dc-9a36-b9e4a585473e}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {67eed5ad-3616-40c5-a15c-26afec404a93}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -15523,10 +15470,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {aeb14eec-a11c-4495-b283-f98c2eca3dbf}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {596977b5-40f6-4ecc-86ff-08f9c1c221ab}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   6.096, 48.768, 8.5366,                  !- X,Y,Z Vertex 1 {m}
@@ -15536,14 +15483,14 @@ OS:Surface,
 
 OS:Surface,
   {f65b4b7f-53b2-4364-a2bf-f11f7762129b}, !- Handle
-  Surface 122,                            !- Name
+  Lobby_Records_Flr_1_Ceiling_5,          !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {ebe6e839-d2fb-4757-8148-ae01cb77f2b7}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {4366c426-157e-42b9-bdbf-5767d0e00b89}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   6.096, 48.768, 4.2683,                  !- X,Y,Z Vertex 1 {m}
@@ -15557,10 +15504,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {7c3f7787-1a2c-4af2-b30d-c5fe68177501}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {a6c52c5e-a0fb-4cad-b3fd-bb230ad262dd}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   65.532, 4.572, 17.0732,                 !- X,Y,Z Vertex 1 {m}
@@ -15591,7 +15538,7 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {6a8c5c6f-369f-4ab1-867d-7f5523a9610f}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
@@ -15608,8 +15555,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {6a8c5c6f-369f-4ab1-867d-7f5523a9610f}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {0df92f1a-9dc0-41e1-9498-d7dc395b26ac}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -15625,10 +15572,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {7f22e5a6-e759-445a-84cb-6b454b893756}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {99724be1-e9f3-4ca3-98dd-fdeb03f0ef5b}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   9.144, 4.572, 17.0732,                  !- X,Y,Z Vertex 1 {m}
@@ -15642,17 +15589,16 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {d7e311f6-f2c1-47c2-b301-cbba90b6f733}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {9856f526-25bf-47c5-b839-8fd160828349}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   15.24, 10.668, 17.0732,                 !- X,Y,Z Vertex 1 {m}
-  15.24, 19.812, 17.0732,                 !- X,Y,Z Vertex 2 {m}
-  15.24, 33.528, 17.0732,                 !- X,Y,Z Vertex 3 {m}
-  9.144, 33.528, 17.0732,                 !- X,Y,Z Vertex 4 {m}
-  9.144, 10.668, 17.0732;                 !- X,Y,Z Vertex 5 {m}
+  15.24, 33.528, 17.0732,                 !- X,Y,Z Vertex 2 {m}
+  9.144, 33.528, 17.0732,                 !- X,Y,Z Vertex 3 {m}
+  9.144, 10.668, 17.0732;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {95f382df-6256-48af-a274-6407639c0883}, !- Handle
@@ -15660,10 +15606,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e9e27262-9df7-40dc-9a36-b9e4a585473e}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {35d16a43-528e-4bb0-b366-0307cf03d08b}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   62.484, 4.572, 12.8049,                 !- X,Y,Z Vertex 1 {m}
@@ -15677,17 +15623,16 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {e8233850-2c26-457b-b983-e0a87242a5d7}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {0aeeafec-bf8f-44e0-8a34-f7210d40505a}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   28.956, 4.572, 8.5366,                  !- X,Y,Z Vertex 1 {m}
   28.956, 10.668, 8.5366,                 !- X,Y,Z Vertex 2 {m}
   4.572, 10.668, 8.5366,                  !- X,Y,Z Vertex 3 {m}
-  4.572, 4.572, 8.5366,                   !- X,Y,Z Vertex 4 {m}
-  6.096, 4.572, 8.5366;                   !- X,Y,Z Vertex 5 {m}
+  4.572, 4.572, 8.5366;                   !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {a6dda79a-4fad-4fdd-a5c4-fe1394697114}, !- Handle
@@ -15712,10 +15657,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {7802b3f6-be28-4f7e-ab11-b2ff579c4766}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {31936f26-632e-426b-8dc8-030f5fac62ef}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   9.144, 15.24, 21.3415,                  !- X,Y,Z Vertex 1 {m}
@@ -15729,7 +15674,7 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {75111445-9889-4e0e-bf8b-33e4ad0474cb}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
@@ -15746,10 +15691,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {7f22e5a6-e759-445a-84cb-6b454b893756}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {e5c03150-746e-4fe1-8fb1-37a1549d0391}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   15.24, 4.572, 17.0732,                  !- X,Y,Z Vertex 1 {m}
@@ -15763,7 +15708,7 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {7802b3f6-be28-4f7e-ab11-b2ff579c4766}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
@@ -15780,8 +15725,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {7802b3f6-be28-4f7e-ab11-b2ff579c4766}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {2391a487-d650-448e-adba-57399e0d8f4f}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -15797,10 +15742,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {7f22e5a6-e759-445a-84cb-6b454b893756}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {db26f88b-0461-4e36-9106-29af9c7210f4}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   9.144, 7.622, 17.0732,                  !- X,Y,Z Vertex 1 {m}
@@ -15831,10 +15776,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {7802b3f6-be28-4f7e-ab11-b2ff579c4766}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {4683bd42-b498-4e6a-8c9d-da6dd09913cf}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   9.144, 48.768, 21.3415,                 !- X,Y,Z Vertex 1 {m}
@@ -15865,10 +15810,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e02691e9-a447-40e1-aa67-039878424ae6}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {76751c10-af53-4e72-a903-a6af1ab73bc0}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   9.144, 48.768, 21.3415,                 !- X,Y,Z Vertex 1 {m}
@@ -15882,10 +15827,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {7f22e5a6-e759-445a-84cb-6b454b893756}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {2561ced8-dbd1-483c-8f7a-0f3c663991a5}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   39.624, 4.572, 17.0732,                 !- X,Y,Z Vertex 1 {m}
@@ -15899,8 +15844,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {7cce3ac6-5d1d-4960-9e9f-f0d99f44c040}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {1b7dfdb2-d6b9-4af1-bf74-e5631a0519db}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -15908,8 +15853,7 @@ OS:Surface,
   48.768, 48.768, 4.2683,                 !- X,Y,Z Vertex 1 {m}
   48.768, 47.244, 4.2683,                 !- X,Y,Z Vertex 2 {m}
   39.624, 47.244, 4.2683,                 !- X,Y,Z Vertex 3 {m}
-  39.624, 48.768, 4.2683,                 !- X,Y,Z Vertex 4 {m}
-  45.72, 48.768, 4.2683;                  !- X,Y,Z Vertex 5 {m}
+  39.624, 48.768, 4.2683;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {b7981715-198d-4c47-bc1c-51fdd02cef6f}, !- Handle
@@ -15917,7 +15861,7 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {7cce3ac6-5d1d-4960-9e9f-f0d99f44c040}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
@@ -15951,28 +15895,27 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {dc66d323-72f5-4969-aebb-d547b4919d13}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   4.572, 15.24, 17.0732,                  !- X,Y,Z Vertex 1 {m}
-  4.572, 10.668, 17.0732,                 !- X,Y,Z Vertex 2 {m}
-  4.572, 8.992, 17.0732,                  !- X,Y,Z Vertex 3 {m}
-  0, 8.992, 17.0732,                      !- X,Y,Z Vertex 4 {m}
-  0, 15.24, 17.0732;                      !- X,Y,Z Vertex 5 {m}
+  4.572, 8.992, 17.0732,                  !- X,Y,Z Vertex 2 {m}
+  0, 8.992, 17.0732,                      !- X,Y,Z Vertex 3 {m}
+  0, 15.24, 17.0732;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {2345f1a9-96d4-4f6f-94db-b3e50f42535e}, !- Handle
-  Surface 147,                            !- Name
+  Basement_Ceiling_14,                    !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {8cefc791-4220-41cf-852d-0cd472e915e7}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   45.72, 48.768, 0,                       !- X,Y,Z Vertex 1 {m}
@@ -15999,14 +15942,14 @@ OS:Surface,
 
 OS:Surface,
   {97165dc0-87f3-40e3-b9c7-9ecb39e05843}, !- Handle
-  Surface 149,                            !- Name
+  Basement_Ceiling_12,                    !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {8cefc791-4220-41cf-852d-0cd472e915e7}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   70.104, 48.768, 0,                      !- X,Y,Z Vertex 1 {m}
@@ -16016,14 +15959,14 @@ OS:Surface,
 
 OS:Surface,
   {7b906724-8319-4614-887d-bcaaa7fd5f08}, !- Handle
-  Surface 150,                            !- Name
+  Basement_Ceiling_8,                     !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {8cefc791-4220-41cf-852d-0cd472e915e7}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   70.104, 0, 0,                           !- X,Y,Z Vertex 1 {m}
@@ -16033,14 +15976,14 @@ OS:Surface,
 
 OS:Surface,
   {38db96bb-d919-494d-ad5e-37351a2c7afc}, !- Handle
-  Surface 151,                            !- Name
+  Basement_Ceiling_5,                     !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {8cefc791-4220-41cf-852d-0cd472e915e7}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   64.008, 4.572, 0,                       !- X,Y,Z Vertex 1 {m}
@@ -16050,19 +15993,18 @@ OS:Surface,
   64.008, 39.624, 0,                      !- X,Y,Z Vertex 5 {m}
   64.008, 48.768, 0,                      !- X,Y,Z Vertex 6 {m}
   39.624, 48.768, 0,                      !- X,Y,Z Vertex 7 {m}
-  39.624, 4.572, 0,                       !- X,Y,Z Vertex 8 {m}
-  45.72, 4.572, 0;                        !- X,Y,Z Vertex 9 {m}
+  39.624, 4.572, 0;                       !- X,Y,Z Vertex 8 {m}
 
 OS:Surface,
   {375ce222-47ea-406e-89cf-a099e1eae452}, !- Handle
-  Surface 152,                            !- Name
+  Basement_Ceiling_7,                     !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {8cefc791-4220-41cf-852d-0cd472e915e7}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   64.008, 0, 0,                           !- X,Y,Z Vertex 1 {m}
@@ -16072,14 +16014,14 @@ OS:Surface,
 
 OS:Surface,
   {a8df02b8-d7b0-456a-b443-554e2dfbc3c7}, !- Handle
-  Surface 153,                            !- Name
+  Basement_Ceiling_13,                    !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {8cefc791-4220-41cf-852d-0cd472e915e7}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   64.008, 48.768, 0,                      !- X,Y,Z Vertex 1 {m}
@@ -16089,14 +16031,14 @@ OS:Surface,
 
 OS:Surface,
   {6cf60f34-9b41-4de1-99ee-1424125a8f52}, !- Handle
-  Surface 154,                            !- Name
+  Basement_Ceiling_11,                    !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {8cefc791-4220-41cf-852d-0cd472e915e7}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   70.104, 39.624, 0,                      !- X,Y,Z Vertex 1 {m}
@@ -16106,14 +16048,14 @@ OS:Surface,
 
 OS:Surface,
   {2afb2ee6-b9a0-440b-9a67-0cc13b5c10be}, !- Handle
-  Surface 155,                            !- Name
+  Basement_Ceiling_10,                    !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {8cefc791-4220-41cf-852d-0cd472e915e7}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   70.104, 9.144, 0,                       !- X,Y,Z Vertex 1 {m}
@@ -16123,14 +16065,14 @@ OS:Surface,
 
 OS:Surface,
   {298b48dd-e4f9-44cb-bf11-26cdf1c1e96b}, !- Handle
-  Surface 156,                            !- Name
+  Basement_Ceiling_4,                     !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {8cefc791-4220-41cf-852d-0cd472e915e7}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   21.3415, 0, 0,                          !- X,Y,Z Vertex 1 {m}
@@ -16144,10 +16086,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {8ec78f13-57f2-4f0e-9746-f05360546e20}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {dacfed6f-6ad3-45b6-a644-8af9444f6f45}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   0, 48.768, 8.5366,                      !- X,Y,Z Vertex 1 {m}
@@ -16174,14 +16116,14 @@ OS:Surface,
 
 OS:Surface,
   {568c28e0-56e4-4e5a-b7f9-e1e737ca82c0}, !- Handle
-  Surface 159,                            !- Name
+  Lobby_Records_Flr_1_Ceiling_2,          !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {ebe6e839-d2fb-4757-8148-ae01cb77f2b7}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {961b5dd0-285c-4ee0-8795-4f6340006009}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   28.956, 21.3415, 4.2683,                !- X,Y,Z Vertex 1 {m}
@@ -16212,10 +16154,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e8233850-2c26-457b-b983-e0a87242a5d7}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   4.572, 21.3415, 8.5366,                 !- X,Y,Z Vertex 1 {m}
@@ -16225,14 +16167,14 @@ OS:Surface,
 
 OS:Surface,
   {566aea66-c1c2-4225-a368-75dd867cfee9}, !- Handle
-  Surface 162,                            !- Name
+  Lobby_Records_Flr_1_Ceiling_4,          !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {ebe6e839-d2fb-4757-8148-ae01cb77f2b7}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {779ede2e-8551-4f30-8c54-e211e6c20c3b}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   4.572, 44.196, 4.2683,                  !- X,Y,Z Vertex 1 {m}
@@ -16242,7 +16184,7 @@ OS:Surface,
 
 OS:Surface,
   {dee36a69-8a1f-4fc4-a04c-ba65947c3620}, !- Handle
-  Surface 163,                            !- Name
+  Lobby_Records_Flr_1_Ceiling_6,          !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {ebe6e839-d2fb-4757-8148-ae01cb77f2b7}, !- Space Name
@@ -16263,8 +16205,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {f4b6e0eb-817b-405c-98f0-c425865851fb}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {f36d2d43-71c7-46de-844a-219ec8723829}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -16276,14 +16218,14 @@ OS:Surface,
 
 OS:Surface,
   {fadb667e-b842-4205-bfc4-16869d1662c8}, !- Handle
-  Surface 165,                            !- Name
+  Lobby_Records_Flr_1_Ceiling_1,          !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {ebe6e839-d2fb-4757-8148-ae01cb77f2b7}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {ed09367e-45b9-4b95-8e1c-d7390d6a5443}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   28.956, 0, 4.2683,                      !- X,Y,Z Vertex 1 {m}
@@ -16335,7 +16277,7 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {e0b3f21a-5417-4d6d-9bad-44c2b5fb3717}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
@@ -16352,10 +16294,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {e421471b-c574-4e8a-b7a8-245348dd3775}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   70.104, 16.764, 4.2683,                 !- X,Y,Z Vertex 1 {m}
@@ -16371,17 +16313,16 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {e0b3f21a-5417-4d6d-9bad-44c2b5fb3717}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   70.104, 41.148, 8.5366,                 !- X,Y,Z Vertex 1 {m}
   70.104, 47.244, 8.5366,                 !- X,Y,Z Vertex 2 {m}
   65.532, 47.244, 8.5366,                 !- X,Y,Z Vertex 3 {m}
-  65.532, 42.672, 8.5366,                 !- X,Y,Z Vertex 4 {m}
-  65.532, 41.148, 8.5366;                 !- X,Y,Z Vertex 5 {m}
+  65.532, 41.148, 8.5366;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {8247b613-1770-4e1f-aec7-aa8fbc3d9a54}, !- Handle
@@ -16389,7 +16330,7 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {e9e27262-9df7-40dc-9a36-b9e4a585473e}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
@@ -16406,10 +16347,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {e8233850-2c26-457b-b983-e0a87242a5d7}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   28.956, 0, 8.5366,                      !- X,Y,Z Vertex 1 {m}
@@ -16440,7 +16381,7 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {e8233850-2c26-457b-b983-e0a87242a5d7}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
@@ -16453,7 +16394,7 @@ OS:Surface,
 
 OS:Surface,
   {54671b08-e7e7-4b89-b42d-cfafb4dae615}, !- Handle
-  Surface 175,                            !- Name
+  Lobby_Records_Flr_1_Ceiling_3,          !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {ebe6e839-d2fb-4757-8148-ae01cb77f2b7}, !- Space Name

--- a/data/geometry/ASHRAE9012013LargeHotel.osm
+++ b/data/geometry/ASHRAE9012013LargeHotel.osm
@@ -328,12 +328,12 @@ OS:Space,
 
 OS:Surface,
   {019125a0-77bb-419d-a7f6-68140c061ebb}, !- Handle
-  Corridor_Flr_6_Wall_2_West,             !- Name
+  Corridor_Flr_6_Wall_3_West,           !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {727f620c-8075-4586-8703-48bde7f60f5c}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {405b1243-c659-4257-a298-4e039e7e28f6}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -505,8 +505,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {33e71202-8fbd-4e14-b534-3eb0a82a5cec}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {b07c7525-68e4-441d-9fd3-3a523914d0a1}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -752,12 +752,12 @@ OS:Surface,
 
 OS:Surface,
   {b07c7525-68e4-441d-9fd3-3a523914d0a1}, !- Handle
-  Room_1_Flr_6_Wall_East,                 !- Name
+  Room_1_Flr_6_Wall_2_East,               !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {0de59da8-57c0-4247-98db-94f06e2019a8}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {8cfcc863-8692-441a-98ac-1f13f4ce09d5}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -795,8 +795,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {53c7fa8b-d0a9-4d59-9f72-ab5b6de28e90}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {f202c5d1-e9da-449b-8c2b-152d6fa4c82d}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -953,8 +953,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {1c9aeaea-a105-4381-890b-4d9f9ad931ee}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {bcb06a09-eb3e-4a7a-9f08-d0becac6dd99}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -966,12 +966,12 @@ OS:Surface,
 
 OS:Surface,
   {f202c5d1-e9da-449b-8c2b-152d6fa4c82d}, !- Handle
-  Corridor_Flr_6_Wall_4_North,            !- Name
+  Corridor_Flr_6_Wall_5_North,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {727f620c-8075-4586-8703-48bde7f60f5c}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {ee353920-82ca-4e34-ba33-e311074ca69f}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -1068,7 +1068,7 @@ OS:Surface,
 
 OS:Surface,
   {2d68abc0-59d1-4be1-a1b8-f0d7820a5f5f}, !- Handle
-  Corridor_Flr_6_Wall_3_West,             !- Name
+  Corridor_Flr_6_Wall_2_West,             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {727f620c-8075-4586-8703-48bde7f60f5c}, !- Space Name
@@ -1797,8 +1797,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {33e71202-8fbd-4e14-b534-3eb0a82a5cec}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {6cdf2faa-409d-424e-9d2d-0dccfbf5211c}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -2126,8 +2126,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d81b1c84-0be2-437e-b28a-9c633814a0e1}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {beaa08de-dfbc-4feb-86c1-3ea7f29199fa}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -2184,8 +2184,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {727f620c-8075-4586-8703-48bde7f60f5c}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {c881f11a-b737-4cf0-a807-6f7f04fa2ccc}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -2201,8 +2201,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {cb2c0215-3476-427c-ac46-083a99e88a0b}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {9772f990-c5b5-483f-a5f0-7f68989b5779}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -2324,8 +2324,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {72c99aa5-adda-4d43-8716-a054b8639a94}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {0599c616-e76e-454d-8afd-11c49eb0b47c}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -2341,8 +2341,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {1c9aeaea-a105-4381-890b-4d9f9ad931ee}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {d904c676-7923-46d2-bbc3-55f47db955ee}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -2589,8 +2589,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {72c99aa5-adda-4d43-8716-a054b8639a94}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {bbb1b8b9-0d25-40ad-b953-8e2dd4de4cab}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -3033,8 +3033,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d81b1c84-0be2-437e-b28a-9c633814a0e1}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {2f7820a9-298e-4391-80e6-c6ca401f3a0c}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -3437,8 +3437,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {1c9aeaea-a105-4381-890b-4d9f9ad931ee}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {29156245-4904-4397-96fd-e4153d4d1d1b}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -3684,8 +3684,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {735c6fa8-525c-45a3-82b3-b38ec3245a8f}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {4a7ade21-c30d-45b3-b6d3-aa4bfd84e3a2}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -3820,8 +3820,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {1c9aeaea-a105-4381-890b-4d9f9ad931ee}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {4fd0ceb9-b75a-4943-a6cf-25343f3a9d2c}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -5978,14 +5978,14 @@ OS:ZoneHVAC:EquipmentList,
 
 OS:Surface,
   {405b1243-c659-4257-a298-4e039e7e28f6}, !- Handle
-  Surface 1,                              !- Name
+  Room_1_Flr_6_Wall_1_East,               !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {0de59da8-57c0-4247-98db-94f06e2019a8}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {019125a0-77bb-419d-a7f6-68140c061ebb}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   4.572, 9.449, 19.2,                     !- X,Y,Z Vertex 1 {m}
@@ -5995,14 +5995,14 @@ OS:Surface,
 
 OS:Surface,
   {4a7ade21-c30d-45b3-b6d3-aa4bfd84e3a2}, !- Handle
-  Surface 2,                              !- Name
+  Corridor_Flr_6_Wall_4_West,           !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {727f620c-8075-4586-8703-48bde7f60f5c}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {42308ad9-fe2e-428f-a256-cdbd926bb164}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   4.572, 22.86, 19.2,                     !- X,Y,Z Vertex 1 {m}
@@ -6012,7 +6012,7 @@ OS:Surface,
 
 OS:Surface,
   {a52e8020-e226-44a4-b61f-9a0977c53252}, !- Handle
-  Surface 3,                              !- Name
+  Corridor_Flr_3_Wall_4_North,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {1c9aeaea-a105-4381-890b-4d9f9ad931ee}, !- Space Name
@@ -6029,7 +6029,7 @@ OS:Surface,
 
 OS:Surface,
   {8697c23d-99d0-4c94-a96b-9b6595940f00}, !- Handle
-  Surface 4,                              !- Name
+  Corridor_Flr_3_Wall_4_South,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {1c9aeaea-a105-4381-890b-4d9f9ad931ee}, !- Space Name
@@ -6046,7 +6046,7 @@ OS:Surface,
 
 OS:Surface,
   {9abc0bf5-44eb-416c-ad7c-a60be0b0a68f}, !- Handle
-  Surface 5,                              !- Name
+  Corridor_Flr_6_Wall_3_South,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {727f620c-8075-4586-8703-48bde7f60f5c}, !- Space Name
@@ -6063,14 +6063,14 @@ OS:Surface,
 
 OS:Surface,
   {9772f990-c5b5-483f-a5f0-7f68989b5779}, !- Handle
-  Surface 6,                              !- Name
+  Corridor_Flr_6_Wall_4_North,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {727f620c-8075-4586-8703-48bde7f60f5c}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {74a82d58-f92a-4905-a14a-b51a33462d6d}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   79.553, 12.497, 19.2,                   !- X,Y,Z Vertex 1 {m}

--- a/data/geometry/ASHRAE9012013MidriseApartment.osm
+++ b/data/geometry/ASHRAE9012013MidriseApartment.osm
@@ -32,9 +32,9 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
-  34.7455054899131,                       !- X Origin {m}
+  34.7455,                                !- X Origin {m}
   0,                                      !- Y Origin {m}
-  9.14355407629293,                       !- Z Origin {m}
+  9.1436,                                 !- Z Origin {m}
   {7a967551-5561-4b56-b05a-af0754ca7895}, !- Building Story Name
   {d488cb92-552f-458c-b7a1-bfc62115ba2b}; !- Thermal Zone Name
 
@@ -46,7 +46,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  7.61962839691078,                       !- Y Origin {m}
+  7.6196,                                 !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {adca533c-0468-407c-b890-d518ccf74735}, !- Building Story Name
   {623c2ede-649f-43bc-892f-8ef2e416714f}; !- Thermal Zone Name
@@ -80,10 +80,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 1 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {66195dd7-4158-483d-b874-3388a680b571}, !- Handle
@@ -94,7 +94,7 @@ OS:Space,
   0,                                      !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
   0,                                      !- Y Origin {m}
-  9.14355407629293,                       !- Z Origin {m}
+  9.1436,                                 !- Z Origin {m}
   {7a967551-5561-4b56-b05a-af0754ca7895}, !- Building Story Name
   {b9c75708-2d22-4595-80d4-8a0f68150303}; !- Thermal Zone Name
 
@@ -110,10 +110,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {6912ab22-717f-4315-a8ff-9c62dd3bb665}, !- Handle
@@ -122,9 +122,9 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
-  23.1636703266088,                       !- X Origin {m}
+  23.1637,                                !- X Origin {m}
   0,                                      !- Y Origin {m}
-  3.04785135876431,                       !- Z Origin {m}
+  3.0479,                                 !- Z Origin {m}
   {271f3401-76be-4edd-8369-7d5a808299e2}, !- Building Story Name
   {4a48168f-73de-4c04-a40a-b8a18d185b7f}; !- Thermal Zone Name
 
@@ -135,9 +135,9 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
-  34.7455054899131,                       !- X Origin {m}
+  34.7455,                                !- X Origin {m}
   0,                                      !- Y Origin {m}
-  3.04785135876431,                       !- Z Origin {m}
+  3.0479,                                 !- Z Origin {m}
   {271f3401-76be-4edd-8369-7d5a808299e2}, !- Building Story Name
   {020188ba-5065-4680-b6f0-5da34ddbb98a}; !- Thermal Zone Name
 
@@ -153,10 +153,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -1.63304301636913e-07, 7.619628, 3.047851, !- X,Y,Z Vertex 1 {m}
-  -1.63304301636913e-07, 7.619628, 0,     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {fdb38349-a07f-4613-871c-2a0d97c95f4f}, !- Handle
@@ -170,10 +170,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 0, 3.047851,                         !- X,Y,Z Vertex 1 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {22d8b173-d774-48ce-9aac-7d6a7840f33f}, !- Handle
@@ -182,9 +182,9 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
-  11.5818351633044,                       !- X Origin {m}
-  9.29594664423115,                       !- Y Origin {m}
-  9.14355407629293,                       !- Z Origin {m}
+  11.5818,                                !- X Origin {m}
+  9.2959,                                 !- Y Origin {m}
+  9.1436,                                 !- Z Origin {m}
   {7a967551-5561-4b56-b05a-af0754ca7895}, !- Building Story Name
   {0f1f6080-513c-478d-b579-82fe7dd48a72}; !- Thermal Zone Name
 
@@ -196,8 +196,8 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   ,                                       !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  7.61962839691078,                       !- Y Origin {m}
-  9.14355407629293,                       !- Z Origin {m}
+  7.6196,                                 !- Y Origin {m}
+  9.1436,                                 !- Z Origin {m}
   {7a967551-5561-4b56-b05a-af0754ca7895}, !- Building Story Name
   {5355740a-64f7-4413-b7ff-309f94ec0f7d}; !- Thermal Zone Name
 
@@ -213,10 +213,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.1636701633044, 1.67631824732037, 3.047851, !- X,Y,Z Vertex 1 {m}
-  23.1636701633044, 1.67631824732037, 0,  !- X,Y,Z Vertex 2 {m}
-  11.5818351633044, 1.67631824732037, 0,  !- X,Y,Z Vertex 3 {m}
-  11.5818351633044, 1.67631824732037, 3.047851; !- X,Y,Z Vertex 4 {m}
+  23.1637, 1.6763, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  23.1637, 1.6763, 0,                     !- X,Y,Z Vertex 2 {m}
+  11.5818, 1.6763, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 1.6763, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {9167359e-9688-41e4-ae83-b41424807596}, !- Handle
@@ -225,9 +225,9 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
-  23.1636703266088,                       !- X Origin {m}
-  9.29594664423115,                       !- Y Origin {m}
-  9.14355407629293,                       !- Z Origin {m}
+  23.1637,                                !- X Origin {m}
+  9.2959,                                 !- Y Origin {m}
+  9.1436,                                 !- Z Origin {m}
   {7a967551-5561-4b56-b05a-af0754ca7895}, !- Building Story Name
   {30cda89d-c5e7-4017-a8fd-53e389f7bdf7}; !- Thermal Zone Name
 
@@ -243,10 +243,10 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   1,                                      !- Multiplier
   ,                                       !- Number of Vertices
-  8.686, 7.619628, 2.1732,                !- X,Y,Z Vertex 1 {m}
-  8.686, 7.619628, 0.954,                 !- X,Y,Z Vertex 2 {m}
-  2.89498950131234, 7.619628, 0.954,      !- X,Y,Z Vertex 3 {m}
-  2.89498950131234, 7.619628, 2.1732;     !- X,Y,Z Vertex 4 {m}
+  8.686, 7.6196, 2.1732,                  !- X,Y,Z Vertex 1 {m}
+  8.686, 7.6196, 0.954,                   !- X,Y,Z Vertex 2 {m}
+  2.89498950131234, 7.6196, 0.954,        !- X,Y,Z Vertex 3 {m}
+  2.89498950131234, 7.6196, 2.1732;       !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {0464b6fc-0025-4ea5-80cb-899a8d9af70c}, !- Handle
@@ -260,10 +260,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 3.047851;                  !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {7c013759-803b-46ae-9919-4e21adf7c78d}, !- Handle
@@ -274,7 +274,7 @@ OS:Space,
   0,                                      !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
   0,                                      !- Y Origin {m}
-  3.04785135876431,                       !- Z Origin {m}
+  3.0479,                                 !- Z Origin {m}
   {271f3401-76be-4edd-8369-7d5a808299e2}, !- Building Story Name
   {4a329905-de5e-494f-8931-fee8c5f3df9b}; !- Thermal Zone Name
 
@@ -290,10 +290,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {0fe08715-548f-4b65-befe-40ea29ebf953}, !- Handle
@@ -303,8 +303,8 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  9.29594664423115,                       !- Y Origin {m}
-  9.14355407629293,                       !- Z Origin {m}
+  9.2959,                                 !- Y Origin {m}
+  9.1436,                                 !- Z Origin {m}
   {7a967551-5561-4b56-b05a-af0754ca7895}, !- Building Story Name
   {2df663ad-5d5a-4867-bdcc-066715e68801}; !- Thermal Zone Name
 
@@ -320,10 +320,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.327341, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  46.327341, 1.676318, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 1.676318, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  46.3273, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  46.3273, 1.6763, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 1.6763, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {fec56cd7-1bb5-4bb0-8e3b-dab87b5a2de0}, !- Handle
@@ -333,8 +333,8 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   ,                                       !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  7.61962839691078,                       !- Y Origin {m}
-  3.04785135876431,                       !- Z Origin {m}
+  7.6196,                                 !- Y Origin {m}
+  3.0479,                                 !- Z Origin {m}
   {271f3401-76be-4edd-8369-7d5a808299e2}, !- Building Story Name
   {cb484884-90ac-4f1d-b1c6-2ffb06d28e0e}; !- Thermal Zone Name
 
@@ -350,10 +350,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 0, 3.047851,                         !- X,Y,Z Vertex 1 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {3f1c5090-169e-4dca-b8f2-31c064cffb7d}, !- Handle
@@ -362,7 +362,7 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
-  11.5818351633044,                       !- X Origin {m}
+  11.5818,                                !- X Origin {m}
   0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {adca533c-0468-407c-b890-d518ccf74735}, !- Building Story Name
@@ -380,10 +380,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {695f347d-e36c-4348-b06b-48f78bb2529b}, !- Handle
@@ -392,7 +392,7 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
-  23.1636703266088,                       !- X Origin {m}
+  23.1637,                                !- X Origin {m}
   0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {adca533c-0468-407c-b890-d518ccf74735}, !- Building Story Name
@@ -410,10 +410,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -1.63304399336539e-07, 7.619628, 3.047851, !- X,Y,Z Vertex 1 {m}
-  -1.63304399336539e-07, 7.619628, 0,     !- X,Y,Z Vertex 2 {m}
-  -1.63304399336539e-07, 0, 0,            !- X,Y,Z Vertex 3 {m}
-  -1.63304399336539e-07, 0, 3.047851;     !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {14098aef-319d-416c-a469-3b909122a632}, !- Handle
@@ -427,10 +427,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {d70594d1-39e9-4527-baca-7be02e206c76}, !- Handle
@@ -444,10 +444,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 3.047851;                  !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {f025dc15-ffd2-401c-a986-d4284339a97c}, !- Handle
@@ -461,10 +461,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 0, 3.047851,                         !- X,Y,Z Vertex 1 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
-  11.5818351633044, -3.9691078068671e-07, 0, !- X,Y,Z Vertex 3 {m}
-  11.5818351633044, -3.9691078068671e-07, 3.047851; !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {e339bfd6-0b62-4f74-861b-a1bc50f642b6}, !- Handle
@@ -478,10 +478,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {0038fd5f-f228-4b0a-a724-e0084dd5bbd8}, !- Handle
@@ -490,9 +490,9 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
-  34.7455054899131,                       !- X Origin {m}
-  9.29594664423115,                       !- Y Origin {m}
-  3.04785135876431,                       !- Z Origin {m}
+  34.7455,                                !- X Origin {m}
+  9.2959,                                 !- Y Origin {m}
+  3.0479,                                 !- Z Origin {m}
   {271f3401-76be-4edd-8369-7d5a808299e2}, !- Building Story Name
   {188f9e65-dcd6-4588-8381-2d826bdeec39}; !- Thermal Zone Name
 
@@ -508,10 +508,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {d94f0b48-364b-4bd9-83bf-e9b13823aa40}, !- Handle
@@ -520,9 +520,9 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
-  34.7455054899131,                       !- X Origin {m}
-  9.29594664423115,                       !- Y Origin {m}
-  9.14355407629293,                       !- Z Origin {m}
+  34.7455,                                !- X Origin {m}
+  9.2959,                                 !- Y Origin {m}
+  9.1436,                                 !- Z Origin {m}
   {7a967551-5561-4b56-b05a-af0754ca7895}, !- Building Story Name
   {e3834db8-d7c8-4401-8fea-17e93733ad4a}; !- Thermal Zone Name
 
@@ -534,7 +534,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  9.29594664423115,                       !- Y Origin {m}
+  9.2959,                                 !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {adca533c-0468-407c-b890-d518ccf74735}, !- Building Story Name
   {96a975fe-e07c-4cee-9da9-414bc502094c}; !- Thermal Zone Name
@@ -546,9 +546,9 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
-  11.5818351633044,                       !- X Origin {m}
+  11.5818,                                !- X Origin {m}
   0,                                      !- Y Origin {m}
-  9.14355407629293,                       !- Z Origin {m}
+  9.1436,                                 !- Z Origin {m}
   {7a967551-5561-4b56-b05a-af0754ca7895}, !- Building Story Name
   {7d281d86-c33a-4123-8f68-4d64504bfd1e}; !- Thermal Zone Name
 
@@ -559,9 +559,9 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
-  11.5818351633044,                       !- X Origin {m}
-  9.29594664423115,                       !- Y Origin {m}
-  3.04785135876431,                       !- Z Origin {m}
+  11.5818,                                !- X Origin {m}
+  9.2959,                                 !- Y Origin {m}
+  3.0479,                                 !- Z Origin {m}
   {271f3401-76be-4edd-8369-7d5a808299e2}, !- Building Story Name
   {aeef2340-5ece-48db-9e5e-ce03eb1235b3}; !- Thermal Zone Name
 
@@ -572,7 +572,7 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
-  34.7455054899131,                       !- X Origin {m}
+  34.7455,                                !- X Origin {m}
   0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {adca533c-0468-407c-b890-d518ccf74735}, !- Building Story Name
@@ -590,10 +590,10 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   1,                                      !- Multiplier
   ,                                       !- Number of Vertices
-  8.686, 7.619628, 2.1732,                !- X,Y,Z Vertex 1 {m}
-  8.686, 7.619628, 0.954,                 !- X,Y,Z Vertex 2 {m}
-  2.89498950131234, 7.619628, 0.954,      !- X,Y,Z Vertex 3 {m}
-  2.89498950131234, 7.619628, 2.1732;     !- X,Y,Z Vertex 4 {m}
+  8.686, 7.6196, 2.1732,                  !- X,Y,Z Vertex 1 {m}
+  8.686, 7.6196, 0.954,                   !- X,Y,Z Vertex 2 {m}
+  2.89498950131234, 7.6196, 0.954,        !- X,Y,Z Vertex 3 {m}
+  2.89498950131234, 7.6196, 2.1732;       !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {acec2d78-fb19-4e60-af60-27e9bec82ddb}, !- Handle
@@ -607,10 +607,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 3.047851;                  !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {2474fa55-e493-4710-b009-0cdaa0c1a981}, !- Handle
@@ -624,10 +624,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {6630228a-e074-4b5a-815a-de9c195b4f85}, !- Handle
@@ -636,8 +636,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
-  34.7455054899131,                       !- X Origin {m}
-  9.29594664423115,                       !- Y Origin {m}
+  34.7455,                                !- X Origin {m}
+  9.2959,                                 !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {adca533c-0468-407c-b890-d518ccf74735}, !- Building Story Name
   {b9a531da-0d4e-4e0b-9f92-7ba262e97278}; !- Thermal Zone Name
@@ -671,10 +671,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 0, 3.047851,                         !- X,Y,Z Vertex 1 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {c43f7335-3ac7-490e-9b49-890ffac7f0d6}, !- Handle
@@ -683,9 +683,9 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
-  23.1636703266088,                       !- X Origin {m}
+  23.1637,                                !- X Origin {m}
   0,                                      !- Y Origin {m}
-  9.14355407629293,                       !- Z Origin {m}
+  9.1436,                                 !- Z Origin {m}
   {7a967551-5561-4b56-b05a-af0754ca7895}, !- Building Story Name
   {2fa59ca2-45b2-475e-8587-608186ce840a}; !- Thermal Zone Name
 
@@ -714,10 +714,10 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   1,                                      !- Multiplier
   ,                                       !- Number of Vertices
-  8.686, 7.619628, 2.1732,                !- X,Y,Z Vertex 1 {m}
-  8.686, 7.619628, 0.954,                 !- X,Y,Z Vertex 2 {m}
-  2.89498950131234, 7.619628, 0.954,      !- X,Y,Z Vertex 3 {m}
-  2.89498950131234, 7.619628, 2.1732;     !- X,Y,Z Vertex 4 {m}
+  8.686, 7.6196, 2.1732,                  !- X,Y,Z Vertex 1 {m}
+  8.686, 7.6196, 0.954,                   !- X,Y,Z Vertex 2 {m}
+  2.89498950131234, 7.6196, 0.954,        !- X,Y,Z Vertex 3 {m}
+  2.89498950131234, 7.6196, 2.1732;       !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {fee4e034-e583-42cb-a68f-da971eb2a504}, !- Handle
@@ -731,10 +731,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  -1.63304399336539e-07, 7.619628, 0,     !- X,Y,Z Vertex 3 {m}
-  -1.63304399336539e-07, 7.619628, 3.047851; !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {5c7ad500-0f3b-486f-9052-f98babde7c3f}, !- Handle
@@ -743,9 +743,9 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
-  23.1636703266088,                       !- X Origin {m}
-  9.29594664423115,                       !- Y Origin {m}
-  3.04785135876431,                       !- Z Origin {m}
+  23.1637,                                !- X Origin {m}
+  9.2959,                                 !- Y Origin {m}
+  3.0479,                                 !- Z Origin {m}
   {271f3401-76be-4edd-8369-7d5a808299e2}, !- Building Story Name
   {ae16cd79-19cc-4315-a036-df10c3eee92e}; !- Thermal Zone Name
 
@@ -761,10 +761,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 3.047851;                  !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {d5e79dcd-d6de-49ea-bd40-36d0e0890630}, !- Handle
@@ -778,10 +778,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.327341, 1.676318, 0,                 !- X,Y,Z Vertex 1 {m}
-  46.327341, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  46.3273, 1.6763, 0,                     !- X,Y,Z Vertex 1 {m}
+  46.3273, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 1.676318, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 1.6763, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {95295c9e-17f2-4ee1-872c-772c6b0afbab}, !- Handle
@@ -795,10 +795,10 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   1,                                      !- Multiplier
   ,                                       !- Number of Vertices
-  8.686, 7.619628, 2.1732,                !- X,Y,Z Vertex 1 {m}
-  8.686, 7.619628, 0.954,                 !- X,Y,Z Vertex 2 {m}
-  2.89498950131234, 7.619628, 0.954,      !- X,Y,Z Vertex 3 {m}
-  2.89498950131234, 7.619628, 2.1732;     !- X,Y,Z Vertex 4 {m}
+  8.686, 7.6196, 2.1732,                  !- X,Y,Z Vertex 1 {m}
+  8.686, 7.6196, 0.954,                   !- X,Y,Z Vertex 2 {m}
+  2.89498950131234, 7.6196, 0.954,        !- X,Y,Z Vertex 3 {m}
+  2.89498950131234, 7.6196, 2.1732;       !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {046d83cc-62cd-44ec-a21f-b10efa3109b4}, !- Handle
@@ -812,10 +812,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 3.047851;                  !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {4834aa70-7bab-448d-bb6a-90d87c21dd3a}, !- Handle
@@ -829,10 +829,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -1.63304399336539e-07, 0, 3.047851,     !- X,Y,Z Vertex 1 {m}
-  -1.63304399336539e-07, 0, 0,            !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {c604a7fc-75c5-4c12-aac1-a25d32baac6e}, !- Handle
@@ -846,10 +846,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {ce26f5cd-65b0-45e8-a387-a4885dbe55dd}, !- Handle
@@ -880,10 +880,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 1 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {9922a5a5-bd1e-44c4-afea-f3b3deb36d4f}, !- Handle
@@ -897,10 +897,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {656acd56-e898-40e0-8ffe-95e3c2336bc7}, !- Handle
@@ -909,8 +909,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
-  11.5818351633044,                       !- X Origin {m}
-  9.29594664423115,                       !- Y Origin {m}
+  11.5818,                                !- X Origin {m}
+  9.2959,                                 !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {adca533c-0468-407c-b890-d518ccf74735}, !- Building Story Name
   {96aaf9e9-a334-4880-91c9-f3013e20b8d3}; !- Thermal Zone Name
@@ -927,10 +927,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -1.63304399336539e-07, 7.619628, 3.047851, !- X,Y,Z Vertex 1 {m}
-  -1.63304399336539e-07, 7.619628, 0,     !- X,Y,Z Vertex 2 {m}
-  -1.63304399336539e-07, 0, 0,            !- X,Y,Z Vertex 3 {m}
-  -1.63304399336539e-07, 0, 3.047851;     !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {ca421e4e-b3a1-4307-b10c-eebccdb88991}, !- Handle
@@ -944,10 +944,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {26154c94-49af-490b-8d3e-6c5673ae8961}, !- Handle
@@ -961,10 +961,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -1.63304301636913e-07, 7.619628, 3.047851, !- X,Y,Z Vertex 1 {m}
-  -1.63304301636913e-07, 7.619628, 0,     !- X,Y,Z Vertex 2 {m}
-  -1.63304301636913e-07, 0, 0,            !- X,Y,Z Vertex 3 {m}
-  -1.63304301636913e-07, 0, 3.047851;     !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {60223897-f4da-42ad-a2bb-5820651546af}, !- Handle
@@ -978,10 +978,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.327341, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  46.327341, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  46.327341, 1.676318, 0,                 !- X,Y,Z Vertex 3 {m}
-  46.327341, 1.676318, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  46.3273, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  46.3273, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  46.3273, 1.6763, 0,                     !- X,Y,Z Vertex 3 {m}
+  46.3273, 1.6763, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {da0582e0-c615-4686-846f-5fa728e7e69d}, !- Handle
@@ -1012,10 +1012,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 0, 3.047851,                         !- X,Y,Z Vertex 1 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {4db869d3-2221-499c-b634-035d0d161b35}, !- Handle
@@ -1029,10 +1029,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 0, 3.047851,                         !- X,Y,Z Vertex 1 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Output:Meter,
   {29f7895e-ac0c-4623-926d-975974086e4e}, !- Handle
@@ -1048,8 +1048,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
-  23.1636703266088,                       !- X Origin {m}
-  9.29594664423115,                       !- Y Origin {m}
+  23.1637,                                !- X Origin {m}
+  9.2959,                                 !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {adca533c-0468-407c-b890-d518ccf74735}, !- Building Story Name
   {b794cfbb-716a-4aa1-b1a4-7c94e245c179}; !- Thermal Zone Name
@@ -1066,10 +1066,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  -1.63304301636913e-07, 7.619628, 0,     !- X,Y,Z Vertex 3 {m}
-  -1.63304301636913e-07, 7.619628, 3.047851; !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {064f3759-a4a1-4253-9ad0-9ab203f7738d}, !- Handle
@@ -1083,10 +1083,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  34.7455054899131, -3.9691078068671e-07, 3.047851, !- X,Y,Z Vertex 1 {m}
-  34.7455054899131, -3.9691078068671e-07, 0, !- X,Y,Z Vertex 2 {m}
-  46.3273404899131, -3.9691078068671e-07, 0, !- X,Y,Z Vertex 3 {m}
-  46.3273404899131, -3.9691078068671e-07, 3.047851; !- X,Y,Z Vertex 4 {m}
+  34.7455, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  34.7455, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  46.3273, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  46.3273, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Building,
   {761ed503-73d7-48c5-8197-2a7009e22170}, !- Handle
@@ -1111,9 +1111,9 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
-  11.5818351633044,                       !- X Origin {m}
+  11.5818,                                !- X Origin {m}
   0,                                      !- Y Origin {m}
-  3.04785135876431,                       !- Z Origin {m}
+  3.0479,                                 !- Z Origin {m}
   {271f3401-76be-4edd-8369-7d5a808299e2}, !- Building Story Name
   {8034a3e3-15df-445b-ad23-d83b38062d6a}; !- Thermal Zone Name
 
@@ -1129,10 +1129,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {9bc8f935-cc7d-467e-95a2-473d08a7beb3}, !- Handle
@@ -1146,10 +1146,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.327341, 1.676318, 0,                 !- X,Y,Z Vertex 1 {m}
-  46.327341, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  46.3273, 1.6763, 0,                     !- X,Y,Z Vertex 1 {m}
+  46.3273, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 1.676318, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 1.6763, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {685992b0-44ad-47d5-b7f8-0ed36982b7ad}, !- Handle
@@ -1180,10 +1180,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 1 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {716b6360-a915-4a30-b1c8-ec181c534c51}, !- Handle
@@ -1197,10 +1197,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  -1.63304301636913e-07, 7.619628, 0,     !- X,Y,Z Vertex 3 {m}
-  -1.63304301636913e-07, 7.619628, 3.047851; !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {bc24c062-0ad7-4301-a61b-d50a7be3035f}, !- Handle
@@ -1214,10 +1214,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  34.7455054899131, -3.9691078068671e-07, 3.047851, !- X,Y,Z Vertex 1 {m}
-  34.7455054899131, -3.9691078068671e-07, 0, !- X,Y,Z Vertex 2 {m}
-  46.327341, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  46.327341, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  34.7455, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  34.7455, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  46.3273, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  46.3273, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {adb10805-b9f8-461d-9a8e-200d436b3ab3}, !- Handle
@@ -1231,10 +1231,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {c50c13d9-9cc1-43b4-a1b5-c8006d7d3014}, !- Handle
@@ -1248,10 +1248,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {32d2e447-31a9-4381-88cc-71b272037fc1}, !- Handle
@@ -1265,10 +1265,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Output:Meter,
   {a822ff24-e4e3-4c6b-8a4e-4fe82b0bb29b}, !- Handle
@@ -1289,10 +1289,10 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   1,                                      !- Multiplier
   ,                                       !- Number of Vertices
-  11.581835, 1.9049, 2.1732,              !- X,Y,Z Vertex 1 {m}
-  11.581835, 1.9049, 0.954,               !- X,Y,Z Vertex 2 {m}
-  11.581835, 5.7149, 0.954,               !- X,Y,Z Vertex 3 {m}
-  11.581835, 5.7149, 2.1732;              !- X,Y,Z Vertex 4 {m}
+  11.5818, 1.9049, 2.1732,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 1.9049, 0.954,                 !- X,Y,Z Vertex 2 {m}
+  11.5818, 5.7149, 0.954,                 !- X,Y,Z Vertex 3 {m}
+  11.5818, 5.7149, 2.1732;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {179af04c-9de7-4777-bfb2-e88c98794834}, !- Handle
@@ -1306,10 +1306,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {46903d54-4518-4e75-8031-146e60314b95}, !- Handle
@@ -1323,10 +1323,10 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   1,                                      !- Multiplier
   ,                                       !- Number of Vertices
-  11.581835, 1.9049, 2.1732,              !- X,Y,Z Vertex 1 {m}
-  11.581835, 1.9049, 0.954,               !- X,Y,Z Vertex 2 {m}
-  11.581835, 5.7149, 0.954,               !- X,Y,Z Vertex 3 {m}
-  11.581835, 5.7149, 2.1732;              !- X,Y,Z Vertex 4 {m}
+  11.5818, 1.9049, 2.1732,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 1.9049, 0.954,                 !- X,Y,Z Vertex 2 {m}
+  11.5818, 5.7149, 0.954,                 !- X,Y,Z Vertex 3 {m}
+  11.5818, 5.7149, 2.1732;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {6052717a-b449-46d4-ada5-bad81bf70f7a}, !- Handle
@@ -1340,10 +1340,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {6176e360-54d0-44ac-a266-d10aedab6668}, !- Handle
@@ -1357,10 +1357,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {4a93ea5e-ff36-4193-b6f6-b66539496a32}, !- Handle
@@ -1391,10 +1391,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 0, 3.047851,                         !- X,Y,Z Vertex 1 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {fae2b8a5-01f7-4c28-bf70-47cc485f5410}, !- Handle
@@ -1408,10 +1408,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {9db63e42-1d44-497a-9b0e-5325f861f301}, !- Handle
@@ -1425,10 +1425,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 1 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 2 {m}
-  -1.63304399336539e-07, 0, 0,            !- X,Y,Z Vertex 3 {m}
-  -1.63304399336539e-07, 0, 3.047851;     !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {78881d4e-03fe-4770-82cf-c22685e2945c}, !- Handle
@@ -1442,10 +1442,10 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   1,                                      !- Multiplier
   ,                                       !- Number of Vertices
-  11.581835, 1.9049, 2.1732,              !- X,Y,Z Vertex 1 {m}
-  11.581835, 1.9049, 0.954,               !- X,Y,Z Vertex 2 {m}
-  11.581835, 5.7149, 0.954,               !- X,Y,Z Vertex 3 {m}
-  11.581835, 5.7149, 2.1732;              !- X,Y,Z Vertex 4 {m}
+  11.5818, 1.9049, 2.1732,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 1.9049, 0.954,                 !- X,Y,Z Vertex 2 {m}
+  11.5818, 5.7149, 0.954,                 !- X,Y,Z Vertex 3 {m}
+  11.5818, 5.7149, 2.1732;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {b8e8faef-f7f6-4298-aa37-e27d3552ccd2}, !- Handle
@@ -1459,10 +1459,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {82bd34d1-195e-4406-a19d-2eb1810917bb}, !- Handle
@@ -1476,10 +1476,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {6315ab11-826e-4bfb-9416-671d68329af7}, !- Handle
@@ -1493,10 +1493,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 0, 3.047851,                         !- X,Y,Z Vertex 1 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {7508456a-940b-402f-bf6d-eb01a235c2c4}, !- Handle
@@ -1510,10 +1510,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 1.676318, 3.047851,                  !- X,Y,Z Vertex 1 {m}
-  0, 1.676318, 0,                         !- X,Y,Z Vertex 2 {m}
+  0, 1.6763, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 1.6763, 0,                           !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Timestep,
   {edfa6676-4fa1-4f8d-b586-211f30877da9}, !- Handle
@@ -1531,10 +1531,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 3.047851;                  !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {4bf23822-96d1-4966-b977-44c557377193}, !- Handle
@@ -1548,10 +1548,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  34.7455054899131, -3.9691078068671e-07, 3.047851, !- X,Y,Z Vertex 1 {m}
-  34.7455054899131, -3.9691078068671e-07, 0, !- X,Y,Z Vertex 2 {m}
-  46.327341, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  46.327341, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  34.7455, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  34.7455, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  46.3273, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  46.3273, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {f326f129-5c15-4001-b1e7-53f56fa397e7}, !- Handle
@@ -1565,10 +1565,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 0, 3.047851,                         !- X,Y,Z Vertex 1 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {38a63ba5-45e3-4ae8-a074-18f7334f96c4}, !- Handle
@@ -1582,10 +1582,10 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   1,                                      !- Multiplier
   ,                                       !- Number of Vertices
-  8.686, 7.619628, 2.1732,                !- X,Y,Z Vertex 1 {m}
-  8.686, 7.619628, 0.954,                 !- X,Y,Z Vertex 2 {m}
-  2.89498950131234, 7.619628, 0.954,      !- X,Y,Z Vertex 3 {m}
-  2.89498950131234, 7.619628, 2.1732;     !- X,Y,Z Vertex 4 {m}
+  8.686, 7.6196, 2.1732,                  !- X,Y,Z Vertex 1 {m}
+  8.686, 7.6196, 0.954,                   !- X,Y,Z Vertex 2 {m}
+  2.89498950131234, 7.6196, 0.954,        !- X,Y,Z Vertex 3 {m}
+  2.89498950131234, 7.6196, 2.1732;       !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {38233d6c-a038-4da7-aad0-fc35f2bcabc3}, !- Handle
@@ -1599,10 +1599,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 3.047851;                  !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {0973397c-a7cd-4f4c-b030-9a1a5fc1bd68}, !- Handle
@@ -1616,10 +1616,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {7ecf1ef3-c703-46bd-8b01-82977e66eb9d}, !- Handle
@@ -1633,10 +1633,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {2e33118a-bc3d-497a-9549-aaffb48e7c31}, !- Handle
@@ -1650,10 +1650,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -1.63304399336539e-07, 7.619628, 3.047851, !- X,Y,Z Vertex 1 {m}
-  -1.63304399336539e-07, 7.619628, 0,     !- X,Y,Z Vertex 2 {m}
-  -1.63304399336539e-07, 0, 0,            !- X,Y,Z Vertex 3 {m}
-  -1.63304399336539e-07, 0, 3.047851;     !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {c558d82c-5613-4ed0-8d46-457e8216c57d}, !- Handle
@@ -1667,10 +1667,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  -1.63304399336539e-07, 7.619628, 0,     !- X,Y,Z Vertex 3 {m}
-  -1.63304399336539e-07, 7.619628, 3.047851; !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {ba5b2bc2-eaf4-469d-b8b1-d92bbfef86ce}, !- Handle
@@ -1684,10 +1684,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 1 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {af29dfb6-7496-4f93-84eb-9aea6f24ec16}, !- Handle
@@ -1701,10 +1701,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {aa77ea57-67c6-4d67-bc88-32429135eec4}, !- Handle
@@ -1718,10 +1718,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {c23f7327-8225-448f-8249-f1ef8e586e17}, !- Handle
@@ -1735,10 +1735,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -1.63304399336539e-07, 7.619628, 3.047851, !- X,Y,Z Vertex 1 {m}
-  -1.63304399336539e-07, 7.619628, 0,     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {533c2d73-c8a4-4335-9970-cab144718379}, !- Handle
@@ -1752,10 +1752,10 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   1,                                      !- Multiplier
   ,                                       !- Number of Vertices
-  8.686, 7.619628, 2.1732,                !- X,Y,Z Vertex 1 {m}
-  8.686, 7.619628, 0.954,                 !- X,Y,Z Vertex 2 {m}
-  2.89498950131234, 7.619628, 0.954,      !- X,Y,Z Vertex 3 {m}
-  2.89498950131234, 7.619628, 2.1732;     !- X,Y,Z Vertex 4 {m}
+  8.686, 7.6196, 2.1732,                  !- X,Y,Z Vertex 1 {m}
+  8.686, 7.6196, 0.954,                   !- X,Y,Z Vertex 2 {m}
+  2.89498950131234, 7.6196, 0.954,        !- X,Y,Z Vertex 3 {m}
+  2.89498950131234, 7.6196, 2.1732;       !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {bc83631d-4a58-46ad-b52c-4055924d46cc}, !- Handle
@@ -1769,10 +1769,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {5758e5f8-053a-4ce6-9c81-c38fbad69ad9}, !- Handle
@@ -1786,10 +1786,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {d251f702-03b3-4ba8-9b7c-08259a4ea42e}, !- Handle
@@ -1799,8 +1799,8 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  9.29594664423115,                       !- Y Origin {m}
-  3.04785135876431,                       !- Z Origin {m}
+  9.2959,                                 !- Y Origin {m}
+  3.0479,                                 !- Z Origin {m}
   {271f3401-76be-4edd-8369-7d5a808299e2}, !- Building Story Name
   {e3ca4010-a6a5-4821-b2e6-107bd08eb6e8}; !- Thermal Zone Name
 
@@ -1816,10 +1816,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 0, 3.047851,                         !- X,Y,Z Vertex 1 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {38f883df-0f73-4a2a-9fd1-26a91e2ee0cd}, !- Handle
@@ -1833,10 +1833,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.1636701633044, 1.67631824732037, 3.047851, !- X,Y,Z Vertex 1 {m}
-  23.1636701633044, 1.67631824732037, 0,  !- X,Y,Z Vertex 2 {m}
-  11.5818351633044, 1.67631824732037, 0,  !- X,Y,Z Vertex 3 {m}
-  11.5818351633044, 1.67631824732037, 3.047851; !- X,Y,Z Vertex 4 {m}
+  23.1637, 1.6763, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  23.1637, 1.6763, 0,                     !- X,Y,Z Vertex 2 {m}
+  11.5818, 1.6763, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 1.6763, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {7097f868-5195-4814-a8b5-63f7bf661805}, !- Handle
@@ -1850,10 +1850,10 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   1,                                      !- Multiplier
   ,                                       !- Number of Vertices
-  11.581835, 1.9049, 2.1732,              !- X,Y,Z Vertex 1 {m}
-  11.581835, 1.9049, 0.954,               !- X,Y,Z Vertex 2 {m}
-  11.581835, 5.7149, 0.954,               !- X,Y,Z Vertex 3 {m}
-  11.581835, 5.7149, 2.1732;              !- X,Y,Z Vertex 4 {m}
+  11.5818, 1.9049, 2.1732,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 1.9049, 0.954,                 !- X,Y,Z Vertex 2 {m}
+  11.5818, 5.7149, 0.954,                 !- X,Y,Z Vertex 3 {m}
+  11.5818, 5.7149, 2.1732;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {90963fab-d41a-4776-8158-5800d81f7f47}, !- Handle
@@ -1867,10 +1867,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {c467be40-c8ea-41d0-995a-a4656ec97f84}, !- Handle
@@ -1884,10 +1884,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 0, 3.047851,                         !- X,Y,Z Vertex 1 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {5c041ba7-f105-4185-a779-998bd6cb0ad0}, !- Handle
@@ -1901,10 +1901,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.327341, 1.676318, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  46.327341, 1.676318, 0,                 !- X,Y,Z Vertex 2 {m}
-  34.7455054899131, 1.67631824732037, 0,  !- X,Y,Z Vertex 3 {m}
-  34.7455054899131, 1.67631824732037, 3.047851; !- X,Y,Z Vertex 4 {m}
+  46.3273, 1.6763, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  46.3273, 1.6763, 0,                     !- X,Y,Z Vertex 2 {m}
+  34.7455, 1.6763, 0,                     !- X,Y,Z Vertex 3 {m}
+  34.7455, 1.6763, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {abaef75f-9aa1-4865-9baa-5058002f5f6d}, !- Handle
@@ -1935,10 +1935,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 1 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {6110bce7-d14f-4734-b786-3368f1fa9fd9}, !- Handle
@@ -1952,10 +1952,10 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   1,                                      !- Multiplier
   ,                                       !- Number of Vertices
-  8.686, 7.619628, 2.1732,                !- X,Y,Z Vertex 1 {m}
-  8.686, 7.619628, 0.954,                 !- X,Y,Z Vertex 2 {m}
-  2.89498950131234, 7.619628, 0.954,      !- X,Y,Z Vertex 3 {m}
-  2.89498950131234, 7.619628, 2.1732;     !- X,Y,Z Vertex 4 {m}
+  8.686, 7.6196, 2.1732,                  !- X,Y,Z Vertex 1 {m}
+  8.686, 7.6196, 0.954,                   !- X,Y,Z Vertex 2 {m}
+  2.89498950131234, 7.6196, 0.954,        !- X,Y,Z Vertex 3 {m}
+  2.89498950131234, 7.6196, 2.1732;       !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {329cc372-873c-43a5-9272-e604a7426627}, !- Handle
@@ -1969,10 +1969,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 3.047851;                  !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {e6970b9f-5b70-45dd-a129-a0873e1f12a8}, !- Handle
@@ -1986,10 +1986,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -1.63304399336539e-07, 0, 3.047851,     !- X,Y,Z Vertex 1 {m}
-  -1.63304399336539e-07, 0, 0,            !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {31a041ea-149a-4d29-a8df-e2ec4e7981ab}, !- Handle
@@ -2003,10 +2003,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.1636701633044, 1.67631824732037, 3.047851, !- X,Y,Z Vertex 1 {m}
-  23.1636701633044, 1.67631824732037, 0,  !- X,Y,Z Vertex 2 {m}
-  11.5818351633044, 1.67631824732037, 0,  !- X,Y,Z Vertex 3 {m}
-  11.5818351633044, 1.67631824732037, 3.047851; !- X,Y,Z Vertex 4 {m}
+  23.1637, 1.6763, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  23.1637, 1.6763, 0,                     !- X,Y,Z Vertex 2 {m}
+  11.5818, 1.6763, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 1.6763, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {a390f85d-1e0f-4539-bd6b-77d9a7d49e91}, !- Handle
@@ -2020,10 +2020,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 0, 3.047851,                         !- X,Y,Z Vertex 1 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {5197ae2f-835b-4413-b43b-e1f2a6717eb1}, !- Handle
@@ -2037,10 +2037,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.327341, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  46.327341, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  46.327341, 1.676318, 0,                 !- X,Y,Z Vertex 3 {m}
-  46.327341, 1.676318, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  46.3273, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  46.3273, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  46.3273, 1.6763, 0,                     !- X,Y,Z Vertex 3 {m}
+  46.3273, 1.6763, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {717aacc9-d91e-4e59-9778-924657ad38d8}, !- Handle
@@ -2054,10 +2054,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  -1.63304399336539e-07, 7.619628, 0,     !- X,Y,Z Vertex 3 {m}
-  -1.63304399336539e-07, 7.619628, 3.047851; !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {7f9ec0f2-4a12-4979-8fb3-3df3d28f0d08}, !- Handle
@@ -2071,10 +2071,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {c00ca208-b2e0-4988-8b8f-59ea5e2e725c}, !- Handle
@@ -2088,10 +2088,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {30b4a10c-a054-43f2-b636-8739035a194f}, !- Handle
@@ -2105,10 +2105,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 3.047851;                  !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {a3ac4274-3a90-4438-a2c6-d9b489ae50ff}, !- Handle
@@ -2122,10 +2122,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, -3.9691078068671e-07, 3.047851, !- X,Y,Z Vertex 1 {m}
-  11.581835, -3.9691078068671e-07, 0,     !- X,Y,Z Vertex 2 {m}
-  23.1636703266088, -3.9691078068671e-07, 0, !- X,Y,Z Vertex 3 {m}
-  23.1636703266088, -3.9691078068671e-07, 3.047851; !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  23.1637, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  23.1637, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {062bf596-5683-48c3-aa87-d2bf9f13ad26}, !- Handle
@@ -2139,10 +2139,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {7cf04123-6bd6-4886-abb9-59405b5a5d3d}, !- Handle
@@ -2156,10 +2156,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 1 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {bfbb4bab-02b4-4dd5-9a25-d0ce73b9d2a1}, !- Handle
@@ -2173,10 +2173,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {f886c264-0c3a-4fcf-a573-b9ce3c891ec0}, !- Handle
@@ -2190,10 +2190,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {49b9efbf-1872-4f67-ad3e-c15cfac54455}, !- Handle
@@ -2207,10 +2207,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 3.047851;                  !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {03ebae37-082f-43ed-838c-33e3a167d8a7}, !- Handle
@@ -2224,10 +2224,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.5818351633044, -3.9691078068671e-07, 3.047851, !- X,Y,Z Vertex 1 {m}
-  11.5818351633044, -3.9691078068671e-07, 0, !- X,Y,Z Vertex 2 {m}
-  23.1636701633044, -3.9691078068671e-07, 0, !- X,Y,Z Vertex 3 {m}
-  23.1636701633044, -3.9691078068671e-07, 3.047851; !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  23.1637, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  23.1637, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {b60ed3e7-62cf-4284-9988-cb23e2ff0a1c}, !- Handle
@@ -2241,10 +2241,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {86a0c6c6-2f67-41ea-a22b-0eed7f018635}, !- Handle
@@ -2258,10 +2258,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 1 {m}
-  -1.63304399336539e-07, 7.619628, 0,     !- X,Y,Z Vertex 2 {m}
-  -1.63304399336539e-07, 0, 0,            !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {2c1fb5cb-d744-485f-b19b-edb542a335ee}, !- Handle
@@ -2275,10 +2275,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {4f1ec902-d894-430d-bf35-9684cdbb4ad3}, !- Handle
@@ -2292,10 +2292,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 0, 3.047851,                         !- X,Y,Z Vertex 1 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {e41b7305-7b07-4aa3-a452-3c8444b4e344}, !- Handle
@@ -2309,10 +2309,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.5818351633044, 1.67631824732037, 3.047851, !- X,Y,Z Vertex 1 {m}
-  11.5818351633044, 1.67631824732037, 0,  !- X,Y,Z Vertex 2 {m}
-  0, 1.676318, 0,                         !- X,Y,Z Vertex 3 {m}
-  0, 1.67631824732037, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 1.6763, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 1.6763, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 1.6763, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 1.6763, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {ae1a3426-8fbe-4aa4-9b96-265d1ab44c17}, !- Handle
@@ -2326,10 +2326,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 0, 3.047851,                         !- X,Y,Z Vertex 1 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {b340da59-e4f6-4224-acdd-1740a5bcfa0b}, !- Handle
@@ -2343,10 +2343,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.5818351633044, 1.67631824732037, 3.047851, !- X,Y,Z Vertex 1 {m}
-  11.5818351633044, 1.67631824732037, 0,  !- X,Y,Z Vertex 2 {m}
-  0, 1.67631824732037, 0,                 !- X,Y,Z Vertex 3 {m}
-  0, 1.67631824732037, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 1.6763, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 1.6763, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 1.6763, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 1.6763, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {d631ce51-4ce6-49db-9914-73bbcf409eb3}, !- Handle
@@ -2360,10 +2360,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 0, 3.047851,                         !- X,Y,Z Vertex 1 {m}
-  -1.63304399336539e-07, 0, 0,            !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {4ba3edf7-d8cf-4248-8c68-3c2a4f2b5e7a}, !- Handle
@@ -2377,10 +2377,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {06bbdf9c-3c49-4c88-8c4b-0191b1091d67}, !- Handle
@@ -2394,10 +2394,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {423aae32-5565-4476-aeef-4342771309eb}, !- Handle
@@ -2428,10 +2428,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 1 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {34b4c81e-9b09-4e82-a10f-1f713ebf0b11}, !- Handle
@@ -2445,10 +2445,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {c83f9036-726e-4da7-9e5d-3295ece930cc}, !- Handle
@@ -2462,10 +2462,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.3273404899131, -3.9691078068671e-07, 3.047851, !- X,Y,Z Vertex 1 {m}
-  46.3273404899131, -3.9691078068671e-07, 0, !- X,Y,Z Vertex 2 {m}
-  46.327341, 1.676318, 0,                 !- X,Y,Z Vertex 3 {m}
-  46.3273404899131, 1.67631824732037, 3.047851; !- X,Y,Z Vertex 4 {m}
+  46.3273, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  46.3273, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  46.3273, 1.6763, 0,                     !- X,Y,Z Vertex 3 {m}
+  46.3273, 1.6763, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {1b69fa2b-40bf-4f4c-9dbb-b45b3e3e44a2}, !- Handle
@@ -2479,10 +2479,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {ded4e408-7c4a-4b73-934e-290e877cbbff}, !- Handle
@@ -2496,10 +2496,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.327341, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  46.327341, 1.676318, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 1.676318, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  46.3273, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  46.3273, 1.6763, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 1.6763, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {00a58f76-1083-44a9-98b5-4d1abb762575}, !- Handle
@@ -2513,10 +2513,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {6a43f181-503a-4ef0-b7b4-c6287181f587}, !- Handle
@@ -2547,10 +2547,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {e0f7e2eb-7fa9-4cac-a318-a956e44304ff}, !- Handle
@@ -2564,10 +2564,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {eb3e0266-afad-475f-861e-c5a267f69950}, !- Handle
@@ -2581,10 +2581,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {75fd5c8a-5998-43b5-97e6-c018c31fedd4}, !- Handle
@@ -2598,10 +2598,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {a001ef4a-7d6c-48d4-bd74-450d0824361f}, !- Handle
@@ -2615,10 +2615,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 1 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {d16dbe4a-4631-46f4-a078-d25c75315c43}, !- Handle
@@ -2649,10 +2649,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:RunPeriod,
   {17246936-3daa-4b32-8968-1e0c617730af}, !- Handle
@@ -2685,10 +2685,10 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   1,                                      !- Multiplier
   ,                                       !- Number of Vertices
-  8.686, 7.619628, 2.1732,                !- X,Y,Z Vertex 1 {m}
-  8.686, 7.619628, 0.954,                 !- X,Y,Z Vertex 2 {m}
-  2.89498950131234, 7.619628, 0.954,      !- X,Y,Z Vertex 3 {m}
-  2.89498950131234, 7.619628, 2.1732;     !- X,Y,Z Vertex 4 {m}
+  8.686, 7.6196, 2.1732,                  !- X,Y,Z Vertex 1 {m}
+  8.686, 7.6196, 0.954,                   !- X,Y,Z Vertex 2 {m}
+  2.89498950131234, 7.6196, 0.954,        !- X,Y,Z Vertex 3 {m}
+  2.89498950131234, 7.6196, 2.1732;       !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {2de693c3-45db-4f7f-be74-82fc1220c3c3}, !- Handle
@@ -2702,10 +2702,10 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   1,                                      !- Multiplier
   ,                                       !- Number of Vertices
-  46.327341, 0.381000000012441, 2.1731,   !- X,Y,Z Vertex 1 {m}
-  46.327341, 0.381000000012441, 0.954,    !- X,Y,Z Vertex 2 {m}
-  46.327341, 1.29530000001236, 0.954,     !- X,Y,Z Vertex 3 {m}
-  46.327341, 1.29530000001236, 2.1731;    !- X,Y,Z Vertex 4 {m}
+  46.3273, 0.381000000012441, 2.1731,     !- X,Y,Z Vertex 1 {m}
+  46.3273, 0.381000000012441, 0.954,      !- X,Y,Z Vertex 2 {m}
+  46.3273, 1.29530000001236, 0.954,       !- X,Y,Z Vertex 3 {m}
+  46.3273, 1.29530000001236, 2.1731;      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {bd8ce1a2-fa04-48b6-b755-c5c9659eb5aa}, !- Handle
@@ -2719,10 +2719,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {844d8a65-aa9a-4388-905d-0eba9f481575}, !- Handle
@@ -2736,10 +2736,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 1 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  -1.63304399336539e-07, 0, 3.047851;     !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {35569ce9-6ed1-474e-94ed-b9b53c411482}, !- Handle
@@ -2753,10 +2753,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.327341, 1.676318, 0,                 !- X,Y,Z Vertex 1 {m}
-  46.327341, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  46.3273, 1.6763, 0,                     !- X,Y,Z Vertex 1 {m}
+  46.3273, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 1.676318, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 1.6763, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {d9fb3c9b-dfbd-411c-81f4-1ee8d5b73d0f}, !- Handle
@@ -2770,10 +2770,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 1.67631824732037, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  0, 1.67631824732037, 0,                 !- X,Y,Z Vertex 2 {m}
+  0, 1.6763, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 1.6763, 0,                           !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {ded359fe-9e00-4904-9917-e7115e3e3eaf}, !- Handle
@@ -2787,10 +2787,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {7798389d-c509-40d9-91d6-adc1aec9c8a2}, !- Handle
@@ -2804,10 +2804,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 1 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {7347fd37-c284-440c-af33-38b0962a4f06}, !- Handle
@@ -2821,10 +2821,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {74c4318f-e443-4d02-9a26-c7e64a6d5271}, !- Handle
@@ -2838,10 +2838,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {fe8f496c-357d-4c24-b069-cb1c352df354}, !- Handle
@@ -2872,10 +2872,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -1.63304399336539e-07, 0, 3.047851,     !- X,Y,Z Vertex 1 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {18d892cd-e1a0-44c5-912c-483cf40d5e4b}, !- Handle
@@ -2889,10 +2889,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  34.7455053266088, 1.67631824732037, 3.047851, !- X,Y,Z Vertex 1 {m}
-  34.7455053266088, 1.67631824732037, 0,  !- X,Y,Z Vertex 2 {m}
-  23.1636701633044, 1.67631824732037, 0,  !- X,Y,Z Vertex 3 {m}
-  23.1636701633044, 1.67631824732037, 3.047851; !- X,Y,Z Vertex 4 {m}
+  34.7455, 1.6763, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  34.7455, 1.6763, 0,                     !- X,Y,Z Vertex 2 {m}
+  23.1637, 1.6763, 0,                     !- X,Y,Z Vertex 3 {m}
+  23.1637, 1.6763, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {8a224810-4373-4cae-9881-b0bb511c13e0}, !- Handle
@@ -2906,10 +2906,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -1.63304399336539e-07, 0, 3.047851,     !- X,Y,Z Vertex 1 {m}
-  -1.63304399336539e-07, 0, 0,            !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {1eb08487-139c-4b7e-9c80-62df703ec34a}, !- Handle
@@ -2923,10 +2923,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  34.7455054899131, 1.67631824732037, 3.047851, !- X,Y,Z Vertex 1 {m}
-  34.7455054899131, 1.67631824732037, 0,  !- X,Y,Z Vertex 2 {m}
-  23.1636701633044, 1.67631824732037, 0,  !- X,Y,Z Vertex 3 {m}
-  23.1636701633044, 1.67631824732037, 3.047851; !- X,Y,Z Vertex 4 {m}
+  34.7455, 1.6763, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  34.7455, 1.6763, 0,                     !- X,Y,Z Vertex 2 {m}
+  23.1637, 1.6763, 0,                     !- X,Y,Z Vertex 3 {m}
+  23.1637, 1.6763, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {0122e97d-e5f0-4bbe-ac4b-60a57dd65143}, !- Handle
@@ -2940,10 +2940,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {516e7d8c-7643-4ced-8226-66cb619a2c42}, !- Handle
@@ -2957,10 +2957,10 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   1,                                      !- Multiplier
   ,                                       !- Number of Vertices
-  11.581835, 1.9049, 2.1732,              !- X,Y,Z Vertex 1 {m}
-  11.581835, 1.9049, 0.954,               !- X,Y,Z Vertex 2 {m}
-  11.581835, 5.7149, 0.954,               !- X,Y,Z Vertex 3 {m}
-  11.581835, 5.7149, 2.1732;              !- X,Y,Z Vertex 4 {m}
+  11.5818, 1.9049, 2.1732,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 1.9049, 0.954,                 !- X,Y,Z Vertex 2 {m}
+  11.5818, 5.7149, 0.954,                 !- X,Y,Z Vertex 3 {m}
+  11.5818, 5.7149, 2.1732;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {b656eb60-f5b7-4c91-b0bf-9e7c799dbd8e}, !- Handle
@@ -2974,10 +2974,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {cb41c7b0-bd18-4bef-8b7d-0ec200982c49}, !- Handle
@@ -2991,10 +2991,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -1.63304399336539e-07, 0, 3.047851,     !- X,Y,Z Vertex 1 {m}
-  -1.63304399336539e-07, 0, 0,            !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {2df42518-f3bc-4d0b-814b-5de908c94fbe}, !- Handle
@@ -3008,10 +3008,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {ceabc2d2-2c2d-4f75-8882-483069268c42}, !- Handle
@@ -3042,10 +3042,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {4608bfe5-cb9f-42f7-b7fe-387d9e1982ad}, !- Handle
@@ -3076,10 +3076,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -1.63304301636913e-07, 0, 3.047851,     !- X,Y,Z Vertex 1 {m}
-  -1.63304301636913e-07, 0, 0,            !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {23b45aae-e2e1-4523-b04d-86aa560b5716}, !- Handle
@@ -3093,10 +3093,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 3.047851;                  !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {bf48e683-2c32-4038-bf2c-4e4e9ff3646f}, !- Handle
@@ -3110,10 +3110,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 0, 3.047851,                         !- X,Y,Z Vertex 1 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
-  11.5818351633044, -3.9691078068671e-07, 0, !- X,Y,Z Vertex 3 {m}
-  11.5818351633044, -3.9691078068671e-07, 3.047851; !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {b525bb62-38a2-465b-b99e-ce5a3c7c32df}, !- Handle
@@ -3127,10 +3127,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {9f8624c5-40a1-49d1-89f1-802dd3649e49}, !- Handle
@@ -3161,10 +3161,10 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   1,                                      !- Multiplier
   ,                                       !- Number of Vertices
-  8.686, 7.619628, 2.1732,                !- X,Y,Z Vertex 1 {m}
-  8.686, 7.619628, 0.954,                 !- X,Y,Z Vertex 2 {m}
-  2.89498950131234, 7.619628, 0.954,      !- X,Y,Z Vertex 3 {m}
-  2.89498950131234, 7.619628, 2.1732;     !- X,Y,Z Vertex 4 {m}
+  8.686, 7.6196, 2.1732,                  !- X,Y,Z Vertex 1 {m}
+  8.686, 7.6196, 0.954,                   !- X,Y,Z Vertex 2 {m}
+  2.89498950131234, 7.6196, 0.954,        !- X,Y,Z Vertex 3 {m}
+  2.89498950131234, 7.6196, 2.1732;       !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {5b9c5e1f-745c-4b9e-86aa-c7fa2fddd93b}, !- Handle
@@ -3178,10 +3178,10 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   1,                                      !- Multiplier
   ,                                       !- Number of Vertices
-  46.3273404466331, 0.0508000000062577, 2.13349999999656, !- X,Y,Z Vertex 1 {m}
-  46.3273406230384, 0.0508000000061772, 0.0253999999966025, !- X,Y,Z Vertex 2 {m}
-  46.3273408626211, 1.62550000000607, 0.0253999999966627, !- X,Y,Z Vertex 3 {m}
-  46.3273406862158, 1.62550000000615, 2.13349999999662; !- X,Y,Z Vertex 4 {m}
+  46.3273, 0.0508000000062577, 2.13349999999656, !- X,Y,Z Vertex 1 {m}
+  46.3273, 0.0508000000061772, 0.0253999999966025, !- X,Y,Z Vertex 2 {m}
+  46.3273, 1.62550000000607, 0.0253999999966627, !- X,Y,Z Vertex 3 {m}
+  46.3273, 1.62550000000615, 2.13349999999662; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {39149afc-8412-4cf6-9fdb-b7671cf27e75}, !- Handle
@@ -3195,10 +3195,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.327341, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  46.327341, 1.676318, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 1.676318, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  46.3273, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  46.3273, 1.6763, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 1.6763, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Output:Meter,
   {fcf53c68-a8b2-4d87-9da1-5081300f1aa9}, !- Handle
@@ -3219,10 +3219,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  -1.63304399336539e-07, 7.619628, 0,     !- X,Y,Z Vertex 3 {m}
-  -1.63304399336539e-07, 7.619628, 3.047851; !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {e1bd7483-b3ca-45f7-a077-89814288befe}, !- Handle
@@ -3236,10 +3236,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.1636701633044, -3.9691078068671e-07, 3.047851, !- X,Y,Z Vertex 1 {m}
-  23.1636701633044, -3.9691078068671e-07, 0, !- X,Y,Z Vertex 2 {m}
-  34.7455054899131, -3.9691078068671e-07, 0, !- X,Y,Z Vertex 3 {m}
-  34.7455054899131, -3.9691078068671e-07, 3.047851; !- X,Y,Z Vertex 4 {m}
+  23.1637, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  23.1637, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  34.7455, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  34.7455, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {16d0e2c8-b3d9-460d-b9a6-f0430ab1508d}, !- Handle
@@ -3253,10 +3253,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {86cd0499-a033-4062-8d70-a2279875a2ec}, !- Handle
@@ -3270,10 +3270,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 1 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {76702075-4def-4826-896f-771ca21d6190}, !- Handle
@@ -3287,10 +3287,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 1.67631824732037, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  0, 1.676318, 0,                         !- X,Y,Z Vertex 2 {m}
-  0, -3.9691078068671e-07, 0,             !- X,Y,Z Vertex 3 {m}
-  0, -3.9691078068671e-07, 3.047851;      !- X,Y,Z Vertex 4 {m}
+  0, 1.6763, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 1.6763, 0,                           !- X,Y,Z Vertex 2 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {c3e60ffa-1992-4ef1-bc27-c17be997af81}, !- Handle
@@ -3321,10 +3321,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {6fd01f23-7167-4a4e-977b-43f8309750da}, !- Handle
@@ -3338,10 +3338,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 1 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {b5f48544-dfff-4cbf-b9eb-ce095bf2a985}, !- Handle
@@ -3355,10 +3355,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {8c1920fe-9292-4fc9-a4db-eae6da22f4cc}, !- Handle
@@ -3372,10 +3372,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -1.63304399336539e-07, 0, 3.047851,     !- X,Y,Z Vertex 1 {m}
-  -1.63304399336539e-07, 0, 0,            !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {287e7e6d-963f-4faa-9c92-5ca8556465c2}, !- Handle
@@ -3389,10 +3389,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  34.7455054899131, 1.67631824732037, 3.047851, !- X,Y,Z Vertex 1 {m}
-  34.7455054899131, 1.67631824732037, 0,  !- X,Y,Z Vertex 2 {m}
-  23.1636701633044, 1.67631824732037, 0,  !- X,Y,Z Vertex 3 {m}
-  23.1636701633044, 1.67631824732037, 3.047851; !- X,Y,Z Vertex 4 {m}
+  34.7455, 1.6763, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  34.7455, 1.6763, 0,                     !- X,Y,Z Vertex 2 {m}
+  23.1637, 1.6763, 0,                     !- X,Y,Z Vertex 3 {m}
+  23.1637, 1.6763, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {2da5ffa2-72af-4994-b7c0-e0130ca16d87}, !- Handle
@@ -3406,10 +3406,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {73b80291-0c26-4ad4-86ff-39ce0ff3320d}, !- Handle
@@ -3423,10 +3423,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {881b6c21-3f1b-469c-a6d3-0ab94ee4c5f0}, !- Handle
@@ -3440,10 +3440,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 0, 3.047851,                         !- X,Y,Z Vertex 1 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {b24f9329-4728-49b7-bbda-cef3fe20c637}, !- Handle
@@ -3457,10 +3457,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.327341, 1.676318, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  46.327341, 1.676318, 0,                 !- X,Y,Z Vertex 2 {m}
-  34.7455053266088, 1.67631824732037, 0,  !- X,Y,Z Vertex 3 {m}
-  34.7455053266088, 1.67631824732037, 3.047851; !- X,Y,Z Vertex 4 {m}
+  46.3273, 1.6763, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  46.3273, 1.6763, 0,                     !- X,Y,Z Vertex 2 {m}
+  34.7455, 1.6763, 0,                     !- X,Y,Z Vertex 3 {m}
+  34.7455, 1.6763, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {41b2e3c5-e83f-42af-9b69-368c3a807697}, !- Handle
@@ -3474,10 +3474,10 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   1,                                      !- Multiplier
   ,                                       !- Number of Vertices
-  11.581835, 1.9049, 2.1732,              !- X,Y,Z Vertex 1 {m}
-  11.581835, 1.9049, 0.954,               !- X,Y,Z Vertex 2 {m}
-  11.581835, 5.7149, 0.954,               !- X,Y,Z Vertex 3 {m}
-  11.581835, 5.7149, 2.1732;              !- X,Y,Z Vertex 4 {m}
+  11.5818, 1.9049, 2.1732,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 1.9049, 0.954,                 !- X,Y,Z Vertex 2 {m}
+  11.5818, 5.7149, 0.954,                 !- X,Y,Z Vertex 3 {m}
+  11.5818, 5.7149, 2.1732;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {3dbd93e7-32e4-4f53-b639-ab0832e6c891}, !- Handle
@@ -3491,10 +3491,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 3.047851;                  !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {237f47e9-942b-4bfc-8e38-d34b101a0b88}, !- Handle
@@ -3508,10 +3508,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {52c84127-ec57-4a89-9285-bd8955f7b657}, !- Handle
@@ -3525,10 +3525,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {0b109f71-d4cc-45c3-b039-71764d46d4d3}, !- Handle
@@ -3542,10 +3542,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 1 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {9ae5d935-056d-4b66-bbc3-992d52fd6f7d}, !- Handle
@@ -3559,10 +3559,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {3dcdb189-9fd1-4c0d-985e-07b309b7dce6}, !- Handle
@@ -3576,10 +3576,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {2b0cc56c-1454-4617-ba61-125ca4e5ae9b}, !- Handle
@@ -3593,10 +3593,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  -1.63304399336539e-07, 7.619628, 0,     !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 3.047851;                  !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {b8ee2181-e3b2-4ab8-af8a-4120fdffdb97}, !- Handle
@@ -3610,10 +3610,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.5818351633044, -3.9691078068671e-07, 3.047851, !- X,Y,Z Vertex 1 {m}
-  11.5818351633044, -3.9691078068671e-07, 0, !- X,Y,Z Vertex 2 {m}
-  23.1636703266088, -3.9691078068671e-07, 0, !- X,Y,Z Vertex 3 {m}
-  23.1636703266088, -3.9691078068671e-07, 3.047851; !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  23.1637, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  23.1637, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {772936a8-54ee-4ead-a5d9-615785de8335}, !- Handle
@@ -3627,10 +3627,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 0, 3.047851,                         !- X,Y,Z Vertex 1 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {68e6e7a1-756e-4412-a08e-a55123509bbb}, !- Handle
@@ -3644,10 +3644,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.5818351633044, 1.67631824732037, 3.047851, !- X,Y,Z Vertex 1 {m}
-  11.5818351633044, 1.67631824732037, 0,  !- X,Y,Z Vertex 2 {m}
-  0, 1.676318, 0,                         !- X,Y,Z Vertex 3 {m}
-  0, 1.676318, 3.047851;                  !- X,Y,Z Vertex 4 {m}
+  11.5818, 1.6763, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 1.6763, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 1.6763, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 1.6763, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {d1b674ab-0acc-4deb-bc48-755a8ad4cd9e}, !- Handle
@@ -3678,10 +3678,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {5f148495-c6a8-4a28-afeb-1a1e6b8ea81f}, !- Handle
@@ -3695,10 +3695,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  -1.63304301636913e-07, 7.619628, 0,     !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 3.047851;                  !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {608daf55-87bf-4e6c-890d-b8673ef911dc}, !- Handle
@@ -3712,10 +3712,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {ca03ccf8-71b9-415e-aa14-de43b4da791b}, !- Handle
@@ -3746,10 +3746,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 0, 3.047851,                         !- X,Y,Z Vertex 1 {m}
-  -1.63304301636913e-07, 0, 0,            !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {2ac605d2-229b-48f2-80ef-680280f90109}, !- Handle
@@ -3763,10 +3763,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.3273404899131, 1.67631824732037, 3.047851, !- X,Y,Z Vertex 1 {m}
-  46.327341, 1.676318, 0,                 !- X,Y,Z Vertex 2 {m}
-  34.7455054899131, 1.67631824732037, 0,  !- X,Y,Z Vertex 3 {m}
-  34.7455054899131, 1.67631824732037, 3.047851; !- X,Y,Z Vertex 4 {m}
+  46.3273, 1.6763, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  46.3273, 1.6763, 0,                     !- X,Y,Z Vertex 2 {m}
+  34.7455, 1.6763, 0,                     !- X,Y,Z Vertex 3 {m}
+  34.7455, 1.6763, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {8e3c24bf-b7ed-4525-bea2-435e8469ba20}, !- Handle
@@ -3780,10 +3780,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  -1.63304399336539e-07, 7.619628, 0,     !- X,Y,Z Vertex 3 {m}
-  -1.63304399336539e-07, 7.619628, 3.047851; !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {5ea7bc0c-45fb-4944-a6be-d73dc3c4576f}, !- Handle
@@ -3797,10 +3797,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.1636703266088, -3.9691078068671e-07, 3.047851, !- X,Y,Z Vertex 1 {m}
-  23.1636703266088, -3.9691078068671e-07, 0, !- X,Y,Z Vertex 2 {m}
-  34.7455054899131, -3.9691078068671e-07, 0, !- X,Y,Z Vertex 3 {m}
-  34.7455054899131, -3.9691078068671e-07, 3.047851; !- X,Y,Z Vertex 4 {m}
+  23.1637, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  23.1637, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  34.7455, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  34.7455, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:HeatBalanceAlgorithm,
   {1dece26d-d2e9-45ee-a6a9-a9c584ed7381}, !- Handle
@@ -3819,10 +3819,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  -1.63304399336539e-07, 7.619628, 0,     !- X,Y,Z Vertex 3 {m}
-  -1.63304399336539e-07, 7.619628, 3.047851; !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {928da7a6-6da5-49c5-b921-883d1c6c7527}, !- Handle
@@ -3836,10 +3836,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.1636703266088, -3.9691078068671e-07, 3.047851, !- X,Y,Z Vertex 1 {m}
-  23.1636703266088, -3.9691078068671e-07, 0, !- X,Y,Z Vertex 2 {m}
-  34.7455054899131, -3.9691078068671e-07, 0, !- X,Y,Z Vertex 3 {m}
-  34.7455054899131, -3.9691078068671e-07, 3.047851; !- X,Y,Z Vertex 4 {m}
+  23.1637, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  23.1637, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  34.7455, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  34.7455, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {62194174-081f-4cf0-97e6-fa8d19a434fc}, !- Handle
@@ -3853,10 +3853,10 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   1,                                      !- Multiplier
   ,                                       !- Number of Vertices
-  46.327341, 0.381, 2.1731,               !- X,Y,Z Vertex 1 {m}
-  46.327341, 0.381, 0.954,                !- X,Y,Z Vertex 2 {m}
-  46.327341, 1.2953, 0.954,               !- X,Y,Z Vertex 3 {m}
-  46.327341, 1.2953, 2.1731;              !- X,Y,Z Vertex 4 {m}
+  46.3273, 0.381, 2.1731,                 !- X,Y,Z Vertex 1 {m}
+  46.3273, 0.381, 0.954,                  !- X,Y,Z Vertex 2 {m}
+  46.3273, 1.2953, 0.954,                 !- X,Y,Z Vertex 3 {m}
+  46.3273, 1.2953, 2.1731;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {6da1a970-a01d-4919-b89d-9ee5fc864ede}, !- Handle
@@ -3870,10 +3870,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {40c22506-4400-4641-9898-b438f3b99abd}, !- Handle
@@ -3887,10 +3887,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {a2d4e737-1919-4fc7-a409-570c4d66d232}, !- Handle
@@ -3921,10 +3921,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {0ea10bb2-1a83-47ce-9eb1-2fb7fd05d986}, !- Handle
@@ -3938,10 +3938,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {af3544a8-454c-4522-b0ae-6770d11d41fb}, !- Handle
@@ -3955,10 +3955,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 1 {m}
-  -1.63304301636913e-07, 7.619628, 0,     !- X,Y,Z Vertex 2 {m}
-  -1.63304301636913e-07, 0, 0,            !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {46b91a49-d5cc-4a47-8849-e84d40345d42}, !- Handle
@@ -3972,10 +3972,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {8907f6af-2052-4773-9da8-7d2085c2f716}, !- Handle
@@ -3989,10 +3989,10 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   1,                                      !- Multiplier
   ,                                       !- Number of Vertices
-  8.686, 7.619628, 2.1732,                !- X,Y,Z Vertex 1 {m}
-  8.686, 7.619628, 0.954,                 !- X,Y,Z Vertex 2 {m}
-  2.89498950131234, 7.619628, 0.954,      !- X,Y,Z Vertex 3 {m}
-  2.89498950131234, 7.619628, 2.1732;     !- X,Y,Z Vertex 4 {m}
+  8.686, 7.6196, 2.1732,                  !- X,Y,Z Vertex 1 {m}
+  8.686, 7.6196, 0.954,                   !- X,Y,Z Vertex 2 {m}
+  2.89498950131234, 7.6196, 0.954,        !- X,Y,Z Vertex 3 {m}
+  2.89498950131234, 7.6196, 2.1732;       !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {6aeccaed-5a77-4560-81d1-ac6a229ba228}, !- Handle
@@ -4006,10 +4006,10 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   1,                                      !- Multiplier
   ,                                       !- Number of Vertices
-  8.686, 7.619628, 2.1732,                !- X,Y,Z Vertex 1 {m}
-  8.686, 7.619628, 0.954,                 !- X,Y,Z Vertex 2 {m}
-  2.89498950131234, 7.619628, 0.954,      !- X,Y,Z Vertex 3 {m}
-  2.89498950131234, 7.619628, 2.1732;     !- X,Y,Z Vertex 4 {m}
+  8.686, 7.6196, 2.1732,                  !- X,Y,Z Vertex 1 {m}
+  8.686, 7.6196, 0.954,                   !- X,Y,Z Vertex 2 {m}
+  2.89498950131234, 7.6196, 0.954,        !- X,Y,Z Vertex 3 {m}
+  2.89498950131234, 7.6196, 2.1732;       !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {9abb6a67-4697-4c5b-b8ef-16dc3a4a680e}, !- Handle
@@ -4023,10 +4023,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 3.047851;                  !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {a5048412-65cd-4699-a9c8-18a8b83c8e48}, !- Handle
@@ -4040,10 +4040,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {c6089f26-f990-4d65-8bbb-9bccbeffe3be}, !- Handle
@@ -4057,10 +4057,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -1.63304399336539e-07, 7.619628, 3.047851, !- X,Y,Z Vertex 1 {m}
-  -1.63304399336539e-07, 7.619628, 0,     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {14020247-2488-4f77-847c-2444299c9f21}, !- Handle
@@ -4074,10 +4074,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 3.047851;                  !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {23f5bcdd-4d96-4b79-aaa3-fa5d4ff54e2f}, !- Handle
@@ -4091,10 +4091,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, -3.9691078068671e-07, 3.047851,      !- X,Y,Z Vertex 1 {m}
-  0, -3.9691078068671e-07, 0,             !- X,Y,Z Vertex 2 {m}
-  11.581835, -3.9691078068671e-07, 0,     !- X,Y,Z Vertex 3 {m}
-  11.581835, -3.9691078068671e-07, 3.047851; !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {12411267-2c07-43b4-8bf0-459c91ceb16b}, !- Handle
@@ -4108,10 +4108,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {517cd48e-a3d9-4002-b8eb-f01f36c6d818}, !- Handle
@@ -4125,10 +4125,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -1.63304399336539e-07, 7.619628, 3.047851, !- X,Y,Z Vertex 1 {m}
-  -1.63304399336539e-07, 7.619628, 0,     !- X,Y,Z Vertex 2 {m}
-  -1.63304399336539e-07, 0, 0,            !- X,Y,Z Vertex 3 {m}
-  -1.63304399336539e-07, 0, 3.047851;     !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {ced355ab-ccf1-48d3-99d6-818e78f2476e}, !- Handle
@@ -4142,10 +4142,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {11565674-4a54-4b56-b376-80434ac0d4dd}, !- Handle
@@ -4159,10 +4159,10 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   1,                                      !- Multiplier
   ,                                       !- Number of Vertices
-  8.686, 7.619628, 2.1732,                !- X,Y,Z Vertex 1 {m}
-  8.686, 7.619628, 0.954,                 !- X,Y,Z Vertex 2 {m}
-  2.89498950131234, 7.619628, 0.954,      !- X,Y,Z Vertex 3 {m}
-  2.89498950131234, 7.619628, 2.1732;     !- X,Y,Z Vertex 4 {m}
+  8.686, 7.6196, 2.1732,                  !- X,Y,Z Vertex 1 {m}
+  8.686, 7.6196, 0.954,                   !- X,Y,Z Vertex 2 {m}
+  2.89498950131234, 7.6196, 0.954,        !- X,Y,Z Vertex 3 {m}
+  2.89498950131234, 7.6196, 2.1732;       !- X,Y,Z Vertex 4 {m}
 
 OS:Facility,
   {a088617f-bd6c-4c3c-8620-c25da6ddb620}; !- Handle

--- a/data/geometry/ASHRAE9012013SuperMarket.osm
+++ b/data/geometry/ASHRAE9012013SuperMarket.osm
@@ -168,10 +168,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {9871e5b3-040a-44e4-9df8-f5fa1e1e10af}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {cc30f6ab-6b11-467b-9ac6-f27fa0f61a99}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   23.4807, 4.57199999999984, 4.572,       !- X,Y,Z Vertex 1 {m}
@@ -185,10 +185,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {9871e5b3-040a-44e4-9df8-f5fa1e1e10af}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {ca2f05a1-a2bd-48a2-9153-89c97999e6da}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   1.25873118711682e-017, 4.57199999999984, 4.572, !- X,Y,Z Vertex 1 {m}
@@ -251,10 +251,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {0f799d38-5e12-4224-a2f6-65f846eb1148}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {39c15528-345e-45ac-b158-66756973609d}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   1.06465271808986e-016, 43.8197999999998, 4.572, !- X,Y,Z Vertex 1 {m}
@@ -285,10 +285,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {0f799d38-5e12-4224-a2f6-65f846eb1148}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {45a6d2ff-634c-4124-9381-0a5008ab5137}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   8.19169458172421e-017, 4.57199999999984, 4.572, !- X,Y,Z Vertex 1 {m}
@@ -402,10 +402,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {403f025b-298f-491c-a18a-1bbad23b565c}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {94aaca25-d5ce-45d4-8879-ebafdd3e303d}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   29.5767, 4.57199999999984, 4.572,       !- X,Y,Z Vertex 1 {m}
@@ -536,10 +536,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {27cc4560-6291-4c1f-b14c-c4f5c6d2b6e7}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {83ca7553-a425-4e10-b748-ac025bcea02c}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   53.0574, 4.57199999999984, 4.57199999999999, !- X,Y,Z Vertex 1 {m}
@@ -553,10 +553,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {27cc4560-6291-4c1f-b14c-c4f5c6d2b6e7}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {cbd1d764-f9b9-4bcc-bf58-0cd93bdb6c3c}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   53.0574, 1.82093990566872e-015, 4.57199999999999, !- X,Y,Z Vertex 1 {m}
@@ -670,10 +670,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {027a0cdc-6550-4760-91ae-c3f5379af193}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {05e52492-8e20-42a9-97f4-72c244e07fbd}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   53.0574, 4.57199999999984, 4.572,       !- X,Y,Z Vertex 1 {m}
@@ -770,10 +770,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {0fd60f7d-ee76-49e8-8ff8-533766628f82}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {04c7a1a7-94a7-4401-89e2-84f28f38ad30}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   7.37341704866608e-017, 43.8197999999998, 4.572, !- X,Y,Z Vertex 1 {m}
@@ -787,10 +787,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {0fd60f7d-ee76-49e8-8ff8-533766628f82}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {8dbd9195-13b2-4fec-a680-c9d0e67f8f4c}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   15.9211, 43.8197999999998, 4.572,       !- X,Y,Z Vertex 1 {m}
@@ -804,10 +804,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {0fd60f7d-ee76-49e8-8ff8-533766628f82}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {ae4bd153-24b9-4f2b-8c40-2777d85cc1ae}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   53.0574, 21.1184999999998, 4.572,       !- X,Y,Z Vertex 1 {m}
@@ -821,10 +821,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {0fd60f7d-ee76-49e8-8ff8-533766628f82}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {8bc8cf51-4ddd-4a8a-b0e9-12969a554249}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   29.5767, 4.57199999999984, 4.572,       !- X,Y,Z Vertex 1 {m}
@@ -887,10 +887,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {02a20178-5cec-4076-8aed-244e2d3a36c6}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {9ed1c977-dbf6-43ee-8dca-5e1b1dcad969}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   62.9555, 43.8197999999998, 4.57199999999997, !- X,Y,Z Vertex 1 {m}
@@ -904,10 +904,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {02a20178-5cec-4076-8aed-244e2d3a36c6}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {bb3a51da-60c7-497f-b289-f56f9b0ce096}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   53.0574, 43.8197999999998, 4.57199999999998, !- X,Y,Z Vertex 1 {m}
@@ -987,10 +987,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e49a5709-1d20-4e6a-9a0e-227ee997614f}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {b47087bd-ed4a-4f56-a76e-bdcd8e373a53}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   15.9211, 45.3564999999998, 4.57199999999997, !- X,Y,Z Vertex 1 {m}
@@ -1055,10 +1055,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e49a5709-1d20-4e6a-9a0e-227ee997614f}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {5bbadb78-ba61-4d27-89df-4b57c7867d38}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   53.0574, 43.8197999999998, 4.57199999999999, !- X,Y,Z Vertex 1 {m}
@@ -1104,10 +1104,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d856eb50-0aea-4645-9879-1b42620e7dc0}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {567f0fc0-f34e-49fc-a8eb-0e37671ab03b}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   -12.4919, 45.3564999999998, 4.57199999999992, !- X,Y,Z Vertex 1 {m}
@@ -1138,10 +1138,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d856eb50-0aea-4645-9879-1b42620e7dc0}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {8cd47b03-c056-4b81-aeb1-12e7630c1d02}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   1.06465271808984e-016, 43.8197999999998, 4.57199999999992, !- X,Y,Z Vertex 1 {m}
@@ -1172,10 +1172,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d856eb50-0aea-4645-9879-1b42620e7dc0}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {fc3499fd-4ab8-46c3-babc-d977059d3882}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   15.9211, 43.8197999999998, 4.57199999999992, !- X,Y,Z Vertex 1 {m}
@@ -1272,10 +1272,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f3162082-eda4-4375-8ef5-d49ffc070545}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {f8c699a4-0a9f-4393-80fe-86e47e7847b0}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   15.9211, 45.3564999999998, 4.57199999999997, !- X,Y,Z Vertex 1 {m}
@@ -1289,10 +1289,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f3162082-eda4-4375-8ef5-d49ffc070545}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {40961984-fc31-498e-9f76-19d825533ac1}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   8.42809999999998, 45.3564999999998, 4.57199999999997, !- X,Y,Z Vertex 1 {m}
@@ -1406,10 +1406,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {b39118ad-8025-406a-bd98-a3296de4495f}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {225b9589-d9b4-4e5f-8730-5a4098b03192}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   -0.00147500000000655, 45.3564999999998, 4.57199999999998, !- X,Y,Z Vertex 1 {m}
@@ -1523,10 +1523,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {924465bf-33f6-40f8-b618-98b028c09193}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {5199c356-0c9b-462b-815e-8e39e1c50346}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   -6.24670000000001, 45.3564999999998, 4.57199999999998, !- X,Y,Z Vertex 1 {m}
@@ -1606,10 +1606,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {7ea97877-f957-4cb1-abcf-6afbcfc66d5e}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {0baee146-05eb-43fb-88ac-227dc1eb002a}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   -12.4919, 45.3564999999998, 4.57199999999998, !- X,Y,Z Vertex 1 {m}
@@ -1757,10 +1757,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {37d6525f-e4c5-4606-bcf6-d3716d739007}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {00e7a68f-4d45-4211-a43f-ad3099780eda}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   -16.2338, 45.3564999999998, 4.57199999999998, !- X,Y,Z Vertex 1 {m}
@@ -1774,10 +1774,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e49a5709-1d20-4e6a-9a0e-227ee997614f}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {8a28a781-590c-4c1c-b3c0-8cc99d8a24df}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   15.9211, 43.8197999999998, 4.57199999999999, !- X,Y,Z Vertex 1 {m}
@@ -1791,10 +1791,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e49a5709-1d20-4e6a-9a0e-227ee997614f}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {d4b047d6-8c26-4f9d-8e04-542d97518490}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   15.9211, 52.7954999999998, 4.57199999999999, !- X,Y,Z Vertex 1 {m}
@@ -1808,10 +1808,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d856eb50-0aea-4645-9879-1b42620e7dc0}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {3e7a79c5-ba48-4346-9fcd-41743c54ca21}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   8.42809999999998, 45.3564999999998, 4.57199999999997, !- X,Y,Z Vertex 1 {m}
@@ -1825,10 +1825,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d856eb50-0aea-4645-9879-1b42620e7dc0}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {ac0ce12f-188b-4571-9afa-1b8a94e4a842}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   -6.24670000000001, 45.3564999999998, 4.57199999999998, !- X,Y,Z Vertex 1 {m}
@@ -1842,10 +1842,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d856eb50-0aea-4645-9879-1b42620e7dc0}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {efcc3f09-ccd9-4e3d-8daf-d600378b6bed}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   15.9211, 45.3564999999998, 4.57199999999991, !- X,Y,Z Vertex 1 {m}
@@ -1859,10 +1859,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d856eb50-0aea-4645-9879-1b42620e7dc0}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {6b50ef9f-eb3b-4f5f-bccb-c4ac9e48b600}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   -0.00147500000000655, 45.3564999999998, 4.57199999999992, !- X,Y,Z Vertex 1 {m}
@@ -1876,10 +1876,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d856eb50-0aea-4645-9879-1b42620e7dc0}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {b704588a-eedd-4cb2-a229-24f26120554c}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   -16.2338, 43.8197999999998, 4.57199999999992, !- X,Y,Z Vertex 1 {m}
@@ -1893,10 +1893,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {0fd60f7d-ee76-49e8-8ff8-533766628f82}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {075fe905-f3fb-46fd-beac-c788ce0e4b59}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   23.4807, 4.57199999999984, 4.572,       !- X,Y,Z Vertex 1 {m}
@@ -1910,10 +1910,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {0fd60f7d-ee76-49e8-8ff8-533766628f82}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {8e09faea-b97e-487d-acd0-d8e97fd38ade}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   53.0574, 4.57199999999984, 4.572,       !- X,Y,Z Vertex 1 {m}
@@ -1927,10 +1927,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {0fd60f7d-ee76-49e8-8ff8-533766628f82}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {e1c39006-1ee1-4a56-9416-1453b51240f7}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   53.0574, 43.8197999999998, 4.572,       !- X,Y,Z Vertex 1 {m}
@@ -1944,10 +1944,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {0fd60f7d-ee76-49e8-8ff8-533766628f82}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {8d613320-1876-4a18-9083-6c630fddcd43}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   7.37341704866608e-017, 4.57199999999984, 4.572, !- X,Y,Z Vertex 1 {m}
@@ -1961,10 +1961,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {027a0cdc-6550-4760-91ae-c3f5379af193}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {054641de-6b49-4e29-9178-f658c23cfb41}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   53.0574, 21.1184999999998, 4.572,       !- X,Y,Z Vertex 1 {m}
@@ -1978,10 +1978,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {0f799d38-5e12-4224-a2f6-65f846eb1148}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {b778e4c0-40db-47f0-b31f-5d3d1800674f}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   9.82824964784047e-017, 5.29316363196444e-017, 4.572, !- X,Y,Z Vertex 1 {m}

--- a/data/geometry/ASHRAEHospital.osm
+++ b/data/geometry/ASHRAEHospital.osm
@@ -52,10 +52,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {4b0352d7-5b15-44a5-874c-f4c860e83600}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
+  Outdoors,                               !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  NoSun,                                  !- Sun Exposure
-  NoWind,                                 !- Wind Exposure
+  SunExposed,                             !- Sun Exposure
+  WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   65.532, 42.672, 17.0732,                !- X,Y,Z Vertex 1 {m}
@@ -638,8 +638,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {5fa7a66e-65f8-47fe-850f-4aff5015d62b}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {fe2e086f-e1c3-46d3-8a4e-3176da4a96b9}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -655,8 +655,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e9e27262-9df7-40dc-9a36-b9e4a585473e}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {d196909f-e708-424c-8b62-e23fef048807}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -694,8 +694,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {6ad47ab4-cb8c-4b6f-9311-9dc048eb2eda}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {c4401f19-9005-41d6-a222-faa155cf3b10}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -733,8 +733,8 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {8c173263-502d-42ba-a69e-93df43e4d6ca}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {ad242bae-a693-422e-8f2d-435218ff6c70}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -979,8 +979,8 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {e8233850-2c26-457b-b983-e0a87242a5d7}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {a261d29f-e590-443c-b9b2-963577043ae6}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -1018,8 +1018,8 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {013d2c94-7239-4063-ba94-06ba14717adc}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {180f3ef3-222b-4e7f-b133-0d4ed36ecae5}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -1075,8 +1075,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {17ae9a84-1b9c-49a1-8f48-a49619cb8e39}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {d6ca60ce-5dad-4c3e-98bc-9cc81225ac71}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -1215,8 +1215,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {7f22e5a6-e759-445a-84cb-6b454b893756}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {105afa91-3779-4fdb-a60f-7eb9abc56556}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -1271,8 +1271,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e9e27262-9df7-40dc-9a36-b9e4a585473e}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {0614854f-06fb-446e-9f2c-d99714b3ac6b}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -1361,8 +1361,8 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {42cd4d82-e24e-4e11-88d4-f870740fe240}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {89741c59-d0b7-4b54-b9dd-b090e722293c}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -1523,8 +1523,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {fc9bddfe-4ba5-4685-8ab9-4aa035cfc214}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {412a52da-a12c-4d25-8be6-37fe167cf8d3}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -1820,8 +1820,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c8b8007f-d842-489f-b119-fad0f32ca54d}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {d850a3ba-d291-4fbd-bdba-0b03e083d270}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -1993,8 +1993,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {e02691e9-a447-40e1-aa67-039878424ae6}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {535c1521-f95a-4c01-8070-9bdd078da2f2}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -2010,8 +2010,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e0b3f21a-5417-4d6d-9bad-44c2b5fb3717}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {ae375c1a-a6f6-4f72-97c7-68988455a7f8}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -2055,8 +2055,8 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  9.144, 33.582, 12.8049,                 !- X,Y,Z Vertex 1 {m}
-  9.144, 33.582, 8.5366,                  !- X,Y,Z Vertex 2 {m}
+  9.144, 33.528, 12.8049,                 !- X,Y,Z Vertex 1 {m}
+  9.144, 33.528, 8.5366,                  !- X,Y,Z Vertex 2 {m}
   9.144, 10.668, 8.5366,                  !- X,Y,Z Vertex 3 {m}
   9.144, 10.668, 12.8049;                 !- X,Y,Z Vertex 4 {m}
 
@@ -2127,8 +2127,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {aeb14eec-a11c-4495-b283-f98c2eca3dbf}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {8a25afd7-2df1-44cc-92b0-e18a1af635e8}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -2166,8 +2166,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {3a43a92b-6516-45e6-9f37-eb7bf8bccb83}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {da355684-968c-4d14-8f9a-fe93e8dc43a4}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -2279,8 +2279,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3d0a884f-f38a-4024-ba41-a3615b0d597f}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {cc5daf66-ae7d-4362-b67f-5e2dbf8edce6}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -2313,8 +2313,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {0ebf2d87-9a96-4832-a366-f21cea5fd615}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {e5bbcbda-e9f3-421f-ad21-70a134c8eddf}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -2381,8 +2381,8 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {970b3b19-607d-49a6-8d29-1ec76a5b55c6}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {d7e28700-9bb9-4a66-b4e9-e80b64edc423}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -2398,8 +2398,8 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {47d5f6b5-5e98-43ad-8669-c046505a937d}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {a1a5acfa-4f4f-454e-ad2b-5a734513d70a}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -2411,7 +2411,7 @@ OS:Surface,
 
 OS:Surface,
   {2fc319e1-7021-4537-8de4-7748516e5208}, !- Handle
-  Basement_Ceiling,                       !- Name
+  Basement_Ceiling_1,                     !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {8cefc791-4220-41cf-852d-0cd472e915e7}, !- Space Name
@@ -2432,8 +2432,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {970b3b19-607d-49a6-8d29-1ec76a5b55c6}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {0f5129da-3b5a-4c1f-8345-6c0d899b9136}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -2466,8 +2466,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {668fd0fa-a605-4127-8009-961514db81c7}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {f4107467-8586-4570-bd47-61c25e12dad9}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -2561,8 +2561,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e421471b-c574-4e8a-b7a8-245348dd3775}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {7163f711-d161-48b1-9c62-d24ff670b839}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -2578,8 +2578,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {dc66d323-72f5-4969-aebb-d547b4919d13}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {4f081654-d3d2-4dba-adea-41898dc054ab}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -2646,8 +2646,8 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {3d0a884f-f38a-4024-ba41-a3615b0d597f}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {5f90fb4b-00a3-4f7c-9da6-bb0d2f6c8dbd}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -2736,8 +2736,8 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {0b208f03-204c-460e-a229-d14790739b8b}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {da752f69-bdad-4b32-ac33-e2cc3121c7c2}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -2753,8 +2753,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e8233850-2c26-457b-b983-e0a87242a5d7}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {408e3a40-2f14-41c8-9928-575db1e3557c}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -2804,8 +2804,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {dc66d323-72f5-4969-aebb-d547b4919d13}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {cc411283-bef9-439d-a74e-bc4b9b61ff44}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -2821,14 +2821,14 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3a43a92b-6516-45e6-9f37-eb7bf8bccb83}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {24bcd3a9-6470-4ea5-bf35-65bd4e056a6c}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  9.144, 33.582, 12.8049,                 !- X,Y,Z Vertex 1 {m}
-  9.144, 33.582, 8.5366,                  !- X,Y,Z Vertex 2 {m}
+  9.144, 33.528, 12.8049,                 !- X,Y,Z Vertex 1 {m}
+  9.144, 33.528, 8.5366,                  !- X,Y,Z Vertex 2 {m}
   9.144, 42.672, 8.5366,                  !- X,Y,Z Vertex 3 {m}
   9.144, 42.672, 12.8049;                 !- X,Y,Z Vertex 4 {m}
 
@@ -2855,8 +2855,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {16b36206-de28-4cc5-a003-3fd3fdc223f7}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {95de039e-5c85-4126-9b27-cd5b8bbead5b}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -2889,16 +2889,16 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {31390124-80ad-4222-b08a-01be2ad61163}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {a976292f-4ede-486d-87c0-a38da8a2e980}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   9.144, 42.672, 17.0732,                 !- X,Y,Z Vertex 1 {m}
   9.144, 42.672, 12.8049,                 !- X,Y,Z Vertex 2 {m}
-  9.144, 33.582, 12.8049,                 !- X,Y,Z Vertex 3 {m}
-  9.144, 33.582, 17.0732;                 !- X,Y,Z Vertex 4 {m}
+  9.144, 33.528, 12.8049,                 !- X,Y,Z Vertex 3 {m}
+  9.144, 33.528, 17.0732;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {a261d29f-e590-443c-b9b2-963577043ae6}, !- Handle
@@ -2906,8 +2906,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {17ae9a84-1b9c-49a1-8f48-a49619cb8e39}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {a7283700-b96f-4e4a-bf96-8a3847614eec}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -2923,8 +2923,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {2870f103-d956-457d-b911-977241d8c35a}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {87a8cecf-d74c-4115-bcc9-a0322bce880a}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -2957,8 +2957,8 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {e0b3f21a-5417-4d6d-9bad-44c2b5fb3717}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {9b112bf1-35e7-48c7-b4ad-10eb23646c10}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -3014,8 +3014,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {7cce3ac6-5d1d-4960-9e9f-f0d99f44c040}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {ab5dc732-1429-454f-b178-6d7ab8802397}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -3031,8 +3031,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3a43a92b-6516-45e6-9f37-eb7bf8bccb83}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {8100d5a6-c544-40ae-a4b9-73c0a13030eb}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -3056,8 +3056,8 @@ OS:Surface,
   ,                                       !- Number of Vertices
   9.144, 10.668, 17.0732,                 !- X,Y,Z Vertex 1 {m}
   9.144, 10.668, 12.8049,                 !- X,Y,Z Vertex 2 {m}
-  9.144, 33.582, 12.8049,                 !- X,Y,Z Vertex 3 {m}
-  9.144, 33.582, 17.0732;                 !- X,Y,Z Vertex 4 {m}
+  9.144, 33.528, 12.8049,                 !- X,Y,Z Vertex 3 {m}
+  9.144, 33.528, 17.0732;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {b782f2b1-1e64-4013-94e5-41e118efa0ab}, !- Handle
@@ -3082,8 +3082,8 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {7c3f7787-1a2c-4af2-b30d-c5fe68177501}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {70b061cf-e29f-42b2-9040-b3ec1d5081d6}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -3099,10 +3099,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {648db5a6-f0b0-425d-a12c-a9502504cf7a}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
+  Outdoors,                               !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  NoSun,                                  !- Sun Exposure
-  NoWind,                                 !- Wind Exposure
+  SunExposed,                             !- Sun Exposure
+  WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   28.956, 48.768, 8.5366,                 !- X,Y,Z Vertex 1 {m}
@@ -3172,8 +3172,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {6ad47ab4-cb8c-4b6f-9311-9dc048eb2eda}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {321ebd9e-1534-4ef2-ad0f-6b94f572965c}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -3279,8 +3279,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {aeb14eec-a11c-4495-b283-f98c2eca3dbf}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {5d1af081-760d-4073-86fc-554f40c9d098}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -3296,8 +3296,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {47d5f6b5-5e98-43ad-8669-c046505a937d}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {3a399768-0d26-442c-9545-fa8762c0feaa}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -3330,8 +3330,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {ebe6e839-d2fb-4757-8148-ae01cb77f2b7}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {50744263-980a-4528-9751-466442515973}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -3364,8 +3364,8 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {31390124-80ad-4222-b08a-01be2ad61163}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {183a3138-9faa-4755-bcbb-2d6c659f9046}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -3489,8 +3489,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {e8233850-2c26-457b-b983-e0a87242a5d7}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {59f4e05d-6b43-4dd0-a783-a1872de59aa2}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -3557,8 +3557,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {2870f103-d956-457d-b911-977241d8c35a}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {1de7e67f-db3e-4e3a-a755-e1366589446e}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -3608,8 +3608,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {70b3b79a-870d-4657-b97f-0bf50ccd6e7e}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {df001918-25be-4ed1-bce4-e17d08cc1280}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -3676,8 +3676,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {47d5f6b5-5e98-43ad-8669-c046505a937d}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {d083477d-f5f6-4089-9cf1-32e6a9f6476f}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -3693,8 +3693,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {7802b3f6-be28-4f7e-ab11-b2ff579c4766}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {feb3cd91-7b93-4a5e-aa7c-2fbee94841c9}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -3761,8 +3761,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {60897f76-ccc0-4353-9cbd-ce8e06f8207c}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {fd013922-61d4-4254-898d-c5edb2872080}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -3795,8 +3795,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {bc7d28d5-92bd-44ec-8fa2-e6e43ce5010c}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {c3843fc1-61f6-47cc-a580-460f266cc43b}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -3829,8 +3829,8 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {668fd0fa-a605-4127-8009-961514db81c7}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {8f42ab0d-a8b5-4e68-91fd-573be1236742}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -3931,8 +3931,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {75111445-9889-4e0e-bf8b-33e4ad0474cb}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {7808f468-dc70-4ff4-a590-ac5164eec1e0}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -3999,8 +3999,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e421471b-c574-4e8a-b7a8-245348dd3775}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {930f0a63-ef53-4c72-aa79-3180e600ce8b}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -4067,8 +4067,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e9e27262-9df7-40dc-9a36-b9e4a585473e}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {67c22901-cea0-4a8a-8b4c-11b22bdbaff9}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -4084,8 +4084,8 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {7cce3ac6-5d1d-4960-9e9f-f0d99f44c040}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {6080b08a-0606-4e51-bc61-1b4a45829dd2}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -4225,10 +4225,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3a43a92b-6516-45e6-9f37-eb7bf8bccb83}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
+  Outdoors,                               !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  NoSun,                                  !- Sun Exposure
-  NoWind,                                 !- Wind Exposure
+  SunExposed,                             !- Sun Exposure
+  WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   4.572, 48.768, 12.8049,                 !- X,Y,Z Vertex 1 {m}
@@ -4344,8 +4344,8 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {5fa7a66e-65f8-47fe-850f-4aff5015d62b}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {e7f8efab-d31d-41ac-8837-33b965268455}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -4446,8 +4446,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {1c76f8a5-14f0-4ef9-aedd-f22672148afa}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {02cd7f4d-8e39-4d68-bcdc-d9c5f9dab7e1}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -4473,11 +4473,10 @@ OS:Surface,
   28.956, 0, 0,                           !- X,Y,Z Vertex 2 {m}
   21.3415, 0, 0,                          !- X,Y,Z Vertex 3 {m}
   21.3415, 4.572, 0,                      !- X,Y,Z Vertex 4 {m}
-  9.144, 4.572, 0,                        !- X,Y,Z Vertex 5 {m}
-  6.096, 4.572, 0,                        !- X,Y,Z Vertex 6 {m}
-  6.096, 0, 0,                            !- X,Y,Z Vertex 7 {m}
-  0, 0, 0,                                !- X,Y,Z Vertex 8 {m}
-  0, 53.34, 0;                            !- X,Y,Z Vertex 9 {m}
+  6.096, 4.572, 0,                        !- X,Y,Z Vertex 5 {m}
+  6.096, 0, 0,                            !- X,Y,Z Vertex 6 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 7 {m}
+  0, 53.34, 0;                            !- X,Y,Z Vertex 8 {m}
 
 OS:Surface,
   {dacfed6f-6ad3-45b6-a644-8af9444f6f45}, !- Handle
@@ -4485,8 +4484,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {b32db625-e874-459e-ae5c-6213262e2622}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {0a1a9391-a2ac-4f69-b095-21184607c477}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -4553,8 +4552,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {1168441b-e4e6-4d44-a00f-18b75cc06a24}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {f044d43a-09b1-4ef7-ba9a-a3c019bc4caf}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -4587,8 +4586,8 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {bc7d28d5-92bd-44ec-8fa2-e6e43ce5010c}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {e04ef9d0-4d2c-4947-a41d-10e22e657bb2}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -4621,8 +4620,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {bc7d28d5-92bd-44ec-8fa2-e6e43ce5010c}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {a85cd5d7-0061-4546-8ede-2b3366185288}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -4676,8 +4675,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {e0b3f21a-5417-4d6d-9bad-44c2b5fb3717}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {ec1fa491-9b4e-420d-98c2-0c60ef628b7c}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -4710,14 +4709,14 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {4b0352d7-5b15-44a5-874c-f4c860e83600}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {15ff06d9-e3cb-4784-9c9b-bb1b8a14a4ff}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  9.144, 33.582, 17.0732,                 !- X,Y,Z Vertex 1 {m}
-  9.144, 33.582, 12.8049,                 !- X,Y,Z Vertex 2 {m}
+  9.144, 33.528, 17.0732,                 !- X,Y,Z Vertex 1 {m}
+  9.144, 33.528, 12.8049,                 !- X,Y,Z Vertex 2 {m}
   9.144, 42.672, 12.8049,                 !- X,Y,Z Vertex 3 {m}
   9.144, 42.672, 17.0732;                 !- X,Y,Z Vertex 4 {m}
 
@@ -4846,8 +4845,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {432827a6-9676-48d3-9de8-55f3ed327c07}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {55eea7c2-83a9-4e38-8a66-58fb7d0ea97b}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -4863,8 +4862,8 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {d7e311f6-f2c1-47c2-b301-cbba90b6f733}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {0531c0e6-eff2-4166-8878-f8d977783239}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -4931,8 +4930,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {013d2c94-7239-4063-ba94-06ba14717adc}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {f7d1c174-8880-40b1-8a01-4128252bc5ba}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -4990,8 +4989,8 @@ OS:Surface,
   ,                                       !- Number of Vertices
   9.144, 10.668, 12.8049,                 !- X,Y,Z Vertex 1 {m}
   9.144, 10.668, 8.5366,                  !- X,Y,Z Vertex 2 {m}
-  9.144, 33.582, 8.5366,                  !- X,Y,Z Vertex 3 {m}
-  9.144, 33.582, 12.8049;                 !- X,Y,Z Vertex 4 {m}
+  9.144, 33.528, 8.5366,                  !- X,Y,Z Vertex 3 {m}
+  9.144, 33.528, 12.8049;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {eb0262d2-8e7c-4c4a-968d-1650eb5b4d57}, !- Handle
@@ -5033,10 +5032,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {5fa7a66e-65f8-47fe-850f-4aff5015d62b}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
+  Outdoors,                               !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  NoSun,                                  !- Sun Exposure
-  NoWind,                                 !- Wind Exposure
+  SunExposed,                             !- Sun Exposure
+  WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   70.104, 0, 8.5366,                      !- X,Y,Z Vertex 1 {m}
@@ -5050,10 +5049,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3a43a92b-6516-45e6-9f37-eb7bf8bccb83}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
+  Outdoors,                               !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  NoSun,                                  !- Sun Exposure
-  NoWind,                                 !- Wind Exposure
+  SunExposed,                             !- Sun Exposure
+  WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   65.532, 42.672, 12.8049,                !- X,Y,Z Vertex 1 {m}
@@ -5084,10 +5083,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e421471b-c574-4e8a-b7a8-245348dd3775}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
+  Outdoors,                               !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  NoSun,                                  !- Sun Exposure
-  NoWind,                                 !- Wind Exposure
+  SunExposed,                             !- Sun Exposure
+  WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   64.008, 39.624, 4.2683,                 !- X,Y,Z Vertex 1 {m}
@@ -5186,8 +5185,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {b32db625-e874-459e-ae5c-6213262e2622}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {1903696b-25a7-49b1-a8cc-ebf957bee218}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -5254,8 +5253,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {2d4ce43e-14fd-4122-b641-b757121d5aba}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {910a644d-62d5-4bc9-9b07-0c9555e0a6a0}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -5339,8 +5338,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {ccee8f2b-c192-4f18-9407-cda799f28f23}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {a6afa6ba-8312-4b32-b3c3-0f89b074aad4}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -5356,10 +5355,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {4b0352d7-5b15-44a5-874c-f4c860e83600}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
+  Outdoors,                               !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  NoSun,                                  !- Sun Exposure
-  NoWind,                                 !- Wind Exposure
+  SunExposed,                             !- Sun Exposure
+  WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   4.572, 48.768, 17.0732,                 !- X,Y,Z Vertex 1 {m}
@@ -5390,8 +5389,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {2294b9a3-413c-42bf-8af1-ea3aba2f3837}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {d9a758ae-dcd7-4d45-b706-04207108bdd4}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -5424,8 +5423,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {5fa7a66e-65f8-47fe-850f-4aff5015d62b}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {3c18a7bb-601a-4568-888c-3b6527ee2940}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -5526,8 +5525,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {7802b3f6-be28-4f7e-ab11-b2ff579c4766}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {6698567c-510f-4b65-afa5-58a4c50774b9}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -5543,8 +5542,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c8b8007f-d842-489f-b119-fad0f32ca54d}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {09c670f2-9441-44d7-a2bb-34dce17b7748}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -5628,8 +5627,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e8233850-2c26-457b-b983-e0a87242a5d7}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {17a70b6c-8903-4e80-96bd-1960fa8bc233}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -5662,8 +5661,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d2b1807c-c9f4-44c2-8597-3b555b94b37c}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {9b381fb4-9c86-461e-856f-43ca207a6a40}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -5696,8 +5695,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {2294b9a3-413c-42bf-8af1-ea3aba2f3837}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {2b051b4f-5dc8-43d9-8dff-c15a4d4567c8}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -5742,9 +5741,8 @@ OS:Surface,
   70.104, 13.716, 0,                      !- X,Y,Z Vertex 4 {m}
   64.008, 13.716, 0,                      !- X,Y,Z Vertex 5 {m}
   64.008, 4.572, 0,                       !- X,Y,Z Vertex 6 {m}
-  45.72, 4.572, 0,                        !- X,Y,Z Vertex 7 {m}
-  39.624, 4.572, 0,                       !- X,Y,Z Vertex 8 {m}
-  39.624, 48.768, 0;                      !- X,Y,Z Vertex 9 {m}
+  39.624, 4.572, 0,                       !- X,Y,Z Vertex 7 {m}
+  39.624, 48.768, 0;                      !- X,Y,Z Vertex 8 {m}
 
 OS:Surface,
   {42df4b75-1019-42be-bc4d-2ee09b7f435e}, !- Handle
@@ -5769,8 +5767,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {8ec78f13-57f2-4f0e-9746-f05360546e20}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {ce5242ce-fd5f-4765-8667-993660abc344}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -5820,8 +5818,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {0f8481b9-82a8-4c09-8d52-f278649c4c33}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {4f7c7d74-b707-42e0-8016-b122c650983d}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -5854,8 +5852,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {1fd4c829-a755-45de-b877-ff8108b86807}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {a9fd89f8-ff30-4d8b-b749-c8aef4cb2067}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -5871,8 +5869,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {4b0352d7-5b15-44a5-874c-f4c860e83600}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {fb2dd5d4-8d33-41f8-a714-19d3ed1740be}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -5888,8 +5886,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e02691e9-a447-40e1-aa67-039878424ae6}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {dfe8b32d-a617-4cfb-a47e-5cb4e5fda3c2}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -5962,8 +5960,8 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  9.144, 33.582, 17.0732,                 !- X,Y,Z Vertex 1 {m}
-  9.144, 33.582, 12.8049,                 !- X,Y,Z Vertex 2 {m}
+  9.144, 33.528, 17.0732,                 !- X,Y,Z Vertex 1 {m}
+  9.144, 33.528, 12.8049,                 !- X,Y,Z Vertex 2 {m}
   9.144, 10.668, 12.8049,                 !- X,Y,Z Vertex 3 {m}
   9.144, 10.668, 17.0732;                 !- X,Y,Z Vertex 4 {m}
 
@@ -5973,8 +5971,8 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {aeb14eec-a11c-4495-b283-f98c2eca3dbf}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {74928bcc-d6f5-4e09-ab22-149fe06810a7}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -5992,8 +5990,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {42cd4d82-e24e-4e11-88d4-f870740fe240}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {9ac64baf-a3e5-43da-94ea-f686057557fd}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -6009,8 +6007,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {47d5f6b5-5e98-43ad-8669-c046505a937d}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {a2f4aec2-5325-4fea-90b8-6ed5d99e7c0a}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -6043,8 +6041,8 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {16b36206-de28-4cc5-a003-3fd3fdc223f7}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {45c90384-502d-43bb-aac4-52f28bba930e}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -6151,8 +6149,8 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {1c76f8a5-14f0-4ef9-aedd-f22672148afa}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {2412ef37-5701-4282-a20b-f2571ccb5b10}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -6202,8 +6200,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {f4b6e0eb-817b-405c-98f0-c425865851fb}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {b630a08c-bea4-44d4-a20a-0993fe636feb}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -6211,8 +6209,7 @@ OS:Surface,
   39.624, 42.672, 8.5366,                 !- X,Y,Z Vertex 1 {m}
   39.624, 10.668, 8.5366,                 !- X,Y,Z Vertex 2 {m}
   28.956, 10.668, 8.5366,                 !- X,Y,Z Vertex 3 {m}
-  28.956, 19.812, 8.5366,                 !- X,Y,Z Vertex 4 {m}
-  28.956, 42.672, 8.5366;                 !- X,Y,Z Vertex 5 {m}
+  28.956, 42.672, 8.5366;                 !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {d870ae02-c6b9-4cf0-8ba5-38dade2d06b9}, !- Handle
@@ -6288,8 +6285,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0bb10f6e-83ca-443c-bdd6-76ddf2ef5dd5}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {27fcfb48-1e0c-42d6-a359-d3df26e02d48}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -6305,8 +6302,8 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {0ebf2d87-9a96-4832-a366-f21cea5fd615}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {81909e64-bb6b-48a8-8805-33ea6099986a}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -6398,10 +6395,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {b32db625-e874-459e-ae5c-6213262e2622}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
+  Outdoors,                               !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  NoSun,                                  !- Sun Exposure
-  NoWind,                                 !- Wind Exposure
+  SunExposed,                             !- Sun Exposure
+  WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   4.572, 44.196, 8.5366,                  !- X,Y,Z Vertex 1 {m}
@@ -6483,8 +6480,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {7f22e5a6-e759-445a-84cb-6b454b893756}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {aa125bee-678f-4d05-9785-ac1e49b2918e}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -6551,8 +6548,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {0f8481b9-82a8-4c09-8d52-f278649c4c33}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {336ad7d8-eac6-422f-9792-d29f3da28d43}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -6619,16 +6616,16 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {2870f103-d956-457d-b911-977241d8c35a}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {b561fd0f-55af-433e-86cc-3619d4454fba}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  28.956, 42.672, 8.5366,                 !- X,Y,Z Vertex 1 {m}
-  39.624, 42.672, 8.5366,                 !- X,Y,Z Vertex 2 {m}
-  39.624, 53.34, 8.5366,                  !- X,Y,Z Vertex 3 {m}
-  28.956, 53.34, 8.5366;                  !- X,Y,Z Vertex 4 {m}
+  39.624, 42.672, 8.5366,                 !- X,Y,Z Vertex 1 {m}
+  39.624, 53.34, 8.5366,                  !- X,Y,Z Vertex 2 {m}
+  28.956, 53.34, 8.5366,                  !- X,Y,Z Vertex 3 {m}
+  28.956, 42.672, 8.5366;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {b64d3ced-5885-4afc-9b49-969554c8d520}, !- Handle
@@ -6653,8 +6650,8 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {7f22e5a6-e759-445a-84cb-6b454b893756}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {bbe5ef4c-9228-44af-b64a-afac7b888d58}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -6670,8 +6667,8 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {7698b8f9-ce74-4b6b-806d-12cdef049900}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {69c18cae-9d2f-4864-9c57-e3dd9c93faac}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -6704,8 +6701,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {7f22e5a6-e759-445a-84cb-6b454b893756}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {da7d1709-9f24-4cad-aead-c169da645664}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -6721,8 +6718,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {7cce3ac6-5d1d-4960-9e9f-f0d99f44c040}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {dc428305-ab12-4661-b7b1-c7fe4452e5bd}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -6806,8 +6803,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e9e27262-9df7-40dc-9a36-b9e4a585473e}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {6306c332-37b5-4191-a945-60d8db12ae79}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -6857,8 +6854,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {aeb14eec-a11c-4495-b283-f98c2eca3dbf}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {568c28e0-56e4-4e5a-b7f9-e1e737ca82c0}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -6874,8 +6871,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {d2b1807c-c9f4-44c2-8597-3b555b94b37c}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {e05141f5-0506-4551-a154-a78e3f9ae2f5}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -6883,8 +6880,7 @@ OS:Surface,
   70.104, 4.572, 8.5366,                  !- X,Y,Z Vertex 1 {m}
   70.104, 0, 8.5366,                      !- X,Y,Z Vertex 2 {m}
   62.484, 0, 8.5366,                      !- X,Y,Z Vertex 3 {m}
-  62.484, 4.572, 8.5366,                  !- X,Y,Z Vertex 4 {m}
-  65.532, 4.572, 8.5366;                  !- X,Y,Z Vertex 5 {m}
+  62.484, 4.572, 8.5366;                  !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {b843d441-7b16-4de8-94cf-6f2b473bb75d}, !- Handle
@@ -6926,8 +6922,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3a43a92b-6516-45e6-9f37-eb7bf8bccb83}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {f3331ec8-ffff-46f4-bf5e-8fb4f9182175}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -6960,8 +6956,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {6a8c5c6f-369f-4ab1-867d-7f5523a9610f}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {893b5944-e696-48a1-9f14-6a7f84f9bf00}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -7030,16 +7026,16 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f4b6e0eb-817b-405c-98f0-c425865851fb}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {9a8d1b7e-2bf8-4e2a-a412-7fda7f7a0dc4}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   9.144, 42.672, 12.8049,                 !- X,Y,Z Vertex 1 {m}
   9.144, 42.672, 8.5366,                  !- X,Y,Z Vertex 2 {m}
-  9.144, 33.582, 8.5366,                  !- X,Y,Z Vertex 3 {m}
-  9.144, 33.582, 12.8049;                 !- X,Y,Z Vertex 4 {m}
+  9.144, 33.528, 8.5366,                  !- X,Y,Z Vertex 3 {m}
+  9.144, 33.528, 12.8049;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {ec770f09-5270-4b1c-a6c3-cd094f6dabad}, !- Handle
@@ -7047,8 +7043,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {648db5a6-f0b0-425d-a12c-a9502504cf7a}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {559d9ceb-a704-4792-8838-6a6e587138d6}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -7098,8 +7094,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {b32db625-e874-459e-ae5c-6213262e2622}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {566aea66-c1c2-4225-a368-75dd867cfee9}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -7268,8 +7264,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {e9e27262-9df7-40dc-9a36-b9e4a585473e}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {551d1ef7-9c86-44a8-9afc-22e0a9ab1f1a}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -7277,8 +7273,7 @@ OS:Surface,
   39.624, 10.668, 8.5366,                 !- X,Y,Z Vertex 1 {m}
   39.624, 0, 8.5366,                      !- X,Y,Z Vertex 2 {m}
   28.956, 0, 8.5366,                      !- X,Y,Z Vertex 3 {m}
-  28.956, 4.572, 8.5366,                  !- X,Y,Z Vertex 4 {m}
-  28.956, 10.668, 8.5366;                 !- X,Y,Z Vertex 5 {m}
+  28.956, 10.668, 8.5366;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {ae8350b7-ec38-46c6-8acb-8c06e3b6faab}, !- Handle
@@ -7303,8 +7298,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {648db5a6-f0b0-425d-a12c-a9502504cf7a}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {954ccdd2-26e4-4255-963b-d913f6d989e5}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -7320,17 +7315,16 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {4b0352d7-5b15-44a5-874c-f4c860e83600}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {34e15ad4-259e-4af7-9d47-f9dfb6b78bc5}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   65.532, 42.672, 17.0732,                !- X,Y,Z Vertex 1 {m}
   65.532, 48.768, 17.0732,                !- X,Y,Z Vertex 2 {m}
-  44.196, 48.768, 17.0732,                !- X,Y,Z Vertex 3 {m}
-  39.624, 48.768, 17.0732,                !- X,Y,Z Vertex 4 {m}
-  39.624, 42.672, 17.0732;                !- X,Y,Z Vertex 5 {m}
+  39.624, 48.768, 17.0732,                !- X,Y,Z Vertex 3 {m}
+  39.624, 42.672, 17.0732;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {6e4f4a74-187d-4a88-926a-34d8540efa56}, !- Handle
@@ -7372,8 +7366,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {4b0352d7-5b15-44a5-874c-f4c860e83600}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {9db115fe-ad70-4d1e-892f-1edcd327f067}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -7457,8 +7451,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0b208f03-204c-460e-a229-d14790739b8b}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {7bfa6a2b-a70c-4473-bc4d-b5967f24998d}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -7559,8 +7553,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {75111445-9889-4e0e-bf8b-33e4ad0474cb}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {95204fa4-665a-4b00-a779-bff0de5c8d00}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -7576,8 +7570,8 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {fc9bddfe-4ba5-4685-8ab9-4aa035cfc214}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {9133f20c-d88a-4829-a000-fb019b06a3ce}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -7657,12 +7651,12 @@ OS:Surface,
 
 OS:Surface,
   {e96fc82c-6c5b-4af8-a100-419e9d3c075d}, !- Handle
-  Lobby_Records_Flr_1_Ceiling,            !- Name
+  Lobby_Records_Flr_1_Ceiling_7,          !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {ebe6e839-d2fb-4757-8148-ae01cb77f2b7}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {c6f60957-7c7b-4701-869e-309bc5a9c8b8}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -7678,8 +7672,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {0b208f03-204c-460e-a229-d14790739b8b}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {fd48f5e5-33a4-4c32-be55-d8550897f6ee}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -7797,8 +7791,8 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {e421471b-c574-4e8a-b7a8-245348dd3775}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {a6d15c65-3ddb-42e8-bd00-926e749c5bb2}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -7814,8 +7808,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {7c3f7787-1a2c-4af2-b30d-c5fe68177501}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {9dda3cae-4368-4b00-b7c0-c5d8074b8b07}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -7831,8 +7825,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {668fd0fa-a605-4127-8009-961514db81c7}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {13605f1c-0e05-4326-921b-7e624ee89f8e}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -7899,8 +7893,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {7f22e5a6-e759-445a-84cb-6b454b893756}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {c00a9beb-b35b-49fc-bcc6-a995e78f18ba}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -7952,8 +7946,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {648db5a6-f0b0-425d-a12c-a9502504cf7a}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {e96fc82c-6c5b-4af8-a100-419e9d3c075d}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -8054,8 +8048,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {8c173263-502d-42ba-a69e-93df43e4d6ca}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {caf4cc39-e649-4a8e-97d6-92706769731d}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -8122,8 +8116,8 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {e141e567-31a6-4982-92aa-a4d8a75baef0}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {0d4215b1-8595-4963-9141-7c99a30aa72a}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -8190,8 +8184,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {70b3b79a-870d-4657-b97f-0bf50ccd6e7e}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {121140cd-91e6-4cd8-9607-22b0820c02ca}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -8241,8 +8235,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {7802b3f6-be28-4f7e-ab11-b2ff579c4766}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {3f2b4ec2-15be-4a4c-a833-f64fec9a790e}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -8258,8 +8252,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e421471b-c574-4e8a-b7a8-245348dd3775}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {ea8819e9-6cae-4415-8b5d-ad4f793ec62e}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -8275,8 +8269,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0f8481b9-82a8-4c09-8d52-f278649c4c33}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {480b6e18-959a-4136-945d-0d8861aee250}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -8309,8 +8303,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {8c173263-502d-42ba-a69e-93df43e4d6ca}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {c27b97a8-164a-4e15-bfe6-7c60415d80e8}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -8326,8 +8320,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {aeb14eec-a11c-4495-b283-f98c2eca3dbf}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {c09c7b3e-ddce-4c0a-9de6-2affe7be9003}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -8343,8 +8337,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e421471b-c574-4e8a-b7a8-245348dd3775}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {8a4effad-3dbc-4f6d-a435-b77af1ceb8d8}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -8394,8 +8388,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {8ec78f13-57f2-4f0e-9746-f05360546e20}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {f65b4b7f-53b2-4364-a2bf-f11f7762129b}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -8445,8 +8439,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {70b3b79a-870d-4657-b97f-0bf50ccd6e7e}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {d62beb34-0bfd-432f-9b95-7bd4d29a60f7}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -8462,8 +8456,8 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {dd7a92d0-924e-4003-b630-567ab7ab69ab}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {97922924-522a-4635-948a-6783f5aca89c}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -8496,8 +8490,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {5fa7a66e-65f8-47fe-850f-4aff5015d62b}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {f4f214a8-9297-4fdd-b258-0b4f49c38e82}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -8632,17 +8626,16 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {60897f76-ccc0-4353-9cbd-ce8e06f8207c}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {507a5052-c6fa-4e80-96ea-d8413460cc49}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   70.104, 53.34, 8.5366,                  !- X,Y,Z Vertex 1 {m}
   70.104, 48.768, 8.5366,                 !- X,Y,Z Vertex 2 {m}
-  65.532, 48.768, 8.5366,                 !- X,Y,Z Vertex 3 {m}
-  62.484, 48.768, 8.5366,                 !- X,Y,Z Vertex 4 {m}
-  62.484, 53.34, 8.5366;                  !- X,Y,Z Vertex 5 {m}
+  62.484, 48.768, 8.5366,                 !- X,Y,Z Vertex 3 {m}
+  62.484, 53.34, 8.5366;                  !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {e5bbcbda-e9f3-421f-ad21-70a134c8eddf}, !- Handle
@@ -8650,8 +8643,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3d0a884f-f38a-4024-ba41-a3615b0d597f}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {789768d7-4e4d-4e4f-9b7e-713957ac932a}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -8667,8 +8660,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {5fa7a66e-65f8-47fe-850f-4aff5015d62b}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {4c218e21-829e-40f1-b307-b53fc546cefc}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -8684,8 +8677,8 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {aeb14eec-a11c-4495-b283-f98c2eca3dbf}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {ec770f09-5270-4b1c-a6c3-cd094f6dabad}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -8735,8 +8728,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {7cce3ac6-5d1d-4960-9e9f-f0d99f44c040}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {454cbf73-dfa7-47ba-a828-0828df01b895}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -13419,8 +13412,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0bb10f6e-83ca-443c-bdd6-76ddf2ef5dd5}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {de282c3d-a726-4d05-8a15-925ca4e7d132}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -13428,8 +13421,7 @@ OS:Surface,
   65.532, 48.768, 17.0732,                !- X,Y,Z Vertex 1 {m}
   65.532, 42.672, 17.0732,                !- X,Y,Z Vertex 2 {m}
   39.624, 42.672, 17.0732,                !- X,Y,Z Vertex 3 {m}
-  39.624, 48.768, 17.0732,                !- X,Y,Z Vertex 4 {m}
-  44.196, 48.768, 17.0732;                !- X,Y,Z Vertex 5 {m}
+  39.624, 48.768, 17.0732;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {412a52da-a12c-4d25-8be6-37fe167cf8d3}, !- Handle
@@ -13437,10 +13429,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {4b0352d7-5b15-44a5-874c-f4c860e83600}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {d1cde792-5d5b-4b79-bf30-303541cc52d4}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   65.532, 48.768, 17.0732,                !- X,Y,Z Vertex 1 {m}
@@ -13454,17 +13446,16 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {0b208f03-204c-460e-a229-d14790739b8b}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {104a676f-f42a-42ec-9913-0bd5765a2d70}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   70.104, 48.768, 8.5366,                 !- X,Y,Z Vertex 1 {m}
   70.104, 53.34, 8.5366,                  !- X,Y,Z Vertex 2 {m}
   62.484, 53.34, 8.5366,                  !- X,Y,Z Vertex 3 {m}
-  62.484, 48.768, 8.5366,                 !- X,Y,Z Vertex 4 {m}
-  65.532, 48.768, 8.5366;                 !- X,Y,Z Vertex 5 {m}
+  62.484, 48.768, 8.5366;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {b561fd0f-55af-433e-86cc-3619d4454fba}, !- Handle
@@ -13472,8 +13463,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {3a43a92b-6516-45e6-9f37-eb7bf8bccb83}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {a34060eb-629e-44b9-9bab-9e16f4d1c1d4}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -13489,10 +13480,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {5fa7a66e-65f8-47fe-850f-4aff5015d62b}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {b926dc39-e6df-46a2-8046-049a672f85d2}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   60.96, 41.148, 8.5366,                  !- X,Y,Z Vertex 1 {m}
@@ -13506,10 +13497,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {0b208f03-204c-460e-a229-d14790739b8b}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   70.104, 47.244, 8.5366,                 !- X,Y,Z Vertex 1 {m}
@@ -13523,10 +13514,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {0b208f03-204c-460e-a229-d14790739b8b}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   62.484, 48.768, 8.5366,                 !- X,Y,Z Vertex 1 {m}
@@ -13540,8 +13531,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0b208f03-204c-460e-a229-d14790739b8b}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {8d7d3535-822d-4af4-af50-36d9e3c3a88f}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -13557,7 +13548,7 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0b208f03-204c-460e-a229-d14790739b8b}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
@@ -13574,7 +13565,7 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0b208f03-204c-460e-a229-d14790739b8b}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
@@ -13591,10 +13582,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {e421471b-c574-4e8a-b7a8-245348dd3775}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {6a6e1363-5fc3-4ab3-9556-228d03728c55}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   48.768, 22.86, 4.2683,                  !- X,Y,Z Vertex 1 {m}
@@ -13608,8 +13599,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0bb10f6e-83ca-443c-bdd6-76ddf2ef5dd5}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {5fb01ad6-bcc3-4db8-82f2-601839f41937}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -13625,10 +13616,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {4b0352d7-5b15-44a5-874c-f4c860e83600}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {a77db2c4-8926-4d0e-9568-46de22677065}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   39.624, 42.672, 17.0732,                !- X,Y,Z Vertex 1 {m}
@@ -13644,8 +13635,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0bb10f6e-83ca-443c-bdd6-76ddf2ef5dd5}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {b122dd8a-4220-45dd-9ccc-1e7dbad31d46}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -13661,10 +13652,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {7698b8f9-ce74-4b6b-806d-12cdef049900}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {9b1470be-8962-416f-af66-cc76ba6757a0}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   60.96, 19.812, 17.0732,                 !- X,Y,Z Vertex 1 {m}
@@ -13678,8 +13669,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0bb10f6e-83ca-443c-bdd6-76ddf2ef5dd5}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {4b9655f2-d1be-484c-9f0a-6ef973008a80}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -13695,10 +13686,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {7f22e5a6-e759-445a-84cb-6b454b893756}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {2ecb2394-f5a0-4485-acaf-9040f713ec3f}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   65.532, 4.572, 17.0732,                 !- X,Y,Z Vertex 1 {m}
@@ -13714,7 +13705,7 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0bb10f6e-83ca-443c-bdd6-76ddf2ef5dd5}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
@@ -13731,7 +13722,7 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0bb10f6e-83ca-443c-bdd6-76ddf2ef5dd5}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
@@ -13748,10 +13739,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {0ebf2d87-9a96-4832-a366-f21cea5fd615}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {d783e1e5-26da-45f4-8c0f-ef2fcd399af0}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   6.096, 4.572, 17.0732,                  !- X,Y,Z Vertex 1 {m}
@@ -13765,8 +13756,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {75111445-9889-4e0e-bf8b-33e4ad0474cb}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {5890b7f1-0b9c-4e00-9e5e-98b462edea85}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -13799,17 +13790,16 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {5fa7a66e-65f8-47fe-850f-4aff5015d62b}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {a088dfcb-4ae1-49b1-87dd-c42b51b97f8e}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   60.96, 42.672, 8.5366,                  !- X,Y,Z Vertex 1 {m}
   60.96, 48.768, 8.5366,                  !- X,Y,Z Vertex 2 {m}
   48.768, 48.768, 8.5366,                 !- X,Y,Z Vertex 3 {m}
-  48.768, 47.244, 8.5366,                 !- X,Y,Z Vertex 4 {m}
-  48.768, 42.672, 8.5366;                 !- X,Y,Z Vertex 5 {m}
+  48.768, 42.672, 8.5366;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {35d16a43-528e-4bb0-b366-0307cf03d08b}, !- Handle
@@ -13817,10 +13807,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d2b1807c-c9f4-44c2-8597-3b555b94b37c}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {95f382df-6256-48af-a274-6407639c0883}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   65.532, 4.572, 12.8049,                 !- X,Y,Z Vertex 1 {m}
@@ -13851,10 +13841,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {1168441b-e4e6-4d44-a00f-18b75cc06a24}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {4d33cad5-3e08-4e8e-ba52-86193eec8414}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   39.624, 48.768, 4.2683,                 !- X,Y,Z Vertex 1 {m}
@@ -13864,14 +13854,14 @@ OS:Surface,
 
 OS:Surface,
   {b33dba6b-b3dc-431f-999e-546c9d49159b}, !- Handle
-  Surface 27,                             !- Name
+  Basement_Ceiling_9,                     !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {8cefc791-4220-41cf-852d-0cd472e915e7}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   70.104, 4.572, 0,                       !- X,Y,Z Vertex 1 {m}
@@ -13881,14 +13871,14 @@ OS:Surface,
 
 OS:Surface,
   {07d1efb5-c730-49b2-92e2-6a2db754d803}, !- Handle
-  Surface 28,                             !- Name
+  Basement_Ceiling_3,                     !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {8cefc791-4220-41cf-852d-0cd472e915e7}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   9.144, 0, 0,                            !- X,Y,Z Vertex 1 {m}
@@ -13902,10 +13892,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {1168441b-e4e6-4d44-a00f-18b75cc06a24}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {c77ef648-aa43-4660-b559-2470b4eeec10}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   39.624, 4.572, 4.2683,                  !- X,Y,Z Vertex 1 {m}
@@ -13919,8 +13909,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {5fa7a66e-65f8-47fe-850f-4aff5015d62b}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {3914e10d-e717-4f5f-8bba-657fd562eb2f}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -13932,14 +13922,14 @@ OS:Surface,
 
 OS:Surface,
   {1ba6552c-7435-41e0-a11f-91a17d369f0f}, !- Handle
-  Surface 31,                             !- Name
+  Basement_Ceiling_6,                     !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {8cefc791-4220-41cf-852d-0cd472e915e7}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   45.72, 0, 0,                            !- X,Y,Z Vertex 1 {m}
@@ -13953,10 +13943,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e421471b-c574-4e8a-b7a8-245348dd3775}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   64.008, 9.144, 4.2683,                  !- X,Y,Z Vertex 1 {m}
@@ -13970,10 +13960,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {17ae9a84-1b9c-49a1-8f48-a49619cb8e39}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {8d1abac8-f396-44b2-b345-b854e9ba8614}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   6.096, 4.572, 12.8049,                  !- X,Y,Z Vertex 1 {m}
@@ -13987,10 +13977,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {e8233850-2c26-457b-b983-e0a87242a5d7}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {6a1cc8f6-c49b-42bf-82b2-ce9fb0f1f148}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   9.144, 10.668, 8.5366,                  !- X,Y,Z Vertex 1 {m}
@@ -14017,14 +14007,14 @@ OS:Surface,
 
 OS:Surface,
   {49de8715-0c8d-4155-8d49-022f93ad0fe6}, !- Handle
-  Surface 36,                             !- Name
+  Basement_Ceiling_2,                     !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {8cefc791-4220-41cf-852d-0cd472e915e7}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   28.956, 0, 0,                           !- X,Y,Z Vertex 1 {m}
@@ -14033,9 +14023,8 @@ OS:Surface,
   0, 0, 0,                                !- X,Y,Z Vertex 4 {m}
   6.096, 0, 0,                            !- X,Y,Z Vertex 5 {m}
   6.096, 4.572, 0,                        !- X,Y,Z Vertex 6 {m}
-  9.144, 4.572, 0,                        !- X,Y,Z Vertex 7 {m}
-  21.3415, 4.572, 0,                      !- X,Y,Z Vertex 8 {m}
-  21.3415, 0, 0;                          !- X,Y,Z Vertex 9 {m}
+  21.3415, 4.572, 0,                      !- X,Y,Z Vertex 7 {m}
+  21.3415, 0, 0;                          !- X,Y,Z Vertex 8 {m}
 
 OS:Surface,
   {ed09367e-45b9-4b95-8e1c-d7390d6a5443}, !- Handle
@@ -14043,8 +14032,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {e8233850-2c26-457b-b983-e0a87242a5d7}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {fadb667e-b842-4205-bfc4-16869d1662c8}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -14081,10 +14070,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {1fd4c829-a755-45de-b877-ff8108b86807}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   0, 48.768, 12.8049,                     !- X,Y,Z Vertex 1 {m}
@@ -14115,10 +14104,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3a43a92b-6516-45e6-9f37-eb7bf8bccb83}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {99da29b0-ecf9-4219-b1b2-77c181f7b238}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   65.532, 48.768, 12.8049,                !- X,Y,Z Vertex 1 {m}
@@ -14132,10 +14121,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {7cce3ac6-5d1d-4960-9e9f-f0d99f44c040}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {2157d3c9-b429-40f3-aef5-751c8f567336}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   48.768, 47.244, 8.5366,                 !- X,Y,Z Vertex 1 {m}
@@ -14149,17 +14138,16 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {2870f103-d956-457d-b911-977241d8c35a}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {b674e94a-8db4-4aec-86b1-38cfb4fce66a}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   39.624, 0, 8.5366,                      !- X,Y,Z Vertex 1 {m}
   39.624, 10.668, 8.5366,                 !- X,Y,Z Vertex 2 {m}
   28.956, 10.668, 8.5366,                 !- X,Y,Z Vertex 3 {m}
-  28.956, 4.572, 8.5366,                  !- X,Y,Z Vertex 4 {m}
-  28.956, 0, 8.5366;                      !- X,Y,Z Vertex 5 {m}
+  28.956, 0, 8.5366;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {a1a5acfa-4f4f-454e-ad2b-5a734513d70a}, !- Handle
@@ -14167,8 +14155,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {3a43a92b-6516-45e6-9f37-eb7bf8bccb83}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {b074cb71-fb94-4162-b579-f4b1e2d17787}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -14184,8 +14172,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {3a43a92b-6516-45e6-9f37-eb7bf8bccb83}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {4a93ca53-3812-404b-bacb-6323cf144129}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -14203,10 +14191,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {2870f103-d956-457d-b911-977241d8c35a}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {1db65e93-f31b-4dd3-a095-aeaa0204e60e}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   39.624, 0, 8.5366,                      !- X,Y,Z Vertex 1 {m}
@@ -14220,10 +14208,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {2870f103-d956-457d-b911-977241d8c35a}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {0b531984-10df-44cf-8486-0d7689121893}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   39.624, 47.244, 8.5366,                 !- X,Y,Z Vertex 1 {m}
@@ -14237,10 +14225,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {2870f103-d956-457d-b911-977241d8c35a}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {1c11fa53-d214-44f4-9985-0c989328dc1a}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   28.956, 48.768, 8.5366,                 !- X,Y,Z Vertex 1 {m}
@@ -14254,10 +14242,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {2870f103-d956-457d-b911-977241d8c35a}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {11539731-965f-4e25-968d-efea3a7439dd}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   28.956, 21.3415, 8.5366,                !- X,Y,Z Vertex 1 {m}
@@ -14271,17 +14259,16 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {2870f103-d956-457d-b911-977241d8c35a}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {29966189-c7fb-46c0-a00c-cf24b396e627}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   39.624, 10.668, 8.5366,                 !- X,Y,Z Vertex 1 {m}
   39.624, 42.672, 8.5366,                 !- X,Y,Z Vertex 2 {m}
   28.956, 42.672, 8.5366,                 !- X,Y,Z Vertex 3 {m}
-  28.956, 19.812, 8.5366,                 !- X,Y,Z Vertex 4 {m}
-  28.956, 10.668, 8.5366;                 !- X,Y,Z Vertex 5 {m}
+  28.956, 10.668, 8.5366;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {96f62409-b4bf-4749-acd1-afc5ee334e0e}, !- Handle
@@ -14289,19 +14276,18 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {e9e27262-9df7-40dc-9a36-b9e4a585473e}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {f33b6919-bfe0-4f0c-b26f-e6f926c6a2e3}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   65.532, 16.764, 8.5366,                 !- X,Y,Z Vertex 1 {m}
   65.532, 4.572, 8.5366,                  !- X,Y,Z Vertex 2 {m}
-  44.196, 4.572, 8.5366,                  !- X,Y,Z Vertex 3 {m}
-  39.624, 4.572, 8.5366,                  !- X,Y,Z Vertex 4 {m}
-  39.624, 10.668, 8.5366,                 !- X,Y,Z Vertex 5 {m}
-  60.96, 10.668, 8.5366,                  !- X,Y,Z Vertex 6 {m}
-  60.96, 16.764, 8.5366;                  !- X,Y,Z Vertex 7 {m}
+  39.624, 4.572, 8.5366,                  !- X,Y,Z Vertex 3 {m}
+  39.624, 10.668, 8.5366,                 !- X,Y,Z Vertex 4 {m}
+  60.96, 10.668, 8.5366,                  !- X,Y,Z Vertex 5 {m}
+  60.96, 16.764, 8.5366;                  !- X,Y,Z Vertex 6 {m}
 
 OS:Surface,
   {0aeeafec-bf8f-44e0-8a34-f7210d40505a}, !- Handle
@@ -14309,17 +14295,16 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {e9e27262-9df7-40dc-9a36-b9e4a585473e}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {3224e308-1e8b-47cd-a39c-f7acb7ec22a9}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   28.956, 10.668, 8.5366,                 !- X,Y,Z Vertex 1 {m}
   28.956, 4.572, 8.5366,                  !- X,Y,Z Vertex 2 {m}
-  6.096, 4.572, 8.5366,                   !- X,Y,Z Vertex 3 {m}
-  4.572, 4.572, 8.5366,                   !- X,Y,Z Vertex 4 {m}
-  4.572, 10.668, 8.5366;                  !- X,Y,Z Vertex 5 {m}
+  4.572, 4.572, 8.5366,                   !- X,Y,Z Vertex 3 {m}
+  4.572, 10.668, 8.5366;                  !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {d5e9709c-4d29-495d-a67c-50d56e96896c}, !- Handle
@@ -14327,8 +14312,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {f4b6e0eb-817b-405c-98f0-c425865851fb}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {95118cea-f630-4aa1-8959-0be3b482e32b}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -14344,8 +14329,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {f4b6e0eb-817b-405c-98f0-c425865851fb}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {9c50da0f-5462-4ba7-b29f-786e23f02d5c}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -14363,8 +14348,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {2d4ce43e-14fd-4122-b641-b757121d5aba}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {101de97d-d023-4197-a46d-934a10b1803f}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -14380,10 +14365,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {31390124-80ad-4222-b08a-01be2ad61163}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {0411ebb3-9af3-489e-9871-d57d5b3f4f78}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   39.624, 10.668, 17.0732,                !- X,Y,Z Vertex 1 {m}
@@ -14399,8 +14384,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {2d4ce43e-14fd-4122-b641-b757121d5aba}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {13d8edca-f17b-4a9f-8402-de08ca4175c3}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -14416,8 +14401,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {2d4ce43e-14fd-4122-b641-b757121d5aba}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {8f9ee008-87d1-4be3-8629-11e2ebf9c233}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -14433,8 +14418,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {2d4ce43e-14fd-4122-b641-b757121d5aba}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {617a8237-69b6-4911-afc0-0416a9c98fb2}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -14452,8 +14437,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {2d4ce43e-14fd-4122-b641-b757121d5aba}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {2a8311e7-db40-40b8-8239-77f5c79faae5}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -14469,7 +14454,7 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {2d4ce43e-14fd-4122-b641-b757121d5aba}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
@@ -14486,10 +14471,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {7f22e5a6-e759-445a-84cb-6b454b893756}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {17217052-44a7-45f0-a4a5-29f86bf77b1a}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   39.624, 0, 17.0732,                     !- X,Y,Z Vertex 1 {m}
@@ -14505,7 +14490,7 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {2d4ce43e-14fd-4122-b641-b757121d5aba}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
@@ -14517,32 +14502,15 @@ OS:Surface,
   44.196, 4.572, 17.0732;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {56d9ebe4-0f0b-4971-8274-dc732b649d4b}, !- Handle
-  Surface 64,                             !- Name
-  Wall,                                   !- Surface Type
-  ,                                       !- Construction Name
-  {31390124-80ad-4222-b08a-01be2ad61163}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
-  ,                                       !- View Factor to Ground
-  ,                                       !- Number of Vertices
-  9.144, 33.582, 17.0732,                 !- X,Y,Z Vertex 1 {m}
-  9.144, 33.582, 12.8049,                 !- X,Y,Z Vertex 2 {m}
-  9.144, 33.528, 12.8049,                 !- X,Y,Z Vertex 3 {m}
-  9.144, 33.528, 17.0732;                 !- X,Y,Z Vertex 4 {m}
-
-OS:Surface,
   {feb3cd91-7b93-4a5e-aa7c-2fbee94841c9}, !- Handle
   Surface 65,                             !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {31390124-80ad-4222-b08a-01be2ad61163}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {63efed9b-3ebb-4b0a-a394-be0bcc77d0d0}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   15.24, 33.528, 17.0732,                 !- X,Y,Z Vertex 1 {m}
@@ -14556,8 +14524,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {6a8c5c6f-369f-4ab1-867d-7f5523a9610f}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {3b831813-daa7-4e21-ba35-7ae7358899e1}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -14575,8 +14543,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {7802b3f6-be28-4f7e-ab11-b2ff579c4766}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {ab6d2ab6-f09d-48e4-93d8-053b64214bcc}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -14594,8 +14562,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {7802b3f6-be28-4f7e-ab11-b2ff579c4766}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {c31985c6-696a-4728-8aa7-0fcc9dad2166}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -14611,8 +14579,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {3a43a92b-6516-45e6-9f37-eb7bf8bccb83}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {0ee28c4d-2fff-48bf-89fd-8fbf762777b9}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -14620,8 +14588,7 @@ OS:Surface,
   60.96, 48.768, 8.5366,                  !- X,Y,Z Vertex 1 {m}
   60.96, 42.672, 8.5366,                  !- X,Y,Z Vertex 2 {m}
   48.768, 42.672, 8.5366,                 !- X,Y,Z Vertex 3 {m}
-  48.768, 47.244, 8.5366,                 !- X,Y,Z Vertex 4 {m}
-  48.768, 48.768, 8.5366;                 !- X,Y,Z Vertex 5 {m}
+  48.768, 48.768, 8.5366;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {a6afa6ba-8312-4b32-b3c3-0f89b074aad4}, !- Handle
@@ -14629,10 +14596,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {47d5f6b5-5e98-43ad-8669-c046505a937d}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {dda133d5-d34b-49d8-a529-83269944fe95}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   48.768, 22.86, 8.5366,                  !- X,Y,Z Vertex 1 {m}
@@ -14646,8 +14613,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {3a43a92b-6516-45e6-9f37-eb7bf8bccb83}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {ce525ba1-8b6c-4461-8bbc-16843874a57e}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -14663,8 +14630,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {3a43a92b-6516-45e6-9f37-eb7bf8bccb83}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {a1e8f15f-fd94-4b4c-9a60-7855723dfe6a}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -14680,10 +14647,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {5fa7a66e-65f8-47fe-850f-4aff5015d62b}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   60.96, 48.768, 8.5366,                  !- X,Y,Z Vertex 1 {m}
@@ -14697,10 +14664,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {5fa7a66e-65f8-47fe-850f-4aff5015d62b}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {0cb91d1d-9040-4769-b6f2-94fb3647aced}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   44.196, 0, 8.5366,                      !- X,Y,Z Vertex 1 {m}
@@ -14727,14 +14694,14 @@ OS:Surface,
 
 OS:Surface,
   {038126fd-8d40-49c0-87e2-0858891d0d28}, !- Handle
-  Surface 76,                             !- Name
+  PatRoom4_Flr_3_Wall_South_2,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {60897f76-ccc0-4353-9cbd-ce8e06f8207c}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   65.532, 48.768, 12.8049,                !- X,Y,Z Vertex 1 {m}
@@ -14748,10 +14715,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {7cce3ac6-5d1d-4960-9e9f-f0d99f44c040}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   48.768, 48.768, 8.5366,                 !- X,Y,Z Vertex 1 {m}
@@ -14765,8 +14732,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {3a43a92b-6516-45e6-9f37-eb7bf8bccb83}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {5ebaf1c8-5af5-452e-b8d5-34386d73d882}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -14782,10 +14749,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {aeb14eec-a11c-4495-b283-f98c2eca3dbf}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {13edc9f8-a4ee-490a-8562-610b66c5c1cc}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   15.24, 21.3415, 8.5366,                 !- X,Y,Z Vertex 1 {m}
@@ -14799,10 +14766,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {e0b3f21a-5417-4d6d-9bad-44c2b5fb3717}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {e8ff1da0-fcb7-461f-a6c1-15b27400104d}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   65.532, 41.148, 8.5366,                 !- X,Y,Z Vertex 1 {m}
@@ -14816,10 +14783,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {e8233850-2c26-457b-b983-e0a87242a5d7}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {8802ccb7-7644-405b-bf66-70f8d64141ea}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   28.956, 10.668, 8.5366,                 !- X,Y,Z Vertex 1 {m}
@@ -14830,32 +14797,15 @@ OS:Surface,
   9.144, 10.668, 8.5366;                  !- X,Y,Z Vertex 6 {m}
 
 OS:Surface,
-  {bae7a3f5-d15a-4b0a-b30b-bb02b97a722a}, !- Handle
-  Surface 82,                             !- Name
-  Wall,                                   !- Surface Type
-  ,                                       !- Construction Name
-  {f4b6e0eb-817b-405c-98f0-c425865851fb}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
-  ,                                       !- View Factor to Ground
-  ,                                       !- Number of Vertices
-  9.144, 33.582, 12.8049,                 !- X,Y,Z Vertex 1 {m}
-  9.144, 33.582, 8.5366,                  !- X,Y,Z Vertex 2 {m}
-  9.144, 33.528, 8.5366,                  !- X,Y,Z Vertex 3 {m}
-  9.144, 33.528, 12.8049;                 !- X,Y,Z Vertex 4 {m}
-
-OS:Surface,
   {4f081654-d3d2-4dba-adea-41898dc054ab}, !- Handle
   Surface 83,                             !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {3d0a884f-f38a-4024-ba41-a3615b0d597f}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {3e6a3d3a-6a2a-4cf4-925a-cae531c8555d}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   4.572, 7.622, 17.0732,                  !- X,Y,Z Vertex 1 {m}
@@ -14869,8 +14819,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {75111445-9889-4e0e-bf8b-33e4ad0474cb}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {91f86ee3-c05a-44ac-bee0-a34219e6de08}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -14903,8 +14853,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {dc66d323-72f5-4969-aebb-d547b4919d13}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {4e621ede-a418-4a72-9010-f8bfc8fd1f0f}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -14920,10 +14870,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {42cd4d82-e24e-4e11-88d4-f870740fe240}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   0, 48.768, 17.0732,                     !- X,Y,Z Vertex 1 {m}
@@ -14954,8 +14904,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {e02691e9-a447-40e1-aa67-039878424ae6}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {6e221b4f-3b78-4339-a9b5-208a7fc55974}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -14971,8 +14921,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {432827a6-9676-48d3-9de8-55f3ed327c07}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {3db7e024-2170-425e-8b6c-d81b41ef16e5}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -14990,10 +14940,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {aeb14eec-a11c-4495-b283-f98c2eca3dbf}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {cbe72b1c-c01c-47a9-8751-42bdfeab7763}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   28.956, 21.3415, 8.5366,                !- X,Y,Z Vertex 1 {m}
@@ -15009,10 +14959,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {e8233850-2c26-457b-b983-e0a87242a5d7}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {db58abbf-cf32-422e-9e19-0ec1fb4a2cd9}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   28.956, 19.812, 8.5366,                 !- X,Y,Z Vertex 1 {m}
@@ -15026,10 +14976,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {e8233850-2c26-457b-b983-e0a87242a5d7}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {463cca08-e8ef-4b87-860f-f962ffa9593e}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   4.572, 4.572, 8.5366,                   !- X,Y,Z Vertex 1 {m}
@@ -15043,10 +14993,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {5fa7a66e-65f8-47fe-850f-4aff5015d62b}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {5804467d-b360-438d-a6eb-dee91a910386}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   48.768, 53.34, 8.5366,                  !- X,Y,Z Vertex 1 {m}
@@ -15060,8 +15010,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {ccee8f2b-c192-4f18-9407-cda799f28f23}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {ba0b6826-c03b-462d-851a-fe16dad1d27c}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -15079,10 +15029,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {e421471b-c574-4e8a-b7a8-245348dd3775}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {3b65cbde-616e-4931-a07d-06cee9adee11}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   64.008, 4.572, 4.2683,                  !- X,Y,Z Vertex 1 {m}
@@ -15102,10 +15052,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {4b0352d7-5b15-44a5-874c-f4c860e83600}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {92b944fe-d698-48f6-98ff-783f4764bfd9}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   9.144, 10.668, 17.0732,                 !- X,Y,Z Vertex 1 {m}
@@ -15119,7 +15069,7 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {7802b3f6-be28-4f7e-ab11-b2ff579c4766}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
@@ -15136,10 +15086,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {4b0352d7-5b15-44a5-874c-f4c860e83600}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {3a502aa6-ea26-4ee2-9371-3dd9cfc19268}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   9.144, 45.72, 17.0732,                  !- X,Y,Z Vertex 1 {m}
@@ -15153,8 +15103,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {dc66d323-72f5-4969-aebb-d547b4919d13}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {328cfaee-7c78-4f9b-886a-2fea099225ed}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -15187,7 +15137,7 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {e02691e9-a447-40e1-aa67-039878424ae6}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
@@ -15204,7 +15154,7 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {e02691e9-a447-40e1-aa67-039878424ae6}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
@@ -15234,14 +15184,14 @@ OS:Surface,
 
 OS:Surface,
   {d9f4932c-0144-4f08-9b6c-6acd9bd5a8db}, !- Handle
-  Surface 105,                            !- Name
+  PatRoom4_Flr_4_Wall_South_2,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {fc9bddfe-4ba5-4685-8ab9-4aa035cfc214}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   65.532, 48.768, 17.0732,                !- X,Y,Z Vertex 1 {m}
@@ -15255,10 +15205,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {5fa7a66e-65f8-47fe-850f-4aff5015d62b}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {0f7bbba8-4f31-4675-90ba-e49aaade92ef}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   60.96, 19.812, 8.5366,                  !- X,Y,Z Vertex 1 {m}
@@ -15274,8 +15224,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {5fa7a66e-65f8-47fe-850f-4aff5015d62b}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {cb0b520a-8d39-475d-a422-c8e2c3984eee}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -15291,17 +15241,16 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {5fa7a66e-65f8-47fe-850f-4aff5015d62b}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {fd6f0296-86e9-41d9-8b85-8edd5f8c3c8e}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   70.104, 0, 8.5366,                      !- X,Y,Z Vertex 1 {m}
   70.104, 4.572, 8.5366,                  !- X,Y,Z Vertex 2 {m}
-  65.532, 4.572, 8.5366,                  !- X,Y,Z Vertex 3 {m}
-  62.484, 4.572, 8.5366,                  !- X,Y,Z Vertex 4 {m}
-  62.484, 0, 8.5366;                      !- X,Y,Z Vertex 5 {m}
+  62.484, 4.572, 8.5366,                  !- X,Y,Z Vertex 3 {m}
+  62.484, 0, 8.5366;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {f33b6919-bfe0-4f0c-b26f-e6f926c6a2e3}, !- Handle
@@ -15309,10 +15258,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {5fa7a66e-65f8-47fe-850f-4aff5015d62b}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {96f62409-b4bf-4749-acd1-afc5ee334e0e}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   65.532, 4.572, 8.5366,                  !- X,Y,Z Vertex 1 {m}
@@ -15320,8 +15269,7 @@ OS:Surface,
   60.96, 16.764, 8.5366,                  !- X,Y,Z Vertex 3 {m}
   60.96, 10.668, 8.5366,                  !- X,Y,Z Vertex 4 {m}
   39.624, 10.668, 8.5366,                 !- X,Y,Z Vertex 5 {m}
-  39.624, 4.572, 8.5366,                  !- X,Y,Z Vertex 6 {m}
-  44.196, 4.572, 8.5366;                  !- X,Y,Z Vertex 7 {m}
+  39.624, 4.572, 8.5366;                  !- X,Y,Z Vertex 6 {m}
 
 OS:Surface,
   {bcadfddd-4979-45bd-9665-353edfa4e55e}, !- Handle
@@ -15346,8 +15294,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {5fa7a66e-65f8-47fe-850f-4aff5015d62b}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {4f7dc632-0fb5-4bb6-91d3-69d7946afc91}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -15369,7 +15317,7 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {5fa7a66e-65f8-47fe-850f-4aff5015d62b}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
@@ -15386,7 +15334,7 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {5fa7a66e-65f8-47fe-850f-4aff5015d62b}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
@@ -15403,7 +15351,7 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {5fa7a66e-65f8-47fe-850f-4aff5015d62b}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
@@ -15420,10 +15368,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {e421471b-c574-4e8a-b7a8-245348dd3775}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {22832320-2ed0-477e-b344-8094cfb6d28c}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   64.008, 41.148, 4.2683,                 !- X,Y,Z Vertex 1 {m}
@@ -15437,17 +15385,16 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {e421471b-c574-4e8a-b7a8-245348dd3775}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {60201699-f7b9-44a5-bfa3-a8d27cc696d7}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   48.768, 47.244, 4.2683,                 !- X,Y,Z Vertex 1 {m}
   48.768, 48.768, 4.2683,                 !- X,Y,Z Vertex 2 {m}
-  45.72, 48.768, 4.2683,                  !- X,Y,Z Vertex 3 {m}
-  39.624, 48.768, 4.2683,                 !- X,Y,Z Vertex 4 {m}
-  39.624, 47.244, 4.2683;                 !- X,Y,Z Vertex 5 {m}
+  39.624, 48.768, 4.2683,                 !- X,Y,Z Vertex 3 {m}
+  39.624, 47.244, 4.2683;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {7744bd5d-b704-41bf-916d-7a598d03cf17}, !- Handle
@@ -15455,10 +15402,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {5fa7a66e-65f8-47fe-850f-4aff5015d62b}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   62.484, 0, 8.5366,                      !- X,Y,Z Vertex 1 {m}
@@ -15472,10 +15419,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {5fa7a66e-65f8-47fe-850f-4aff5015d62b}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {d5e9709c-4d29-495d-a67c-50d56e96896c}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   60.96, 10.668, 8.5366,                  !- X,Y,Z Vertex 1 {m}
@@ -15489,10 +15436,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {5fa7a66e-65f8-47fe-850f-4aff5015d62b}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   70.104, 8.992, 8.5366,                  !- X,Y,Z Vertex 1 {m}
@@ -15506,8 +15453,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {e9e27262-9df7-40dc-9a36-b9e4a585473e}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {67eed5ad-3616-40c5-a15c-26afec404a93}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -15523,10 +15470,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {aeb14eec-a11c-4495-b283-f98c2eca3dbf}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {596977b5-40f6-4ecc-86ff-08f9c1c221ab}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   6.096, 48.768, 8.5366,                  !- X,Y,Z Vertex 1 {m}
@@ -15536,14 +15483,14 @@ OS:Surface,
 
 OS:Surface,
   {f65b4b7f-53b2-4364-a2bf-f11f7762129b}, !- Handle
-  Surface 122,                            !- Name
+  Lobby_Records_Flr_1_Ceiling_5,          !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {ebe6e839-d2fb-4757-8148-ae01cb77f2b7}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {4366c426-157e-42b9-bdbf-5767d0e00b89}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   6.096, 48.768, 4.2683,                  !- X,Y,Z Vertex 1 {m}
@@ -15557,10 +15504,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {7c3f7787-1a2c-4af2-b30d-c5fe68177501}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {a6c52c5e-a0fb-4cad-b3fd-bb230ad262dd}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   65.532, 4.572, 17.0732,                 !- X,Y,Z Vertex 1 {m}
@@ -15591,7 +15538,7 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {6a8c5c6f-369f-4ab1-867d-7f5523a9610f}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
@@ -15608,8 +15555,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {6a8c5c6f-369f-4ab1-867d-7f5523a9610f}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {0df92f1a-9dc0-41e1-9498-d7dc395b26ac}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -15625,10 +15572,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {7f22e5a6-e759-445a-84cb-6b454b893756}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {99724be1-e9f3-4ca3-98dd-fdeb03f0ef5b}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   9.144, 4.572, 17.0732,                  !- X,Y,Z Vertex 1 {m}
@@ -15642,17 +15589,16 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {d7e311f6-f2c1-47c2-b301-cbba90b6f733}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {9856f526-25bf-47c5-b839-8fd160828349}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   15.24, 10.668, 17.0732,                 !- X,Y,Z Vertex 1 {m}
-  15.24, 19.812, 17.0732,                 !- X,Y,Z Vertex 2 {m}
-  15.24, 33.528, 17.0732,                 !- X,Y,Z Vertex 3 {m}
-  9.144, 33.528, 17.0732,                 !- X,Y,Z Vertex 4 {m}
-  9.144, 10.668, 17.0732;                 !- X,Y,Z Vertex 5 {m}
+  15.24, 33.528, 17.0732,                 !- X,Y,Z Vertex 2 {m}
+  9.144, 33.528, 17.0732,                 !- X,Y,Z Vertex 3 {m}
+  9.144, 10.668, 17.0732;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {95f382df-6256-48af-a274-6407639c0883}, !- Handle
@@ -15660,10 +15606,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e9e27262-9df7-40dc-9a36-b9e4a585473e}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {35d16a43-528e-4bb0-b366-0307cf03d08b}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   62.484, 4.572, 12.8049,                 !- X,Y,Z Vertex 1 {m}
@@ -15677,17 +15623,16 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {e8233850-2c26-457b-b983-e0a87242a5d7}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {0aeeafec-bf8f-44e0-8a34-f7210d40505a}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   28.956, 4.572, 8.5366,                  !- X,Y,Z Vertex 1 {m}
   28.956, 10.668, 8.5366,                 !- X,Y,Z Vertex 2 {m}
   4.572, 10.668, 8.5366,                  !- X,Y,Z Vertex 3 {m}
-  4.572, 4.572, 8.5366,                   !- X,Y,Z Vertex 4 {m}
-  6.096, 4.572, 8.5366;                   !- X,Y,Z Vertex 5 {m}
+  4.572, 4.572, 8.5366;                   !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {a6dda79a-4fad-4fdd-a5c4-fe1394697114}, !- Handle
@@ -15712,10 +15657,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {7802b3f6-be28-4f7e-ab11-b2ff579c4766}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {31936f26-632e-426b-8dc8-030f5fac62ef}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   9.144, 15.24, 21.3415,                  !- X,Y,Z Vertex 1 {m}
@@ -15729,7 +15674,7 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {75111445-9889-4e0e-bf8b-33e4ad0474cb}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
@@ -15746,10 +15691,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {7f22e5a6-e759-445a-84cb-6b454b893756}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {e5c03150-746e-4fe1-8fb1-37a1549d0391}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   15.24, 4.572, 17.0732,                  !- X,Y,Z Vertex 1 {m}
@@ -15763,7 +15708,7 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {7802b3f6-be28-4f7e-ab11-b2ff579c4766}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
@@ -15780,8 +15725,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {7802b3f6-be28-4f7e-ab11-b2ff579c4766}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {2391a487-d650-448e-adba-57399e0d8f4f}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -15797,10 +15742,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {7f22e5a6-e759-445a-84cb-6b454b893756}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {db26f88b-0461-4e36-9106-29af9c7210f4}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   9.144, 7.622, 17.0732,                  !- X,Y,Z Vertex 1 {m}
@@ -15831,10 +15776,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {7802b3f6-be28-4f7e-ab11-b2ff579c4766}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {4683bd42-b498-4e6a-8c9d-da6dd09913cf}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   9.144, 48.768, 21.3415,                 !- X,Y,Z Vertex 1 {m}
@@ -15865,10 +15810,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e02691e9-a447-40e1-aa67-039878424ae6}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {76751c10-af53-4e72-a903-a6af1ab73bc0}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   9.144, 48.768, 21.3415,                 !- X,Y,Z Vertex 1 {m}
@@ -15882,10 +15827,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {7f22e5a6-e759-445a-84cb-6b454b893756}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {2561ced8-dbd1-483c-8f7a-0f3c663991a5}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   39.624, 4.572, 17.0732,                 !- X,Y,Z Vertex 1 {m}
@@ -15899,8 +15844,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {7cce3ac6-5d1d-4960-9e9f-f0d99f44c040}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {1b7dfdb2-d6b9-4af1-bf74-e5631a0519db}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -15908,8 +15853,7 @@ OS:Surface,
   48.768, 48.768, 4.2683,                 !- X,Y,Z Vertex 1 {m}
   48.768, 47.244, 4.2683,                 !- X,Y,Z Vertex 2 {m}
   39.624, 47.244, 4.2683,                 !- X,Y,Z Vertex 3 {m}
-  39.624, 48.768, 4.2683,                 !- X,Y,Z Vertex 4 {m}
-  45.72, 48.768, 4.2683;                  !- X,Y,Z Vertex 5 {m}
+  39.624, 48.768, 4.2683;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {b7981715-198d-4c47-bc1c-51fdd02cef6f}, !- Handle
@@ -15917,7 +15861,7 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {7cce3ac6-5d1d-4960-9e9f-f0d99f44c040}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
@@ -15951,28 +15895,27 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {dc66d323-72f5-4969-aebb-d547b4919d13}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   4.572, 15.24, 17.0732,                  !- X,Y,Z Vertex 1 {m}
-  4.572, 10.668, 17.0732,                 !- X,Y,Z Vertex 2 {m}
-  4.572, 8.992, 17.0732,                  !- X,Y,Z Vertex 3 {m}
-  0, 8.992, 17.0732,                      !- X,Y,Z Vertex 4 {m}
-  0, 15.24, 17.0732;                      !- X,Y,Z Vertex 5 {m}
+  4.572, 8.992, 17.0732,                  !- X,Y,Z Vertex 2 {m}
+  0, 8.992, 17.0732,                      !- X,Y,Z Vertex 3 {m}
+  0, 15.24, 17.0732;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {2345f1a9-96d4-4f6f-94db-b3e50f42535e}, !- Handle
-  Surface 147,                            !- Name
+  Basement_Ceiling_14,                    !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {8cefc791-4220-41cf-852d-0cd472e915e7}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   45.72, 48.768, 0,                       !- X,Y,Z Vertex 1 {m}
@@ -15999,14 +15942,14 @@ OS:Surface,
 
 OS:Surface,
   {97165dc0-87f3-40e3-b9c7-9ecb39e05843}, !- Handle
-  Surface 149,                            !- Name
+  Basement_Ceiling_12,                    !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {8cefc791-4220-41cf-852d-0cd472e915e7}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   70.104, 48.768, 0,                      !- X,Y,Z Vertex 1 {m}
@@ -16016,14 +15959,14 @@ OS:Surface,
 
 OS:Surface,
   {7b906724-8319-4614-887d-bcaaa7fd5f08}, !- Handle
-  Surface 150,                            !- Name
+  Basement_Ceiling_8,                     !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {8cefc791-4220-41cf-852d-0cd472e915e7}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   70.104, 0, 0,                           !- X,Y,Z Vertex 1 {m}
@@ -16033,14 +15976,14 @@ OS:Surface,
 
 OS:Surface,
   {38db96bb-d919-494d-ad5e-37351a2c7afc}, !- Handle
-  Surface 151,                            !- Name
+  Basement_Ceiling_5,                     !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {8cefc791-4220-41cf-852d-0cd472e915e7}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   64.008, 4.572, 0,                       !- X,Y,Z Vertex 1 {m}
@@ -16050,19 +15993,18 @@ OS:Surface,
   64.008, 39.624, 0,                      !- X,Y,Z Vertex 5 {m}
   64.008, 48.768, 0,                      !- X,Y,Z Vertex 6 {m}
   39.624, 48.768, 0,                      !- X,Y,Z Vertex 7 {m}
-  39.624, 4.572, 0,                       !- X,Y,Z Vertex 8 {m}
-  45.72, 4.572, 0;                        !- X,Y,Z Vertex 9 {m}
+  39.624, 4.572, 0;                       !- X,Y,Z Vertex 8 {m}
 
 OS:Surface,
   {375ce222-47ea-406e-89cf-a099e1eae452}, !- Handle
-  Surface 152,                            !- Name
+  Basement_Ceiling_7,                     !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {8cefc791-4220-41cf-852d-0cd472e915e7}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   64.008, 0, 0,                           !- X,Y,Z Vertex 1 {m}
@@ -16072,14 +16014,14 @@ OS:Surface,
 
 OS:Surface,
   {a8df02b8-d7b0-456a-b443-554e2dfbc3c7}, !- Handle
-  Surface 153,                            !- Name
+  Basement_Ceiling_13,                    !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {8cefc791-4220-41cf-852d-0cd472e915e7}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   64.008, 48.768, 0,                      !- X,Y,Z Vertex 1 {m}
@@ -16089,14 +16031,14 @@ OS:Surface,
 
 OS:Surface,
   {6cf60f34-9b41-4de1-99ee-1424125a8f52}, !- Handle
-  Surface 154,                            !- Name
+  Basement_Ceiling_11,                    !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {8cefc791-4220-41cf-852d-0cd472e915e7}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   70.104, 39.624, 0,                      !- X,Y,Z Vertex 1 {m}
@@ -16106,14 +16048,14 @@ OS:Surface,
 
 OS:Surface,
   {2afb2ee6-b9a0-440b-9a67-0cc13b5c10be}, !- Handle
-  Surface 155,                            !- Name
+  Basement_Ceiling_10,                    !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {8cefc791-4220-41cf-852d-0cd472e915e7}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   70.104, 9.144, 0,                       !- X,Y,Z Vertex 1 {m}
@@ -16123,14 +16065,14 @@ OS:Surface,
 
 OS:Surface,
   {298b48dd-e4f9-44cb-bf11-26cdf1c1e96b}, !- Handle
-  Surface 156,                            !- Name
+  Basement_Ceiling_4,                     !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {8cefc791-4220-41cf-852d-0cd472e915e7}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   21.3415, 0, 0,                          !- X,Y,Z Vertex 1 {m}
@@ -16144,10 +16086,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {8ec78f13-57f2-4f0e-9746-f05360546e20}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {dacfed6f-6ad3-45b6-a644-8af9444f6f45}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   0, 48.768, 8.5366,                      !- X,Y,Z Vertex 1 {m}
@@ -16174,14 +16116,14 @@ OS:Surface,
 
 OS:Surface,
   {568c28e0-56e4-4e5a-b7f9-e1e737ca82c0}, !- Handle
-  Surface 159,                            !- Name
+  Lobby_Records_Flr_1_Ceiling_2,          !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {ebe6e839-d2fb-4757-8148-ae01cb77f2b7}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {961b5dd0-285c-4ee0-8795-4f6340006009}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   28.956, 21.3415, 4.2683,                !- X,Y,Z Vertex 1 {m}
@@ -16212,10 +16154,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e8233850-2c26-457b-b983-e0a87242a5d7}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   4.572, 21.3415, 8.5366,                 !- X,Y,Z Vertex 1 {m}
@@ -16225,14 +16167,14 @@ OS:Surface,
 
 OS:Surface,
   {566aea66-c1c2-4225-a368-75dd867cfee9}, !- Handle
-  Surface 162,                            !- Name
+  Lobby_Records_Flr_1_Ceiling_4,          !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {ebe6e839-d2fb-4757-8148-ae01cb77f2b7}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {779ede2e-8551-4f30-8c54-e211e6c20c3b}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   4.572, 44.196, 4.2683,                  !- X,Y,Z Vertex 1 {m}
@@ -16242,7 +16184,7 @@ OS:Surface,
 
 OS:Surface,
   {dee36a69-8a1f-4fc4-a04c-ba65947c3620}, !- Handle
-  Surface 163,                            !- Name
+  Lobby_Records_Flr_1_Ceiling_6,          !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {ebe6e839-d2fb-4757-8148-ae01cb77f2b7}, !- Space Name
@@ -16263,8 +16205,8 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {f4b6e0eb-817b-405c-98f0-c425865851fb}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
+  Surface,                                !- Outside Boundary Condition
+  {f36d2d43-71c7-46de-844a-219ec8723829}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -16276,14 +16218,14 @@ OS:Surface,
 
 OS:Surface,
   {fadb667e-b842-4205-bfc4-16869d1662c8}, !- Handle
-  Surface 165,                            !- Name
+  Lobby_Records_Flr_1_Ceiling_1,          !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {ebe6e839-d2fb-4757-8148-ae01cb77f2b7}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {ed09367e-45b9-4b95-8e1c-d7390d6a5443}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   28.956, 0, 4.2683,                      !- X,Y,Z Vertex 1 {m}
@@ -16335,7 +16277,7 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {e0b3f21a-5417-4d6d-9bad-44c2b5fb3717}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
@@ -16352,10 +16294,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {e421471b-c574-4e8a-b7a8-245348dd3775}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   70.104, 16.764, 4.2683,                 !- X,Y,Z Vertex 1 {m}
@@ -16371,17 +16313,16 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {e0b3f21a-5417-4d6d-9bad-44c2b5fb3717}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   70.104, 41.148, 8.5366,                 !- X,Y,Z Vertex 1 {m}
   70.104, 47.244, 8.5366,                 !- X,Y,Z Vertex 2 {m}
   65.532, 47.244, 8.5366,                 !- X,Y,Z Vertex 3 {m}
-  65.532, 42.672, 8.5366,                 !- X,Y,Z Vertex 4 {m}
-  65.532, 41.148, 8.5366;                 !- X,Y,Z Vertex 5 {m}
+  65.532, 41.148, 8.5366;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {8247b613-1770-4e1f-aec7-aa8fbc3d9a54}, !- Handle
@@ -16389,7 +16330,7 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {e9e27262-9df7-40dc-9a36-b9e4a585473e}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
@@ -16406,10 +16347,10 @@ OS:Surface,
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {e8233850-2c26-457b-b983-e0a87242a5d7}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   28.956, 0, 8.5366,                      !- X,Y,Z Vertex 1 {m}
@@ -16440,7 +16381,7 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {e8233850-2c26-457b-b983-e0a87242a5d7}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
@@ -16453,7 +16394,7 @@ OS:Surface,
 
 OS:Surface,
   {54671b08-e7e7-4b89-b42d-cfafb4dae615}, !- Handle
-  Surface 175,                            !- Name
+  Lobby_Records_Flr_1_Ceiling_3,          !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {ebe6e839-d2fb-4757-8148-ae01cb77f2b7}, !- Space Name

--- a/data/geometry/ASHRAEMidriseApartment.osm
+++ b/data/geometry/ASHRAEMidriseApartment.osm
@@ -32,9 +32,9 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
-  34.7455054899131,                       !- X Origin {m}
+  34.7455,                                !- X Origin {m}
   0,                                      !- Y Origin {m}
-  9.14355407629293,                       !- Z Origin {m}
+  9.1436,                                 !- Z Origin {m}
   {7a967551-5561-4b56-b05a-af0754ca7895}, !- Building Story Name
   {d488cb92-552f-458c-b7a1-bfc62115ba2b}; !- Thermal Zone Name
 
@@ -46,7 +46,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  7.61962839691078,                       !- Y Origin {m}
+  7.6196,                                 !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {adca533c-0468-407c-b890-d518ccf74735}, !- Building Story Name
   {623c2ede-649f-43bc-892f-8ef2e416714f}; !- Thermal Zone Name
@@ -80,10 +80,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 1 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {66195dd7-4158-483d-b874-3388a680b571}, !- Handle
@@ -94,7 +94,7 @@ OS:Space,
   0,                                      !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
   0,                                      !- Y Origin {m}
-  9.14355407629293,                       !- Z Origin {m}
+  9.1436,                                 !- Z Origin {m}
   {7a967551-5561-4b56-b05a-af0754ca7895}, !- Building Story Name
   {b9c75708-2d22-4595-80d4-8a0f68150303}; !- Thermal Zone Name
 
@@ -110,10 +110,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {6912ab22-717f-4315-a8ff-9c62dd3bb665}, !- Handle
@@ -122,9 +122,9 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
-  23.1636703266088,                       !- X Origin {m}
+  23.1637,                                !- X Origin {m}
   0,                                      !- Y Origin {m}
-  3.04785135876431,                       !- Z Origin {m}
+  3.0479,                                 !- Z Origin {m}
   {271f3401-76be-4edd-8369-7d5a808299e2}, !- Building Story Name
   {4a48168f-73de-4c04-a40a-b8a18d185b7f}; !- Thermal Zone Name
 
@@ -135,9 +135,9 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
-  34.7455054899131,                       !- X Origin {m}
+  34.7455,                                !- X Origin {m}
   0,                                      !- Y Origin {m}
-  3.04785135876431,                       !- Z Origin {m}
+  3.0479,                                 !- Z Origin {m}
   {271f3401-76be-4edd-8369-7d5a808299e2}, !- Building Story Name
   {020188ba-5065-4680-b6f0-5da34ddbb98a}; !- Thermal Zone Name
 
@@ -153,10 +153,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -1.63304301636913e-07, 7.619628, 3.047851, !- X,Y,Z Vertex 1 {m}
-  -1.63304301636913e-07, 7.619628, 0,     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {fdb38349-a07f-4613-871c-2a0d97c95f4f}, !- Handle
@@ -170,10 +170,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 0, 3.047851,                         !- X,Y,Z Vertex 1 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {22d8b173-d774-48ce-9aac-7d6a7840f33f}, !- Handle
@@ -182,9 +182,9 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
-  11.5818351633044,                       !- X Origin {m}
-  9.29594664423115,                       !- Y Origin {m}
-  9.14355407629293,                       !- Z Origin {m}
+  11.5818,                                !- X Origin {m}
+  9.2959,                                 !- Y Origin {m}
+  9.1436,                                 !- Z Origin {m}
   {7a967551-5561-4b56-b05a-af0754ca7895}, !- Building Story Name
   {0f1f6080-513c-478d-b579-82fe7dd48a72}; !- Thermal Zone Name
 
@@ -196,8 +196,8 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   ,                                       !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  7.61962839691078,                       !- Y Origin {m}
-  9.14355407629293,                       !- Z Origin {m}
+  7.6196,                                 !- Y Origin {m}
+  9.1436,                                 !- Z Origin {m}
   {7a967551-5561-4b56-b05a-af0754ca7895}, !- Building Story Name
   {5355740a-64f7-4413-b7ff-309f94ec0f7d}; !- Thermal Zone Name
 
@@ -213,10 +213,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.1636701633044, 1.67631824732037, 3.047851, !- X,Y,Z Vertex 1 {m}
-  23.1636701633044, 1.67631824732037, 0,  !- X,Y,Z Vertex 2 {m}
-  11.5818351633044, 1.67631824732037, 0,  !- X,Y,Z Vertex 3 {m}
-  11.5818351633044, 1.67631824732037, 3.047851; !- X,Y,Z Vertex 4 {m}
+  23.1637, 1.6763, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  23.1637, 1.6763, 0,                     !- X,Y,Z Vertex 2 {m}
+  11.5818, 1.6763, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 1.6763, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {9167359e-9688-41e4-ae83-b41424807596}, !- Handle
@@ -225,9 +225,9 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
-  23.1636703266088,                       !- X Origin {m}
-  9.29594664423115,                       !- Y Origin {m}
-  9.14355407629293,                       !- Z Origin {m}
+  23.1637,                                !- X Origin {m}
+  9.2959,                                 !- Y Origin {m}
+  9.1436,                                 !- Z Origin {m}
   {7a967551-5561-4b56-b05a-af0754ca7895}, !- Building Story Name
   {30cda89d-c5e7-4017-a8fd-53e389f7bdf7}; !- Thermal Zone Name
 
@@ -243,10 +243,10 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   1,                                      !- Multiplier
   ,                                       !- Number of Vertices
-  8.686, 7.619628, 2.1732,                !- X,Y,Z Vertex 1 {m}
-  8.686, 7.619628, 0.954,                 !- X,Y,Z Vertex 2 {m}
-  2.89498950131234, 7.619628, 0.954,      !- X,Y,Z Vertex 3 {m}
-  2.89498950131234, 7.619628, 2.1732;     !- X,Y,Z Vertex 4 {m}
+  8.686, 7.6196, 2.1732,                  !- X,Y,Z Vertex 1 {m}
+  8.686, 7.6196, 0.954,                   !- X,Y,Z Vertex 2 {m}
+  2.89498950131234, 7.6196, 0.954,        !- X,Y,Z Vertex 3 {m}
+  2.89498950131234, 7.6196, 2.1732;       !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {0464b6fc-0025-4ea5-80cb-899a8d9af70c}, !- Handle
@@ -260,10 +260,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 3.047851;                  !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {7c013759-803b-46ae-9919-4e21adf7c78d}, !- Handle
@@ -274,7 +274,7 @@ OS:Space,
   0,                                      !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
   0,                                      !- Y Origin {m}
-  3.04785135876431,                       !- Z Origin {m}
+  3.0479,                                 !- Z Origin {m}
   {271f3401-76be-4edd-8369-7d5a808299e2}, !- Building Story Name
   {4a329905-de5e-494f-8931-fee8c5f3df9b}; !- Thermal Zone Name
 
@@ -290,10 +290,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {0fe08715-548f-4b65-befe-40ea29ebf953}, !- Handle
@@ -303,8 +303,8 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  9.29594664423115,                       !- Y Origin {m}
-  9.14355407629293,                       !- Z Origin {m}
+  9.2959,                                 !- Y Origin {m}
+  9.1436,                                 !- Z Origin {m}
   {7a967551-5561-4b56-b05a-af0754ca7895}, !- Building Story Name
   {2df663ad-5d5a-4867-bdcc-066715e68801}; !- Thermal Zone Name
 
@@ -320,10 +320,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.327341, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  46.327341, 1.676318, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 1.676318, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  46.3273, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  46.3273, 1.6763, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 1.6763, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {fec56cd7-1bb5-4bb0-8e3b-dab87b5a2de0}, !- Handle
@@ -333,8 +333,8 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   ,                                       !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  7.61962839691078,                       !- Y Origin {m}
-  3.04785135876431,                       !- Z Origin {m}
+  7.6196,                                 !- Y Origin {m}
+  3.0479,                                 !- Z Origin {m}
   {271f3401-76be-4edd-8369-7d5a808299e2}, !- Building Story Name
   {cb484884-90ac-4f1d-b1c6-2ffb06d28e0e}; !- Thermal Zone Name
 
@@ -350,10 +350,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 0, 3.047851,                         !- X,Y,Z Vertex 1 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {3f1c5090-169e-4dca-b8f2-31c064cffb7d}, !- Handle
@@ -362,7 +362,7 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
-  11.5818351633044,                       !- X Origin {m}
+  11.5818,                                !- X Origin {m}
   0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {adca533c-0468-407c-b890-d518ccf74735}, !- Building Story Name
@@ -380,10 +380,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {695f347d-e36c-4348-b06b-48f78bb2529b}, !- Handle
@@ -392,7 +392,7 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
-  23.1636703266088,                       !- X Origin {m}
+  23.1637,                                !- X Origin {m}
   0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {adca533c-0468-407c-b890-d518ccf74735}, !- Building Story Name
@@ -410,10 +410,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -1.63304399336539e-07, 7.619628, 3.047851, !- X,Y,Z Vertex 1 {m}
-  -1.63304399336539e-07, 7.619628, 0,     !- X,Y,Z Vertex 2 {m}
-  -1.63304399336539e-07, 0, 0,            !- X,Y,Z Vertex 3 {m}
-  -1.63304399336539e-07, 0, 3.047851;     !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {14098aef-319d-416c-a469-3b909122a632}, !- Handle
@@ -427,10 +427,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {d70594d1-39e9-4527-baca-7be02e206c76}, !- Handle
@@ -444,10 +444,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 3.047851;                  !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {f025dc15-ffd2-401c-a986-d4284339a97c}, !- Handle
@@ -461,10 +461,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 0, 3.047851,                         !- X,Y,Z Vertex 1 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
-  11.5818351633044, -3.9691078068671e-07, 0, !- X,Y,Z Vertex 3 {m}
-  11.5818351633044, -3.9691078068671e-07, 3.047851; !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {e339bfd6-0b62-4f74-861b-a1bc50f642b6}, !- Handle
@@ -478,10 +478,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {0038fd5f-f228-4b0a-a724-e0084dd5bbd8}, !- Handle
@@ -490,9 +490,9 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
-  34.7455054899131,                       !- X Origin {m}
-  9.29594664423115,                       !- Y Origin {m}
-  3.04785135876431,                       !- Z Origin {m}
+  34.7455,                                !- X Origin {m}
+  9.2959,                                 !- Y Origin {m}
+  3.0479,                                 !- Z Origin {m}
   {271f3401-76be-4edd-8369-7d5a808299e2}, !- Building Story Name
   {188f9e65-dcd6-4588-8381-2d826bdeec39}; !- Thermal Zone Name
 
@@ -508,10 +508,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {d94f0b48-364b-4bd9-83bf-e9b13823aa40}, !- Handle
@@ -520,9 +520,9 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
-  34.7455054899131,                       !- X Origin {m}
-  9.29594664423115,                       !- Y Origin {m}
-  9.14355407629293,                       !- Z Origin {m}
+  34.7455,                                !- X Origin {m}
+  9.2959,                                 !- Y Origin {m}
+  9.1436,                                 !- Z Origin {m}
   {7a967551-5561-4b56-b05a-af0754ca7895}, !- Building Story Name
   {e3834db8-d7c8-4401-8fea-17e93733ad4a}; !- Thermal Zone Name
 
@@ -534,7 +534,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  9.29594664423115,                       !- Y Origin {m}
+  9.2959,                                 !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {adca533c-0468-407c-b890-d518ccf74735}, !- Building Story Name
   {96a975fe-e07c-4cee-9da9-414bc502094c}; !- Thermal Zone Name
@@ -546,9 +546,9 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
-  11.5818351633044,                       !- X Origin {m}
+  11.5818,                                !- X Origin {m}
   0,                                      !- Y Origin {m}
-  9.14355407629293,                       !- Z Origin {m}
+  9.1436,                                 !- Z Origin {m}
   {7a967551-5561-4b56-b05a-af0754ca7895}, !- Building Story Name
   {7d281d86-c33a-4123-8f68-4d64504bfd1e}; !- Thermal Zone Name
 
@@ -559,9 +559,9 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
-  11.5818351633044,                       !- X Origin {m}
-  9.29594664423115,                       !- Y Origin {m}
-  3.04785135876431,                       !- Z Origin {m}
+  11.5818,                                !- X Origin {m}
+  9.2959,                                 !- Y Origin {m}
+  3.0479,                                 !- Z Origin {m}
   {271f3401-76be-4edd-8369-7d5a808299e2}, !- Building Story Name
   {aeef2340-5ece-48db-9e5e-ce03eb1235b3}; !- Thermal Zone Name
 
@@ -572,7 +572,7 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
-  34.7455054899131,                       !- X Origin {m}
+  34.7455,                                !- X Origin {m}
   0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {adca533c-0468-407c-b890-d518ccf74735}, !- Building Story Name
@@ -590,10 +590,10 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   1,                                      !- Multiplier
   ,                                       !- Number of Vertices
-  8.686, 7.619628, 2.1732,                !- X,Y,Z Vertex 1 {m}
-  8.686, 7.619628, 0.954,                 !- X,Y,Z Vertex 2 {m}
-  2.89498950131234, 7.619628, 0.954,      !- X,Y,Z Vertex 3 {m}
-  2.89498950131234, 7.619628, 2.1732;     !- X,Y,Z Vertex 4 {m}
+  8.686, 7.6196, 2.1732,                  !- X,Y,Z Vertex 1 {m}
+  8.686, 7.6196, 0.954,                   !- X,Y,Z Vertex 2 {m}
+  2.89498950131234, 7.6196, 0.954,        !- X,Y,Z Vertex 3 {m}
+  2.89498950131234, 7.6196, 2.1732;       !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {acec2d78-fb19-4e60-af60-27e9bec82ddb}, !- Handle
@@ -607,10 +607,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 3.047851;                  !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {2474fa55-e493-4710-b009-0cdaa0c1a981}, !- Handle
@@ -624,10 +624,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {6630228a-e074-4b5a-815a-de9c195b4f85}, !- Handle
@@ -636,8 +636,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
-  34.7455054899131,                       !- X Origin {m}
-  9.29594664423115,                       !- Y Origin {m}
+  34.7455,                                !- X Origin {m}
+  9.2959,                                 !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {adca533c-0468-407c-b890-d518ccf74735}, !- Building Story Name
   {b9a531da-0d4e-4e0b-9f92-7ba262e97278}; !- Thermal Zone Name
@@ -671,10 +671,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 0, 3.047851,                         !- X,Y,Z Vertex 1 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {c43f7335-3ac7-490e-9b49-890ffac7f0d6}, !- Handle
@@ -683,9 +683,9 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
-  23.1636703266088,                       !- X Origin {m}
+  23.1637,                                !- X Origin {m}
   0,                                      !- Y Origin {m}
-  9.14355407629293,                       !- Z Origin {m}
+  9.1436,                                 !- Z Origin {m}
   {7a967551-5561-4b56-b05a-af0754ca7895}, !- Building Story Name
   {2fa59ca2-45b2-475e-8587-608186ce840a}; !- Thermal Zone Name
 
@@ -714,10 +714,10 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   1,                                      !- Multiplier
   ,                                       !- Number of Vertices
-  8.686, 7.619628, 2.1732,                !- X,Y,Z Vertex 1 {m}
-  8.686, 7.619628, 0.954,                 !- X,Y,Z Vertex 2 {m}
-  2.89498950131234, 7.619628, 0.954,      !- X,Y,Z Vertex 3 {m}
-  2.89498950131234, 7.619628, 2.1732;     !- X,Y,Z Vertex 4 {m}
+  8.686, 7.6196, 2.1732,                  !- X,Y,Z Vertex 1 {m}
+  8.686, 7.6196, 0.954,                   !- X,Y,Z Vertex 2 {m}
+  2.89498950131234, 7.6196, 0.954,        !- X,Y,Z Vertex 3 {m}
+  2.89498950131234, 7.6196, 2.1732;       !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {fee4e034-e583-42cb-a68f-da971eb2a504}, !- Handle
@@ -731,10 +731,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  -1.63304399336539e-07, 7.619628, 0,     !- X,Y,Z Vertex 3 {m}
-  -1.63304399336539e-07, 7.619628, 3.047851; !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {5c7ad500-0f3b-486f-9052-f98babde7c3f}, !- Handle
@@ -743,9 +743,9 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
-  23.1636703266088,                       !- X Origin {m}
-  9.29594664423115,                       !- Y Origin {m}
-  3.04785135876431,                       !- Z Origin {m}
+  23.1637,                                !- X Origin {m}
+  9.2959,                                 !- Y Origin {m}
+  3.0479,                                 !- Z Origin {m}
   {271f3401-76be-4edd-8369-7d5a808299e2}, !- Building Story Name
   {ae16cd79-19cc-4315-a036-df10c3eee92e}; !- Thermal Zone Name
 
@@ -761,10 +761,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 3.047851;                  !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {d5e79dcd-d6de-49ea-bd40-36d0e0890630}, !- Handle
@@ -778,10 +778,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.327341, 1.676318, 0,                 !- X,Y,Z Vertex 1 {m}
-  46.327341, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  46.3273, 1.6763, 0,                     !- X,Y,Z Vertex 1 {m}
+  46.3273, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 1.676318, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 1.6763, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {95295c9e-17f2-4ee1-872c-772c6b0afbab}, !- Handle
@@ -795,10 +795,10 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   1,                                      !- Multiplier
   ,                                       !- Number of Vertices
-  8.686, 7.619628, 2.1732,                !- X,Y,Z Vertex 1 {m}
-  8.686, 7.619628, 0.954,                 !- X,Y,Z Vertex 2 {m}
-  2.89498950131234, 7.619628, 0.954,      !- X,Y,Z Vertex 3 {m}
-  2.89498950131234, 7.619628, 2.1732;     !- X,Y,Z Vertex 4 {m}
+  8.686, 7.6196, 2.1732,                  !- X,Y,Z Vertex 1 {m}
+  8.686, 7.6196, 0.954,                   !- X,Y,Z Vertex 2 {m}
+  2.89498950131234, 7.6196, 0.954,        !- X,Y,Z Vertex 3 {m}
+  2.89498950131234, 7.6196, 2.1732;       !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {046d83cc-62cd-44ec-a21f-b10efa3109b4}, !- Handle
@@ -812,10 +812,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 3.047851;                  !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {4834aa70-7bab-448d-bb6a-90d87c21dd3a}, !- Handle
@@ -829,10 +829,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -1.63304399336539e-07, 0, 3.047851,     !- X,Y,Z Vertex 1 {m}
-  -1.63304399336539e-07, 0, 0,            !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {c604a7fc-75c5-4c12-aac1-a25d32baac6e}, !- Handle
@@ -846,10 +846,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {ce26f5cd-65b0-45e8-a387-a4885dbe55dd}, !- Handle
@@ -880,10 +880,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 1 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {9922a5a5-bd1e-44c4-afea-f3b3deb36d4f}, !- Handle
@@ -897,10 +897,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {656acd56-e898-40e0-8ffe-95e3c2336bc7}, !- Handle
@@ -909,8 +909,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
-  11.5818351633044,                       !- X Origin {m}
-  9.29594664423115,                       !- Y Origin {m}
+  11.5818,                                !- X Origin {m}
+  9.2959,                                 !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {adca533c-0468-407c-b890-d518ccf74735}, !- Building Story Name
   {96aaf9e9-a334-4880-91c9-f3013e20b8d3}; !- Thermal Zone Name
@@ -927,10 +927,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -1.63304399336539e-07, 7.619628, 3.047851, !- X,Y,Z Vertex 1 {m}
-  -1.63304399336539e-07, 7.619628, 0,     !- X,Y,Z Vertex 2 {m}
-  -1.63304399336539e-07, 0, 0,            !- X,Y,Z Vertex 3 {m}
-  -1.63304399336539e-07, 0, 3.047851;     !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {ca421e4e-b3a1-4307-b10c-eebccdb88991}, !- Handle
@@ -944,10 +944,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {26154c94-49af-490b-8d3e-6c5673ae8961}, !- Handle
@@ -961,10 +961,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -1.63304301636913e-07, 7.619628, 3.047851, !- X,Y,Z Vertex 1 {m}
-  -1.63304301636913e-07, 7.619628, 0,     !- X,Y,Z Vertex 2 {m}
-  -1.63304301636913e-07, 0, 0,            !- X,Y,Z Vertex 3 {m}
-  -1.63304301636913e-07, 0, 3.047851;     !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {60223897-f4da-42ad-a2bb-5820651546af}, !- Handle
@@ -978,10 +978,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.327341, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  46.327341, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  46.327341, 1.676318, 0,                 !- X,Y,Z Vertex 3 {m}
-  46.327341, 1.676318, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  46.3273, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  46.3273, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  46.3273, 1.6763, 0,                     !- X,Y,Z Vertex 3 {m}
+  46.3273, 1.6763, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {da0582e0-c615-4686-846f-5fa728e7e69d}, !- Handle
@@ -1012,10 +1012,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 0, 3.047851,                         !- X,Y,Z Vertex 1 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {4db869d3-2221-499c-b634-035d0d161b35}, !- Handle
@@ -1029,10 +1029,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 0, 3.047851,                         !- X,Y,Z Vertex 1 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Output:Meter,
   {29f7895e-ac0c-4623-926d-975974086e4e}, !- Handle
@@ -1048,8 +1048,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
-  23.1636703266088,                       !- X Origin {m}
-  9.29594664423115,                       !- Y Origin {m}
+  23.1637,                                !- X Origin {m}
+  9.2959,                                 !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {adca533c-0468-407c-b890-d518ccf74735}, !- Building Story Name
   {b794cfbb-716a-4aa1-b1a4-7c94e245c179}; !- Thermal Zone Name
@@ -1066,10 +1066,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  -1.63304301636913e-07, 7.619628, 0,     !- X,Y,Z Vertex 3 {m}
-  -1.63304301636913e-07, 7.619628, 3.047851; !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {064f3759-a4a1-4253-9ad0-9ab203f7738d}, !- Handle
@@ -1083,10 +1083,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  34.7455054899131, -3.9691078068671e-07, 3.047851, !- X,Y,Z Vertex 1 {m}
-  34.7455054899131, -3.9691078068671e-07, 0, !- X,Y,Z Vertex 2 {m}
-  46.3273404899131, -3.9691078068671e-07, 0, !- X,Y,Z Vertex 3 {m}
-  46.3273404899131, -3.9691078068671e-07, 3.047851; !- X,Y,Z Vertex 4 {m}
+  34.7455, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  34.7455, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  46.3273, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  46.3273, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Building,
   {761ed503-73d7-48c5-8197-2a7009e22170}, !- Handle
@@ -1111,9 +1111,9 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
-  11.5818351633044,                       !- X Origin {m}
+  11.5818,                                !- X Origin {m}
   0,                                      !- Y Origin {m}
-  3.04785135876431,                       !- Z Origin {m}
+  3.0479,                                 !- Z Origin {m}
   {271f3401-76be-4edd-8369-7d5a808299e2}, !- Building Story Name
   {8034a3e3-15df-445b-ad23-d83b38062d6a}; !- Thermal Zone Name
 
@@ -1129,10 +1129,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {9bc8f935-cc7d-467e-95a2-473d08a7beb3}, !- Handle
@@ -1146,10 +1146,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.327341, 1.676318, 0,                 !- X,Y,Z Vertex 1 {m}
-  46.327341, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  46.3273, 1.6763, 0,                     !- X,Y,Z Vertex 1 {m}
+  46.3273, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 1.676318, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 1.6763, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {685992b0-44ad-47d5-b7f8-0ed36982b7ad}, !- Handle
@@ -1180,10 +1180,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 1 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {716b6360-a915-4a30-b1c8-ec181c534c51}, !- Handle
@@ -1197,10 +1197,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  -1.63304301636913e-07, 7.619628, 0,     !- X,Y,Z Vertex 3 {m}
-  -1.63304301636913e-07, 7.619628, 3.047851; !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {bc24c062-0ad7-4301-a61b-d50a7be3035f}, !- Handle
@@ -1214,10 +1214,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  34.7455054899131, -3.9691078068671e-07, 3.047851, !- X,Y,Z Vertex 1 {m}
-  34.7455054899131, -3.9691078068671e-07, 0, !- X,Y,Z Vertex 2 {m}
-  46.327341, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  46.327341, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  34.7455, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  34.7455, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  46.3273, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  46.3273, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {adb10805-b9f8-461d-9a8e-200d436b3ab3}, !- Handle
@@ -1231,10 +1231,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {c50c13d9-9cc1-43b4-a1b5-c8006d7d3014}, !- Handle
@@ -1248,10 +1248,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {32d2e447-31a9-4381-88cc-71b272037fc1}, !- Handle
@@ -1265,10 +1265,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Output:Meter,
   {a822ff24-e4e3-4c6b-8a4e-4fe82b0bb29b}, !- Handle
@@ -1289,10 +1289,10 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   1,                                      !- Multiplier
   ,                                       !- Number of Vertices
-  11.581835, 1.9049, 2.1732,              !- X,Y,Z Vertex 1 {m}
-  11.581835, 1.9049, 0.954,               !- X,Y,Z Vertex 2 {m}
-  11.581835, 5.7149, 0.954,               !- X,Y,Z Vertex 3 {m}
-  11.581835, 5.7149, 2.1732;              !- X,Y,Z Vertex 4 {m}
+  11.5818, 1.9049, 2.1732,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 1.9049, 0.954,                 !- X,Y,Z Vertex 2 {m}
+  11.5818, 5.7149, 0.954,                 !- X,Y,Z Vertex 3 {m}
+  11.5818, 5.7149, 2.1732;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {179af04c-9de7-4777-bfb2-e88c98794834}, !- Handle
@@ -1306,10 +1306,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {46903d54-4518-4e75-8031-146e60314b95}, !- Handle
@@ -1323,10 +1323,10 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   1,                                      !- Multiplier
   ,                                       !- Number of Vertices
-  11.581835, 1.9049, 2.1732,              !- X,Y,Z Vertex 1 {m}
-  11.581835, 1.9049, 0.954,               !- X,Y,Z Vertex 2 {m}
-  11.581835, 5.7149, 0.954,               !- X,Y,Z Vertex 3 {m}
-  11.581835, 5.7149, 2.1732;              !- X,Y,Z Vertex 4 {m}
+  11.5818, 1.9049, 2.1732,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 1.9049, 0.954,                 !- X,Y,Z Vertex 2 {m}
+  11.5818, 5.7149, 0.954,                 !- X,Y,Z Vertex 3 {m}
+  11.5818, 5.7149, 2.1732;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {6052717a-b449-46d4-ada5-bad81bf70f7a}, !- Handle
@@ -1340,10 +1340,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {6176e360-54d0-44ac-a266-d10aedab6668}, !- Handle
@@ -1357,10 +1357,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {4a93ea5e-ff36-4193-b6f6-b66539496a32}, !- Handle
@@ -1391,10 +1391,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 0, 3.047851,                         !- X,Y,Z Vertex 1 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {fae2b8a5-01f7-4c28-bf70-47cc485f5410}, !- Handle
@@ -1408,10 +1408,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {9db63e42-1d44-497a-9b0e-5325f861f301}, !- Handle
@@ -1425,10 +1425,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 1 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 2 {m}
-  -1.63304399336539e-07, 0, 0,            !- X,Y,Z Vertex 3 {m}
-  -1.63304399336539e-07, 0, 3.047851;     !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {78881d4e-03fe-4770-82cf-c22685e2945c}, !- Handle
@@ -1442,10 +1442,10 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   1,                                      !- Multiplier
   ,                                       !- Number of Vertices
-  11.581835, 1.9049, 2.1732,              !- X,Y,Z Vertex 1 {m}
-  11.581835, 1.9049, 0.954,               !- X,Y,Z Vertex 2 {m}
-  11.581835, 5.7149, 0.954,               !- X,Y,Z Vertex 3 {m}
-  11.581835, 5.7149, 2.1732;              !- X,Y,Z Vertex 4 {m}
+  11.5818, 1.9049, 2.1732,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 1.9049, 0.954,                 !- X,Y,Z Vertex 2 {m}
+  11.5818, 5.7149, 0.954,                 !- X,Y,Z Vertex 3 {m}
+  11.5818, 5.7149, 2.1732;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {b8e8faef-f7f6-4298-aa37-e27d3552ccd2}, !- Handle
@@ -1459,10 +1459,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {82bd34d1-195e-4406-a19d-2eb1810917bb}, !- Handle
@@ -1476,10 +1476,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {6315ab11-826e-4bfb-9416-671d68329af7}, !- Handle
@@ -1493,10 +1493,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 0, 3.047851,                         !- X,Y,Z Vertex 1 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {7508456a-940b-402f-bf6d-eb01a235c2c4}, !- Handle
@@ -1510,10 +1510,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 1.676318, 3.047851,                  !- X,Y,Z Vertex 1 {m}
-  0, 1.676318, 0,                         !- X,Y,Z Vertex 2 {m}
+  0, 1.6763, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 1.6763, 0,                           !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Timestep,
   {edfa6676-4fa1-4f8d-b586-211f30877da9}, !- Handle
@@ -1531,10 +1531,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 3.047851;                  !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {4bf23822-96d1-4966-b977-44c557377193}, !- Handle
@@ -1548,10 +1548,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  34.7455054899131, -3.9691078068671e-07, 3.047851, !- X,Y,Z Vertex 1 {m}
-  34.7455054899131, -3.9691078068671e-07, 0, !- X,Y,Z Vertex 2 {m}
-  46.327341, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  46.327341, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  34.7455, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  34.7455, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  46.3273, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  46.3273, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {f326f129-5c15-4001-b1e7-53f56fa397e7}, !- Handle
@@ -1565,10 +1565,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 0, 3.047851,                         !- X,Y,Z Vertex 1 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {38a63ba5-45e3-4ae8-a074-18f7334f96c4}, !- Handle
@@ -1582,10 +1582,10 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   1,                                      !- Multiplier
   ,                                       !- Number of Vertices
-  8.686, 7.619628, 2.1732,                !- X,Y,Z Vertex 1 {m}
-  8.686, 7.619628, 0.954,                 !- X,Y,Z Vertex 2 {m}
-  2.89498950131234, 7.619628, 0.954,      !- X,Y,Z Vertex 3 {m}
-  2.89498950131234, 7.619628, 2.1732;     !- X,Y,Z Vertex 4 {m}
+  8.686, 7.6196, 2.1732,                  !- X,Y,Z Vertex 1 {m}
+  8.686, 7.6196, 0.954,                   !- X,Y,Z Vertex 2 {m}
+  2.89498950131234, 7.6196, 0.954,        !- X,Y,Z Vertex 3 {m}
+  2.89498950131234, 7.6196, 2.1732;       !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {38233d6c-a038-4da7-aad0-fc35f2bcabc3}, !- Handle
@@ -1599,10 +1599,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 3.047851;                  !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {0973397c-a7cd-4f4c-b030-9a1a5fc1bd68}, !- Handle
@@ -1616,10 +1616,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {7ecf1ef3-c703-46bd-8b01-82977e66eb9d}, !- Handle
@@ -1633,10 +1633,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {2e33118a-bc3d-497a-9549-aaffb48e7c31}, !- Handle
@@ -1650,10 +1650,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -1.63304399336539e-07, 7.619628, 3.047851, !- X,Y,Z Vertex 1 {m}
-  -1.63304399336539e-07, 7.619628, 0,     !- X,Y,Z Vertex 2 {m}
-  -1.63304399336539e-07, 0, 0,            !- X,Y,Z Vertex 3 {m}
-  -1.63304399336539e-07, 0, 3.047851;     !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {c558d82c-5613-4ed0-8d46-457e8216c57d}, !- Handle
@@ -1667,10 +1667,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  -1.63304399336539e-07, 7.619628, 0,     !- X,Y,Z Vertex 3 {m}
-  -1.63304399336539e-07, 7.619628, 3.047851; !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {ba5b2bc2-eaf4-469d-b8b1-d92bbfef86ce}, !- Handle
@@ -1684,10 +1684,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 1 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {af29dfb6-7496-4f93-84eb-9aea6f24ec16}, !- Handle
@@ -1701,10 +1701,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {aa77ea57-67c6-4d67-bc88-32429135eec4}, !- Handle
@@ -1718,10 +1718,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {c23f7327-8225-448f-8249-f1ef8e586e17}, !- Handle
@@ -1735,10 +1735,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -1.63304399336539e-07, 7.619628, 3.047851, !- X,Y,Z Vertex 1 {m}
-  -1.63304399336539e-07, 7.619628, 0,     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {533c2d73-c8a4-4335-9970-cab144718379}, !- Handle
@@ -1752,10 +1752,10 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   1,                                      !- Multiplier
   ,                                       !- Number of Vertices
-  8.686, 7.619628, 2.1732,                !- X,Y,Z Vertex 1 {m}
-  8.686, 7.619628, 0.954,                 !- X,Y,Z Vertex 2 {m}
-  2.89498950131234, 7.619628, 0.954,      !- X,Y,Z Vertex 3 {m}
-  2.89498950131234, 7.619628, 2.1732;     !- X,Y,Z Vertex 4 {m}
+  8.686, 7.6196, 2.1732,                  !- X,Y,Z Vertex 1 {m}
+  8.686, 7.6196, 0.954,                   !- X,Y,Z Vertex 2 {m}
+  2.89498950131234, 7.6196, 0.954,        !- X,Y,Z Vertex 3 {m}
+  2.89498950131234, 7.6196, 2.1732;       !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {bc83631d-4a58-46ad-b52c-4055924d46cc}, !- Handle
@@ -1769,10 +1769,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {5758e5f8-053a-4ce6-9c81-c38fbad69ad9}, !- Handle
@@ -1786,10 +1786,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {d251f702-03b3-4ba8-9b7c-08259a4ea42e}, !- Handle
@@ -1799,8 +1799,8 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  9.29594664423115,                       !- Y Origin {m}
-  3.04785135876431,                       !- Z Origin {m}
+  9.2959,                                 !- Y Origin {m}
+  3.0479,                                 !- Z Origin {m}
   {271f3401-76be-4edd-8369-7d5a808299e2}, !- Building Story Name
   {e3ca4010-a6a5-4821-b2e6-107bd08eb6e8}; !- Thermal Zone Name
 
@@ -1816,10 +1816,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 0, 3.047851,                         !- X,Y,Z Vertex 1 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {38f883df-0f73-4a2a-9fd1-26a91e2ee0cd}, !- Handle
@@ -1833,10 +1833,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.1636701633044, 1.67631824732037, 3.047851, !- X,Y,Z Vertex 1 {m}
-  23.1636701633044, 1.67631824732037, 0,  !- X,Y,Z Vertex 2 {m}
-  11.5818351633044, 1.67631824732037, 0,  !- X,Y,Z Vertex 3 {m}
-  11.5818351633044, 1.67631824732037, 3.047851; !- X,Y,Z Vertex 4 {m}
+  23.1637, 1.6763, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  23.1637, 1.6763, 0,                     !- X,Y,Z Vertex 2 {m}
+  11.5818, 1.6763, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 1.6763, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {7097f868-5195-4814-a8b5-63f7bf661805}, !- Handle
@@ -1850,10 +1850,10 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   1,                                      !- Multiplier
   ,                                       !- Number of Vertices
-  11.581835, 1.9049, 2.1732,              !- X,Y,Z Vertex 1 {m}
-  11.581835, 1.9049, 0.954,               !- X,Y,Z Vertex 2 {m}
-  11.581835, 5.7149, 0.954,               !- X,Y,Z Vertex 3 {m}
-  11.581835, 5.7149, 2.1732;              !- X,Y,Z Vertex 4 {m}
+  11.5818, 1.9049, 2.1732,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 1.9049, 0.954,                 !- X,Y,Z Vertex 2 {m}
+  11.5818, 5.7149, 0.954,                 !- X,Y,Z Vertex 3 {m}
+  11.5818, 5.7149, 2.1732;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {90963fab-d41a-4776-8158-5800d81f7f47}, !- Handle
@@ -1867,10 +1867,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {c467be40-c8ea-41d0-995a-a4656ec97f84}, !- Handle
@@ -1884,10 +1884,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 0, 3.047851,                         !- X,Y,Z Vertex 1 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {5c041ba7-f105-4185-a779-998bd6cb0ad0}, !- Handle
@@ -1901,10 +1901,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.327341, 1.676318, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  46.327341, 1.676318, 0,                 !- X,Y,Z Vertex 2 {m}
-  34.7455054899131, 1.67631824732037, 0,  !- X,Y,Z Vertex 3 {m}
-  34.7455054899131, 1.67631824732037, 3.047851; !- X,Y,Z Vertex 4 {m}
+  46.3273, 1.6763, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  46.3273, 1.6763, 0,                     !- X,Y,Z Vertex 2 {m}
+  34.7455, 1.6763, 0,                     !- X,Y,Z Vertex 3 {m}
+  34.7455, 1.6763, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {abaef75f-9aa1-4865-9baa-5058002f5f6d}, !- Handle
@@ -1935,10 +1935,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 1 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {6110bce7-d14f-4734-b786-3368f1fa9fd9}, !- Handle
@@ -1952,10 +1952,10 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   1,                                      !- Multiplier
   ,                                       !- Number of Vertices
-  8.686, 7.619628, 2.1732,                !- X,Y,Z Vertex 1 {m}
-  8.686, 7.619628, 0.954,                 !- X,Y,Z Vertex 2 {m}
-  2.89498950131234, 7.619628, 0.954,      !- X,Y,Z Vertex 3 {m}
-  2.89498950131234, 7.619628, 2.1732;     !- X,Y,Z Vertex 4 {m}
+  8.686, 7.6196, 2.1732,                  !- X,Y,Z Vertex 1 {m}
+  8.686, 7.6196, 0.954,                   !- X,Y,Z Vertex 2 {m}
+  2.89498950131234, 7.6196, 0.954,        !- X,Y,Z Vertex 3 {m}
+  2.89498950131234, 7.6196, 2.1732;       !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {329cc372-873c-43a5-9272-e604a7426627}, !- Handle
@@ -1969,10 +1969,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 3.047851;                  !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {e6970b9f-5b70-45dd-a129-a0873e1f12a8}, !- Handle
@@ -1986,10 +1986,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -1.63304399336539e-07, 0, 3.047851,     !- X,Y,Z Vertex 1 {m}
-  -1.63304399336539e-07, 0, 0,            !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {31a041ea-149a-4d29-a8df-e2ec4e7981ab}, !- Handle
@@ -2003,10 +2003,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.1636701633044, 1.67631824732037, 3.047851, !- X,Y,Z Vertex 1 {m}
-  23.1636701633044, 1.67631824732037, 0,  !- X,Y,Z Vertex 2 {m}
-  11.5818351633044, 1.67631824732037, 0,  !- X,Y,Z Vertex 3 {m}
-  11.5818351633044, 1.67631824732037, 3.047851; !- X,Y,Z Vertex 4 {m}
+  23.1637, 1.6763, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  23.1637, 1.6763, 0,                     !- X,Y,Z Vertex 2 {m}
+  11.5818, 1.6763, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 1.6763, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {a390f85d-1e0f-4539-bd6b-77d9a7d49e91}, !- Handle
@@ -2020,10 +2020,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 0, 3.047851,                         !- X,Y,Z Vertex 1 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {5197ae2f-835b-4413-b43b-e1f2a6717eb1}, !- Handle
@@ -2037,10 +2037,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.327341, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  46.327341, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  46.327341, 1.676318, 0,                 !- X,Y,Z Vertex 3 {m}
-  46.327341, 1.676318, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  46.3273, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  46.3273, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  46.3273, 1.6763, 0,                     !- X,Y,Z Vertex 3 {m}
+  46.3273, 1.6763, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {717aacc9-d91e-4e59-9778-924657ad38d8}, !- Handle
@@ -2054,10 +2054,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  -1.63304399336539e-07, 7.619628, 0,     !- X,Y,Z Vertex 3 {m}
-  -1.63304399336539e-07, 7.619628, 3.047851; !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {7f9ec0f2-4a12-4979-8fb3-3df3d28f0d08}, !- Handle
@@ -2071,10 +2071,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {c00ca208-b2e0-4988-8b8f-59ea5e2e725c}, !- Handle
@@ -2088,10 +2088,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {30b4a10c-a054-43f2-b636-8739035a194f}, !- Handle
@@ -2105,10 +2105,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 3.047851;                  !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {a3ac4274-3a90-4438-a2c6-d9b489ae50ff}, !- Handle
@@ -2122,10 +2122,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, -3.9691078068671e-07, 3.047851, !- X,Y,Z Vertex 1 {m}
-  11.581835, -3.9691078068671e-07, 0,     !- X,Y,Z Vertex 2 {m}
-  23.1636703266088, -3.9691078068671e-07, 0, !- X,Y,Z Vertex 3 {m}
-  23.1636703266088, -3.9691078068671e-07, 3.047851; !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  23.1637, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  23.1637, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {062bf596-5683-48c3-aa87-d2bf9f13ad26}, !- Handle
@@ -2139,10 +2139,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {7cf04123-6bd6-4886-abb9-59405b5a5d3d}, !- Handle
@@ -2156,10 +2156,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 1 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {bfbb4bab-02b4-4dd5-9a25-d0ce73b9d2a1}, !- Handle
@@ -2173,10 +2173,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {f886c264-0c3a-4fcf-a573-b9ce3c891ec0}, !- Handle
@@ -2190,10 +2190,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {49b9efbf-1872-4f67-ad3e-c15cfac54455}, !- Handle
@@ -2207,10 +2207,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 3.047851;                  !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {03ebae37-082f-43ed-838c-33e3a167d8a7}, !- Handle
@@ -2224,10 +2224,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.5818351633044, -3.9691078068671e-07, 3.047851, !- X,Y,Z Vertex 1 {m}
-  11.5818351633044, -3.9691078068671e-07, 0, !- X,Y,Z Vertex 2 {m}
-  23.1636701633044, -3.9691078068671e-07, 0, !- X,Y,Z Vertex 3 {m}
-  23.1636701633044, -3.9691078068671e-07, 3.047851; !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  23.1637, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  23.1637, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {b60ed3e7-62cf-4284-9988-cb23e2ff0a1c}, !- Handle
@@ -2241,10 +2241,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {86a0c6c6-2f67-41ea-a22b-0eed7f018635}, !- Handle
@@ -2258,10 +2258,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 1 {m}
-  -1.63304399336539e-07, 7.619628, 0,     !- X,Y,Z Vertex 2 {m}
-  -1.63304399336539e-07, 0, 0,            !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {2c1fb5cb-d744-485f-b19b-edb542a335ee}, !- Handle
@@ -2275,10 +2275,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {4f1ec902-d894-430d-bf35-9684cdbb4ad3}, !- Handle
@@ -2292,10 +2292,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 0, 3.047851,                         !- X,Y,Z Vertex 1 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {e41b7305-7b07-4aa3-a452-3c8444b4e344}, !- Handle
@@ -2309,10 +2309,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.5818351633044, 1.67631824732037, 3.047851, !- X,Y,Z Vertex 1 {m}
-  11.5818351633044, 1.67631824732037, 0,  !- X,Y,Z Vertex 2 {m}
-  0, 1.676318, 0,                         !- X,Y,Z Vertex 3 {m}
-  0, 1.67631824732037, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 1.6763, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 1.6763, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 1.6763, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 1.6763, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {ae1a3426-8fbe-4aa4-9b96-265d1ab44c17}, !- Handle
@@ -2326,10 +2326,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 0, 3.047851,                         !- X,Y,Z Vertex 1 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {b340da59-e4f6-4224-acdd-1740a5bcfa0b}, !- Handle
@@ -2343,10 +2343,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.5818351633044, 1.67631824732037, 3.047851, !- X,Y,Z Vertex 1 {m}
-  11.5818351633044, 1.67631824732037, 0,  !- X,Y,Z Vertex 2 {m}
-  0, 1.67631824732037, 0,                 !- X,Y,Z Vertex 3 {m}
-  0, 1.67631824732037, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 1.6763, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 1.6763, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 1.6763, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 1.6763, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {d631ce51-4ce6-49db-9914-73bbcf409eb3}, !- Handle
@@ -2360,10 +2360,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 0, 3.047851,                         !- X,Y,Z Vertex 1 {m}
-  -1.63304399336539e-07, 0, 0,            !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {4ba3edf7-d8cf-4248-8c68-3c2a4f2b5e7a}, !- Handle
@@ -2377,10 +2377,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {06bbdf9c-3c49-4c88-8c4b-0191b1091d67}, !- Handle
@@ -2394,10 +2394,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {423aae32-5565-4476-aeef-4342771309eb}, !- Handle
@@ -2428,10 +2428,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 1 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {34b4c81e-9b09-4e82-a10f-1f713ebf0b11}, !- Handle
@@ -2445,10 +2445,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {c83f9036-726e-4da7-9e5d-3295ece930cc}, !- Handle
@@ -2462,10 +2462,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.3273404899131, -3.9691078068671e-07, 3.047851, !- X,Y,Z Vertex 1 {m}
-  46.3273404899131, -3.9691078068671e-07, 0, !- X,Y,Z Vertex 2 {m}
-  46.327341, 1.676318, 0,                 !- X,Y,Z Vertex 3 {m}
-  46.3273404899131, 1.67631824732037, 3.047851; !- X,Y,Z Vertex 4 {m}
+  46.3273, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  46.3273, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  46.3273, 1.6763, 0,                     !- X,Y,Z Vertex 3 {m}
+  46.3273, 1.6763, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {1b69fa2b-40bf-4f4c-9dbb-b45b3e3e44a2}, !- Handle
@@ -2479,10 +2479,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {ded4e408-7c4a-4b73-934e-290e877cbbff}, !- Handle
@@ -2496,10 +2496,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.327341, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  46.327341, 1.676318, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 1.676318, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  46.3273, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  46.3273, 1.6763, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 1.6763, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {00a58f76-1083-44a9-98b5-4d1abb762575}, !- Handle
@@ -2513,10 +2513,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {6a43f181-503a-4ef0-b7b4-c6287181f587}, !- Handle
@@ -2547,10 +2547,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {e0f7e2eb-7fa9-4cac-a318-a956e44304ff}, !- Handle
@@ -2564,10 +2564,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {eb3e0266-afad-475f-861e-c5a267f69950}, !- Handle
@@ -2581,10 +2581,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {75fd5c8a-5998-43b5-97e6-c018c31fedd4}, !- Handle
@@ -2598,10 +2598,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {a001ef4a-7d6c-48d4-bd74-450d0824361f}, !- Handle
@@ -2615,10 +2615,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 1 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {d16dbe4a-4631-46f4-a078-d25c75315c43}, !- Handle
@@ -2649,10 +2649,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:RunPeriod,
   {17246936-3daa-4b32-8968-1e0c617730af}, !- Handle
@@ -2685,10 +2685,10 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   1,                                      !- Multiplier
   ,                                       !- Number of Vertices
-  8.686, 7.619628, 2.1732,                !- X,Y,Z Vertex 1 {m}
-  8.686, 7.619628, 0.954,                 !- X,Y,Z Vertex 2 {m}
-  2.89498950131234, 7.619628, 0.954,      !- X,Y,Z Vertex 3 {m}
-  2.89498950131234, 7.619628, 2.1732;     !- X,Y,Z Vertex 4 {m}
+  8.686, 7.6196, 2.1732,                  !- X,Y,Z Vertex 1 {m}
+  8.686, 7.6196, 0.954,                   !- X,Y,Z Vertex 2 {m}
+  2.89498950131234, 7.6196, 0.954,        !- X,Y,Z Vertex 3 {m}
+  2.89498950131234, 7.6196, 2.1732;       !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {2de693c3-45db-4f7f-be74-82fc1220c3c3}, !- Handle
@@ -2702,10 +2702,10 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   1,                                      !- Multiplier
   ,                                       !- Number of Vertices
-  46.327341, 0.381000000012441, 2.1731,   !- X,Y,Z Vertex 1 {m}
-  46.327341, 0.381000000012441, 0.954,    !- X,Y,Z Vertex 2 {m}
-  46.327341, 1.29530000001236, 0.954,     !- X,Y,Z Vertex 3 {m}
-  46.327341, 1.29530000001236, 2.1731;    !- X,Y,Z Vertex 4 {m}
+  46.3273, 0.381000000012441, 2.1731,     !- X,Y,Z Vertex 1 {m}
+  46.3273, 0.381000000012441, 0.954,      !- X,Y,Z Vertex 2 {m}
+  46.3273, 1.29530000001236, 0.954,       !- X,Y,Z Vertex 3 {m}
+  46.3273, 1.29530000001236, 2.1731;      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {bd8ce1a2-fa04-48b6-b755-c5c9659eb5aa}, !- Handle
@@ -2719,10 +2719,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {844d8a65-aa9a-4388-905d-0eba9f481575}, !- Handle
@@ -2736,10 +2736,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 1 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  -1.63304399336539e-07, 0, 3.047851;     !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {35569ce9-6ed1-474e-94ed-b9b53c411482}, !- Handle
@@ -2753,10 +2753,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.327341, 1.676318, 0,                 !- X,Y,Z Vertex 1 {m}
-  46.327341, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  46.3273, 1.6763, 0,                     !- X,Y,Z Vertex 1 {m}
+  46.3273, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 1.676318, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 1.6763, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {d9fb3c9b-dfbd-411c-81f4-1ee8d5b73d0f}, !- Handle
@@ -2770,10 +2770,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 1.67631824732037, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  0, 1.67631824732037, 0,                 !- X,Y,Z Vertex 2 {m}
+  0, 1.6763, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 1.6763, 0,                           !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {ded359fe-9e00-4904-9917-e7115e3e3eaf}, !- Handle
@@ -2787,10 +2787,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {7798389d-c509-40d9-91d6-adc1aec9c8a2}, !- Handle
@@ -2804,10 +2804,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 1 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {7347fd37-c284-440c-af33-38b0962a4f06}, !- Handle
@@ -2821,10 +2821,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {74c4318f-e443-4d02-9a26-c7e64a6d5271}, !- Handle
@@ -2838,10 +2838,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {fe8f496c-357d-4c24-b069-cb1c352df354}, !- Handle
@@ -2872,10 +2872,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -1.63304399336539e-07, 0, 3.047851,     !- X,Y,Z Vertex 1 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {18d892cd-e1a0-44c5-912c-483cf40d5e4b}, !- Handle
@@ -2889,10 +2889,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  34.7455053266088, 1.67631824732037, 3.047851, !- X,Y,Z Vertex 1 {m}
-  34.7455053266088, 1.67631824732037, 0,  !- X,Y,Z Vertex 2 {m}
-  23.1636701633044, 1.67631824732037, 0,  !- X,Y,Z Vertex 3 {m}
-  23.1636701633044, 1.67631824732037, 3.047851; !- X,Y,Z Vertex 4 {m}
+  34.7455, 1.6763, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  34.7455, 1.6763, 0,                     !- X,Y,Z Vertex 2 {m}
+  23.1637, 1.6763, 0,                     !- X,Y,Z Vertex 3 {m}
+  23.1637, 1.6763, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {8a224810-4373-4cae-9881-b0bb511c13e0}, !- Handle
@@ -2906,10 +2906,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -1.63304399336539e-07, 0, 3.047851,     !- X,Y,Z Vertex 1 {m}
-  -1.63304399336539e-07, 0, 0,            !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {1eb08487-139c-4b7e-9c80-62df703ec34a}, !- Handle
@@ -2923,10 +2923,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  34.7455054899131, 1.67631824732037, 3.047851, !- X,Y,Z Vertex 1 {m}
-  34.7455054899131, 1.67631824732037, 0,  !- X,Y,Z Vertex 2 {m}
-  23.1636701633044, 1.67631824732037, 0,  !- X,Y,Z Vertex 3 {m}
-  23.1636701633044, 1.67631824732037, 3.047851; !- X,Y,Z Vertex 4 {m}
+  34.7455, 1.6763, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  34.7455, 1.6763, 0,                     !- X,Y,Z Vertex 2 {m}
+  23.1637, 1.6763, 0,                     !- X,Y,Z Vertex 3 {m}
+  23.1637, 1.6763, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {0122e97d-e5f0-4bbe-ac4b-60a57dd65143}, !- Handle
@@ -2940,10 +2940,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {516e7d8c-7643-4ced-8226-66cb619a2c42}, !- Handle
@@ -2957,10 +2957,10 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   1,                                      !- Multiplier
   ,                                       !- Number of Vertices
-  11.581835, 1.9049, 2.1732,              !- X,Y,Z Vertex 1 {m}
-  11.581835, 1.9049, 0.954,               !- X,Y,Z Vertex 2 {m}
-  11.581835, 5.7149, 0.954,               !- X,Y,Z Vertex 3 {m}
-  11.581835, 5.7149, 2.1732;              !- X,Y,Z Vertex 4 {m}
+  11.5818, 1.9049, 2.1732,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 1.9049, 0.954,                 !- X,Y,Z Vertex 2 {m}
+  11.5818, 5.7149, 0.954,                 !- X,Y,Z Vertex 3 {m}
+  11.5818, 5.7149, 2.1732;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {b656eb60-f5b7-4c91-b0bf-9e7c799dbd8e}, !- Handle
@@ -2974,10 +2974,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {cb41c7b0-bd18-4bef-8b7d-0ec200982c49}, !- Handle
@@ -2991,10 +2991,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -1.63304399336539e-07, 0, 3.047851,     !- X,Y,Z Vertex 1 {m}
-  -1.63304399336539e-07, 0, 0,            !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {2df42518-f3bc-4d0b-814b-5de908c94fbe}, !- Handle
@@ -3008,10 +3008,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {ceabc2d2-2c2d-4f75-8882-483069268c42}, !- Handle
@@ -3042,10 +3042,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {4608bfe5-cb9f-42f7-b7fe-387d9e1982ad}, !- Handle
@@ -3076,10 +3076,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -1.63304301636913e-07, 0, 3.047851,     !- X,Y,Z Vertex 1 {m}
-  -1.63304301636913e-07, 0, 0,            !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {23b45aae-e2e1-4523-b04d-86aa560b5716}, !- Handle
@@ -3093,10 +3093,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 3.047851;                  !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {bf48e683-2c32-4038-bf2c-4e4e9ff3646f}, !- Handle
@@ -3110,10 +3110,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 0, 3.047851,                         !- X,Y,Z Vertex 1 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
-  11.5818351633044, -3.9691078068671e-07, 0, !- X,Y,Z Vertex 3 {m}
-  11.5818351633044, -3.9691078068671e-07, 3.047851; !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {b525bb62-38a2-465b-b99e-ce5a3c7c32df}, !- Handle
@@ -3127,10 +3127,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {9f8624c5-40a1-49d1-89f1-802dd3649e49}, !- Handle
@@ -3161,10 +3161,10 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   1,                                      !- Multiplier
   ,                                       !- Number of Vertices
-  8.686, 7.619628, 2.1732,                !- X,Y,Z Vertex 1 {m}
-  8.686, 7.619628, 0.954,                 !- X,Y,Z Vertex 2 {m}
-  2.89498950131234, 7.619628, 0.954,      !- X,Y,Z Vertex 3 {m}
-  2.89498950131234, 7.619628, 2.1732;     !- X,Y,Z Vertex 4 {m}
+  8.686, 7.6196, 2.1732,                  !- X,Y,Z Vertex 1 {m}
+  8.686, 7.6196, 0.954,                   !- X,Y,Z Vertex 2 {m}
+  2.89498950131234, 7.6196, 0.954,        !- X,Y,Z Vertex 3 {m}
+  2.89498950131234, 7.6196, 2.1732;       !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {5b9c5e1f-745c-4b9e-86aa-c7fa2fddd93b}, !- Handle
@@ -3178,10 +3178,10 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   1,                                      !- Multiplier
   ,                                       !- Number of Vertices
-  46.3273404466331, 0.0508000000062577, 2.13349999999656, !- X,Y,Z Vertex 1 {m}
-  46.3273406230384, 0.0508000000061772, 0.0253999999966025, !- X,Y,Z Vertex 2 {m}
-  46.3273408626211, 1.62550000000607, 0.0253999999966627, !- X,Y,Z Vertex 3 {m}
-  46.3273406862158, 1.62550000000615, 2.13349999999662; !- X,Y,Z Vertex 4 {m}
+  46.3273, 0.0508000000062577, 2.13349999999656, !- X,Y,Z Vertex 1 {m}
+  46.3273, 0.0508000000061772, 0.0253999999966025, !- X,Y,Z Vertex 2 {m}
+  46.3273, 1.62550000000607, 0.0253999999966627, !- X,Y,Z Vertex 3 {m}
+  46.3273, 1.62550000000615, 2.13349999999662; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {39149afc-8412-4cf6-9fdb-b7671cf27e75}, !- Handle
@@ -3195,10 +3195,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.327341, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  46.327341, 1.676318, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 1.676318, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  46.3273, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  46.3273, 1.6763, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 1.6763, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Output:Meter,
   {fcf53c68-a8b2-4d87-9da1-5081300f1aa9}, !- Handle
@@ -3219,10 +3219,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  -1.63304399336539e-07, 7.619628, 0,     !- X,Y,Z Vertex 3 {m}
-  -1.63304399336539e-07, 7.619628, 3.047851; !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {e1bd7483-b3ca-45f7-a077-89814288befe}, !- Handle
@@ -3236,10 +3236,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.1636701633044, -3.9691078068671e-07, 3.047851, !- X,Y,Z Vertex 1 {m}
-  23.1636701633044, -3.9691078068671e-07, 0, !- X,Y,Z Vertex 2 {m}
-  34.7455054899131, -3.9691078068671e-07, 0, !- X,Y,Z Vertex 3 {m}
-  34.7455054899131, -3.9691078068671e-07, 3.047851; !- X,Y,Z Vertex 4 {m}
+  23.1637, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  23.1637, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  34.7455, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  34.7455, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {16d0e2c8-b3d9-460d-b9a6-f0430ab1508d}, !- Handle
@@ -3253,10 +3253,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {86cd0499-a033-4062-8d70-a2279875a2ec}, !- Handle
@@ -3270,10 +3270,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 1 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {76702075-4def-4826-896f-771ca21d6190}, !- Handle
@@ -3287,10 +3287,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 1.67631824732037, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  0, 1.676318, 0,                         !- X,Y,Z Vertex 2 {m}
-  0, -3.9691078068671e-07, 0,             !- X,Y,Z Vertex 3 {m}
-  0, -3.9691078068671e-07, 3.047851;      !- X,Y,Z Vertex 4 {m}
+  0, 1.6763, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 1.6763, 0,                           !- X,Y,Z Vertex 2 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {c3e60ffa-1992-4ef1-bc27-c17be997af81}, !- Handle
@@ -3321,10 +3321,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {6fd01f23-7167-4a4e-977b-43f8309750da}, !- Handle
@@ -3338,10 +3338,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 1 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {b5f48544-dfff-4cbf-b9eb-ce095bf2a985}, !- Handle
@@ -3355,10 +3355,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {8c1920fe-9292-4fc9-a4db-eae6da22f4cc}, !- Handle
@@ -3372,10 +3372,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -1.63304399336539e-07, 0, 3.047851,     !- X,Y,Z Vertex 1 {m}
-  -1.63304399336539e-07, 0, 0,            !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {287e7e6d-963f-4faa-9c92-5ca8556465c2}, !- Handle
@@ -3389,10 +3389,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  34.7455054899131, 1.67631824732037, 3.047851, !- X,Y,Z Vertex 1 {m}
-  34.7455054899131, 1.67631824732037, 0,  !- X,Y,Z Vertex 2 {m}
-  23.1636701633044, 1.67631824732037, 0,  !- X,Y,Z Vertex 3 {m}
-  23.1636701633044, 1.67631824732037, 3.047851; !- X,Y,Z Vertex 4 {m}
+  34.7455, 1.6763, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  34.7455, 1.6763, 0,                     !- X,Y,Z Vertex 2 {m}
+  23.1637, 1.6763, 0,                     !- X,Y,Z Vertex 3 {m}
+  23.1637, 1.6763, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {2da5ffa2-72af-4994-b7c0-e0130ca16d87}, !- Handle
@@ -3406,10 +3406,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {73b80291-0c26-4ad4-86ff-39ce0ff3320d}, !- Handle
@@ -3423,10 +3423,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {881b6c21-3f1b-469c-a6d3-0ab94ee4c5f0}, !- Handle
@@ -3440,10 +3440,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 0, 3.047851,                         !- X,Y,Z Vertex 1 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {b24f9329-4728-49b7-bbda-cef3fe20c637}, !- Handle
@@ -3457,10 +3457,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.327341, 1.676318, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  46.327341, 1.676318, 0,                 !- X,Y,Z Vertex 2 {m}
-  34.7455053266088, 1.67631824732037, 0,  !- X,Y,Z Vertex 3 {m}
-  34.7455053266088, 1.67631824732037, 3.047851; !- X,Y,Z Vertex 4 {m}
+  46.3273, 1.6763, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  46.3273, 1.6763, 0,                     !- X,Y,Z Vertex 2 {m}
+  34.7455, 1.6763, 0,                     !- X,Y,Z Vertex 3 {m}
+  34.7455, 1.6763, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {41b2e3c5-e83f-42af-9b69-368c3a807697}, !- Handle
@@ -3474,10 +3474,10 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   1,                                      !- Multiplier
   ,                                       !- Number of Vertices
-  11.581835, 1.9049, 2.1732,              !- X,Y,Z Vertex 1 {m}
-  11.581835, 1.9049, 0.954,               !- X,Y,Z Vertex 2 {m}
-  11.581835, 5.7149, 0.954,               !- X,Y,Z Vertex 3 {m}
-  11.581835, 5.7149, 2.1732;              !- X,Y,Z Vertex 4 {m}
+  11.5818, 1.9049, 2.1732,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 1.9049, 0.954,                 !- X,Y,Z Vertex 2 {m}
+  11.5818, 5.7149, 0.954,                 !- X,Y,Z Vertex 3 {m}
+  11.5818, 5.7149, 2.1732;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {3dbd93e7-32e4-4f53-b639-ab0832e6c891}, !- Handle
@@ -3491,10 +3491,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 3.047851;                  !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {237f47e9-942b-4bfc-8e38-d34b101a0b88}, !- Handle
@@ -3508,10 +3508,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {52c84127-ec57-4a89-9285-bd8955f7b657}, !- Handle
@@ -3525,10 +3525,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {0b109f71-d4cc-45c3-b039-71764d46d4d3}, !- Handle
@@ -3542,10 +3542,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 1 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {9ae5d935-056d-4b66-bbc3-992d52fd6f7d}, !- Handle
@@ -3559,10 +3559,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {3dcdb189-9fd1-4c0d-985e-07b309b7dce6}, !- Handle
@@ -3576,10 +3576,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {2b0cc56c-1454-4617-ba61-125ca4e5ae9b}, !- Handle
@@ -3593,10 +3593,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  -1.63304399336539e-07, 7.619628, 0,     !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 3.047851;                  !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {b8ee2181-e3b2-4ab8-af8a-4120fdffdb97}, !- Handle
@@ -3610,10 +3610,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.5818351633044, -3.9691078068671e-07, 3.047851, !- X,Y,Z Vertex 1 {m}
-  11.5818351633044, -3.9691078068671e-07, 0, !- X,Y,Z Vertex 2 {m}
-  23.1636703266088, -3.9691078068671e-07, 0, !- X,Y,Z Vertex 3 {m}
-  23.1636703266088, -3.9691078068671e-07, 3.047851; !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  23.1637, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  23.1637, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {772936a8-54ee-4ead-a5d9-615785de8335}, !- Handle
@@ -3627,10 +3627,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 0, 3.047851,                         !- X,Y,Z Vertex 1 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {68e6e7a1-756e-4412-a08e-a55123509bbb}, !- Handle
@@ -3644,10 +3644,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.5818351633044, 1.67631824732037, 3.047851, !- X,Y,Z Vertex 1 {m}
-  11.5818351633044, 1.67631824732037, 0,  !- X,Y,Z Vertex 2 {m}
-  0, 1.676318, 0,                         !- X,Y,Z Vertex 3 {m}
-  0, 1.676318, 3.047851;                  !- X,Y,Z Vertex 4 {m}
+  11.5818, 1.6763, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 1.6763, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 1.6763, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 1.6763, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {d1b674ab-0acc-4deb-bc48-755a8ad4cd9e}, !- Handle
@@ -3678,10 +3678,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {5f148495-c6a8-4a28-afeb-1a1e6b8ea81f}, !- Handle
@@ -3695,10 +3695,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  -1.63304301636913e-07, 7.619628, 0,     !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 3.047851;                  !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {608daf55-87bf-4e6c-890d-b8673ef911dc}, !- Handle
@@ -3712,10 +3712,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {ca03ccf8-71b9-415e-aa14-de43b4da791b}, !- Handle
@@ -3746,10 +3746,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 0, 3.047851,                         !- X,Y,Z Vertex 1 {m}
-  -1.63304301636913e-07, 0, 0,            !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {2ac605d2-229b-48f2-80ef-680280f90109}, !- Handle
@@ -3763,10 +3763,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.3273404899131, 1.67631824732037, 3.047851, !- X,Y,Z Vertex 1 {m}
-  46.327341, 1.676318, 0,                 !- X,Y,Z Vertex 2 {m}
-  34.7455054899131, 1.67631824732037, 0,  !- X,Y,Z Vertex 3 {m}
-  34.7455054899131, 1.67631824732037, 3.047851; !- X,Y,Z Vertex 4 {m}
+  46.3273, 1.6763, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  46.3273, 1.6763, 0,                     !- X,Y,Z Vertex 2 {m}
+  34.7455, 1.6763, 0,                     !- X,Y,Z Vertex 3 {m}
+  34.7455, 1.6763, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {8e3c24bf-b7ed-4525-bea2-435e8469ba20}, !- Handle
@@ -3780,10 +3780,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  -1.63304399336539e-07, 7.619628, 0,     !- X,Y,Z Vertex 3 {m}
-  -1.63304399336539e-07, 7.619628, 3.047851; !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {5ea7bc0c-45fb-4944-a6be-d73dc3c4576f}, !- Handle
@@ -3797,10 +3797,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.1636703266088, -3.9691078068671e-07, 3.047851, !- X,Y,Z Vertex 1 {m}
-  23.1636703266088, -3.9691078068671e-07, 0, !- X,Y,Z Vertex 2 {m}
-  34.7455054899131, -3.9691078068671e-07, 0, !- X,Y,Z Vertex 3 {m}
-  34.7455054899131, -3.9691078068671e-07, 3.047851; !- X,Y,Z Vertex 4 {m}
+  23.1637, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  23.1637, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  34.7455, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  34.7455, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:HeatBalanceAlgorithm,
   {1dece26d-d2e9-45ee-a6a9-a9c584ed7381}, !- Handle
@@ -3819,10 +3819,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  -1.63304399336539e-07, 7.619628, 0,     !- X,Y,Z Vertex 3 {m}
-  -1.63304399336539e-07, 7.619628, 3.047851; !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {928da7a6-6da5-49c5-b921-883d1c6c7527}, !- Handle
@@ -3836,10 +3836,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.1636703266088, -3.9691078068671e-07, 3.047851, !- X,Y,Z Vertex 1 {m}
-  23.1636703266088, -3.9691078068671e-07, 0, !- X,Y,Z Vertex 2 {m}
-  34.7455054899131, -3.9691078068671e-07, 0, !- X,Y,Z Vertex 3 {m}
-  34.7455054899131, -3.9691078068671e-07, 3.047851; !- X,Y,Z Vertex 4 {m}
+  23.1637, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  23.1637, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  34.7455, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  34.7455, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {62194174-081f-4cf0-97e6-fa8d19a434fc}, !- Handle
@@ -3853,10 +3853,10 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   1,                                      !- Multiplier
   ,                                       !- Number of Vertices
-  46.327341, 0.381, 2.1731,               !- X,Y,Z Vertex 1 {m}
-  46.327341, 0.381, 0.954,                !- X,Y,Z Vertex 2 {m}
-  46.327341, 1.2953, 0.954,               !- X,Y,Z Vertex 3 {m}
-  46.327341, 1.2953, 2.1731;              !- X,Y,Z Vertex 4 {m}
+  46.3273, 0.381, 2.1731,                 !- X,Y,Z Vertex 1 {m}
+  46.3273, 0.381, 0.954,                  !- X,Y,Z Vertex 2 {m}
+  46.3273, 1.2953, 0.954,                 !- X,Y,Z Vertex 3 {m}
+  46.3273, 1.2953, 2.1731;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {6da1a970-a01d-4919-b89d-9ee5fc864ede}, !- Handle
@@ -3870,10 +3870,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {40c22506-4400-4641-9898-b438f3b99abd}, !- Handle
@@ -3887,10 +3887,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {a2d4e737-1919-4fc7-a409-570c4d66d232}, !- Handle
@@ -3921,10 +3921,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {0ea10bb2-1a83-47ce-9eb1-2fb7fd05d986}, !- Handle
@@ -3938,10 +3938,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {af3544a8-454c-4522-b0ae-6770d11d41fb}, !- Handle
@@ -3955,10 +3955,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 1 {m}
-  -1.63304301636913e-07, 7.619628, 0,     !- X,Y,Z Vertex 2 {m}
-  -1.63304301636913e-07, 0, 0,            !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {46b91a49-d5cc-4a47-8849-e84d40345d42}, !- Handle
@@ -3972,10 +3972,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {8907f6af-2052-4773-9da8-7d2085c2f716}, !- Handle
@@ -3989,10 +3989,10 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   1,                                      !- Multiplier
   ,                                       !- Number of Vertices
-  8.686, 7.619628, 2.1732,                !- X,Y,Z Vertex 1 {m}
-  8.686, 7.619628, 0.954,                 !- X,Y,Z Vertex 2 {m}
-  2.89498950131234, 7.619628, 0.954,      !- X,Y,Z Vertex 3 {m}
-  2.89498950131234, 7.619628, 2.1732;     !- X,Y,Z Vertex 4 {m}
+  8.686, 7.6196, 2.1732,                  !- X,Y,Z Vertex 1 {m}
+  8.686, 7.6196, 0.954,                   !- X,Y,Z Vertex 2 {m}
+  2.89498950131234, 7.6196, 0.954,        !- X,Y,Z Vertex 3 {m}
+  2.89498950131234, 7.6196, 2.1732;       !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {6aeccaed-5a77-4560-81d1-ac6a229ba228}, !- Handle
@@ -4006,10 +4006,10 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   1,                                      !- Multiplier
   ,                                       !- Number of Vertices
-  8.686, 7.619628, 2.1732,                !- X,Y,Z Vertex 1 {m}
-  8.686, 7.619628, 0.954,                 !- X,Y,Z Vertex 2 {m}
-  2.89498950131234, 7.619628, 0.954,      !- X,Y,Z Vertex 3 {m}
-  2.89498950131234, 7.619628, 2.1732;     !- X,Y,Z Vertex 4 {m}
+  8.686, 7.6196, 2.1732,                  !- X,Y,Z Vertex 1 {m}
+  8.686, 7.6196, 0.954,                   !- X,Y,Z Vertex 2 {m}
+  2.89498950131234, 7.6196, 0.954,        !- X,Y,Z Vertex 3 {m}
+  2.89498950131234, 7.6196, 2.1732;       !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {9abb6a67-4697-4c5b-b8ef-16dc3a4a680e}, !- Handle
@@ -4023,10 +4023,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 3.047851;                  !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {a5048412-65cd-4699-a9c8-18a8b83c8e48}, !- Handle
@@ -4040,10 +4040,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {c6089f26-f990-4d65-8bbb-9bccbeffe3be}, !- Handle
@@ -4057,10 +4057,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -1.63304399336539e-07, 7.619628, 3.047851, !- X,Y,Z Vertex 1 {m}
-  -1.63304399336539e-07, 7.619628, 0,     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {14020247-2488-4f77-847c-2444299c9f21}, !- Handle
@@ -4074,10 +4074,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 3.047851;                  !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {23f5bcdd-4d96-4b79-aaa3-fa5d4ff54e2f}, !- Handle
@@ -4091,10 +4091,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, -3.9691078068671e-07, 3.047851,      !- X,Y,Z Vertex 1 {m}
-  0, -3.9691078068671e-07, 0,             !- X,Y,Z Vertex 2 {m}
-  11.581835, -3.9691078068671e-07, 0,     !- X,Y,Z Vertex 3 {m}
-  11.581835, -3.9691078068671e-07, 3.047851; !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {12411267-2c07-43b4-8bf0-459c91ceb16b}, !- Handle
@@ -4108,10 +4108,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {517cd48e-a3d9-4002-b8eb-f01f36c6d818}, !- Handle
@@ -4125,10 +4125,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -1.63304399336539e-07, 7.619628, 3.047851, !- X,Y,Z Vertex 1 {m}
-  -1.63304399336539e-07, 7.619628, 0,     !- X,Y,Z Vertex 2 {m}
-  -1.63304399336539e-07, 0, 0,            !- X,Y,Z Vertex 3 {m}
-  -1.63304399336539e-07, 0, 3.047851;     !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {ced355ab-ccf1-48d3-99d6-818e78f2476e}, !- Handle
@@ -4142,10 +4142,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {11565674-4a54-4b56-b376-80434ac0d4dd}, !- Handle
@@ -4159,10 +4159,10 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   1,                                      !- Multiplier
   ,                                       !- Number of Vertices
-  8.686, 7.619628, 2.1732,                !- X,Y,Z Vertex 1 {m}
-  8.686, 7.619628, 0.954,                 !- X,Y,Z Vertex 2 {m}
-  2.89498950131234, 7.619628, 0.954,      !- X,Y,Z Vertex 3 {m}
-  2.89498950131234, 7.619628, 2.1732;     !- X,Y,Z Vertex 4 {m}
+  8.686, 7.6196, 2.1732,                  !- X,Y,Z Vertex 1 {m}
+  8.686, 7.6196, 0.954,                   !- X,Y,Z Vertex 2 {m}
+  2.89498950131234, 7.6196, 0.954,        !- X,Y,Z Vertex 3 {m}
+  2.89498950131234, 7.6196, 2.1732;       !- X,Y,Z Vertex 4 {m}
 
 OS:Facility,
   {a088617f-bd6c-4c3c-8620-c25da6ddb620}; !- Handle

--- a/data/geometry/ASHRAESuperMarket.osm
+++ b/data/geometry/ASHRAESuperMarket.osm
@@ -168,10 +168,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {9871e5b3-040a-44e4-9df8-f5fa1e1e10af}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {cc30f6ab-6b11-467b-9ac6-f27fa0f61a99}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   23.4807, 4.57199999999984, 4.572,       !- X,Y,Z Vertex 1 {m}
@@ -185,10 +185,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {9871e5b3-040a-44e4-9df8-f5fa1e1e10af}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {ca2f05a1-a2bd-48a2-9153-89c97999e6da}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   1.25873118711682e-017, 4.57199999999984, 4.572, !- X,Y,Z Vertex 1 {m}
@@ -251,10 +251,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {0f799d38-5e12-4224-a2f6-65f846eb1148}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {39c15528-345e-45ac-b158-66756973609d}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   1.06465271808986e-016, 43.8197999999998, 4.572, !- X,Y,Z Vertex 1 {m}
@@ -285,10 +285,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {0f799d38-5e12-4224-a2f6-65f846eb1148}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {45a6d2ff-634c-4124-9381-0a5008ab5137}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   8.19169458172421e-017, 4.57199999999984, 4.572, !- X,Y,Z Vertex 1 {m}
@@ -402,10 +402,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {403f025b-298f-491c-a18a-1bbad23b565c}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {94aaca25-d5ce-45d4-8879-ebafdd3e303d}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   29.5767, 4.57199999999984, 4.572,       !- X,Y,Z Vertex 1 {m}
@@ -536,10 +536,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {27cc4560-6291-4c1f-b14c-c4f5c6d2b6e7}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {83ca7553-a425-4e10-b748-ac025bcea02c}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   53.0574, 4.57199999999984, 4.57199999999999, !- X,Y,Z Vertex 1 {m}
@@ -553,10 +553,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {27cc4560-6291-4c1f-b14c-c4f5c6d2b6e7}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {cbd1d764-f9b9-4bcc-bf58-0cd93bdb6c3c}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   53.0574, 1.82093990566872e-015, 4.57199999999999, !- X,Y,Z Vertex 1 {m}
@@ -670,10 +670,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {027a0cdc-6550-4760-91ae-c3f5379af193}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {05e52492-8e20-42a9-97f4-72c244e07fbd}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   53.0574, 4.57199999999984, 4.572,       !- X,Y,Z Vertex 1 {m}
@@ -770,10 +770,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {0fd60f7d-ee76-49e8-8ff8-533766628f82}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {04c7a1a7-94a7-4401-89e2-84f28f38ad30}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   7.37341704866608e-017, 43.8197999999998, 4.572, !- X,Y,Z Vertex 1 {m}
@@ -787,10 +787,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {0fd60f7d-ee76-49e8-8ff8-533766628f82}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {8dbd9195-13b2-4fec-a680-c9d0e67f8f4c}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   15.9211, 43.8197999999998, 4.572,       !- X,Y,Z Vertex 1 {m}
@@ -804,10 +804,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {0fd60f7d-ee76-49e8-8ff8-533766628f82}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {ae4bd153-24b9-4f2b-8c40-2777d85cc1ae}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   53.0574, 21.1184999999998, 4.572,       !- X,Y,Z Vertex 1 {m}
@@ -821,10 +821,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {0fd60f7d-ee76-49e8-8ff8-533766628f82}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {8bc8cf51-4ddd-4a8a-b0e9-12969a554249}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   29.5767, 4.57199999999984, 4.572,       !- X,Y,Z Vertex 1 {m}
@@ -887,10 +887,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {02a20178-5cec-4076-8aed-244e2d3a36c6}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {9ed1c977-dbf6-43ee-8dca-5e1b1dcad969}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   62.9555, 43.8197999999998, 4.57199999999997, !- X,Y,Z Vertex 1 {m}
@@ -904,10 +904,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {02a20178-5cec-4076-8aed-244e2d3a36c6}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {bb3a51da-60c7-497f-b289-f56f9b0ce096}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   53.0574, 43.8197999999998, 4.57199999999998, !- X,Y,Z Vertex 1 {m}
@@ -987,10 +987,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e49a5709-1d20-4e6a-9a0e-227ee997614f}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {b47087bd-ed4a-4f56-a76e-bdcd8e373a53}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   15.9211, 45.3564999999998, 4.57199999999997, !- X,Y,Z Vertex 1 {m}
@@ -1055,10 +1055,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e49a5709-1d20-4e6a-9a0e-227ee997614f}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {5bbadb78-ba61-4d27-89df-4b57c7867d38}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   53.0574, 43.8197999999998, 4.57199999999999, !- X,Y,Z Vertex 1 {m}
@@ -1104,10 +1104,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d856eb50-0aea-4645-9879-1b42620e7dc0}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {567f0fc0-f34e-49fc-a8eb-0e37671ab03b}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   -12.4919, 45.3564999999998, 4.57199999999992, !- X,Y,Z Vertex 1 {m}
@@ -1138,10 +1138,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d856eb50-0aea-4645-9879-1b42620e7dc0}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {8cd47b03-c056-4b81-aeb1-12e7630c1d02}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   1.06465271808984e-016, 43.8197999999998, 4.57199999999992, !- X,Y,Z Vertex 1 {m}
@@ -1172,10 +1172,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d856eb50-0aea-4645-9879-1b42620e7dc0}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {fc3499fd-4ab8-46c3-babc-d977059d3882}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   15.9211, 43.8197999999998, 4.57199999999992, !- X,Y,Z Vertex 1 {m}
@@ -1272,10 +1272,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f3162082-eda4-4375-8ef5-d49ffc070545}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {f8c699a4-0a9f-4393-80fe-86e47e7847b0}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   15.9211, 45.3564999999998, 4.57199999999997, !- X,Y,Z Vertex 1 {m}
@@ -1289,10 +1289,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f3162082-eda4-4375-8ef5-d49ffc070545}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {40961984-fc31-498e-9f76-19d825533ac1}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   8.42809999999998, 45.3564999999998, 4.57199999999997, !- X,Y,Z Vertex 1 {m}
@@ -1406,10 +1406,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {b39118ad-8025-406a-bd98-a3296de4495f}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {225b9589-d9b4-4e5f-8730-5a4098b03192}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   -0.00147500000000655, 45.3564999999998, 4.57199999999998, !- X,Y,Z Vertex 1 {m}
@@ -1523,10 +1523,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {924465bf-33f6-40f8-b618-98b028c09193}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {5199c356-0c9b-462b-815e-8e39e1c50346}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   -6.24670000000001, 45.3564999999998, 4.57199999999998, !- X,Y,Z Vertex 1 {m}
@@ -1606,10 +1606,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {7ea97877-f957-4cb1-abcf-6afbcfc66d5e}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {0baee146-05eb-43fb-88ac-227dc1eb002a}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   -12.4919, 45.3564999999998, 4.57199999999998, !- X,Y,Z Vertex 1 {m}
@@ -1757,10 +1757,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {37d6525f-e4c5-4606-bcf6-d3716d739007}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {00e7a68f-4d45-4211-a43f-ad3099780eda}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   -16.2338, 45.3564999999998, 4.57199999999998, !- X,Y,Z Vertex 1 {m}
@@ -1774,10 +1774,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e49a5709-1d20-4e6a-9a0e-227ee997614f}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {8a28a781-590c-4c1c-b3c0-8cc99d8a24df}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   15.9211, 43.8197999999998, 4.57199999999999, !- X,Y,Z Vertex 1 {m}
@@ -1791,10 +1791,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e49a5709-1d20-4e6a-9a0e-227ee997614f}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {d4b047d6-8c26-4f9d-8e04-542d97518490}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   15.9211, 52.7954999999998, 4.57199999999999, !- X,Y,Z Vertex 1 {m}
@@ -1808,10 +1808,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d856eb50-0aea-4645-9879-1b42620e7dc0}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {3e7a79c5-ba48-4346-9fcd-41743c54ca21}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   8.42809999999998, 45.3564999999998, 4.57199999999997, !- X,Y,Z Vertex 1 {m}
@@ -1825,10 +1825,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d856eb50-0aea-4645-9879-1b42620e7dc0}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {ac0ce12f-188b-4571-9afa-1b8a94e4a842}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   -6.24670000000001, 45.3564999999998, 4.57199999999998, !- X,Y,Z Vertex 1 {m}
@@ -1842,10 +1842,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d856eb50-0aea-4645-9879-1b42620e7dc0}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {efcc3f09-ccd9-4e3d-8daf-d600378b6bed}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   15.9211, 45.3564999999998, 4.57199999999991, !- X,Y,Z Vertex 1 {m}
@@ -1859,10 +1859,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d856eb50-0aea-4645-9879-1b42620e7dc0}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {6b50ef9f-eb3b-4f5f-bccb-c4ac9e48b600}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   -0.00147500000000655, 45.3564999999998, 4.57199999999992, !- X,Y,Z Vertex 1 {m}
@@ -1876,10 +1876,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d856eb50-0aea-4645-9879-1b42620e7dc0}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {b704588a-eedd-4cb2-a229-24f26120554c}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   -16.2338, 43.8197999999998, 4.57199999999992, !- X,Y,Z Vertex 1 {m}
@@ -1893,10 +1893,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {0fd60f7d-ee76-49e8-8ff8-533766628f82}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {075fe905-f3fb-46fd-beac-c788ce0e4b59}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   23.4807, 4.57199999999984, 4.572,       !- X,Y,Z Vertex 1 {m}
@@ -1910,10 +1910,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {0fd60f7d-ee76-49e8-8ff8-533766628f82}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {8e09faea-b97e-487d-acd0-d8e97fd38ade}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   53.0574, 4.57199999999984, 4.572,       !- X,Y,Z Vertex 1 {m}
@@ -1927,10 +1927,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {0fd60f7d-ee76-49e8-8ff8-533766628f82}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {e1c39006-1ee1-4a56-9416-1453b51240f7}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   53.0574, 43.8197999999998, 4.572,       !- X,Y,Z Vertex 1 {m}
@@ -1944,10 +1944,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {0fd60f7d-ee76-49e8-8ff8-533766628f82}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {8d613320-1876-4a18-9083-6c630fddcd43}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   7.37341704866608e-017, 4.57199999999984, 4.572, !- X,Y,Z Vertex 1 {m}
@@ -1961,10 +1961,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {027a0cdc-6550-4760-91ae-c3f5379af193}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {054641de-6b49-4e29-9178-f658c23cfb41}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   53.0574, 21.1184999999998, 4.572,       !- X,Y,Z Vertex 1 {m}
@@ -1978,10 +1978,10 @@ OS:Surface,
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {0f799d38-5e12-4224-a2f6-65f846eb1148}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {b778e4c0-40db-47f0-b31f-5d3d1800674f}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   9.82824964784047e-017, 5.29316363196444e-017, 4.572, !- X,Y,Z Vertex 1 {m}

--- a/data/geometry/DOERefMidriseApartment.osm
+++ b/data/geometry/DOERefMidriseApartment.osm
@@ -32,9 +32,9 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
-  34.7455054899131,                       !- X Origin {m}
+  34.7455,                                !- X Origin {m}
   0,                                      !- Y Origin {m}
-  9.14355407629293,                       !- Z Origin {m}
+  9.1436,                                 !- Z Origin {m}
   {7a967551-5561-4b56-b05a-af0754ca7895}, !- Building Story Name
   {d488cb92-552f-458c-b7a1-bfc62115ba2b}; !- Thermal Zone Name
 
@@ -46,7 +46,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  7.61962839691078,                       !- Y Origin {m}
+  7.6196,                                 !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {adca533c-0468-407c-b890-d518ccf74735}, !- Building Story Name
   {623c2ede-649f-43bc-892f-8ef2e416714f}; !- Thermal Zone Name
@@ -80,10 +80,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 1 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {66195dd7-4158-483d-b874-3388a680b571}, !- Handle
@@ -94,7 +94,7 @@ OS:Space,
   0,                                      !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
   0,                                      !- Y Origin {m}
-  9.14355407629293,                       !- Z Origin {m}
+  9.1436,                                 !- Z Origin {m}
   {7a967551-5561-4b56-b05a-af0754ca7895}, !- Building Story Name
   {b9c75708-2d22-4595-80d4-8a0f68150303}; !- Thermal Zone Name
 
@@ -110,10 +110,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {6912ab22-717f-4315-a8ff-9c62dd3bb665}, !- Handle
@@ -122,9 +122,9 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
-  23.1636703266088,                       !- X Origin {m}
+  23.1637,                                !- X Origin {m}
   0,                                      !- Y Origin {m}
-  3.04785135876431,                       !- Z Origin {m}
+  3.0479,                                 !- Z Origin {m}
   {271f3401-76be-4edd-8369-7d5a808299e2}, !- Building Story Name
   {4a48168f-73de-4c04-a40a-b8a18d185b7f}; !- Thermal Zone Name
 
@@ -135,9 +135,9 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
-  34.7455054899131,                       !- X Origin {m}
+  34.7455,                                !- X Origin {m}
   0,                                      !- Y Origin {m}
-  3.04785135876431,                       !- Z Origin {m}
+  3.0479,                                 !- Z Origin {m}
   {271f3401-76be-4edd-8369-7d5a808299e2}, !- Building Story Name
   {020188ba-5065-4680-b6f0-5da34ddbb98a}; !- Thermal Zone Name
 
@@ -153,10 +153,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -1.63304301636913e-07, 7.619628, 3.047851, !- X,Y,Z Vertex 1 {m}
-  -1.63304301636913e-07, 7.619628, 0,     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {fdb38349-a07f-4613-871c-2a0d97c95f4f}, !- Handle
@@ -170,10 +170,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 0, 3.047851,                         !- X,Y,Z Vertex 1 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {22d8b173-d774-48ce-9aac-7d6a7840f33f}, !- Handle
@@ -182,9 +182,9 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
-  11.5818351633044,                       !- X Origin {m}
-  9.29594664423115,                       !- Y Origin {m}
-  9.14355407629293,                       !- Z Origin {m}
+  11.5818,                                !- X Origin {m}
+  9.2959,                                 !- Y Origin {m}
+  9.1436,                                 !- Z Origin {m}
   {7a967551-5561-4b56-b05a-af0754ca7895}, !- Building Story Name
   {0f1f6080-513c-478d-b579-82fe7dd48a72}; !- Thermal Zone Name
 
@@ -196,8 +196,8 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   ,                                       !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  7.61962839691078,                       !- Y Origin {m}
-  9.14355407629293,                       !- Z Origin {m}
+  7.6196,                                 !- Y Origin {m}
+  9.1436,                                 !- Z Origin {m}
   {7a967551-5561-4b56-b05a-af0754ca7895}, !- Building Story Name
   {5355740a-64f7-4413-b7ff-309f94ec0f7d}; !- Thermal Zone Name
 
@@ -213,10 +213,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.1636701633044, 1.67631824732037, 3.047851, !- X,Y,Z Vertex 1 {m}
-  23.1636701633044, 1.67631824732037, 0,  !- X,Y,Z Vertex 2 {m}
-  11.5818351633044, 1.67631824732037, 0,  !- X,Y,Z Vertex 3 {m}
-  11.5818351633044, 1.67631824732037, 3.047851; !- X,Y,Z Vertex 4 {m}
+  23.1637, 1.6763, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  23.1637, 1.6763, 0,                     !- X,Y,Z Vertex 2 {m}
+  11.5818, 1.6763, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 1.6763, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {9167359e-9688-41e4-ae83-b41424807596}, !- Handle
@@ -225,9 +225,9 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
-  23.1636703266088,                       !- X Origin {m}
-  9.29594664423115,                       !- Y Origin {m}
-  9.14355407629293,                       !- Z Origin {m}
+  23.1637,                                !- X Origin {m}
+  9.2959,                                 !- Y Origin {m}
+  9.1436,                                 !- Z Origin {m}
   {7a967551-5561-4b56-b05a-af0754ca7895}, !- Building Story Name
   {30cda89d-c5e7-4017-a8fd-53e389f7bdf7}; !- Thermal Zone Name
 
@@ -243,10 +243,10 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   1,                                      !- Multiplier
   ,                                       !- Number of Vertices
-  8.686, 7.619628, 2.1732,                !- X,Y,Z Vertex 1 {m}
-  8.686, 7.619628, 0.954,                 !- X,Y,Z Vertex 2 {m}
-  2.89498950131234, 7.619628, 0.954,      !- X,Y,Z Vertex 3 {m}
-  2.89498950131234, 7.619628, 2.1732;     !- X,Y,Z Vertex 4 {m}
+  8.686, 7.6196, 2.1732,                  !- X,Y,Z Vertex 1 {m}
+  8.686, 7.6196, 0.954,                   !- X,Y,Z Vertex 2 {m}
+  2.89498950131234, 7.6196, 0.954,        !- X,Y,Z Vertex 3 {m}
+  2.89498950131234, 7.6196, 2.1732;       !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {0464b6fc-0025-4ea5-80cb-899a8d9af70c}, !- Handle
@@ -260,10 +260,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 3.047851;                  !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {7c013759-803b-46ae-9919-4e21adf7c78d}, !- Handle
@@ -274,7 +274,7 @@ OS:Space,
   0,                                      !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
   0,                                      !- Y Origin {m}
-  3.04785135876431,                       !- Z Origin {m}
+  3.0479,                                 !- Z Origin {m}
   {271f3401-76be-4edd-8369-7d5a808299e2}, !- Building Story Name
   {4a329905-de5e-494f-8931-fee8c5f3df9b}; !- Thermal Zone Name
 
@@ -290,10 +290,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {0fe08715-548f-4b65-befe-40ea29ebf953}, !- Handle
@@ -303,8 +303,8 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  9.29594664423115,                       !- Y Origin {m}
-  9.14355407629293,                       !- Z Origin {m}
+  9.2959,                                 !- Y Origin {m}
+  9.1436,                                 !- Z Origin {m}
   {7a967551-5561-4b56-b05a-af0754ca7895}, !- Building Story Name
   {2df663ad-5d5a-4867-bdcc-066715e68801}; !- Thermal Zone Name
 
@@ -320,10 +320,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.327341, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  46.327341, 1.676318, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 1.676318, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  46.3273, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  46.3273, 1.6763, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 1.6763, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {fec56cd7-1bb5-4bb0-8e3b-dab87b5a2de0}, !- Handle
@@ -333,8 +333,8 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   ,                                       !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  7.61962839691078,                       !- Y Origin {m}
-  3.04785135876431,                       !- Z Origin {m}
+  7.6196,                                 !- Y Origin {m}
+  3.0479,                                 !- Z Origin {m}
   {271f3401-76be-4edd-8369-7d5a808299e2}, !- Building Story Name
   {cb484884-90ac-4f1d-b1c6-2ffb06d28e0e}; !- Thermal Zone Name
 
@@ -350,10 +350,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 0, 3.047851,                         !- X,Y,Z Vertex 1 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {3f1c5090-169e-4dca-b8f2-31c064cffb7d}, !- Handle
@@ -362,7 +362,7 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
-  11.5818351633044,                       !- X Origin {m}
+  11.5818,                                !- X Origin {m}
   0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {adca533c-0468-407c-b890-d518ccf74735}, !- Building Story Name
@@ -380,10 +380,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {695f347d-e36c-4348-b06b-48f78bb2529b}, !- Handle
@@ -392,7 +392,7 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
-  23.1636703266088,                       !- X Origin {m}
+  23.1637,                                !- X Origin {m}
   0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {adca533c-0468-407c-b890-d518ccf74735}, !- Building Story Name
@@ -410,10 +410,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -1.63304399336539e-07, 7.619628, 3.047851, !- X,Y,Z Vertex 1 {m}
-  -1.63304399336539e-07, 7.619628, 0,     !- X,Y,Z Vertex 2 {m}
-  -1.63304399336539e-07, 0, 0,            !- X,Y,Z Vertex 3 {m}
-  -1.63304399336539e-07, 0, 3.047851;     !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {14098aef-319d-416c-a469-3b909122a632}, !- Handle
@@ -427,10 +427,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {d70594d1-39e9-4527-baca-7be02e206c76}, !- Handle
@@ -444,10 +444,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 3.047851;                  !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {f025dc15-ffd2-401c-a986-d4284339a97c}, !- Handle
@@ -461,10 +461,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 0, 3.047851,                         !- X,Y,Z Vertex 1 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
-  11.5818351633044, -3.9691078068671e-07, 0, !- X,Y,Z Vertex 3 {m}
-  11.5818351633044, -3.9691078068671e-07, 3.047851; !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {e339bfd6-0b62-4f74-861b-a1bc50f642b6}, !- Handle
@@ -478,10 +478,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {0038fd5f-f228-4b0a-a724-e0084dd5bbd8}, !- Handle
@@ -490,9 +490,9 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
-  34.7455054899131,                       !- X Origin {m}
-  9.29594664423115,                       !- Y Origin {m}
-  3.04785135876431,                       !- Z Origin {m}
+  34.7455,                                !- X Origin {m}
+  9.2959,                                 !- Y Origin {m}
+  3.0479,                                 !- Z Origin {m}
   {271f3401-76be-4edd-8369-7d5a808299e2}, !- Building Story Name
   {188f9e65-dcd6-4588-8381-2d826bdeec39}; !- Thermal Zone Name
 
@@ -508,10 +508,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {d94f0b48-364b-4bd9-83bf-e9b13823aa40}, !- Handle
@@ -520,9 +520,9 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
-  34.7455054899131,                       !- X Origin {m}
-  9.29594664423115,                       !- Y Origin {m}
-  9.14355407629293,                       !- Z Origin {m}
+  34.7455,                                !- X Origin {m}
+  9.2959,                                 !- Y Origin {m}
+  9.1436,                                 !- Z Origin {m}
   {7a967551-5561-4b56-b05a-af0754ca7895}, !- Building Story Name
   {e3834db8-d7c8-4401-8fea-17e93733ad4a}; !- Thermal Zone Name
 
@@ -534,7 +534,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  9.29594664423115,                       !- Y Origin {m}
+  9.2959,                                 !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {adca533c-0468-407c-b890-d518ccf74735}, !- Building Story Name
   {96a975fe-e07c-4cee-9da9-414bc502094c}; !- Thermal Zone Name
@@ -546,9 +546,9 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
-  11.5818351633044,                       !- X Origin {m}
+  11.5818,                                !- X Origin {m}
   0,                                      !- Y Origin {m}
-  9.14355407629293,                       !- Z Origin {m}
+  9.1436,                                 !- Z Origin {m}
   {7a967551-5561-4b56-b05a-af0754ca7895}, !- Building Story Name
   {7d281d86-c33a-4123-8f68-4d64504bfd1e}; !- Thermal Zone Name
 
@@ -559,9 +559,9 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
-  11.5818351633044,                       !- X Origin {m}
-  9.29594664423115,                       !- Y Origin {m}
-  3.04785135876431,                       !- Z Origin {m}
+  11.5818,                                !- X Origin {m}
+  9.2959,                                 !- Y Origin {m}
+  3.0479,                                 !- Z Origin {m}
   {271f3401-76be-4edd-8369-7d5a808299e2}, !- Building Story Name
   {aeef2340-5ece-48db-9e5e-ce03eb1235b3}; !- Thermal Zone Name
 
@@ -572,7 +572,7 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
-  34.7455054899131,                       !- X Origin {m}
+  34.7455,                                !- X Origin {m}
   0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {adca533c-0468-407c-b890-d518ccf74735}, !- Building Story Name
@@ -590,10 +590,10 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   1,                                      !- Multiplier
   ,                                       !- Number of Vertices
-  8.686, 7.619628, 2.1732,                !- X,Y,Z Vertex 1 {m}
-  8.686, 7.619628, 0.954,                 !- X,Y,Z Vertex 2 {m}
-  2.89498950131234, 7.619628, 0.954,      !- X,Y,Z Vertex 3 {m}
-  2.89498950131234, 7.619628, 2.1732;     !- X,Y,Z Vertex 4 {m}
+  8.686, 7.6196, 2.1732,                  !- X,Y,Z Vertex 1 {m}
+  8.686, 7.6196, 0.954,                   !- X,Y,Z Vertex 2 {m}
+  2.89498950131234, 7.6196, 0.954,        !- X,Y,Z Vertex 3 {m}
+  2.89498950131234, 7.6196, 2.1732;       !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {acec2d78-fb19-4e60-af60-27e9bec82ddb}, !- Handle
@@ -607,10 +607,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 3.047851;                  !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {2474fa55-e493-4710-b009-0cdaa0c1a981}, !- Handle
@@ -624,10 +624,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {6630228a-e074-4b5a-815a-de9c195b4f85}, !- Handle
@@ -636,8 +636,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
-  34.7455054899131,                       !- X Origin {m}
-  9.29594664423115,                       !- Y Origin {m}
+  34.7455,                                !- X Origin {m}
+  9.2959,                                 !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {adca533c-0468-407c-b890-d518ccf74735}, !- Building Story Name
   {b9a531da-0d4e-4e0b-9f92-7ba262e97278}; !- Thermal Zone Name
@@ -671,10 +671,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 0, 3.047851,                         !- X,Y,Z Vertex 1 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {c43f7335-3ac7-490e-9b49-890ffac7f0d6}, !- Handle
@@ -683,9 +683,9 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
-  23.1636703266088,                       !- X Origin {m}
+  23.1637,                                !- X Origin {m}
   0,                                      !- Y Origin {m}
-  9.14355407629293,                       !- Z Origin {m}
+  9.1436,                                 !- Z Origin {m}
   {7a967551-5561-4b56-b05a-af0754ca7895}, !- Building Story Name
   {2fa59ca2-45b2-475e-8587-608186ce840a}; !- Thermal Zone Name
 
@@ -714,10 +714,10 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   1,                                      !- Multiplier
   ,                                       !- Number of Vertices
-  8.686, 7.619628, 2.1732,                !- X,Y,Z Vertex 1 {m}
-  8.686, 7.619628, 0.954,                 !- X,Y,Z Vertex 2 {m}
-  2.89498950131234, 7.619628, 0.954,      !- X,Y,Z Vertex 3 {m}
-  2.89498950131234, 7.619628, 2.1732;     !- X,Y,Z Vertex 4 {m}
+  8.686, 7.6196, 2.1732,                  !- X,Y,Z Vertex 1 {m}
+  8.686, 7.6196, 0.954,                   !- X,Y,Z Vertex 2 {m}
+  2.89498950131234, 7.6196, 0.954,        !- X,Y,Z Vertex 3 {m}
+  2.89498950131234, 7.6196, 2.1732;       !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {fee4e034-e583-42cb-a68f-da971eb2a504}, !- Handle
@@ -731,10 +731,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  -1.63304399336539e-07, 7.619628, 0,     !- X,Y,Z Vertex 3 {m}
-  -1.63304399336539e-07, 7.619628, 3.047851; !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {5c7ad500-0f3b-486f-9052-f98babde7c3f}, !- Handle
@@ -743,9 +743,9 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
-  23.1636703266088,                       !- X Origin {m}
-  9.29594664423115,                       !- Y Origin {m}
-  3.04785135876431,                       !- Z Origin {m}
+  23.1637,                                !- X Origin {m}
+  9.2959,                                 !- Y Origin {m}
+  3.0479,                                 !- Z Origin {m}
   {271f3401-76be-4edd-8369-7d5a808299e2}, !- Building Story Name
   {ae16cd79-19cc-4315-a036-df10c3eee92e}; !- Thermal Zone Name
 
@@ -761,10 +761,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 3.047851;                  !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {d5e79dcd-d6de-49ea-bd40-36d0e0890630}, !- Handle
@@ -778,10 +778,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.327341, 1.676318, 0,                 !- X,Y,Z Vertex 1 {m}
-  46.327341, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  46.3273, 1.6763, 0,                     !- X,Y,Z Vertex 1 {m}
+  46.3273, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 1.676318, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 1.6763, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {95295c9e-17f2-4ee1-872c-772c6b0afbab}, !- Handle
@@ -795,10 +795,10 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   1,                                      !- Multiplier
   ,                                       !- Number of Vertices
-  8.686, 7.619628, 2.1732,                !- X,Y,Z Vertex 1 {m}
-  8.686, 7.619628, 0.954,                 !- X,Y,Z Vertex 2 {m}
-  2.89498950131234, 7.619628, 0.954,      !- X,Y,Z Vertex 3 {m}
-  2.89498950131234, 7.619628, 2.1732;     !- X,Y,Z Vertex 4 {m}
+  8.686, 7.6196, 2.1732,                  !- X,Y,Z Vertex 1 {m}
+  8.686, 7.6196, 0.954,                   !- X,Y,Z Vertex 2 {m}
+  2.89498950131234, 7.6196, 0.954,        !- X,Y,Z Vertex 3 {m}
+  2.89498950131234, 7.6196, 2.1732;       !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {046d83cc-62cd-44ec-a21f-b10efa3109b4}, !- Handle
@@ -812,10 +812,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 3.047851;                  !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {4834aa70-7bab-448d-bb6a-90d87c21dd3a}, !- Handle
@@ -829,10 +829,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -1.63304399336539e-07, 0, 3.047851,     !- X,Y,Z Vertex 1 {m}
-  -1.63304399336539e-07, 0, 0,            !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {c604a7fc-75c5-4c12-aac1-a25d32baac6e}, !- Handle
@@ -846,10 +846,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {ce26f5cd-65b0-45e8-a387-a4885dbe55dd}, !- Handle
@@ -880,10 +880,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 1 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {9922a5a5-bd1e-44c4-afea-f3b3deb36d4f}, !- Handle
@@ -897,10 +897,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {656acd56-e898-40e0-8ffe-95e3c2336bc7}, !- Handle
@@ -909,8 +909,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
-  11.5818351633044,                       !- X Origin {m}
-  9.29594664423115,                       !- Y Origin {m}
+  11.5818,                                !- X Origin {m}
+  9.2959,                                 !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {adca533c-0468-407c-b890-d518ccf74735}, !- Building Story Name
   {96aaf9e9-a334-4880-91c9-f3013e20b8d3}; !- Thermal Zone Name
@@ -927,10 +927,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -1.63304399336539e-07, 7.619628, 3.047851, !- X,Y,Z Vertex 1 {m}
-  -1.63304399336539e-07, 7.619628, 0,     !- X,Y,Z Vertex 2 {m}
-  -1.63304399336539e-07, 0, 0,            !- X,Y,Z Vertex 3 {m}
-  -1.63304399336539e-07, 0, 3.047851;     !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {ca421e4e-b3a1-4307-b10c-eebccdb88991}, !- Handle
@@ -944,10 +944,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {26154c94-49af-490b-8d3e-6c5673ae8961}, !- Handle
@@ -961,10 +961,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -1.63304301636913e-07, 7.619628, 3.047851, !- X,Y,Z Vertex 1 {m}
-  -1.63304301636913e-07, 7.619628, 0,     !- X,Y,Z Vertex 2 {m}
-  -1.63304301636913e-07, 0, 0,            !- X,Y,Z Vertex 3 {m}
-  -1.63304301636913e-07, 0, 3.047851;     !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {60223897-f4da-42ad-a2bb-5820651546af}, !- Handle
@@ -978,10 +978,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.327341, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  46.327341, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  46.327341, 1.676318, 0,                 !- X,Y,Z Vertex 3 {m}
-  46.327341, 1.676318, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  46.3273, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  46.3273, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  46.3273, 1.6763, 0,                     !- X,Y,Z Vertex 3 {m}
+  46.3273, 1.6763, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {da0582e0-c615-4686-846f-5fa728e7e69d}, !- Handle
@@ -1012,10 +1012,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 0, 3.047851,                         !- X,Y,Z Vertex 1 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {4db869d3-2221-499c-b634-035d0d161b35}, !- Handle
@@ -1029,10 +1029,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 0, 3.047851,                         !- X,Y,Z Vertex 1 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Output:Meter,
   {29f7895e-ac0c-4623-926d-975974086e4e}, !- Handle
@@ -1048,8 +1048,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
-  23.1636703266088,                       !- X Origin {m}
-  9.29594664423115,                       !- Y Origin {m}
+  23.1637,                                !- X Origin {m}
+  9.2959,                                 !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {adca533c-0468-407c-b890-d518ccf74735}, !- Building Story Name
   {b794cfbb-716a-4aa1-b1a4-7c94e245c179}; !- Thermal Zone Name
@@ -1066,10 +1066,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  -1.63304301636913e-07, 7.619628, 0,     !- X,Y,Z Vertex 3 {m}
-  -1.63304301636913e-07, 7.619628, 3.047851; !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {064f3759-a4a1-4253-9ad0-9ab203f7738d}, !- Handle
@@ -1083,10 +1083,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  34.7455054899131, -3.9691078068671e-07, 3.047851, !- X,Y,Z Vertex 1 {m}
-  34.7455054899131, -3.9691078068671e-07, 0, !- X,Y,Z Vertex 2 {m}
-  46.3273404899131, -3.9691078068671e-07, 0, !- X,Y,Z Vertex 3 {m}
-  46.3273404899131, -3.9691078068671e-07, 3.047851; !- X,Y,Z Vertex 4 {m}
+  34.7455, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  34.7455, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  46.3273, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  46.3273, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Building,
   {761ed503-73d7-48c5-8197-2a7009e22170}, !- Handle
@@ -1111,9 +1111,9 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
-  11.5818351633044,                       !- X Origin {m}
+  11.5818,                                !- X Origin {m}
   0,                                      !- Y Origin {m}
-  3.04785135876431,                       !- Z Origin {m}
+  3.0479,                                 !- Z Origin {m}
   {271f3401-76be-4edd-8369-7d5a808299e2}, !- Building Story Name
   {8034a3e3-15df-445b-ad23-d83b38062d6a}; !- Thermal Zone Name
 
@@ -1129,10 +1129,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {9bc8f935-cc7d-467e-95a2-473d08a7beb3}, !- Handle
@@ -1146,10 +1146,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.327341, 1.676318, 0,                 !- X,Y,Z Vertex 1 {m}
-  46.327341, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  46.3273, 1.6763, 0,                     !- X,Y,Z Vertex 1 {m}
+  46.3273, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 1.676318, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 1.6763, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {685992b0-44ad-47d5-b7f8-0ed36982b7ad}, !- Handle
@@ -1180,10 +1180,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 1 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {716b6360-a915-4a30-b1c8-ec181c534c51}, !- Handle
@@ -1197,10 +1197,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  -1.63304301636913e-07, 7.619628, 0,     !- X,Y,Z Vertex 3 {m}
-  -1.63304301636913e-07, 7.619628, 3.047851; !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {bc24c062-0ad7-4301-a61b-d50a7be3035f}, !- Handle
@@ -1214,10 +1214,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  34.7455054899131, -3.9691078068671e-07, 3.047851, !- X,Y,Z Vertex 1 {m}
-  34.7455054899131, -3.9691078068671e-07, 0, !- X,Y,Z Vertex 2 {m}
-  46.327341, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  46.327341, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  34.7455, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  34.7455, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  46.3273, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  46.3273, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {adb10805-b9f8-461d-9a8e-200d436b3ab3}, !- Handle
@@ -1231,10 +1231,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {c50c13d9-9cc1-43b4-a1b5-c8006d7d3014}, !- Handle
@@ -1248,10 +1248,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {32d2e447-31a9-4381-88cc-71b272037fc1}, !- Handle
@@ -1265,10 +1265,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Output:Meter,
   {a822ff24-e4e3-4c6b-8a4e-4fe82b0bb29b}, !- Handle
@@ -1289,10 +1289,10 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   1,                                      !- Multiplier
   ,                                       !- Number of Vertices
-  11.581835, 1.9049, 2.1732,              !- X,Y,Z Vertex 1 {m}
-  11.581835, 1.9049, 0.954,               !- X,Y,Z Vertex 2 {m}
-  11.581835, 5.7149, 0.954,               !- X,Y,Z Vertex 3 {m}
-  11.581835, 5.7149, 2.1732;              !- X,Y,Z Vertex 4 {m}
+  11.5818, 1.9049, 2.1732,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 1.9049, 0.954,                 !- X,Y,Z Vertex 2 {m}
+  11.5818, 5.7149, 0.954,                 !- X,Y,Z Vertex 3 {m}
+  11.5818, 5.7149, 2.1732;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {179af04c-9de7-4777-bfb2-e88c98794834}, !- Handle
@@ -1306,10 +1306,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {46903d54-4518-4e75-8031-146e60314b95}, !- Handle
@@ -1323,10 +1323,10 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   1,                                      !- Multiplier
   ,                                       !- Number of Vertices
-  11.581835, 1.9049, 2.1732,              !- X,Y,Z Vertex 1 {m}
-  11.581835, 1.9049, 0.954,               !- X,Y,Z Vertex 2 {m}
-  11.581835, 5.7149, 0.954,               !- X,Y,Z Vertex 3 {m}
-  11.581835, 5.7149, 2.1732;              !- X,Y,Z Vertex 4 {m}
+  11.5818, 1.9049, 2.1732,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 1.9049, 0.954,                 !- X,Y,Z Vertex 2 {m}
+  11.5818, 5.7149, 0.954,                 !- X,Y,Z Vertex 3 {m}
+  11.5818, 5.7149, 2.1732;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {6052717a-b449-46d4-ada5-bad81bf70f7a}, !- Handle
@@ -1340,10 +1340,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {6176e360-54d0-44ac-a266-d10aedab6668}, !- Handle
@@ -1357,10 +1357,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {4a93ea5e-ff36-4193-b6f6-b66539496a32}, !- Handle
@@ -1391,10 +1391,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 0, 3.047851,                         !- X,Y,Z Vertex 1 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {fae2b8a5-01f7-4c28-bf70-47cc485f5410}, !- Handle
@@ -1408,10 +1408,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {9db63e42-1d44-497a-9b0e-5325f861f301}, !- Handle
@@ -1425,10 +1425,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 1 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 2 {m}
-  -1.63304399336539e-07, 0, 0,            !- X,Y,Z Vertex 3 {m}
-  -1.63304399336539e-07, 0, 3.047851;     !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {78881d4e-03fe-4770-82cf-c22685e2945c}, !- Handle
@@ -1442,10 +1442,10 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   1,                                      !- Multiplier
   ,                                       !- Number of Vertices
-  11.581835, 1.9049, 2.1732,              !- X,Y,Z Vertex 1 {m}
-  11.581835, 1.9049, 0.954,               !- X,Y,Z Vertex 2 {m}
-  11.581835, 5.7149, 0.954,               !- X,Y,Z Vertex 3 {m}
-  11.581835, 5.7149, 2.1732;              !- X,Y,Z Vertex 4 {m}
+  11.5818, 1.9049, 2.1732,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 1.9049, 0.954,                 !- X,Y,Z Vertex 2 {m}
+  11.5818, 5.7149, 0.954,                 !- X,Y,Z Vertex 3 {m}
+  11.5818, 5.7149, 2.1732;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {b8e8faef-f7f6-4298-aa37-e27d3552ccd2}, !- Handle
@@ -1459,10 +1459,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {82bd34d1-195e-4406-a19d-2eb1810917bb}, !- Handle
@@ -1476,10 +1476,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {6315ab11-826e-4bfb-9416-671d68329af7}, !- Handle
@@ -1493,10 +1493,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 0, 3.047851,                         !- X,Y,Z Vertex 1 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {7508456a-940b-402f-bf6d-eb01a235c2c4}, !- Handle
@@ -1510,10 +1510,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 1.676318, 3.047851,                  !- X,Y,Z Vertex 1 {m}
-  0, 1.676318, 0,                         !- X,Y,Z Vertex 2 {m}
+  0, 1.6763, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 1.6763, 0,                           !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Timestep,
   {edfa6676-4fa1-4f8d-b586-211f30877da9}, !- Handle
@@ -1531,10 +1531,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 3.047851;                  !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {4bf23822-96d1-4966-b977-44c557377193}, !- Handle
@@ -1548,10 +1548,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  34.7455054899131, -3.9691078068671e-07, 3.047851, !- X,Y,Z Vertex 1 {m}
-  34.7455054899131, -3.9691078068671e-07, 0, !- X,Y,Z Vertex 2 {m}
-  46.327341, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  46.327341, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  34.7455, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  34.7455, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  46.3273, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  46.3273, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {f326f129-5c15-4001-b1e7-53f56fa397e7}, !- Handle
@@ -1565,10 +1565,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 0, 3.047851,                         !- X,Y,Z Vertex 1 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {38a63ba5-45e3-4ae8-a074-18f7334f96c4}, !- Handle
@@ -1582,10 +1582,10 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   1,                                      !- Multiplier
   ,                                       !- Number of Vertices
-  8.686, 7.619628, 2.1732,                !- X,Y,Z Vertex 1 {m}
-  8.686, 7.619628, 0.954,                 !- X,Y,Z Vertex 2 {m}
-  2.89498950131234, 7.619628, 0.954,      !- X,Y,Z Vertex 3 {m}
-  2.89498950131234, 7.619628, 2.1732;     !- X,Y,Z Vertex 4 {m}
+  8.686, 7.6196, 2.1732,                  !- X,Y,Z Vertex 1 {m}
+  8.686, 7.6196, 0.954,                   !- X,Y,Z Vertex 2 {m}
+  2.89498950131234, 7.6196, 0.954,        !- X,Y,Z Vertex 3 {m}
+  2.89498950131234, 7.6196, 2.1732;       !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {38233d6c-a038-4da7-aad0-fc35f2bcabc3}, !- Handle
@@ -1599,10 +1599,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 3.047851;                  !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {0973397c-a7cd-4f4c-b030-9a1a5fc1bd68}, !- Handle
@@ -1616,10 +1616,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {7ecf1ef3-c703-46bd-8b01-82977e66eb9d}, !- Handle
@@ -1633,10 +1633,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {2e33118a-bc3d-497a-9549-aaffb48e7c31}, !- Handle
@@ -1650,10 +1650,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -1.63304399336539e-07, 7.619628, 3.047851, !- X,Y,Z Vertex 1 {m}
-  -1.63304399336539e-07, 7.619628, 0,     !- X,Y,Z Vertex 2 {m}
-  -1.63304399336539e-07, 0, 0,            !- X,Y,Z Vertex 3 {m}
-  -1.63304399336539e-07, 0, 3.047851;     !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {c558d82c-5613-4ed0-8d46-457e8216c57d}, !- Handle
@@ -1667,10 +1667,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  -1.63304399336539e-07, 7.619628, 0,     !- X,Y,Z Vertex 3 {m}
-  -1.63304399336539e-07, 7.619628, 3.047851; !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {ba5b2bc2-eaf4-469d-b8b1-d92bbfef86ce}, !- Handle
@@ -1684,10 +1684,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 1 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {af29dfb6-7496-4f93-84eb-9aea6f24ec16}, !- Handle
@@ -1701,10 +1701,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {aa77ea57-67c6-4d67-bc88-32429135eec4}, !- Handle
@@ -1718,10 +1718,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {c23f7327-8225-448f-8249-f1ef8e586e17}, !- Handle
@@ -1735,10 +1735,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -1.63304399336539e-07, 7.619628, 3.047851, !- X,Y,Z Vertex 1 {m}
-  -1.63304399336539e-07, 7.619628, 0,     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {533c2d73-c8a4-4335-9970-cab144718379}, !- Handle
@@ -1752,10 +1752,10 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   1,                                      !- Multiplier
   ,                                       !- Number of Vertices
-  8.686, 7.619628, 2.1732,                !- X,Y,Z Vertex 1 {m}
-  8.686, 7.619628, 0.954,                 !- X,Y,Z Vertex 2 {m}
-  2.89498950131234, 7.619628, 0.954,      !- X,Y,Z Vertex 3 {m}
-  2.89498950131234, 7.619628, 2.1732;     !- X,Y,Z Vertex 4 {m}
+  8.686, 7.6196, 2.1732,                  !- X,Y,Z Vertex 1 {m}
+  8.686, 7.6196, 0.954,                   !- X,Y,Z Vertex 2 {m}
+  2.89498950131234, 7.6196, 0.954,        !- X,Y,Z Vertex 3 {m}
+  2.89498950131234, 7.6196, 2.1732;       !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {bc83631d-4a58-46ad-b52c-4055924d46cc}, !- Handle
@@ -1769,10 +1769,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {5758e5f8-053a-4ce6-9c81-c38fbad69ad9}, !- Handle
@@ -1786,10 +1786,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {d251f702-03b3-4ba8-9b7c-08259a4ea42e}, !- Handle
@@ -1799,8 +1799,8 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  9.29594664423115,                       !- Y Origin {m}
-  3.04785135876431,                       !- Z Origin {m}
+  9.2959,                                 !- Y Origin {m}
+  3.0479,                                 !- Z Origin {m}
   {271f3401-76be-4edd-8369-7d5a808299e2}, !- Building Story Name
   {e3ca4010-a6a5-4821-b2e6-107bd08eb6e8}; !- Thermal Zone Name
 
@@ -1816,10 +1816,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 0, 3.047851,                         !- X,Y,Z Vertex 1 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {38f883df-0f73-4a2a-9fd1-26a91e2ee0cd}, !- Handle
@@ -1833,10 +1833,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.1636701633044, 1.67631824732037, 3.047851, !- X,Y,Z Vertex 1 {m}
-  23.1636701633044, 1.67631824732037, 0,  !- X,Y,Z Vertex 2 {m}
-  11.5818351633044, 1.67631824732037, 0,  !- X,Y,Z Vertex 3 {m}
-  11.5818351633044, 1.67631824732037, 3.047851; !- X,Y,Z Vertex 4 {m}
+  23.1637, 1.6763, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  23.1637, 1.6763, 0,                     !- X,Y,Z Vertex 2 {m}
+  11.5818, 1.6763, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 1.6763, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {7097f868-5195-4814-a8b5-63f7bf661805}, !- Handle
@@ -1850,10 +1850,10 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   1,                                      !- Multiplier
   ,                                       !- Number of Vertices
-  11.581835, 1.9049, 2.1732,              !- X,Y,Z Vertex 1 {m}
-  11.581835, 1.9049, 0.954,               !- X,Y,Z Vertex 2 {m}
-  11.581835, 5.7149, 0.954,               !- X,Y,Z Vertex 3 {m}
-  11.581835, 5.7149, 2.1732;              !- X,Y,Z Vertex 4 {m}
+  11.5818, 1.9049, 2.1732,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 1.9049, 0.954,                 !- X,Y,Z Vertex 2 {m}
+  11.5818, 5.7149, 0.954,                 !- X,Y,Z Vertex 3 {m}
+  11.5818, 5.7149, 2.1732;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {90963fab-d41a-4776-8158-5800d81f7f47}, !- Handle
@@ -1867,10 +1867,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {c467be40-c8ea-41d0-995a-a4656ec97f84}, !- Handle
@@ -1884,10 +1884,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 0, 3.047851,                         !- X,Y,Z Vertex 1 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {5c041ba7-f105-4185-a779-998bd6cb0ad0}, !- Handle
@@ -1901,10 +1901,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.327341, 1.676318, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  46.327341, 1.676318, 0,                 !- X,Y,Z Vertex 2 {m}
-  34.7455054899131, 1.67631824732037, 0,  !- X,Y,Z Vertex 3 {m}
-  34.7455054899131, 1.67631824732037, 3.047851; !- X,Y,Z Vertex 4 {m}
+  46.3273, 1.6763, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  46.3273, 1.6763, 0,                     !- X,Y,Z Vertex 2 {m}
+  34.7455, 1.6763, 0,                     !- X,Y,Z Vertex 3 {m}
+  34.7455, 1.6763, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {abaef75f-9aa1-4865-9baa-5058002f5f6d}, !- Handle
@@ -1935,10 +1935,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 1 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {6110bce7-d14f-4734-b786-3368f1fa9fd9}, !- Handle
@@ -1952,10 +1952,10 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   1,                                      !- Multiplier
   ,                                       !- Number of Vertices
-  8.686, 7.619628, 2.1732,                !- X,Y,Z Vertex 1 {m}
-  8.686, 7.619628, 0.954,                 !- X,Y,Z Vertex 2 {m}
-  2.89498950131234, 7.619628, 0.954,      !- X,Y,Z Vertex 3 {m}
-  2.89498950131234, 7.619628, 2.1732;     !- X,Y,Z Vertex 4 {m}
+  8.686, 7.6196, 2.1732,                  !- X,Y,Z Vertex 1 {m}
+  8.686, 7.6196, 0.954,                   !- X,Y,Z Vertex 2 {m}
+  2.89498950131234, 7.6196, 0.954,        !- X,Y,Z Vertex 3 {m}
+  2.89498950131234, 7.6196, 2.1732;       !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {329cc372-873c-43a5-9272-e604a7426627}, !- Handle
@@ -1969,10 +1969,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 3.047851;                  !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {e6970b9f-5b70-45dd-a129-a0873e1f12a8}, !- Handle
@@ -1986,10 +1986,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -1.63304399336539e-07, 0, 3.047851,     !- X,Y,Z Vertex 1 {m}
-  -1.63304399336539e-07, 0, 0,            !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {31a041ea-149a-4d29-a8df-e2ec4e7981ab}, !- Handle
@@ -2003,10 +2003,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.1636701633044, 1.67631824732037, 3.047851, !- X,Y,Z Vertex 1 {m}
-  23.1636701633044, 1.67631824732037, 0,  !- X,Y,Z Vertex 2 {m}
-  11.5818351633044, 1.67631824732037, 0,  !- X,Y,Z Vertex 3 {m}
-  11.5818351633044, 1.67631824732037, 3.047851; !- X,Y,Z Vertex 4 {m}
+  23.1637, 1.6763, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  23.1637, 1.6763, 0,                     !- X,Y,Z Vertex 2 {m}
+  11.5818, 1.6763, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 1.6763, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {a390f85d-1e0f-4539-bd6b-77d9a7d49e91}, !- Handle
@@ -2020,10 +2020,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 0, 3.047851,                         !- X,Y,Z Vertex 1 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {5197ae2f-835b-4413-b43b-e1f2a6717eb1}, !- Handle
@@ -2037,10 +2037,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.327341, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  46.327341, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  46.327341, 1.676318, 0,                 !- X,Y,Z Vertex 3 {m}
-  46.327341, 1.676318, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  46.3273, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  46.3273, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  46.3273, 1.6763, 0,                     !- X,Y,Z Vertex 3 {m}
+  46.3273, 1.6763, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {717aacc9-d91e-4e59-9778-924657ad38d8}, !- Handle
@@ -2054,10 +2054,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  -1.63304399336539e-07, 7.619628, 0,     !- X,Y,Z Vertex 3 {m}
-  -1.63304399336539e-07, 7.619628, 3.047851; !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {7f9ec0f2-4a12-4979-8fb3-3df3d28f0d08}, !- Handle
@@ -2071,10 +2071,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {c00ca208-b2e0-4988-8b8f-59ea5e2e725c}, !- Handle
@@ -2088,10 +2088,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {30b4a10c-a054-43f2-b636-8739035a194f}, !- Handle
@@ -2105,10 +2105,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 3.047851;                  !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {a3ac4274-3a90-4438-a2c6-d9b489ae50ff}, !- Handle
@@ -2122,10 +2122,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, -3.9691078068671e-07, 3.047851, !- X,Y,Z Vertex 1 {m}
-  11.581835, -3.9691078068671e-07, 0,     !- X,Y,Z Vertex 2 {m}
-  23.1636703266088, -3.9691078068671e-07, 0, !- X,Y,Z Vertex 3 {m}
-  23.1636703266088, -3.9691078068671e-07, 3.047851; !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  23.1637, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  23.1637, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {062bf596-5683-48c3-aa87-d2bf9f13ad26}, !- Handle
@@ -2139,10 +2139,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {7cf04123-6bd6-4886-abb9-59405b5a5d3d}, !- Handle
@@ -2156,10 +2156,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 1 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {bfbb4bab-02b4-4dd5-9a25-d0ce73b9d2a1}, !- Handle
@@ -2173,10 +2173,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {f886c264-0c3a-4fcf-a573-b9ce3c891ec0}, !- Handle
@@ -2190,10 +2190,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {49b9efbf-1872-4f67-ad3e-c15cfac54455}, !- Handle
@@ -2207,10 +2207,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 3.047851;                  !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {03ebae37-082f-43ed-838c-33e3a167d8a7}, !- Handle
@@ -2224,10 +2224,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.5818351633044, -3.9691078068671e-07, 3.047851, !- X,Y,Z Vertex 1 {m}
-  11.5818351633044, -3.9691078068671e-07, 0, !- X,Y,Z Vertex 2 {m}
-  23.1636701633044, -3.9691078068671e-07, 0, !- X,Y,Z Vertex 3 {m}
-  23.1636701633044, -3.9691078068671e-07, 3.047851; !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  23.1637, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  23.1637, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {b60ed3e7-62cf-4284-9988-cb23e2ff0a1c}, !- Handle
@@ -2241,10 +2241,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {86a0c6c6-2f67-41ea-a22b-0eed7f018635}, !- Handle
@@ -2258,10 +2258,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 1 {m}
-  -1.63304399336539e-07, 7.619628, 0,     !- X,Y,Z Vertex 2 {m}
-  -1.63304399336539e-07, 0, 0,            !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {2c1fb5cb-d744-485f-b19b-edb542a335ee}, !- Handle
@@ -2275,10 +2275,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {4f1ec902-d894-430d-bf35-9684cdbb4ad3}, !- Handle
@@ -2292,10 +2292,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 0, 3.047851,                         !- X,Y,Z Vertex 1 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {e41b7305-7b07-4aa3-a452-3c8444b4e344}, !- Handle
@@ -2309,10 +2309,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.5818351633044, 1.67631824732037, 3.047851, !- X,Y,Z Vertex 1 {m}
-  11.5818351633044, 1.67631824732037, 0,  !- X,Y,Z Vertex 2 {m}
-  0, 1.676318, 0,                         !- X,Y,Z Vertex 3 {m}
-  0, 1.67631824732037, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 1.6763, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 1.6763, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 1.6763, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 1.6763, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {ae1a3426-8fbe-4aa4-9b96-265d1ab44c17}, !- Handle
@@ -2326,10 +2326,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 0, 3.047851,                         !- X,Y,Z Vertex 1 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {b340da59-e4f6-4224-acdd-1740a5bcfa0b}, !- Handle
@@ -2343,10 +2343,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.5818351633044, 1.67631824732037, 3.047851, !- X,Y,Z Vertex 1 {m}
-  11.5818351633044, 1.67631824732037, 0,  !- X,Y,Z Vertex 2 {m}
-  0, 1.67631824732037, 0,                 !- X,Y,Z Vertex 3 {m}
-  0, 1.67631824732037, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 1.6763, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 1.6763, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 1.6763, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 1.6763, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {d631ce51-4ce6-49db-9914-73bbcf409eb3}, !- Handle
@@ -2360,10 +2360,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 0, 3.047851,                         !- X,Y,Z Vertex 1 {m}
-  -1.63304399336539e-07, 0, 0,            !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {4ba3edf7-d8cf-4248-8c68-3c2a4f2b5e7a}, !- Handle
@@ -2377,10 +2377,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {06bbdf9c-3c49-4c88-8c4b-0191b1091d67}, !- Handle
@@ -2394,10 +2394,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {423aae32-5565-4476-aeef-4342771309eb}, !- Handle
@@ -2428,10 +2428,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 1 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {34b4c81e-9b09-4e82-a10f-1f713ebf0b11}, !- Handle
@@ -2445,10 +2445,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {c83f9036-726e-4da7-9e5d-3295ece930cc}, !- Handle
@@ -2462,10 +2462,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.3273404899131, -3.9691078068671e-07, 3.047851, !- X,Y,Z Vertex 1 {m}
-  46.3273404899131, -3.9691078068671e-07, 0, !- X,Y,Z Vertex 2 {m}
-  46.327341, 1.676318, 0,                 !- X,Y,Z Vertex 3 {m}
-  46.3273404899131, 1.67631824732037, 3.047851; !- X,Y,Z Vertex 4 {m}
+  46.3273, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  46.3273, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  46.3273, 1.6763, 0,                     !- X,Y,Z Vertex 3 {m}
+  46.3273, 1.6763, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {1b69fa2b-40bf-4f4c-9dbb-b45b3e3e44a2}, !- Handle
@@ -2479,10 +2479,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {ded4e408-7c4a-4b73-934e-290e877cbbff}, !- Handle
@@ -2496,10 +2496,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.327341, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  46.327341, 1.676318, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 1.676318, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  46.3273, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  46.3273, 1.6763, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 1.6763, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {00a58f76-1083-44a9-98b5-4d1abb762575}, !- Handle
@@ -2513,10 +2513,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {6a43f181-503a-4ef0-b7b4-c6287181f587}, !- Handle
@@ -2547,10 +2547,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {e0f7e2eb-7fa9-4cac-a318-a956e44304ff}, !- Handle
@@ -2564,10 +2564,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {eb3e0266-afad-475f-861e-c5a267f69950}, !- Handle
@@ -2581,10 +2581,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {75fd5c8a-5998-43b5-97e6-c018c31fedd4}, !- Handle
@@ -2598,10 +2598,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {a001ef4a-7d6c-48d4-bd74-450d0824361f}, !- Handle
@@ -2615,10 +2615,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 1 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {d16dbe4a-4631-46f4-a078-d25c75315c43}, !- Handle
@@ -2649,10 +2649,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:RunPeriod,
   {17246936-3daa-4b32-8968-1e0c617730af}, !- Handle
@@ -2685,10 +2685,10 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   1,                                      !- Multiplier
   ,                                       !- Number of Vertices
-  8.686, 7.619628, 2.1732,                !- X,Y,Z Vertex 1 {m}
-  8.686, 7.619628, 0.954,                 !- X,Y,Z Vertex 2 {m}
-  2.89498950131234, 7.619628, 0.954,      !- X,Y,Z Vertex 3 {m}
-  2.89498950131234, 7.619628, 2.1732;     !- X,Y,Z Vertex 4 {m}
+  8.686, 7.6196, 2.1732,                  !- X,Y,Z Vertex 1 {m}
+  8.686, 7.6196, 0.954,                   !- X,Y,Z Vertex 2 {m}
+  2.89498950131234, 7.6196, 0.954,        !- X,Y,Z Vertex 3 {m}
+  2.89498950131234, 7.6196, 2.1732;       !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {2de693c3-45db-4f7f-be74-82fc1220c3c3}, !- Handle
@@ -2702,10 +2702,10 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   1,                                      !- Multiplier
   ,                                       !- Number of Vertices
-  46.327341, 0.381000000012441, 2.1731,   !- X,Y,Z Vertex 1 {m}
-  46.327341, 0.381000000012441, 0.954,    !- X,Y,Z Vertex 2 {m}
-  46.327341, 1.29530000001236, 0.954,     !- X,Y,Z Vertex 3 {m}
-  46.327341, 1.29530000001236, 2.1731;    !- X,Y,Z Vertex 4 {m}
+  46.3273, 0.381000000012441, 2.1731,     !- X,Y,Z Vertex 1 {m}
+  46.3273, 0.381000000012441, 0.954,      !- X,Y,Z Vertex 2 {m}
+  46.3273, 1.29530000001236, 0.954,       !- X,Y,Z Vertex 3 {m}
+  46.3273, 1.29530000001236, 2.1731;      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {bd8ce1a2-fa04-48b6-b755-c5c9659eb5aa}, !- Handle
@@ -2719,10 +2719,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {844d8a65-aa9a-4388-905d-0eba9f481575}, !- Handle
@@ -2736,10 +2736,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 1 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  -1.63304399336539e-07, 0, 3.047851;     !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {35569ce9-6ed1-474e-94ed-b9b53c411482}, !- Handle
@@ -2753,10 +2753,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.327341, 1.676318, 0,                 !- X,Y,Z Vertex 1 {m}
-  46.327341, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  46.3273, 1.6763, 0,                     !- X,Y,Z Vertex 1 {m}
+  46.3273, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 1.676318, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 1.6763, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {d9fb3c9b-dfbd-411c-81f4-1ee8d5b73d0f}, !- Handle
@@ -2770,10 +2770,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 1.67631824732037, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  0, 1.67631824732037, 0,                 !- X,Y,Z Vertex 2 {m}
+  0, 1.6763, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 1.6763, 0,                           !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {ded359fe-9e00-4904-9917-e7115e3e3eaf}, !- Handle
@@ -2787,10 +2787,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {7798389d-c509-40d9-91d6-adc1aec9c8a2}, !- Handle
@@ -2804,10 +2804,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 1 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {7347fd37-c284-440c-af33-38b0962a4f06}, !- Handle
@@ -2821,10 +2821,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {74c4318f-e443-4d02-9a26-c7e64a6d5271}, !- Handle
@@ -2838,10 +2838,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {fe8f496c-357d-4c24-b069-cb1c352df354}, !- Handle
@@ -2872,10 +2872,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -1.63304399336539e-07, 0, 3.047851,     !- X,Y,Z Vertex 1 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {18d892cd-e1a0-44c5-912c-483cf40d5e4b}, !- Handle
@@ -2889,10 +2889,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  34.7455053266088, 1.67631824732037, 3.047851, !- X,Y,Z Vertex 1 {m}
-  34.7455053266088, 1.67631824732037, 0,  !- X,Y,Z Vertex 2 {m}
-  23.1636701633044, 1.67631824732037, 0,  !- X,Y,Z Vertex 3 {m}
-  23.1636701633044, 1.67631824732037, 3.047851; !- X,Y,Z Vertex 4 {m}
+  34.7455, 1.6763, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  34.7455, 1.6763, 0,                     !- X,Y,Z Vertex 2 {m}
+  23.1637, 1.6763, 0,                     !- X,Y,Z Vertex 3 {m}
+  23.1637, 1.6763, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {8a224810-4373-4cae-9881-b0bb511c13e0}, !- Handle
@@ -2906,10 +2906,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -1.63304399336539e-07, 0, 3.047851,     !- X,Y,Z Vertex 1 {m}
-  -1.63304399336539e-07, 0, 0,            !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {1eb08487-139c-4b7e-9c80-62df703ec34a}, !- Handle
@@ -2923,10 +2923,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  34.7455054899131, 1.67631824732037, 3.047851, !- X,Y,Z Vertex 1 {m}
-  34.7455054899131, 1.67631824732037, 0,  !- X,Y,Z Vertex 2 {m}
-  23.1636701633044, 1.67631824732037, 0,  !- X,Y,Z Vertex 3 {m}
-  23.1636701633044, 1.67631824732037, 3.047851; !- X,Y,Z Vertex 4 {m}
+  34.7455, 1.6763, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  34.7455, 1.6763, 0,                     !- X,Y,Z Vertex 2 {m}
+  23.1637, 1.6763, 0,                     !- X,Y,Z Vertex 3 {m}
+  23.1637, 1.6763, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {0122e97d-e5f0-4bbe-ac4b-60a57dd65143}, !- Handle
@@ -2940,10 +2940,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {516e7d8c-7643-4ced-8226-66cb619a2c42}, !- Handle
@@ -2957,10 +2957,10 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   1,                                      !- Multiplier
   ,                                       !- Number of Vertices
-  11.581835, 1.9049, 2.1732,              !- X,Y,Z Vertex 1 {m}
-  11.581835, 1.9049, 0.954,               !- X,Y,Z Vertex 2 {m}
-  11.581835, 5.7149, 0.954,               !- X,Y,Z Vertex 3 {m}
-  11.581835, 5.7149, 2.1732;              !- X,Y,Z Vertex 4 {m}
+  11.5818, 1.9049, 2.1732,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 1.9049, 0.954,                 !- X,Y,Z Vertex 2 {m}
+  11.5818, 5.7149, 0.954,                 !- X,Y,Z Vertex 3 {m}
+  11.5818, 5.7149, 2.1732;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {b656eb60-f5b7-4c91-b0bf-9e7c799dbd8e}, !- Handle
@@ -2974,10 +2974,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {cb41c7b0-bd18-4bef-8b7d-0ec200982c49}, !- Handle
@@ -2991,10 +2991,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -1.63304399336539e-07, 0, 3.047851,     !- X,Y,Z Vertex 1 {m}
-  -1.63304399336539e-07, 0, 0,            !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {2df42518-f3bc-4d0b-814b-5de908c94fbe}, !- Handle
@@ -3008,10 +3008,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {ceabc2d2-2c2d-4f75-8882-483069268c42}, !- Handle
@@ -3042,10 +3042,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {4608bfe5-cb9f-42f7-b7fe-387d9e1982ad}, !- Handle
@@ -3076,10 +3076,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -1.63304301636913e-07, 0, 3.047851,     !- X,Y,Z Vertex 1 {m}
-  -1.63304301636913e-07, 0, 0,            !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {23b45aae-e2e1-4523-b04d-86aa560b5716}, !- Handle
@@ -3093,10 +3093,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 3.047851;                  !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {bf48e683-2c32-4038-bf2c-4e4e9ff3646f}, !- Handle
@@ -3110,10 +3110,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 0, 3.047851,                         !- X,Y,Z Vertex 1 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
-  11.5818351633044, -3.9691078068671e-07, 0, !- X,Y,Z Vertex 3 {m}
-  11.5818351633044, -3.9691078068671e-07, 3.047851; !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {b525bb62-38a2-465b-b99e-ce5a3c7c32df}, !- Handle
@@ -3127,10 +3127,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {9f8624c5-40a1-49d1-89f1-802dd3649e49}, !- Handle
@@ -3161,10 +3161,10 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   1,                                      !- Multiplier
   ,                                       !- Number of Vertices
-  8.686, 7.619628, 2.1732,                !- X,Y,Z Vertex 1 {m}
-  8.686, 7.619628, 0.954,                 !- X,Y,Z Vertex 2 {m}
-  2.89498950131234, 7.619628, 0.954,      !- X,Y,Z Vertex 3 {m}
-  2.89498950131234, 7.619628, 2.1732;     !- X,Y,Z Vertex 4 {m}
+  8.686, 7.6196, 2.1732,                  !- X,Y,Z Vertex 1 {m}
+  8.686, 7.6196, 0.954,                   !- X,Y,Z Vertex 2 {m}
+  2.89498950131234, 7.6196, 0.954,        !- X,Y,Z Vertex 3 {m}
+  2.89498950131234, 7.6196, 2.1732;       !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {5b9c5e1f-745c-4b9e-86aa-c7fa2fddd93b}, !- Handle
@@ -3178,10 +3178,10 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   1,                                      !- Multiplier
   ,                                       !- Number of Vertices
-  46.3273404466331, 0.0508000000062577, 2.13349999999656, !- X,Y,Z Vertex 1 {m}
-  46.3273406230384, 0.0508000000061772, 0.0253999999966025, !- X,Y,Z Vertex 2 {m}
-  46.3273408626211, 1.62550000000607, 0.0253999999966627, !- X,Y,Z Vertex 3 {m}
-  46.3273406862158, 1.62550000000615, 2.13349999999662; !- X,Y,Z Vertex 4 {m}
+  46.3273, 0.0508000000062577, 2.13349999999656, !- X,Y,Z Vertex 1 {m}
+  46.3273, 0.0508000000061772, 0.0253999999966025, !- X,Y,Z Vertex 2 {m}
+  46.3273, 1.62550000000607, 0.0253999999966627, !- X,Y,Z Vertex 3 {m}
+  46.3273, 1.62550000000615, 2.13349999999662; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {39149afc-8412-4cf6-9fdb-b7671cf27e75}, !- Handle
@@ -3195,10 +3195,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.327341, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  46.327341, 1.676318, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 1.676318, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  46.3273, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  46.3273, 1.6763, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 1.6763, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Output:Meter,
   {fcf53c68-a8b2-4d87-9da1-5081300f1aa9}, !- Handle
@@ -3219,10 +3219,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  -1.63304399336539e-07, 7.619628, 0,     !- X,Y,Z Vertex 3 {m}
-  -1.63304399336539e-07, 7.619628, 3.047851; !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {e1bd7483-b3ca-45f7-a077-89814288befe}, !- Handle
@@ -3236,10 +3236,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.1636701633044, -3.9691078068671e-07, 3.047851, !- X,Y,Z Vertex 1 {m}
-  23.1636701633044, -3.9691078068671e-07, 0, !- X,Y,Z Vertex 2 {m}
-  34.7455054899131, -3.9691078068671e-07, 0, !- X,Y,Z Vertex 3 {m}
-  34.7455054899131, -3.9691078068671e-07, 3.047851; !- X,Y,Z Vertex 4 {m}
+  23.1637, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  23.1637, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  34.7455, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  34.7455, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {16d0e2c8-b3d9-460d-b9a6-f0430ab1508d}, !- Handle
@@ -3253,10 +3253,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {86cd0499-a033-4062-8d70-a2279875a2ec}, !- Handle
@@ -3270,10 +3270,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 1 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {76702075-4def-4826-896f-771ca21d6190}, !- Handle
@@ -3287,10 +3287,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 1.67631824732037, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  0, 1.676318, 0,                         !- X,Y,Z Vertex 2 {m}
-  0, -3.9691078068671e-07, 0,             !- X,Y,Z Vertex 3 {m}
-  0, -3.9691078068671e-07, 3.047851;      !- X,Y,Z Vertex 4 {m}
+  0, 1.6763, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 1.6763, 0,                           !- X,Y,Z Vertex 2 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {c3e60ffa-1992-4ef1-bc27-c17be997af81}, !- Handle
@@ -3321,10 +3321,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {6fd01f23-7167-4a4e-977b-43f8309750da}, !- Handle
@@ -3338,10 +3338,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 1 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {b5f48544-dfff-4cbf-b9eb-ce095bf2a985}, !- Handle
@@ -3355,10 +3355,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {8c1920fe-9292-4fc9-a4db-eae6da22f4cc}, !- Handle
@@ -3372,10 +3372,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -1.63304399336539e-07, 0, 3.047851,     !- X,Y,Z Vertex 1 {m}
-  -1.63304399336539e-07, 0, 0,            !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {287e7e6d-963f-4faa-9c92-5ca8556465c2}, !- Handle
@@ -3389,10 +3389,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  34.7455054899131, 1.67631824732037, 3.047851, !- X,Y,Z Vertex 1 {m}
-  34.7455054899131, 1.67631824732037, 0,  !- X,Y,Z Vertex 2 {m}
-  23.1636701633044, 1.67631824732037, 0,  !- X,Y,Z Vertex 3 {m}
-  23.1636701633044, 1.67631824732037, 3.047851; !- X,Y,Z Vertex 4 {m}
+  34.7455, 1.6763, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  34.7455, 1.6763, 0,                     !- X,Y,Z Vertex 2 {m}
+  23.1637, 1.6763, 0,                     !- X,Y,Z Vertex 3 {m}
+  23.1637, 1.6763, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {2da5ffa2-72af-4994-b7c0-e0130ca16d87}, !- Handle
@@ -3406,10 +3406,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {73b80291-0c26-4ad4-86ff-39ce0ff3320d}, !- Handle
@@ -3423,10 +3423,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {881b6c21-3f1b-469c-a6d3-0ab94ee4c5f0}, !- Handle
@@ -3440,10 +3440,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 0, 3.047851,                         !- X,Y,Z Vertex 1 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {b24f9329-4728-49b7-bbda-cef3fe20c637}, !- Handle
@@ -3457,10 +3457,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.327341, 1.676318, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  46.327341, 1.676318, 0,                 !- X,Y,Z Vertex 2 {m}
-  34.7455053266088, 1.67631824732037, 0,  !- X,Y,Z Vertex 3 {m}
-  34.7455053266088, 1.67631824732037, 3.047851; !- X,Y,Z Vertex 4 {m}
+  46.3273, 1.6763, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  46.3273, 1.6763, 0,                     !- X,Y,Z Vertex 2 {m}
+  34.7455, 1.6763, 0,                     !- X,Y,Z Vertex 3 {m}
+  34.7455, 1.6763, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {41b2e3c5-e83f-42af-9b69-368c3a807697}, !- Handle
@@ -3474,10 +3474,10 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   1,                                      !- Multiplier
   ,                                       !- Number of Vertices
-  11.581835, 1.9049, 2.1732,              !- X,Y,Z Vertex 1 {m}
-  11.581835, 1.9049, 0.954,               !- X,Y,Z Vertex 2 {m}
-  11.581835, 5.7149, 0.954,               !- X,Y,Z Vertex 3 {m}
-  11.581835, 5.7149, 2.1732;              !- X,Y,Z Vertex 4 {m}
+  11.5818, 1.9049, 2.1732,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 1.9049, 0.954,                 !- X,Y,Z Vertex 2 {m}
+  11.5818, 5.7149, 0.954,                 !- X,Y,Z Vertex 3 {m}
+  11.5818, 5.7149, 2.1732;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {3dbd93e7-32e4-4f53-b639-ab0832e6c891}, !- Handle
@@ -3491,10 +3491,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 3.047851;                  !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {237f47e9-942b-4bfc-8e38-d34b101a0b88}, !- Handle
@@ -3508,10 +3508,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {52c84127-ec57-4a89-9285-bd8955f7b657}, !- Handle
@@ -3525,10 +3525,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {0b109f71-d4cc-45c3-b039-71764d46d4d3}, !- Handle
@@ -3542,10 +3542,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 1 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {9ae5d935-056d-4b66-bbc3-992d52fd6f7d}, !- Handle
@@ -3559,10 +3559,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {3dcdb189-9fd1-4c0d-985e-07b309b7dce6}, !- Handle
@@ -3576,10 +3576,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {2b0cc56c-1454-4617-ba61-125ca4e5ae9b}, !- Handle
@@ -3593,10 +3593,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  -1.63304399336539e-07, 7.619628, 0,     !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 3.047851;                  !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {b8ee2181-e3b2-4ab8-af8a-4120fdffdb97}, !- Handle
@@ -3610,10 +3610,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.5818351633044, -3.9691078068671e-07, 3.047851, !- X,Y,Z Vertex 1 {m}
-  11.5818351633044, -3.9691078068671e-07, 0, !- X,Y,Z Vertex 2 {m}
-  23.1636703266088, -3.9691078068671e-07, 0, !- X,Y,Z Vertex 3 {m}
-  23.1636703266088, -3.9691078068671e-07, 3.047851; !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  23.1637, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  23.1637, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {772936a8-54ee-4ead-a5d9-615785de8335}, !- Handle
@@ -3627,10 +3627,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 0, 3.047851,                         !- X,Y,Z Vertex 1 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {68e6e7a1-756e-4412-a08e-a55123509bbb}, !- Handle
@@ -3644,10 +3644,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.5818351633044, 1.67631824732037, 3.047851, !- X,Y,Z Vertex 1 {m}
-  11.5818351633044, 1.67631824732037, 0,  !- X,Y,Z Vertex 2 {m}
-  0, 1.676318, 0,                         !- X,Y,Z Vertex 3 {m}
-  0, 1.676318, 3.047851;                  !- X,Y,Z Vertex 4 {m}
+  11.5818, 1.6763, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 1.6763, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 1.6763, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 1.6763, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {d1b674ab-0acc-4deb-bc48-755a8ad4cd9e}, !- Handle
@@ -3678,10 +3678,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {5f148495-c6a8-4a28-afeb-1a1e6b8ea81f}, !- Handle
@@ -3695,10 +3695,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  -1.63304301636913e-07, 7.619628, 0,     !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 3.047851;                  !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {608daf55-87bf-4e6c-890d-b8673ef911dc}, !- Handle
@@ -3712,10 +3712,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {ca03ccf8-71b9-415e-aa14-de43b4da791b}, !- Handle
@@ -3746,10 +3746,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 0, 3.047851,                         !- X,Y,Z Vertex 1 {m}
-  -1.63304301636913e-07, 0, 0,            !- X,Y,Z Vertex 2 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  11.581835, 0, 3.047851;                 !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {2ac605d2-229b-48f2-80ef-680280f90109}, !- Handle
@@ -3763,10 +3763,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.3273404899131, 1.67631824732037, 3.047851, !- X,Y,Z Vertex 1 {m}
-  46.327341, 1.676318, 0,                 !- X,Y,Z Vertex 2 {m}
-  34.7455054899131, 1.67631824732037, 0,  !- X,Y,Z Vertex 3 {m}
-  34.7455054899131, 1.67631824732037, 3.047851; !- X,Y,Z Vertex 4 {m}
+  46.3273, 1.6763, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  46.3273, 1.6763, 0,                     !- X,Y,Z Vertex 2 {m}
+  34.7455, 1.6763, 0,                     !- X,Y,Z Vertex 3 {m}
+  34.7455, 1.6763, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {8e3c24bf-b7ed-4525-bea2-435e8469ba20}, !- Handle
@@ -3780,10 +3780,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  -1.63304399336539e-07, 7.619628, 0,     !- X,Y,Z Vertex 3 {m}
-  -1.63304399336539e-07, 7.619628, 3.047851; !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {5ea7bc0c-45fb-4944-a6be-d73dc3c4576f}, !- Handle
@@ -3797,10 +3797,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.1636703266088, -3.9691078068671e-07, 3.047851, !- X,Y,Z Vertex 1 {m}
-  23.1636703266088, -3.9691078068671e-07, 0, !- X,Y,Z Vertex 2 {m}
-  34.7455054899131, -3.9691078068671e-07, 0, !- X,Y,Z Vertex 3 {m}
-  34.7455054899131, -3.9691078068671e-07, 3.047851; !- X,Y,Z Vertex 4 {m}
+  23.1637, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  23.1637, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  34.7455, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  34.7455, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:HeatBalanceAlgorithm,
   {1dece26d-d2e9-45ee-a6a9-a9c584ed7381}, !- Handle
@@ -3819,10 +3819,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  -1.63304399336539e-07, 7.619628, 0,     !- X,Y,Z Vertex 3 {m}
-  -1.63304399336539e-07, 7.619628, 3.047851; !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {928da7a6-6da5-49c5-b921-883d1c6c7527}, !- Handle
@@ -3836,10 +3836,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.1636703266088, -3.9691078068671e-07, 3.047851, !- X,Y,Z Vertex 1 {m}
-  23.1636703266088, -3.9691078068671e-07, 0, !- X,Y,Z Vertex 2 {m}
-  34.7455054899131, -3.9691078068671e-07, 0, !- X,Y,Z Vertex 3 {m}
-  34.7455054899131, -3.9691078068671e-07, 3.047851; !- X,Y,Z Vertex 4 {m}
+  23.1637, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  23.1637, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  34.7455, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  34.7455, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {62194174-081f-4cf0-97e6-fa8d19a434fc}, !- Handle
@@ -3853,10 +3853,10 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   1,                                      !- Multiplier
   ,                                       !- Number of Vertices
-  46.327341, 0.381, 2.1731,               !- X,Y,Z Vertex 1 {m}
-  46.327341, 0.381, 0.954,                !- X,Y,Z Vertex 2 {m}
-  46.327341, 1.2953, 0.954,               !- X,Y,Z Vertex 3 {m}
-  46.327341, 1.2953, 2.1731;              !- X,Y,Z Vertex 4 {m}
+  46.3273, 0.381, 2.1731,                 !- X,Y,Z Vertex 1 {m}
+  46.3273, 0.381, 0.954,                  !- X,Y,Z Vertex 2 {m}
+  46.3273, 1.2953, 0.954,                 !- X,Y,Z Vertex 3 {m}
+  46.3273, 1.2953, 2.1731;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {6da1a970-a01d-4919-b89d-9ee5fc864ede}, !- Handle
@@ -3870,10 +3870,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {40c22506-4400-4641-9898-b438f3b99abd}, !- Handle
@@ -3887,10 +3887,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {a2d4e737-1919-4fc7-a409-570c4d66d232}, !- Handle
@@ -3921,10 +3921,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {0ea10bb2-1a83-47ce-9eb1-2fb7fd05d986}, !- Handle
@@ -3938,10 +3938,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {af3544a8-454c-4522-b0ae-6770d11d41fb}, !- Handle
@@ -3955,10 +3955,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 1 {m}
-  -1.63304301636913e-07, 7.619628, 0,     !- X,Y,Z Vertex 2 {m}
-  -1.63304301636913e-07, 0, 0,            !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {46b91a49-d5cc-4a47-8849-e84d40345d42}, !- Handle
@@ -3972,10 +3972,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 3.047851,                  !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {8907f6af-2052-4773-9da8-7d2085c2f716}, !- Handle
@@ -3989,10 +3989,10 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   1,                                      !- Multiplier
   ,                                       !- Number of Vertices
-  8.686, 7.619628, 2.1732,                !- X,Y,Z Vertex 1 {m}
-  8.686, 7.619628, 0.954,                 !- X,Y,Z Vertex 2 {m}
-  2.89498950131234, 7.619628, 0.954,      !- X,Y,Z Vertex 3 {m}
-  2.89498950131234, 7.619628, 2.1732;     !- X,Y,Z Vertex 4 {m}
+  8.686, 7.6196, 2.1732,                  !- X,Y,Z Vertex 1 {m}
+  8.686, 7.6196, 0.954,                   !- X,Y,Z Vertex 2 {m}
+  2.89498950131234, 7.6196, 0.954,        !- X,Y,Z Vertex 3 {m}
+  2.89498950131234, 7.6196, 2.1732;       !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {6aeccaed-5a77-4560-81d1-ac6a229ba228}, !- Handle
@@ -4006,10 +4006,10 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   1,                                      !- Multiplier
   ,                                       !- Number of Vertices
-  8.686, 7.619628, 2.1732,                !- X,Y,Z Vertex 1 {m}
-  8.686, 7.619628, 0.954,                 !- X,Y,Z Vertex 2 {m}
-  2.89498950131234, 7.619628, 0.954,      !- X,Y,Z Vertex 3 {m}
-  2.89498950131234, 7.619628, 2.1732;     !- X,Y,Z Vertex 4 {m}
+  8.686, 7.6196, 2.1732,                  !- X,Y,Z Vertex 1 {m}
+  8.686, 7.6196, 0.954,                   !- X,Y,Z Vertex 2 {m}
+  2.89498950131234, 7.6196, 0.954,        !- X,Y,Z Vertex 3 {m}
+  2.89498950131234, 7.6196, 2.1732;       !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {9abb6a67-4697-4c5b-b8ef-16dc3a4a680e}, !- Handle
@@ -4023,10 +4023,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 3.047851;                  !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {a5048412-65cd-4699-a9c8-18a8b83c8e48}, !- Handle
@@ -4040,10 +4040,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {c6089f26-f990-4d65-8bbb-9bccbeffe3be}, !- Handle
@@ -4057,10 +4057,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -1.63304399336539e-07, 7.619628, 3.047851, !- X,Y,Z Vertex 1 {m}
-  -1.63304399336539e-07, 7.619628, 0,     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 0, 3.047851;                         !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {14020247-2488-4f77-847c-2444299c9f21}, !- Handle
@@ -4074,10 +4074,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 3.047851,          !- X,Y,Z Vertex 1 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 2 {m}
-  0, 7.619628, 0,                         !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 3.047851;                  !- X,Y,Z Vertex 4 {m}
+  11.5818, 7.6196, 3.0479,                !- X,Y,Z Vertex 1 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 2 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 3 {m}
+  0, 7.6196, 3.0479;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {23f5bcdd-4d96-4b79-aaa3-fa5d4ff54e2f}, !- Handle
@@ -4091,10 +4091,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, -3.9691078068671e-07, 3.047851,      !- X,Y,Z Vertex 1 {m}
-  0, -3.9691078068671e-07, 0,             !- X,Y,Z Vertex 2 {m}
-  11.581835, -3.9691078068671e-07, 0,     !- X,Y,Z Vertex 3 {m}
-  11.581835, -3.9691078068671e-07, 3.047851; !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.0479,                           !- X,Y,Z Vertex 1 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  11.5818, 0, 3.0479;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {12411267-2c07-43b4-8bf0-459c91ceb16b}, !- Handle
@@ -4108,10 +4108,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 0, 3.047851,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 3 {m}
-  11.581835, 7.619628, 3.047851;          !- X,Y,Z Vertex 4 {m}
+  11.5818, 0, 3.0479,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 3 {m}
+  11.5818, 7.6196, 3.0479;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {517cd48e-a3d9-4002-b8eb-f01f36c6d818}, !- Handle
@@ -4125,10 +4125,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -1.63304399336539e-07, 7.619628, 3.047851, !- X,Y,Z Vertex 1 {m}
-  -1.63304399336539e-07, 7.619628, 0,     !- X,Y,Z Vertex 2 {m}
-  -1.63304399336539e-07, 0, 0,            !- X,Y,Z Vertex 3 {m}
-  -1.63304399336539e-07, 0, 3.047851;     !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 3.0479,                      !- X,Y,Z Vertex 1 {m}
+  0, 7.6196, 0,                           !- X,Y,Z Vertex 2 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.0479;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {ced355ab-ccf1-48d3-99d6-818e78f2476e}, !- Handle
@@ -4142,10 +4142,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.581835, 7.619628, 0,                 !- X,Y,Z Vertex 1 {m}
-  11.581835, 0, 0,                        !- X,Y,Z Vertex 2 {m}
+  11.5818, 7.6196, 0,                     !- X,Y,Z Vertex 1 {m}
+  11.5818, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
-  0, 7.619628, 0;                         !- X,Y,Z Vertex 4 {m}
+  0, 7.6196, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {11565674-4a54-4b56-b376-80434ac0d4dd}, !- Handle
@@ -4159,10 +4159,10 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   1,                                      !- Multiplier
   ,                                       !- Number of Vertices
-  8.686, 7.619628, 2.1732,                !- X,Y,Z Vertex 1 {m}
-  8.686, 7.619628, 0.954,                 !- X,Y,Z Vertex 2 {m}
-  2.89498950131234, 7.619628, 0.954,      !- X,Y,Z Vertex 3 {m}
-  2.89498950131234, 7.619628, 2.1732;     !- X,Y,Z Vertex 4 {m}
+  8.686, 7.6196, 2.1732,                  !- X,Y,Z Vertex 1 {m}
+  8.686, 7.6196, 0.954,                   !- X,Y,Z Vertex 2 {m}
+  2.89498950131234, 7.6196, 0.954,        !- X,Y,Z Vertex 3 {m}
+  2.89498950131234, 7.6196, 2.1732;       !- X,Y,Z Vertex 4 {m}
 
 OS:Facility,
   {a088617f-bd6c-4c3c-8620-c25da6ddb620}; !- Handle

--- a/data/geometry/DOERefPre1980SmallOffice.osm
+++ b/data/geometry/DOERefPre1980SmallOffice.osm
@@ -242,8 +242,8 @@ OS:Surface,
   ,                                       !- Number of Vertices
   22.69, 5, 3.05,                         !- X,Y,Z Vertex 1 {m}
   22.69, 5, 0,                            !- X,Y,Z Vertex 2 {m}
-  27.69, 2.04187384066908e-015, 0,        !- X,Y,Z Vertex 3 {m}
-  27.69, 2.04187384066908e-015, 3.05;     !- X,Y,Z Vertex 4 {m}
+  27.69, 0, 0,                            !- X,Y,Z Vertex 3 {m}
+  27.69, 0, 3.05;                         !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {b3a474a3-13e3-41a7-b742-f9eedf1247e8}, !- Handle
@@ -774,8 +774,8 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  27.69, 2.04187384066908e-015, 3.05,     !- X,Y,Z Vertex 1 {m}
-  27.69, 2.04187384066908e-015, 0,        !- X,Y,Z Vertex 2 {m}
+  27.69, 0, 3.05,                         !- X,Y,Z Vertex 1 {m}
+  27.69, 0, 0,                            !- X,Y,Z Vertex 2 {m}
   22.69, 5, 0,                            !- X,Y,Z Vertex 3 {m}
   22.69, 5, 3.05;                         !- X,Y,Z Vertex 4 {m}
 


### PR DESCRIPTION
- surface match LargeHotel and SuperMarket walls, rename unnamed surfaces in LargeHotel
- round vertices and origins to nearest 0.1mm in MidriseApartment and SmallOffice
- surface match Hospital floor, ceilings, re-assign surfaces to adiabatic/outdoors as appropriate, and fix malformed core wall
