### PR TITLE
handle terminal method returns as optional double instead of double

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/openstudio-standards
     docker:
-      - image: nrel/openstudio:2.6.0
+      - image: nrel/openstudio
     parallelism: 7
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
       - run:
           name: Install openstudio-standards test dependencies
           command: |
-            bundle install --path ./openstudio_standards_gems
+            bundle install
       - run:
           name: Parallelize Tests
           command: |
@@ -20,7 +20,7 @@ jobs:
       - run:
           name: Run tests
           command: |
-            export BUNDLE_PATH=~/openstudio-standards/openstudio_standards_gems && bundle exec rake test:circleci
+            bundle exec rake test:circleci
       - run:
           name: Summarize test times
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
       - run:
           name: Install openstudio-standards test dependencies
           command: |
-            bundle install
+            bundle install --path ./openstudio_standards_gems
       - run:
           name: Parallelize Tests
           command: |
@@ -20,11 +20,11 @@ jobs:
       - run:
           name: Run tests
           command: |
-            bundle exec rake test:circleci
+            bundle exec rake test:circleci --bundle Gemfile --bundle_path './openstudio_standards_gems'
       - run:
           name: Summarize test times
           command: |
-            bundle exec rake test:times
+            bundle exec rake test:times --bundle Gemfile --bundle_path './openstudio_standards_gems'
       - store_test_results:
           path: test/reports/
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,11 +20,11 @@ jobs:
       - run:
           name: Run tests
           command: |
-            bundle exec rake test:circleci --bundle Gemfile --bundle_path './openstudio_standards_gems'
+            export BUNDLE_PATH=~/openstudio-standards/openstudio_standards_gems && bundle exec rake test:circleci
       - run:
           name: Summarize test times
           command: |
-            bundle exec rake test:times --bundle Gemfile --bundle_path './openstudio_standards_gems'
+            bundle exec rake test:times
       - store_test_results:
           path: test/reports/
       - store_artifacts:

--- a/data/weather/CAN_AB_Banff.CS.711220_CWEC2016.ddy
+++ b/data/weather/CAN_AB_Banff.CS.711220_CWEC2016.ddy
@@ -17,8 +17,10 @@
  Weather Data,    ! Name
    1,             ! Begin Month
    1,             ! Begin Day of Month
+    ,             ! Begin Year
    12,            ! End Month
    31,            ! End Day of Month
+    ,             ! End Year
  Wednesday,      ! Day of Week for Start Day
    No,            ! Use Weather File Holidays and Special Days
    No,            ! Use Weather File Daylight Saving Period

--- a/data/weather/CAN_AB_Calgary.Intl.AP.718770_CWEC2016.ddy
+++ b/data/weather/CAN_AB_Calgary.Intl.AP.718770_CWEC2016.ddy
@@ -17,8 +17,10 @@
  Weather Data,    ! Name
    1,             ! Begin Month
    1,             ! Begin Day of Month
+    ,             ! Begin Year
    12,            ! End Month
    31,            ! End Day of Month
+    ,             ! End Year
  Wednesday,      ! Day of Week for Start Day
    No,            ! Use Weather File Holidays and Special Days
    No,            ! Use Weather File Daylight Saving Period

--- a/data/weather/CAN_AB_Edmonton.Intl.AP.711230_CWEC2016.ddy
+++ b/data/weather/CAN_AB_Edmonton.Intl.AP.711230_CWEC2016.ddy
@@ -17,8 +17,10 @@
  Weather Data,    ! Name
    1,             ! Begin Month
    1,             ! Begin Day of Month
+    ,             ! Begin Year
    12,            ! End Month
    31,            ! End Day of Month
+    ,             ! End Year
  Tuesday,      ! Day of Week for Start Day
    No,            ! Use Weather File Holidays and Special Days
    No,            ! Use Weather File Daylight Saving Period

--- a/data/weather/CAN_AB_Edmonton.Stony.Plain.AP.711270_CWEC2016.ddy
+++ b/data/weather/CAN_AB_Edmonton.Stony.Plain.AP.711270_CWEC2016.ddy
@@ -17,8 +17,10 @@
  Weather Data,    ! Name
    1,             ! Begin Month
    1,             ! Begin Day of Month
+    ,             ! Begin Year
    12,            ! End Month
    31,            ! End Day of Month
+    ,             ! End Year
  Tuesday,      ! Day of Week for Start Day
    No,            ! Use Weather File Holidays and Special Days
    No,            ! Use Weather File Daylight Saving Period

--- a/data/weather/CAN_AB_Fort.McMurray.AP.716890_CWEC2016.ddy
+++ b/data/weather/CAN_AB_Fort.McMurray.AP.716890_CWEC2016.ddy
@@ -17,8 +17,10 @@
  Weather Data,    ! Name
    1,             ! Begin Month
    1,             ! Begin Day of Month
+    ,             ! Begin Year
    12,            ! End Month
    31,            ! End Day of Month
+    ,             ! End Year
  Wednesday,      ! Day of Week for Start Day
    No,            ! Use Weather File Holidays and Special Days
    No,            ! Use Weather File Daylight Saving Period

--- a/data/weather/CAN_AB_Grande.Prairie.AP.719400_CWEC2016.ddy
+++ b/data/weather/CAN_AB_Grande.Prairie.AP.719400_CWEC2016.ddy
@@ -17,8 +17,10 @@
  Weather Data,    ! Name
    1,             ! Begin Month
    1,             ! Begin Day of Month
+    ,             ! Begin Year
    12,            ! End Month
    31,            ! End Day of Month
+    ,             ! End Year
  Tuesday,      ! Day of Week for Start Day
    No,            ! Use Weather File Holidays and Special Days
    No,            ! Use Weather File Daylight Saving Period

--- a/data/weather/CAN_AB_Lethbridge.AP.712430_CWEC2016.ddy
+++ b/data/weather/CAN_AB_Lethbridge.AP.712430_CWEC2016.ddy
@@ -17,8 +17,10 @@
  Weather Data,    ! Name
    1,             ! Begin Month
    1,             ! Begin Day of Month
+    ,             ! Begin Year
    12,            ! End Month
    31,            ! End Day of Month
+    ,             ! End Year
  Tuesday,      ! Day of Week for Start Day
    No,            ! Use Weather File Holidays and Special Days
    No,            ! Use Weather File Daylight Saving Period

--- a/data/weather/CAN_AB_Medicine.Hat.AP.710260_CWEC2016.ddy
+++ b/data/weather/CAN_AB_Medicine.Hat.AP.710260_CWEC2016.ddy
@@ -17,8 +17,10 @@
  Weather Data,    ! Name
    1,             ! Begin Month
    1,             ! Begin Day of Month
+    ,             ! Begin Year
    12,            ! End Month
    31,            ! End Day of Month
+    ,             ! End Year
  Tuesday,      ! Day of Week for Start Day
    No,            ! Use Weather File Holidays and Special Days
    No,            ! Use Weather File Daylight Saving Period

--- a/data/weather/CAN_BC_Abbotsford.Intl.AP.711080_CWEC2016.ddy
+++ b/data/weather/CAN_BC_Abbotsford.Intl.AP.711080_CWEC2016.ddy
@@ -17,8 +17,10 @@
  Weather Data,    ! Name
    1,             ! Begin Month
    1,             ! Begin Day of Month
+    ,             ! Begin Year
    12,            ! End Month
    31,            ! End Day of Month
+    ,             ! End Year
  Thursday,      ! Day of Week for Start Day
    No,            ! Use Weather File Holidays and Special Days
    No,            ! Use Weather File Daylight Saving Period

--- a/data/weather/CAN_BC_Comox.Valley.AP.718930_CWEC2016.ddy
+++ b/data/weather/CAN_BC_Comox.Valley.AP.718930_CWEC2016.ddy
@@ -17,8 +17,10 @@
  Weather Data,    ! Name
    1,             ! Begin Month
    1,             ! Begin Day of Month
+    ,             ! Begin Year
    12,            ! End Month
    31,            ! End Day of Month
+    ,             ! End Year
  Saturday,      ! Day of Week for Start Day
    No,            ! Use Weather File Holidays and Special Days
    No,            ! Use Weather File Daylight Saving Period

--- a/data/weather/CAN_BC_Crankbrook-Canadian.Rockies.Intl.AP.718800_CWEC2016.ddy
+++ b/data/weather/CAN_BC_Crankbrook-Canadian.Rockies.Intl.AP.718800_CWEC2016.ddy
@@ -17,8 +17,10 @@
  Weather Data,    ! Name
    1,             ! Begin Month
    1,             ! Begin Day of Month
+    ,             ! Begin Year
    12,            ! End Month
    31,            ! End Day of Month
+    ,             ! End Year
  Saturday,      ! Day of Week for Start Day
    No,            ! Use Weather File Holidays and Special Days
    No,            ! Use Weather File Daylight Saving Period

--- a/data/weather/CAN_BC_Fort.St.John-North.Peace.Rgnl.AP.719430_CWEC2016.ddy
+++ b/data/weather/CAN_BC_Fort.St.John-North.Peace.Rgnl.AP.719430_CWEC2016.ddy
@@ -17,8 +17,10 @@
  Weather Data,    ! Name
    1,             ! Begin Month
    1,             ! Begin Day of Month
+    ,             ! Begin Year
    12,            ! End Month
    31,            ! End Day of Month
+    ,             ! End Year
  Saturday,      ! Day of Week for Start Day
    No,            ! Use Weather File Holidays and Special Days
    No,            ! Use Weather File Daylight Saving Period

--- a/data/weather/CAN_BC_Hope.Rgnl.Airpark.711870_CWEC2016.ddy
+++ b/data/weather/CAN_BC_Hope.Rgnl.Airpark.711870_CWEC2016.ddy
@@ -17,8 +17,10 @@
  Weather Data,    ! Name
    1,             ! Begin Month
    1,             ! Begin Day of Month
+    ,             ! Begin Year
    12,            ! End Month
    31,            ! End Day of Month
+    ,             ! End Year
  Tuesday,      ! Day of Week for Start Day
    No,            ! Use Weather File Holidays and Special Days
    No,            ! Use Weather File Daylight Saving Period

--- a/data/weather/CAN_BC_Kamloops.AP.718870_CWEC2016.ddy
+++ b/data/weather/CAN_BC_Kamloops.AP.718870_CWEC2016.ddy
@@ -17,8 +17,10 @@
  Weather Data,    ! Name
    1,             ! Begin Month
    1,             ! Begin Day of Month
+    ,             ! Begin Year
    12,            ! End Month
    31,            ! End Day of Month
+    ,             ! End Year
  Tuesday,      ! Day of Week for Start Day
    No,            ! Use Weather File Holidays and Special Days
    No,            ! Use Weather File Daylight Saving Period

--- a/data/weather/CAN_BC_Port.Hardy.AP.711090_CWEC2016.ddy
+++ b/data/weather/CAN_BC_Port.Hardy.AP.711090_CWEC2016.ddy
@@ -17,8 +17,10 @@
  Weather Data,    ! Name
    1,             ! Begin Month
    1,             ! Begin Day of Month
+    ,             ! Begin Year
    12,            ! End Month
    31,            ! End Day of Month
+    ,             ! End Year
  Saturday,      ! Day of Week for Start Day
    No,            ! Use Weather File Holidays and Special Days
    No,            ! Use Weather File Daylight Saving Period

--- a/data/weather/CAN_BC_Prince.George.Intl.AP.718960_CWEC2016.ddy
+++ b/data/weather/CAN_BC_Prince.George.Intl.AP.718960_CWEC2016.ddy
@@ -17,8 +17,10 @@
  Weather Data,    ! Name
    1,             ! Begin Month
    1,             ! Begin Day of Month
+    ,             ! Begin Year
    12,            ! End Month
    31,            ! End Day of Month
+    ,             ! End Year
  Monday,      ! Day of Week for Start Day
    No,            ! Use Weather File Holidays and Special Days
    No,            ! Use Weather File Daylight Saving Period

--- a/data/weather/CAN_BC_Smithers.Rgnl.AP.719500_CWEC2016.ddy
+++ b/data/weather/CAN_BC_Smithers.Rgnl.AP.719500_CWEC2016.ddy
@@ -17,8 +17,10 @@
  Weather Data,    ! Name
    1,             ! Begin Month
    1,             ! Begin Day of Month
+    ,             ! Begin Year
    12,            ! End Month
    31,            ! End Day of Month
+    ,             ! End Year
  Monday,      ! Day of Week for Start Day
    No,            ! Use Weather File Holidays and Special Days
    No,            ! Use Weather File Daylight Saving Period

--- a/data/weather/CAN_BC_Summerland.717680_CWEC2016.ddy
+++ b/data/weather/CAN_BC_Summerland.717680_CWEC2016.ddy
@@ -17,8 +17,10 @@
  Weather Data,    ! Name
    1,             ! Begin Month
    1,             ! Begin Day of Month
+    ,             ! Begin Year
    12,            ! End Month
    31,            ! End Day of Month
+    ,             ! End Year
  Saturday,      ! Day of Week for Start Day
    No,            ! Use Weather File Holidays and Special Days
    No,            ! Use Weather File Daylight Saving Period

--- a/data/weather/CAN_BC_Vancouver.Intl.AP.718920_CWEC2016.ddy
+++ b/data/weather/CAN_BC_Vancouver.Intl.AP.718920_CWEC2016.ddy
@@ -17,8 +17,10 @@
  Weather Data,    ! Name
    1,             ! Begin Month
    1,             ! Begin Day of Month
+    ,             ! Begin Year
    12,            ! End Month
    31,            ! End Day of Month
+    ,             ! End Year
  Saturday,      ! Day of Week for Start Day
    No,            ! Use Weather File Holidays and Special Days
    No,            ! Use Weather File Daylight Saving Period

--- a/data/weather/CAN_BC_Victoria.Intl.AP.717990_CWEC2016.ddy
+++ b/data/weather/CAN_BC_Victoria.Intl.AP.717990_CWEC2016.ddy
@@ -17,8 +17,10 @@
  Weather Data,    ! Name
    1,             ! Begin Month
    1,             ! Begin Day of Month
+    ,             ! Begin Year
    12,            ! End Month
    31,            ! End Day of Month
+    ,             ! End Year
  Saturday,      ! Day of Week for Start Day
    No,            ! Use Weather File Holidays and Special Days
    No,            ! Use Weather File Daylight Saving Period

--- a/data/weather/CAN_MB_Brandon.Muni.AP.711400_CWEC2016.ddy
+++ b/data/weather/CAN_MB_Brandon.Muni.AP.711400_CWEC2016.ddy
@@ -17,8 +17,10 @@
  Weather Data,    ! Name
    1,             ! Begin Month
    1,             ! Begin Day of Month
+    ,             ! Begin Year
    12,            ! End Month
    31,            ! End Day of Month
+    ,             ! End Year
  Thursday,      ! Day of Week for Start Day
    No,            ! Use Weather File Holidays and Special Days
    No,            ! Use Weather File Daylight Saving Period

--- a/data/weather/CAN_MB_The.Pas.AP.718670_CWEC2016.ddy
+++ b/data/weather/CAN_MB_The.Pas.AP.718670_CWEC2016.ddy
@@ -17,8 +17,10 @@
  Weather Data,    ! Name
    1,             ! Begin Month
    1,             ! Begin Day of Month
+    ,             ! Begin Year
    12,            ! End Month
    31,            ! End Day of Month
+    ,             ! End Year
  Wednesday,      ! Day of Week for Start Day
    No,            ! Use Weather File Holidays and Special Days
    No,            ! Use Weather File Daylight Saving Period

--- a/data/weather/CAN_MB_Winnipeg-Richardson.Intl.AP.718520_CWEC2016.ddy
+++ b/data/weather/CAN_MB_Winnipeg-Richardson.Intl.AP.718520_CWEC2016.ddy
@@ -17,8 +17,10 @@
  Weather Data,    ! Name
    1,             ! Begin Month
    1,             ! Begin Day of Month
+    ,             ! Begin Year
    12,            ! End Month
    31,            ! End Day of Month
+    ,             ! End Year
  Tuesday,      ! Day of Week for Start Day
    No,            ! Use Weather File Holidays and Special Days
    No,            ! Use Weather File Daylight Saving Period

--- a/data/weather/CAN_NB_Fredericton.Intl.AP.717000_CWEC2016.ddy
+++ b/data/weather/CAN_NB_Fredericton.Intl.AP.717000_CWEC2016.ddy
@@ -17,8 +17,10 @@
  Weather Data,    ! Name
    1,             ! Begin Month
    1,             ! Begin Day of Month
+    ,             ! Begin Year
    12,            ! End Month
    31,            ! End Day of Month
+    ,             ! End Year
  Saturday,      ! Day of Week for Start Day
    No,            ! Use Weather File Holidays and Special Days
    No,            ! Use Weather File Daylight Saving Period

--- a/data/weather/CAN_NB_Miramichi.AP.717440_CWEC2016.ddy
+++ b/data/weather/CAN_NB_Miramichi.AP.717440_CWEC2016.ddy
@@ -17,8 +17,10 @@
  Weather Data,    ! Name
    1,             ! Begin Month
    1,             ! Begin Day of Month
+    ,             ! Begin Year
    12,            ! End Month
    31,            ! End Day of Month
+    ,             ! End Year
  Saturday,      ! Day of Week for Start Day
    No,            ! Use Weather File Holidays and Special Days
    No,            ! Use Weather File Daylight Saving Period

--- a/data/weather/CAN_NB_Saint.John.AP.716090_CWEC2016.ddy
+++ b/data/weather/CAN_NB_Saint.John.AP.716090_CWEC2016.ddy
@@ -17,8 +17,10 @@
  Weather Data,    ! Name
    1,             ! Begin Month
    1,             ! Begin Day of Month
+    ,             ! Begin Year
    12,            ! End Month
    31,            ! End Day of Month
+    ,             ! End Year
  Saturday,      ! Day of Week for Start Day
    No,            ! Use Weather File Holidays and Special Days
    No,            ! Use Weather File Daylight Saving Period

--- a/data/weather/CAN_NL_Gander.Intl.AP-CFB.Gander.718030_CWEC2016.ddy
+++ b/data/weather/CAN_NL_Gander.Intl.AP-CFB.Gander.718030_CWEC2016.ddy
@@ -17,8 +17,10 @@
  Weather Data,    ! Name
    1,             ! Begin Month
    1,             ! Begin Day of Month
+    ,             ! Begin Year
    12,            ! End Month
    31,            ! End Day of Month
+    ,             ! End Year
  Thursday,      ! Day of Week for Start Day
    No,            ! Use Weather File Holidays and Special Days
    No,            ! Use Weather File Daylight Saving Period

--- a/data/weather/CAN_NL_Goose.Bay.AP-CFB.Goose.Bay.718160_CWEC2016.ddy
+++ b/data/weather/CAN_NL_Goose.Bay.AP-CFB.Goose.Bay.718160_CWEC2016.ddy
@@ -17,8 +17,10 @@
  Weather Data,    ! Name
    1,             ! Begin Month
    1,             ! Begin Day of Month
+    ,             ! Begin Year
    12,            ! End Month
    31,            ! End Day of Month
+    ,             ! End Year
  Saturday,      ! Day of Week for Start Day
    No,            ! Use Weather File Holidays and Special Days
    No,            ! Use Weather File Daylight Saving Period

--- a/data/weather/CAN_NL_St.Johns.Intl.AP.718010_CWEC2016.ddy
+++ b/data/weather/CAN_NL_St.Johns.Intl.AP.718010_CWEC2016.ddy
@@ -17,8 +17,10 @@
  Weather Data,    ! Name
    1,             ! Begin Month
    1,             ! Begin Day of Month
+    ,             ! Begin Year
    12,            ! End Month
    31,            ! End Day of Month
+    ,             ! End Year
  Tuesday,      ! Day of Week for Start Day
    No,            ! Use Weather File Holidays and Special Days
    No,            ! Use Weather File Daylight Saving Period

--- a/data/weather/CAN_NL_Stephenville.Intl.AP.718150_CWEC2016.ddy
+++ b/data/weather/CAN_NL_Stephenville.Intl.AP.718150_CWEC2016.ddy
@@ -17,8 +17,10 @@
  Weather Data,    ! Name
    1,             ! Begin Month
    1,             ! Begin Day of Month
+    ,             ! Begin Year
    12,            ! End Month
    31,            ! End Day of Month
+    ,             ! End Year
  Tuesday,      ! Day of Week for Start Day
    No,            ! Use Weather File Holidays and Special Days
    No,            ! Use Weather File Daylight Saving Period

--- a/data/weather/CAN_NS_CFB.Greenwood.713970_CWEC2016.ddy
+++ b/data/weather/CAN_NS_CFB.Greenwood.713970_CWEC2016.ddy
@@ -17,8 +17,10 @@
  Weather Data,    ! Name
    1,             ! Begin Month
    1,             ! Begin Day of Month
+    ,             ! Begin Year
    12,            ! End Month
    31,            ! End Day of Month
+    ,             ! End Year
  Saturday,      ! Day of Week for Start Day
    No,            ! Use Weather File Holidays and Special Days
    No,            ! Use Weather File Daylight Saving Period

--- a/data/weather/CAN_NS_CFB.Shearwater.716010_CWEC2016.ddy
+++ b/data/weather/CAN_NS_CFB.Shearwater.716010_CWEC2016.ddy
@@ -17,8 +17,10 @@
  Weather Data,    ! Name
    1,             ! Begin Month
    1,             ! Begin Day of Month
+    ,             ! Begin Year
    12,            ! End Month
    31,            ! End Day of Month
+    ,             ! End Year
  Saturday,      ! Day of Week for Start Day
    No,            ! Use Weather File Holidays and Special Days
    No,            ! Use Weather File Daylight Saving Period

--- a/data/weather/CAN_NS_Sable.Island.Natl.Park.716000_CWEC2016.ddy
+++ b/data/weather/CAN_NS_Sable.Island.Natl.Park.716000_CWEC2016.ddy
@@ -17,8 +17,10 @@
  Weather Data,    ! Name
    1,             ! Begin Month
    1,             ! Begin Day of Month
+    ,             ! Begin Year
    12,            ! End Month
    31,            ! End Day of Month
+    ,             ! End Year
  Thursday,      ! Day of Week for Start Day
    No,            ! Use Weather File Holidays and Special Days
    No,            ! Use Weather File Daylight Saving Period

--- a/data/weather/CAN_NT_Inuvik-Zubko.AP.719570_CWEC2016.ddy
+++ b/data/weather/CAN_NT_Inuvik-Zubko.AP.719570_CWEC2016.ddy
@@ -17,8 +17,10 @@
  Weather Data,    ! Name
    1,             ! Begin Month
    1,             ! Begin Day of Month
+    ,             ! Begin Year
    12,            ! End Month
    31,            ! End Day of Month
+    ,             ! End Year
  Tuesday,      ! Day of Week for Start Day
    No,            ! Use Weather File Holidays and Special Days
    No,            ! Use Weather File Daylight Saving Period

--- a/data/weather/CAN_NT_Yellowknife.AP.719360_CWEC2016.ddy
+++ b/data/weather/CAN_NT_Yellowknife.AP.719360_CWEC2016.ddy
@@ -17,8 +17,10 @@
  Weather Data,    ! Name
    1,             ! Begin Month
    1,             ! Begin Day of Month
+    ,             ! Begin Year
    12,            ! End Month
    31,            ! End Day of Month
+    ,             ! End Year
  Thursday,      ! Day of Week for Start Day
    No,            ! Use Weather File Holidays and Special Days
    No,            ! Use Weather File Daylight Saving Period

--- a/data/weather/CAN_NU_Resolute.AP.719240_CWEC2016.ddy
+++ b/data/weather/CAN_NU_Resolute.AP.719240_CWEC2016.ddy
@@ -17,8 +17,10 @@
  Weather Data,    ! Name
    1,             ! Begin Month
    1,             ! Begin Day of Month
+    ,             ! Begin Year
    12,            ! End Month
    31,            ! End Day of Month
+    ,             ! End Year
  Monday,      ! Day of Week for Start Day
    No,            ! Use Weather File Holidays and Special Days
    No,            ! Use Weather File Daylight Saving Period

--- a/data/weather/CAN_ON_Armstrong.AP.718410_CWEC2016.ddy
+++ b/data/weather/CAN_ON_Armstrong.AP.718410_CWEC2016.ddy
@@ -17,8 +17,10 @@
  Weather Data,    ! Name
    1,             ! Begin Month
    1,             ! Begin Day of Month
+    ,             ! Begin Year
    12,            ! End Month
    31,            ! End Day of Month
+    ,             ! End Year
  Saturday,      ! Day of Week for Start Day
    No,            ! Use Weather File Holidays and Special Days
    No,            ! Use Weather File Daylight Saving Period

--- a/data/weather/CAN_ON_CFB.Trenton.716210_CWEC2016.ddy
+++ b/data/weather/CAN_ON_CFB.Trenton.716210_CWEC2016.ddy
@@ -17,8 +17,10 @@
  Weather Data,    ! Name
    1,             ! Begin Month
    1,             ! Begin Day of Month
+    ,             ! Begin Year
    12,            ! End Month
    31,            ! End Day of Month
+    ,             ! End Year
  Saturday,      ! Day of Week for Start Day
    No,            ! Use Weather File Holidays and Special Days
    No,            ! Use Weather File Daylight Saving Period

--- a/data/weather/CAN_ON_Dryden.Rgnl.AP.715270_CWEC2016.ddy
+++ b/data/weather/CAN_ON_Dryden.Rgnl.AP.715270_CWEC2016.ddy
@@ -17,8 +17,10 @@
  Weather Data,    ! Name
    1,             ! Begin Month
    1,             ! Begin Day of Month
+    ,             ! Begin Year
    12,            ! End Month
    31,            ! End Day of Month
+    ,             ! End Year
  Friday,      ! Day of Week for Start Day
    No,            ! Use Weather File Holidays and Special Days
    No,            ! Use Weather File Daylight Saving Period

--- a/data/weather/CAN_ON_London.Intl.AP.716230_CWEC2016.ddy
+++ b/data/weather/CAN_ON_London.Intl.AP.716230_CWEC2016.ddy
@@ -17,8 +17,10 @@
  Weather Data,    ! Name
    1,             ! Begin Month
    1,             ! Begin Day of Month
+    ,             ! Begin Year
    12,            ! End Month
    31,            ! End Day of Month
+    ,             ! End Year
  Friday,      ! Day of Week for Start Day
    No,            ! Use Weather File Holidays and Special Days
    No,            ! Use Weather File Daylight Saving Period

--- a/data/weather/CAN_ON_Moosonee.AP.713980_CWEC2016.ddy
+++ b/data/weather/CAN_ON_Moosonee.AP.713980_CWEC2016.ddy
@@ -17,8 +17,10 @@
  Weather Data,    ! Name
    1,             ! Begin Month
    1,             ! Begin Day of Month
+    ,             ! Begin Year
    12,            ! End Month
    31,            ! End Day of Month
+    ,             ! End Year
  Tuesday,      ! Day of Week for Start Day
    No,            ! Use Weather File Holidays and Special Days
    No,            ! Use Weather File Daylight Saving Period

--- a/data/weather/CAN_ON_Mount.Forest.716310_CWEC2016.ddy
+++ b/data/weather/CAN_ON_Mount.Forest.716310_CWEC2016.ddy
@@ -17,8 +17,10 @@
  Weather Data,    ! Name
    1,             ! Begin Month
    1,             ! Begin Day of Month
+    ,             ! Begin Year
    12,            ! End Month
    31,            ! End Day of Month
+    ,             ! End Year
  Friday,      ! Day of Week for Start Day
    No,            ! Use Weather File Holidays and Special Days
    No,            ! Use Weather File Daylight Saving Period

--- a/data/weather/CAN_ON_North.Bay-Garland.AP.717310_CWEC2016.ddy
+++ b/data/weather/CAN_ON_North.Bay-Garland.AP.717310_CWEC2016.ddy
@@ -17,8 +17,10 @@
  Weather Data,    ! Name
    1,             ! Begin Month
    1,             ! Begin Day of Month
+    ,             ! Begin Year
    12,            ! End Month
    31,            ! End Day of Month
+    ,             ! End Year
  Friday,      ! Day of Week for Start Day
    No,            ! Use Weather File Holidays and Special Days
    No,            ! Use Weather File Daylight Saving Period

--- a/data/weather/CAN_ON_Ottawa-Macdonald-Cartier.Intl.AP.716280_CWEC2016.ddy
+++ b/data/weather/CAN_ON_Ottawa-Macdonald-Cartier.Intl.AP.716280_CWEC2016.ddy
@@ -17,8 +17,10 @@
  Weather Data,    ! Name
    1,             ! Begin Month
    1,             ! Begin Day of Month
+    ,             ! Begin Year
    12,            ! End Month
    31,            ! End Day of Month
+    ,             ! End Year
  Saturday,      ! Day of Week for Start Day
    No,            ! Use Weather File Holidays and Special Days
    No,            ! Use Weather File Daylight Saving Period

--- a/data/weather/CAN_ON_Sault.Ste.Marie.AP.712600_CWEC2016.ddy
+++ b/data/weather/CAN_ON_Sault.Ste.Marie.AP.712600_CWEC2016.ddy
@@ -17,8 +17,10 @@
  Weather Data,    ! Name
    1,             ! Begin Month
    1,             ! Begin Day of Month
+    ,             ! Begin Year
    12,            ! End Month
    31,            ! End Day of Month
+    ,             ! End Year
  Friday,      ! Day of Week for Start Day
    No,            ! Use Weather File Holidays and Special Days
    No,            ! Use Weather File Daylight Saving Period

--- a/data/weather/CAN_ON_Timmins.Power.AP.717390_CWEC2016.ddy
+++ b/data/weather/CAN_ON_Timmins.Power.AP.717390_CWEC2016.ddy
@@ -17,8 +17,10 @@
  Weather Data,    ! Name
    1,             ! Begin Month
    1,             ! Begin Day of Month
+    ,             ! Begin Year
    12,            ! End Month
    31,            ! End Day of Month
+    ,             ! End Year
  Saturday,      ! Day of Week for Start Day
    No,            ! Use Weather File Holidays and Special Days
    No,            ! Use Weather File Daylight Saving Period

--- a/data/weather/CAN_ON_Toronto.Pearson.Intl.AP.716240_CWEC2016.ddy
+++ b/data/weather/CAN_ON_Toronto.Pearson.Intl.AP.716240_CWEC2016.ddy
@@ -17,8 +17,10 @@
  Weather Data,    ! Name
    1,             ! Begin Month
    1,             ! Begin Day of Month
+    ,             ! Begin Year
    12,            ! End Month
    31,            ! End Day of Month
+    ,             ! End Year
  Friday,      ! Day of Week for Start Day
    No,            ! Use Weather File Holidays and Special Days
    No,            ! Use Weather File Daylight Saving Period

--- a/data/weather/CAN_ON_Windsor.Intl.AP.715380_CWEC2016.ddy
+++ b/data/weather/CAN_ON_Windsor.Intl.AP.715380_CWEC2016.ddy
@@ -17,8 +17,10 @@
  Weather Data,    ! Name
    1,             ! Begin Month
    1,             ! Begin Day of Month
+    ,             ! Begin Year
    12,            ! End Month
    31,            ! End Day of Month
+    ,             ! End Year
  Tuesday,      ! Day of Week for Start Day
    No,            ! Use Weather File Holidays and Special Days
    No,            ! Use Weather File Daylight Saving Period

--- a/data/weather/CAN_PE_Charlottetown.AP.717060_CWEC2016.ddy
+++ b/data/weather/CAN_PE_Charlottetown.AP.717060_CWEC2016.ddy
@@ -17,8 +17,10 @@
  Weather Data,    ! Name
    1,             ! Begin Month
    1,             ! Begin Day of Month
+    ,             ! Begin Year
    12,            ! End Month
    31,            ! End Day of Month
+    ,             ! End Year
  Saturday,      ! Day of Week for Start Day
    No,            ! Use Weather File Holidays and Special Days
    No,            ! Use Weather File Daylight Saving Period

--- a/data/weather/CAN_QC_Kuujjuaq.AP.719060_CWEC2016.ddy
+++ b/data/weather/CAN_QC_Kuujjuaq.AP.719060_CWEC2016.ddy
@@ -17,8 +17,10 @@
  Weather Data,    ! Name
    1,             ! Begin Month
    1,             ! Begin Day of Month
+    ,             ! Begin Year
    12,            ! End Month
    31,            ! End Day of Month
+    ,             ! End Year
  Sunday,      ! Day of Week for Start Day
    No,            ! Use Weather File Holidays and Special Days
    No,            ! Use Weather File Daylight Saving Period

--- a/data/weather/CAN_QC_Kuujuarapik.AP.719050_CWEC2016.ddy
+++ b/data/weather/CAN_QC_Kuujuarapik.AP.719050_CWEC2016.ddy
@@ -17,8 +17,10 @@
  Weather Data,    ! Name
    1,             ! Begin Month
    1,             ! Begin Day of Month
+    ,             ! Begin Year
    12,            ! End Month
    31,            ! End Day of Month
+    ,             ! End Year
  Tuesday,      ! Day of Week for Start Day
    No,            ! Use Weather File Holidays and Special Days
    No,            ! Use Weather File Daylight Saving Period

--- a/data/weather/CAN_QC_Lac.Eon.AP.714210_CWEC2016.ddy
+++ b/data/weather/CAN_QC_Lac.Eon.AP.714210_CWEC2016.ddy
@@ -17,8 +17,10 @@
  Weather Data,    ! Name
    1,             ! Begin Month
    1,             ! Begin Day of Month
+    ,             ! Begin Year
    12,            ! End Month
    31,            ! End Day of Month
+    ,             ! End Year
  Saturday,      ! Day of Week for Start Day
    No,            ! Use Weather File Holidays and Special Days
    No,            ! Use Weather File Daylight Saving Period

--- a/data/weather/CAN_QC_Mont-Joli.AP.717180_CWEC2016.ddy
+++ b/data/weather/CAN_QC_Mont-Joli.AP.717180_CWEC2016.ddy
@@ -17,8 +17,10 @@
  Weather Data,    ! Name
    1,             ! Begin Month
    1,             ! Begin Day of Month
+    ,             ! Begin Year
    12,            ! End Month
    31,            ! End Day of Month
+    ,             ! End Year
  Saturday,      ! Day of Week for Start Day
    No,            ! Use Weather File Holidays and Special Days
    No,            ! Use Weather File Daylight Saving Period

--- a/data/weather/CAN_QC_Montreal-Mirabel.Intl.AP.719050_CWEC2016.ddy
+++ b/data/weather/CAN_QC_Montreal-Mirabel.Intl.AP.719050_CWEC2016.ddy
@@ -17,8 +17,10 @@
  Weather Data,    ! Name
    1,             ! Begin Month
    1,             ! Begin Day of Month
+    ,             ! Begin Year
    12,            ! End Month
    31,            ! End Day of Month
+    ,             ! End Year
  Friday,      ! Day of Week for Start Day
    No,            ! Use Weather File Holidays and Special Days
    No,            ! Use Weather File Daylight Saving Period

--- a/data/weather/CAN_QC_Montreal-St-Hubert.Longueuil.AP.713710_CWEC2016.ddy
+++ b/data/weather/CAN_QC_Montreal-St-Hubert.Longueuil.AP.713710_CWEC2016.ddy
@@ -17,8 +17,10 @@
  Weather Data,    ! Name
    1,             ! Begin Month
    1,             ! Begin Day of Month
+    ,             ! Begin Year
    12,            ! End Month
    31,            ! End Day of Month
+    ,             ! End Year
  Friday,      ! Day of Week for Start Day
    No,            ! Use Weather File Holidays and Special Days
    No,            ! Use Weather File Daylight Saving Period

--- a/data/weather/CAN_QC_Montreal-Trudeau.Intl.AP.716270_CWEC2016.ddy
+++ b/data/weather/CAN_QC_Montreal-Trudeau.Intl.AP.716270_CWEC2016.ddy
@@ -17,8 +17,10 @@
  Weather Data,    ! Name
    1,             ! Begin Month
    1,             ! Begin Day of Month
+    ,             ! Begin Year
    12,            ! End Month
    31,            ! End Day of Month
+    ,             ! End Year
  Friday,      ! Day of Week for Start Day
    No,            ! Use Weather File Holidays and Special Days
    No,            ! Use Weather File Daylight Saving Period

--- a/data/weather/CAN_QC_Quebec-Lesage.Intl.AP.717140_CWEC2016.ddy
+++ b/data/weather/CAN_QC_Quebec-Lesage.Intl.AP.717140_CWEC2016.ddy
@@ -17,8 +17,10 @@
  Weather Data,    ! Name
    1,             ! Begin Month
    1,             ! Begin Day of Month
+    ,             ! Begin Year
    12,            ! End Month
    31,            ! End Day of Month
+    ,             ! End Year
  Sunday,      ! Day of Week for Start Day
    No,            ! Use Weather File Holidays and Special Days
    No,            ! Use Weather File Daylight Saving Period

--- a/data/weather/CAN_QC_Riviere-du-Loup.717150_CWEC2016.ddy
+++ b/data/weather/CAN_QC_Riviere-du-Loup.717150_CWEC2016.ddy
@@ -17,8 +17,10 @@
  Weather Data,    ! Name
    1,             ! Begin Month
    1,             ! Begin Day of Month
+    ,             ! Begin Year
    12,            ! End Month
    31,            ! End Day of Month
+    ,             ! End Year
  Friday,      ! Day of Week for Start Day
    No,            ! Use Weather File Holidays and Special Days
    No,            ! Use Weather File Daylight Saving Period

--- a/data/weather/CAN_QC_Roberval.AP.717280_CWEC2016.ddy
+++ b/data/weather/CAN_QC_Roberval.AP.717280_CWEC2016.ddy
@@ -17,8 +17,10 @@
  Weather Data,    ! Name
    1,             ! Begin Month
    1,             ! Begin Day of Month
+    ,             ! Begin Year
    12,            ! End Month
    31,            ! End Day of Month
+    ,             ! End Year
  Sunday,      ! Day of Week for Start Day
    No,            ! Use Weather File Holidays and Special Days
    No,            ! Use Weather File Daylight Saving Period

--- a/data/weather/CAN_QC_Saguenay-Bagotville.AP-CFB.Bagotville.717270_CWEC2016.ddy
+++ b/data/weather/CAN_QC_Saguenay-Bagotville.AP-CFB.Bagotville.717270_CWEC2016.ddy
@@ -17,8 +17,10 @@
  Weather Data,    ! Name
    1,             ! Begin Month
    1,             ! Begin Day of Month
+    ,             ! Begin Year
    12,            ! End Month
    31,            ! End Day of Month
+    ,             ! End Year
  Friday,      ! Day of Week for Start Day
    No,            ! Use Weather File Holidays and Special Days
    No,            ! Use Weather File Daylight Saving Period

--- a/data/weather/CAN_QC_Schefferville.AP.718280_CWEC2016.ddy
+++ b/data/weather/CAN_QC_Schefferville.AP.718280_CWEC2016.ddy
@@ -17,8 +17,10 @@
  Weather Data,    ! Name
    1,             ! Begin Month
    1,             ! Begin Day of Month
+    ,             ! Begin Year
    12,            ! End Month
    31,            ! End Day of Month
+    ,             ! End Year
  Tuesday,      ! Day of Week for Start Day
    No,            ! Use Weather File Holidays and Special Days
    No,            ! Use Weather File Daylight Saving Period

--- a/data/weather/CAN_QC_Sept-Iles.AP.718110_CWEC2016.ddy
+++ b/data/weather/CAN_QC_Sept-Iles.AP.718110_CWEC2016.ddy
@@ -17,8 +17,10 @@
  Weather Data,    ! Name
    1,             ! Begin Month
    1,             ! Begin Day of Month
+    ,             ! Begin Year
    12,            ! End Month
    31,            ! End Day of Month
+    ,             ! End Year
  Sunday,      ! Day of Week for Start Day
    No,            ! Use Weather File Holidays and Special Days
    No,            ! Use Weather File Daylight Saving Period

--- a/data/weather/CAN_QC_Val-d-Or.Rgnl.AP.717250_CWEC2016.ddy
+++ b/data/weather/CAN_QC_Val-d-Or.Rgnl.AP.717250_CWEC2016.ddy
@@ -17,8 +17,10 @@
  Weather Data,    ! Name
    1,             ! Begin Month
    1,             ! Begin Day of Month
+    ,             ! Begin Year
    12,            ! End Month
    31,            ! End Day of Month
+    ,             ! End Year
  Friday,      ! Day of Week for Start Day
    No,            ! Use Weather File Holidays and Special Days
    No,            ! Use Weather File Daylight Saving Period

--- a/data/weather/CAN_SK_Estevan.Rgnl.AP.718620_CWEC2016.ddy
+++ b/data/weather/CAN_SK_Estevan.Rgnl.AP.718620_CWEC2016.ddy
@@ -17,8 +17,10 @@
  Weather Data,    ! Name
    1,             ! Begin Month
    1,             ! Begin Day of Month
+    ,             ! Begin Year
    12,            ! End Month
    31,            ! End Day of Month
+    ,             ! End Year
  Tuesday,      ! Day of Week for Start Day
    No,            ! Use Weather File Holidays and Special Days
    No,            ! Use Weather File Daylight Saving Period

--- a/data/weather/CAN_SK_North.Battleford.AP.718760_CWEC2016.ddy
+++ b/data/weather/CAN_SK_North.Battleford.AP.718760_CWEC2016.ddy
@@ -17,8 +17,10 @@
  Weather Data,    ! Name
    1,             ! Begin Month
    1,             ! Begin Day of Month
+    ,             ! Begin Year
    12,            ! End Month
    31,            ! End Day of Month
+    ,             ! End Year
  Saturday,      ! Day of Week for Start Day
    No,            ! Use Weather File Holidays and Special Days
    No,            ! Use Weather File Daylight Saving Period

--- a/data/weather/CAN_SK_Saskatoon.Intl.AP.718660_CWEC2016.ddy
+++ b/data/weather/CAN_SK_Saskatoon.Intl.AP.718660_CWEC2016.ddy
@@ -17,8 +17,10 @@
  Weather Data,    ! Name
    1,             ! Begin Month
    1,             ! Begin Day of Month
+    ,             ! Begin Year
    12,            ! End Month
    31,            ! End Day of Month
+    ,             ! End Year
  Tuesday,      ! Day of Week for Start Day
    No,            ! Use Weather File Holidays and Special Days
    No,            ! Use Weather File Daylight Saving Period

--- a/data/weather/CAN_YT_Whitehorse.Intl.AP.719640_CWEC2016.ddy
+++ b/data/weather/CAN_YT_Whitehorse.Intl.AP.719640_CWEC2016.ddy
@@ -17,8 +17,10 @@
  Weather Data,    ! Name
    1,             ! Begin Month
    1,             ! Begin Day of Month
+    ,             ! Begin Year
    12,            ! End Month
    31,            ! End Day of Month
+    ,             ! End Year
  Saturday,      ! Day of Week for Start Day
    No,            ! Use Weather File Holidays and Special Days
    No,            ! Use Weather File Daylight Saving Period

--- a/lib/openstudio-standards.rb
+++ b/lib/openstudio-standards.rb
@@ -1,4 +1,5 @@
 require 'singleton'
+require 'open3'
 require_relative 'openstudio-standards/version'
 
 module OpenstudioStandards
@@ -305,4 +306,47 @@ module OpenstudioStandards
   require_relative "#{proto}/cbes/cbes_t24_2008/cbes_t24_2008.FanConstantVolume"
   require_relative "#{proto}/cbes/cbes_t24_2008/cbes_t24_2008.FanOnOff"
   require_relative "#{proto}/cbes/cbes_t24_2008/cbes_t24_2008.FanVariableVolume"
+  
+  # DLM: not sure where this code should go
+  def self.get_run_env()
+    # blank out bundler and gem path modifications, will be re-setup by new call
+    new_env = {}
+    new_env["BUNDLER_ORIG_MANPATH"] = nil
+    new_env["GEM_PATH"] = nil
+    new_env["GEM_HOME"] = nil
+    new_env["BUNDLER_ORIG_PATH"] = nil
+    new_env["BUNDLER_VERSION"] = nil
+    new_env["BUNDLE_BIN_PATH"] = nil
+    new_env["BUNDLE_GEMFILE"] = nil
+    new_env["RUBYLIB"] = nil
+    new_env["RUBYOPT"] = nil
+    
+    bundle_gemfile = ENV['BUNDLE_GEMFILE']
+    bundle_path = ENV['BUNDLE_PATH']    
+    if bundle_gemfile.nil? || bundle_path.nil?
+      new_env['BUNDLE_GEMFILE'] = nil
+      new_env['BUNDLE_PATH'] = nil
+    else
+      new_env['BUNDLE_GEMFILE'] = bundle_gemfile
+      new_env['BUNDLE_PATH'] = bundle_path    
+    end  
+    
+    return new_env
+  end
+  
+  def self.run_command(command)
+    stdout_str, stderr_str, status = Open3.capture3(get_run_env(), command)
+    if status.success?
+      puts "Command completed successfully"
+      #puts "stdout: #{stdout_str}"
+      #puts "stderr: #{stderr_str}"
+      return true
+    else
+      puts "Error running command: '#{command}'"
+      puts "stdout: #{stdout_str}"
+      puts "stderr: #{stderr_str}"
+      return false 
+    end
+  end
+  
 end

--- a/lib/openstudio-standards.rb
+++ b/lib/openstudio-standards.rb
@@ -312,24 +312,27 @@ module OpenstudioStandards
     # blank out bundler and gem path modifications, will be re-setup by new call
     new_env = {}
     new_env["BUNDLER_ORIG_MANPATH"] = nil
-    new_env["GEM_PATH"] = nil
-    new_env["GEM_HOME"] = nil
     new_env["BUNDLER_ORIG_PATH"] = nil
     new_env["BUNDLER_VERSION"] = nil
     new_env["BUNDLE_BIN_PATH"] = nil
-    new_env["BUNDLE_GEMFILE"] = nil
     new_env["RUBYLIB"] = nil
     new_env["RUBYOPT"] = nil
     
-    bundle_gemfile = ENV['BUNDLE_GEMFILE']
-    bundle_path = ENV['BUNDLE_PATH']    
-    if bundle_gemfile.nil? || bundle_path.nil?
+    # DLM: preserve GEM_HOME and GEM_PATH set by current bundle because we are not supporting bundle
+    # requires to ruby gems will work, will fail if we require a native gem
+    #new_env["GEM_PATH"] = nil
+    #new_env["GEM_HOME"] = nil
+    
+    # DLM: for now, ignore current bundle in case it has binary dependencies in it
+    #bundle_gemfile = ENV['BUNDLE_GEMFILE']
+    #bundle_path = ENV['BUNDLE_PATH']    
+    #if bundle_gemfile.nil? || bundle_path.nil?
       new_env['BUNDLE_GEMFILE'] = nil
       new_env['BUNDLE_PATH'] = nil
-    else
-      new_env['BUNDLE_GEMFILE'] = bundle_gemfile
-      new_env['BUNDLE_PATH'] = bundle_path    
-    end  
+    #else
+    #  new_env['BUNDLE_GEMFILE'] = bundle_gemfile
+    #  new_env['BUNDLE_PATH'] = bundle_path    
+    #end  
     
     return new_env
   end

--- a/lib/openstudio-standards/standards/Standards.AirLoopHVAC.rb
+++ b/lib/openstudio-standards/standards/Standards.AirLoopHVAC.rb
@@ -1668,12 +1668,11 @@ class Standard
           end
         elsif equip.to_AirTerminalSingleDuctVAVReheat.is_initialized
           term = equip.to_AirTerminalSingleDuctVAVReheat.get
-          mdp_term = term.constantMinimumAirFlowFraction
-          min_zn_flow = term.fixedMinimumAirFlowRate
-          if min_zn_flow.is_initialized
-            min_zn_flow = min_zn_flow.get
-          else
-            min_zn_flow = 0.0
+          if term.constantMinimumAirFlowFraction.is_initialized
+            mdp_term = term.constantMinimumAirFlowFraction.get
+          end
+          if term.fixedMinimumAirFlowRate.is_initialized
+            min_zn_flow = term.fixedMinimumAirFlowRate.get
           end
         end
       end

--- a/lib/openstudio-standards/standards/Standards.AirTerminalSingleDuctVAVReheat.rb
+++ b/lib/openstudio-standards/standards/Standards.AirTerminalSingleDuctVAVReheat.rb
@@ -43,7 +43,7 @@ class Standard
   # Sets the capacity of the reheat coil based on the minimum flow fraction,
   # and the maximum flow rate.
   def air_terminal_single_duct_vav_reheat_set_heating_cap(air_terminal_single_duct_vav_reheat)
-    flow_rate_fraction = air_terminal_single_duct_vav_reheat.constantMinimumAirFlowFraction
+    flow_rate_fraction = air_terminal_single_duct_vav_reheat.constantMinimumAirFlowFraction.get
     if air_terminal_single_duct_vav_reheat.reheatCoil.to_CoilHeatingWater.is_initialized
       reheat_coil = air_terminal_single_duct_vav_reheat.reheatCoil.to_CoilHeatingWater.get
       if reheat_coil.autosizedRatedCapacity.to_f < 1.0e-6

--- a/lib/openstudio-standards/standards/Standards.AirTerminalSingleDuctVAVReheat.rb
+++ b/lib/openstudio-standards/standards/Standards.AirTerminalSingleDuctVAVReheat.rb
@@ -43,11 +43,14 @@ class Standard
   # Sets the capacity of the reheat coil based on the minimum flow fraction,
   # and the maximum flow rate.
   def air_terminal_single_duct_vav_reheat_set_heating_cap(air_terminal_single_duct_vav_reheat)
-    flow_rate_fraction = air_terminal_single_duct_vav_reheat.constantMinimumAirFlowFraction.get
+    flow_rate_fraction = 0.0
+    if air_terminal_single_duct_vav_reheat.constantMinimumAirFlowFraction.is_initialized
+      flow_rate_fraction = air_terminal_single_duct_vav_reheat.constantMinimumAirFlowFraction.get
+    end
     if air_terminal_single_duct_vav_reheat.reheatCoil.to_CoilHeatingWater.is_initialized
       reheat_coil = air_terminal_single_duct_vav_reheat.reheatCoil.to_CoilHeatingWater.get
       if reheat_coil.autosizedRatedCapacity.to_f < 1.0e-6
-        cap = 1.2 * 1000.0 * air_terminal_single_duct_vav_reheat.constantMinimumAirFlowFraction * air_terminal_single_duct_vav_reheat.autosizedMaximumAirFlowRate.to_f * (18.0 - 13.0)
+        cap = 1.2 * 1000.0 * flow_rate_fraction * air_terminal_single_duct_vav_reheat.autosizedMaximumAirFlowRate.to_f * (18.0 - 13.0)
         reheat_coil.setPerformanceInputMethod('NominalCapacity')
         reheat_coil.setRatedCapacity(cap)
         air_terminal_single_duct_vav_reheat.setMaximumReheatAirTemperature(18.0)

--- a/lib/openstudio-standards/standards/necb/necb_2011/qaqc/necb_qaqc.rb
+++ b/lib/openstudio-standards/standards/necb/necb_2011/qaqc/necb_qaqc.rb
@@ -64,12 +64,10 @@ class NECB2011
 
   # Generates the base data hash mainly used to perform qaqc.
   def create_base_data(model)
-    cli_path = OpenStudio.getOpenStudioCLI
+  
     #construct command with local libs
-    f = open("| \"#{cli_path}\" openstudio_version")
-    os_version = f.read()
-    f = open("| \"#{cli_path}\" energyplus_version")
-    eplus_version = f.read()
+    os_version = OpenStudio.openStudioLongVersion
+    eplus_version = OpenStudio.energyPlusVersion
     puts "\n\n\nOS_version is [#{os_version.strip}]"
     puts "\n\n\nEP_version is [#{eplus_version.strip}]"
 

--- a/lib/openstudio-standards/utilities/simulation.rb
+++ b/lib/openstudio-standards/utilities/simulation.rb
@@ -95,15 +95,11 @@ Standard.class_eval do
 
       cli_path = OpenStudio.getOpenStudioCLI
       cmd = "\"#{cli_path}\" run -w \"#{osw_path}\""
+      #cmd = "\"#{cli_path}\" --verbose run -w \"#{osw_path}\""
       puts cmd
 
-      env_vars = {}
-      env_vars['BUNDLE_GEMFILE'] = nil
-      env_vars['BUNDLE_PATH'] = nil
-
       # Run the sizing run
-      puts "Running sizing run with ENV VARS = '#{env_vars}'"
-      system(env_vars, cmd)
+      OpenstudioStandards.run_command(cmd)
 
       OpenStudio.logFree(OpenStudio::Info, 'openstudio.model.Model', 'Finished run.')
 

--- a/lib/openstudio-standards/utilities/simulation.rb
+++ b/lib/openstudio-standards/utilities/simulation.rb
@@ -103,12 +103,16 @@ Standard.class_eval do
       # inside the openstudio-cli.
       bundle_gemfile = ENV['BUNDLE_GEMFILE']
       bundle_path = ENV['BUNDLE_PATH']
+
+      OpenStudio.logFree(OpenStudio::Warn, 'openstudio.model.Model', "ENV['BUNDLE_GEMFILE'] = '#{bundle_gemfile}'")
+      OpenStudio.logFree(OpenStudio::Warn, 'openstudio.model.Model', "ENV['BUNDLE_PATH'] = '#{bundle_path}'")
+
       if bundle_gemfile.nil? || bundle_path.nil?
         ENV['BUNDLE_GEMFILE'] = nil
         ENV['BUNDLE_PATH'] = nil
-        OpenStudio.logFree(OpenStudio::Debug, 'openstudio.model.Model', "Using gems built into the openstudio CLI for sizing run.")
+        OpenStudio.logFree(OpenStudio::Warn, 'openstudio.model.Model', "Using gems built into the openstudio CLI for sizing run.")
       else
-        OpenStudio.logFree(OpenStudio::Info, 'openstudio.model.Model', "Using gems specified in #{bundle_gemfile} for sizing run.")
+        OpenStudio.logFree(OpenStudio::Warn, 'openstudio.model.Model', "Using gems specified in #{bundle_gemfile} for sizing run.")
       end
 
       # Run the sizing run

--- a/lib/openstudio-standards/utilities/simulation.rb
+++ b/lib/openstudio-standards/utilities/simulation.rb
@@ -103,24 +103,18 @@ Standard.class_eval do
       # inside the openstudio-cli.
       bundle_gemfile = ENV['BUNDLE_GEMFILE']
       bundle_path = ENV['BUNDLE_PATH']
-
-      OpenStudio.logFree(OpenStudio::Warn, 'openstudio.model.Model', "ENV['BUNDLE_GEMFILE'] = '#{bundle_gemfile}'")
-      OpenStudio.logFree(OpenStudio::Warn, 'openstudio.model.Model', "ENV['BUNDLE_PATH'] = '#{bundle_path}'")
-
+      env_vars = {}
       if bundle_gemfile.nil? || bundle_path.nil?
-        ENV['BUNDLE_GEMFILE'] = nil
-        ENV['BUNDLE_PATH'] = nil
-        OpenStudio.logFree(OpenStudio::Warn, 'openstudio.model.Model', "Using gems built into the openstudio CLI for sizing run.")
+        env_vars['BUNDLE_GEMFILE'] = nil
+        env_vars['BUNDLE_PATH'] = nil
       else
-        OpenStudio.logFree(OpenStudio::Warn, 'openstudio.model.Model', "Using gems specified in #{bundle_gemfile} for sizing run.")
+        env_vars['BUNDLE_GEMFILE'] = bundle_gemfile
+        env_vars['BUNDLE_PATH'] = bundle_path
       end
 
       # Run the sizing run
-      system(cmd)
-
-      # Reset the environment variables
-      ENV['BUNDLE_GEMFILE'] = bundle_gemfile unless bundle_gemfile.nil?
-      ENV['BUNDLE_PATH'] = bundle_path unless bundle_path.nil?
+      puts "Running sizing run with ENV VARS = '#{env_vars}'"
+      system(env_vars, cmd)
 
       OpenStudio.logFree(OpenStudio::Info, 'openstudio.model.Model', 'Finished run.')
 

--- a/lib/openstudio-standards/utilities/simulation.rb
+++ b/lib/openstudio-standards/utilities/simulation.rb
@@ -97,20 +97,9 @@ Standard.class_eval do
       cmd = "\"#{cli_path}\" run -w \"#{osw_path}\""
       puts cmd
 
-      # If the appropriate environment variables are set, assume that
-      # the user wants to use the gems from the Gemfile outside the openstudio-cli.
-      # If not, clear both environment variables and run using gems
-      # inside the openstudio-cli.
-      bundle_gemfile = ENV['BUNDLE_GEMFILE']
-      bundle_path = ENV['BUNDLE_PATH']
       env_vars = {}
-      if bundle_gemfile.nil? || bundle_path.nil?
-        env_vars['BUNDLE_GEMFILE'] = nil
-        env_vars['BUNDLE_PATH'] = nil
-      else
-        env_vars['BUNDLE_GEMFILE'] = bundle_gemfile
-        env_vars['BUNDLE_PATH'] = bundle_path
-      end
+      env_vars['BUNDLE_GEMFILE'] = nil
+      env_vars['BUNDLE_PATH'] = nil
 
       # Run the sizing run
       puts "Running sizing run with ENV VARS = '#{env_vars}'"

--- a/lib/openstudio-standards/utilities/simulation.rb
+++ b/lib/openstudio-standards/utilities/simulation.rb
@@ -96,7 +96,27 @@ Standard.class_eval do
       cli_path = OpenStudio.getOpenStudioCLI
       cmd = "\"#{cli_path}\" run -w \"#{osw_path}\""
       puts cmd
+
+      # If the appropriate environment variables are set, assume that
+      # the user wants to use the gems from the Gemfile outside the openstudio-cli.
+      # If not, clear both environment variables and run using gems
+      # inside the openstudio-cli.
+      bundle_gemfile = ENV['BUNDLE_GEMFILE']
+      bundle_path = ENV['BUNDLE_PATH']
+      if bundle_gemfile.nil? || bundle_path.nil?
+        ENV['BUNDLE_GEMFILE'] = nil
+        ENV['BUNDLE_PATH'] = nil
+        OpenStudio.logFree(OpenStudio::Debug, 'openstudio.model.Model', "Using gems built into the openstudio CLI for sizing run.")
+      else
+        OpenStudio.logFree(OpenStudio::Info, 'openstudio.model.Model', "Using gems specified in #{bundle_gemfile} for sizing run.")
+      end
+
+      # Run the sizing run
       system(cmd)
+
+      # Reset the environment variables
+      ENV['BUNDLE_GEMFILE'] = bundle_gemfile unless bundle_gemfile.nil?
+      ENV['BUNDLE_PATH'] = bundle_path unless bundle_path.nil?
 
       OpenStudio.logFree(OpenStudio::Info, 'openstudio.model.Model', 'Finished run.')
 

--- a/lib/openstudio-standards/version.rb
+++ b/lib/openstudio-standards/version.rb
@@ -13,5 +13,5 @@ module OpenstudioStandards
     end
     return 'git-not-found-on-this-system'
   end
-  VERSION = '0.2.5'.freeze
+  VERSION = '0.2.6'.freeze
 end

--- a/lib/openstudio-standards/version.rb
+++ b/lib/openstudio-standards/version.rb
@@ -6,7 +6,7 @@ module OpenstudioStandards
       exts.each do |ext|
         exe = "#{path}/#{cmd}#{ext}"
         if File.executable?(exe)
-          revision = `#{exe} -C #{__dir__} rev-parse --short HEAD`
+          revision = `"#{exe}" -C "#{__dir__}" rev-parse --short HEAD`
           return revision.strip!
         end
       end

--- a/test/90_1_prm/baseline_901_2013_helper.rb
+++ b/test/90_1_prm/baseline_901_2013_helper.rb
@@ -197,7 +197,7 @@ module Baseline9012013
 
           # minimum fraction, which is the greater
           # of the min fraction or the min fixed value converted to a fraction.
-          act_fixed_min_frac = terminal.constantMinimumAirFlowFraction
+          act_fixed_min_frac = terminal.constantMinimumAirFlowFraction.get
           act_oa_min_frac = 0.0
           act_min_flow = terminal.fixedMinimumAirFlowRate
           if act_min_flow.is_initialized

--- a/test/90_1_prm/test_create_performance_rating_method_baseline_bldg_3.rb
+++ b/test/90_1_prm/test_create_performance_rating_method_baseline_bldg_3.rb
@@ -1283,7 +1283,7 @@ class Baseline9012013Test3 < Minitest::Test
             min_flow = 0.0
           end
           unless (expected_min_oa_rates_m3_per_s_hash[spot_check_zone_name] - min_flow).abs < 0.005
-            failure_array << "Expected #{(expected_min_oa_rates_m3_per_s_hash[spot_check_zone_name]*2118.88).round()} cfm Fixed Flow Rate for Zone #{spot_check_zone_name}; found #{(vav_terminal.fixedMinimumAirFlowRate*2118.88).round()} cfm instead"
+            failure_array << "Expected #{(expected_min_oa_rates_m3_per_s_hash[spot_check_zone_name]*2118.88).round()} cfm Fixed Flow Rate for Zone #{spot_check_zone_name}; found #{(vav_terminal.fixedMinimumAirFlowRate.get*2118.88).round()} cfm instead"
           end
         end
       end


### PR DESCRIPTION
AirTerminalSingleDuctVAVReheat method constantMinimumAirFlowFraction returns optional double instead of double in OS v2.7