### PR TITLE
Feature/central ashp

### DIFF
--- a/lib/openstudio-standards.rb
+++ b/lib/openstudio-standards.rb
@@ -230,6 +230,7 @@ module OpenstudioStandards
   require_relative "#{proto}/common/objects/Prototype.AirConditionerVariableRefrigerantFlow"
   require_relative "#{proto}/common/objects/Prototype.AirTerminalSingleDuctVAVReheat"
   require_relative "#{proto}/common/objects/Prototype.BoilerHotWater"
+  require_relative "#{proto}/common/objects/Prototype.CentralAirSourceHeatPump"
   require_relative "#{proto}/common/objects/Prototype.CoilCoolingDXSingleSpeed"
   require_relative "#{proto}/common/objects/Prototype.CoilCoolingDXTwoSpeed"
   require_relative "#{proto}/common/objects/Prototype.CoilCoolingWater"

--- a/lib/openstudio-standards/prototypes/common/objects/Prototype.CentralAirSourceHeatPump.rb
+++ b/lib/openstudio-standards/prototypes/common/objects/Prototype.CentralAirSourceHeatPump.rb
@@ -1,0 +1,213 @@
+class Standard
+  # @!group Central Air Source Heat Pump
+
+  # Prototype CentralAirSourceHeatPump object using PlantComponentUserDefined
+  #
+  # @param hot_water_loop [<OpenStudio::Model::PlantLoop>] a hot water loop served by the central air source heat pump
+  # @param name [String] the name of the central air source heat pump, or nil in which case it will be defaulted
+  # @param cop [Double] air source heat pump rated cop
+  # @todo update curve to better calculate based on the rated cop
+  # @todo refactor to use the new EnergyPlus central air source heat pump object when it becomes available
+  #   set hot_water_loop to an optional keyword argument, and add input keyword arguments for other characteristics
+  def create_central_air_source_heat_pump(model,
+                                          hot_water_loop,
+                                          name: nil,
+                                          cop: 3.65)
+
+    # create the PlantComponentUserDefined object as a proxy for the Central Air Source Heat Pump
+    plant_comp = OpenStudio::Model::PlantComponentUserDefined.new(model)
+    if name.nil?
+      if !hot_water_loop.nil?
+        name = "#{hot_water_loop.name} Central Air Source Heat Pump"
+      else
+        name = 'Central Air Source Heat Pump'
+      end
+    end
+
+    # change equipment name for EMS validity
+    plant_comp.setName(name.gsub(/[ +-.]/, '_'))
+
+    # set plant component properties
+    plant_comp.setPlantLoadingMode('MeetsLoadWithNominalCapacityHiOutLimit')
+    plant_comp.setPlantLoopFlowRequestMode('NeedsFlowIfLoopIsOn')
+
+    # plant design volume flow rate internal variable
+    vdot_des_int_var = OpenStudio::Model::EnergyManagementSystemInternalVariable.new(model, 'Plant Design Volume Flow Rate')
+    vdot_des_int_var.setName("#{plant_comp.name}_Vdot_Des_Int_Var")
+    vdot_des_int_var.setInternalDataIndexKeyName(hot_water_loop.handle.to_s)
+
+    # inlet temperature internal variable
+    tin_int_var = OpenStudio::Model::EnergyManagementSystemInternalVariable.new(model, 'Inlet Temperature for Plant Connection 1')
+    tin_int_var.setName("#{plant_comp.name}_Tin_Int_Var")
+    tin_int_var.setInternalDataIndexKeyName(plant_comp.handle.to_s)
+
+    # inlet mass flow rate internal variable
+    mdot_int_var = OpenStudio::Model::EnergyManagementSystemInternalVariable.new(model, 'Inlet Mass Flow Rate for Plant Connection 1')
+    mdot_int_var.setName("#{plant_comp.name}_Mdot_Int_Var")
+    mdot_int_var.setInternalDataIndexKeyName(plant_comp.handle.to_s)
+
+    # inlet specific heat internal variable
+    cp_int_var = OpenStudio::Model::EnergyManagementSystemInternalVariable.new(model, 'Inlet Specific Heat for Plant Connection 1')
+    cp_int_var.setName("#{plant_comp.name}_Cp_Int_Var")
+    cp_int_var.setInternalDataIndexKeyName(plant_comp.handle.to_s)
+
+    # inlet density internal variable
+    rho_int_var = OpenStudio::Model::EnergyManagementSystemInternalVariable.new(model, 'Inlet Density for Plant Connection 1')
+    rho_int_var.setName("#{plant_comp.name}_rho_Int_Var")
+    rho_int_var.setInternalDataIndexKeyName(plant_comp.handle.to_s)
+
+    # load request internal variable
+    load_int_var = OpenStudio::Model::EnergyManagementSystemInternalVariable.new(model, 'Load Request for Plant Connection 1')
+    load_int_var.setName("#{plant_comp.name}_Load_Int_Var")
+    load_int_var.setInternalDataIndexKeyName(plant_comp.handle.to_s)
+
+    # supply outlet node setpoint temperature sensor
+    setpt_mgr_sch_sen = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'Schedule Value')
+    setpt_mgr_sch_sen.setName("#{plant_comp.name}_Setpt_Mgr_Temp_Sen")
+    hot_water_loop.supplyOutletNode.setpointManagers.each do |m|
+      if m.to_SetpointManagerScheduled.is_initialized
+        setpt_mgr_sch_sen.setKeyName("#{m.to_SetpointManagerScheduled.get.schedule.name}")
+      end
+    end
+
+    # outdoor air drybulb temperature sensor
+    oa_dbt_sen = OpenStudio::Model::EnergyManagementSystemSensor.new(model, 'Site Outdoor Air Drybulb Temperature')
+    oa_dbt_sen.setName("#{plant_comp.name}_OA_DBT_Sen")
+    oa_dbt_sen.setKeyName('Environment')
+
+    # minimum mass flow rate actuator
+    mdot_min_act = plant_comp.minimumMassFlowRateActuator.get
+    mdot_min_act.setName("#{plant_comp.name}_Mdot_Min_Act")
+
+    # maximum mass flow rate actuator
+    mdot_max_act = plant_comp.maximumMassFlowRateActuator.get
+    mdot_max_act.setName("#{plant_comp.name}_Mdot_Max_Act")
+
+    # design flow rate actuator
+    vdot_des_act = plant_comp.designVolumeFlowRateActuator.get
+    vdot_des_act.setName("#{plant_comp.name}_Vdot_Des_Act")
+
+    # minimum loading capacity actuator
+    cap_min_act = plant_comp.minimumLoadingCapacityActuator.get
+    cap_min_act.setName("#{plant_comp.name}_Cap_Min_Act")
+
+    # maximum loading capacity actuator
+    cap_max_act = plant_comp.maximumLoadingCapacityActuator.get
+    cap_max_act.setName("#{plant_comp.name}_Cap_Max_Act")
+
+    # optimal loading capacity actuator
+    cap_opt_act = plant_comp.optimalLoadingCapacityActuator.get
+    cap_opt_act.setName("#{plant_comp.name}_Cap_Opt_Act")
+
+    # outlet temperature actuator
+    tout_act = plant_comp.outletTemperatureActuator.get
+    tout_act.setName("#{plant_comp.name}_Tout_Act")
+
+    # mass flow rate actuator
+    mdot_req_act = plant_comp.massFlowRateActuator.get
+    mdot_req_act.setName("#{plant_comp.name}_Mdot_Req_Act")
+
+    # heat pump COP curve
+    constant_coeff = 1.932 + (cop - 3.65)
+    hp_cop_curve = OpenStudio::Model::CurveQuadratic.new(model)
+    hp_cop_curve.setCoefficient1Constant(constant_coeff)
+    hp_cop_curve.setCoefficient2x(0.227674286)
+    hp_cop_curve.setCoefficient3xPOW2(-0.007313143)
+    hp_cop_curve.setMinimumValueofx(1.67)
+    hp_cop_curve.setMaximumValueofx(12.78)
+    hp_cop_curve.setInputUnitTypeforX('Temperature')
+    hp_cop_curve.setOutputUnitType('Dimensionless')
+
+    # heat pump COP curve index variable
+    hp_cop_curve_idx_var = OpenStudio::Model::EnergyManagementSystemCurveOrTableIndexVariable.new(model, hp_cop_curve)
+
+    # high outlet temperature limit actuator
+    tout_max_act = OpenStudio::Model::EnergyManagementSystemActuator.new(plant_comp, 'Plant Connection 1', 'High Outlet Temperature Limit')
+    tout_max_act.setName("#{plant_comp.name}_Tout_Max_Act")
+
+    # init program
+    init_pgrm = plant_comp.plantInitializationProgram.get
+    init_pgrm.setName("#{plant_comp.name}_Init_Pgrm")
+    init_pgrm_body = <<-EMS
+    SET Loop_Exit_Temp = #{hot_water_loop.sizingPlant.designLoopExitTemperature}
+    SET Loop_Delta_Temp = #{hot_water_loop.sizingPlant.loopDesignTemperatureDifference}
+    SET Cp = @CPHW Loop_Exit_Temp
+    SET rho = @RhoH2O Loop_Exit_Temp
+    SET #{vdot_des_act.handle} = #{vdot_des_int_var.handle}
+    SET #{mdot_min_act.handle} = 0
+    SET Mdot_Max = #{vdot_des_int_var.handle} * rho
+    SET #{mdot_max_act.handle} = Mdot_Max
+    SET Cap = Mdot_Max * Cp * Loop_Delta_Temp
+    SET #{cap_min_act.handle} = 0
+    SET #{cap_max_act.handle} = Cap
+    SET #{cap_opt_act.handle} = 1 * Cap
+    EMS
+    init_pgrm.setBody(init_pgrm_body)
+
+    # sim program
+    sim_pgrm = plant_comp.plantSimulationProgram.get
+    sim_pgrm.setName("#{plant_comp.name}_Sim_Pgrm")
+    sim_pgrm_body = <<-EMS
+    SET tmp = #{load_int_var.handle}
+    SET tmp = #{tin_int_var.handle}
+    SET tmp = #{mdot_int_var.handle}
+    SET #{tout_max_act.handle} = 75.0
+    IF #{load_int_var.handle} == 0
+    SET #{tout_act.handle} = #{tin_int_var.handle}
+    SET #{mdot_req_act.handle} = 0
+    SET Elec = 0
+    RETURN
+    ENDIF
+    IF #{load_int_var.handle} >= #{cap_max_act.handle}
+    SET Qdot = #{cap_max_act.handle}
+    SET Mdot = #{mdot_max_act.handle}
+    SET #{mdot_req_act.handle} = Mdot
+    SET #{tout_act.handle} = (Qdot / (Mdot * #{cp_int_var.handle})) + #{tin_int_var.handle}
+    IF #{tout_act.handle} > #{tout_max_act.handle}
+    SET #{tout_act.handle} = #{tout_max_act.handle}
+    SET Qdot = Mdot * #{cp_int_var.handle} * (#{tout_act.handle} - #{tin_int_var.handle})
+    ENDIF
+    ELSE
+    SET Qdot = #{load_int_var.handle}
+    SET #{tout_act.handle} = #{setpt_mgr_sch_sen.handle}
+    SET Mdot = Qdot / (#{cp_int_var.handle} * (#{tout_act.handle} - #{tin_int_var.handle}))
+    SET #{mdot_req_act.handle} = Mdot
+    ENDIF
+    SET Tdb = #{oa_dbt_sen.handle}
+    SET COP = @CurveValue #{hp_cop_curve_idx_var.handle} Tdb
+    SET EIR = 1 / COP
+    SET Pwr = Qdot * EIR
+    SET Elec = Pwr * SystemTimestep * 3600
+    EMS
+    sim_pgrm.setBody(sim_pgrm_body)
+
+    # init program calling manager
+    init_mgr = plant_comp.plantInitializationProgramCallingManager.get
+    init_mgr.setName("#{plant_comp.name}_Init_Pgrm_Mgr")
+
+    # sim program calling manager
+    sim_mgr = plant_comp.plantSimulationProgramCallingManager.get
+    sim_mgr.setName("#{plant_comp.name}_Sim_Pgrm_Mgr")
+
+    # metered output variable
+    elec_mtr_out_var = OpenStudio::Model::EnergyManagementSystemMeteredOutputVariable.new(model, "#{plant_comp.name} Electricity Consumption")
+    elec_mtr_out_var.setEMSVariableName('Elec')
+    elec_mtr_out_var.setUpdateFrequency('SystemTimestep')
+    elec_mtr_out_var.setString(4, sim_pgrm.handle.to_s)
+    elec_mtr_out_var.setResourceType('Electricity')
+    elec_mtr_out_var.setGroupType('HVAC')
+    elec_mtr_out_var.setEndUseCategory('Heating')
+    elec_mtr_out_var.setEndUseSubcategory('')
+    elec_mtr_out_var.setUnits('J')
+
+    # add to supply side of hot water loop if specified
+    hot_water_loop.addSupplyBranchForComponent(plant_comp) unless hot_water_loop.nil?
+
+    # add operation scheme
+    htg_op_scheme = OpenStudio::Model::PlantEquipmentOperationHeatingLoad.new(model)
+    htg_op_scheme.addEquipment(1000000000, plant_comp)
+    hot_water_loop.setPlantEquipmentOperationHeatingLoad(htg_op_scheme)
+
+    return plant_comp
+  end
+end

--- a/lib/openstudio-standards/prototypes/common/objects/Prototype.Model.hvac.rb
+++ b/lib/openstudio-standards/prototypes/common/objects/Prototype.Model.hvac.rb
@@ -341,18 +341,18 @@ class Standard
       when 'Baseboards'
         case system['heating_type']
         when 'Gas', 'DistrictHeating'
-          hot_water_loop = model_get_or_add_hot_water_loop(model, main_heat_fuel)
+          hot_water_loop = model_get_or_add_hot_water_loop(model, system['heating_type'])
         when 'Electricity'
           hot_water_loop = nil
         when nil
-          OpenStudio.logFree(OpenStudio::Error, 'openstudio.model.Model', "Baseboards must have heating_type specified.")
+          OpenStudio.logFree(OpenStudio::Error, 'openstudio.model.Model', 'Baseboards must have heating_type specified.')
         end
         model_add_baseboard(model,
                             thermal_zones,
                             hot_water_loop: hot_water_loop)
 
       when 'Unconditioned'
-        OpenStudio.logFree(OpenStudio::Info, 'openstudio.model.Model', "System type is Unconditioned.  No system will be added.")
+        OpenStudio.logFree(OpenStudio::Info, 'openstudio.model.Model', 'System type is Unconditioned.  No system will be added.')
 
       else
         OpenStudio.logFree(OpenStudio::Error, 'openstudio.model.Model', "System type '#{system['type']}' is not recognized for system named '#{system['name']}'.  This system will not be added.")
@@ -360,10 +360,10 @@ class Standard
       end
     end
 
-    OpenStudio.logFree(OpenStudio::Info, 'openstudio.model.Model', "Finished adding HVAC")
+    OpenStudio.logFree(OpenStudio::Info, 'openstudio.model.Model', 'Finished adding HVAC')
 
     return true
-  end # add hvac
+  end
 
   # Determine the typical system type given the inputs.
   #

--- a/lib/openstudio-standards/prototypes/common/objects/Prototype.hvac_systems.rb
+++ b/lib/openstudio-standards/prototypes/common/objects/Prototype.hvac_systems.rb
@@ -1752,7 +1752,7 @@ class Standard
     end
 
     # adjusted zone design heating temperature for pvav unless it would cause a temperature higher than reheat water supply temperature
-    if hw_temp_c > OpenStudio.convert(140.0, 'F', 'C').get
+    unless !hot_water_loop.nil? && hw_temp_c < OpenStudio.convert(140.0, 'F', 'C').get
       dsgn_temps['zn_htg_dsgn_sup_air_temp_f'] = 122.0
       dsgn_temps['zn_htg_dsgn_sup_air_temp_c'] = OpenStudio.convert(dsgn_temps['zn_htg_dsgn_sup_air_temp_f'], 'F', 'C').get
     end

--- a/lib/openstudio-standards/prototypes/common/objects/Prototype.hvac_systems.rb
+++ b/lib/openstudio-standards/prototypes/common/objects/Prototype.hvac_systems.rb
@@ -33,8 +33,8 @@ class Standard
   # @param pump_tot_hd [Double] pump head in ft H2O
   # @param boiler_draft_type [String] Boiler type Condensing, MechanicalNoncondensing, Natural (default)
   # @param boiler_eff_curve_temp_eval_var [String] LeavingBoiler or EnteringBoiler temperature for the boiler efficiency curve
-  # @param boiler_lvg_temp_dsgn F [Double] boiler leaving design temperature
-  # @param boiler_out_temp_lmt [Double] boiler outlet temperature limit
+  # @param boiler_lvg_temp_dsgn [Double] boiler leaving design temperature in degrees Fahrenheit
+  # @param boiler_out_temp_lmt [Double] boiler outlet temperature limit in degrees Fahrenheit
   # @param boiler_max_plr [Double] boiler maximum part load ratio
   # @param boiler_sizing_factor [Double] boiler oversizing factor
   # @return [OpenStudio::Model::PlantLoop] the resulting hot water loop
@@ -115,7 +115,7 @@ class Standard
         district_heat.autosizeNominalCapacity
         hot_water_loop.addSupplyBranchForComponent(district_heat)
       # Ambient Loop
-      when 'HeatPump'
+      when 'HeatPump', 'AmbientLoop'
         water_to_water_hp = OpenStudio::Model::HeatPumpWaterToWaterEquationFitHeating.new(model)
         water_to_water_hp.setName("#{hot_water_loop.name} Water to Water Heat Pump")
         hot_water_loop.addSupplyBranchForComponent(water_to_water_hp)
@@ -124,6 +124,9 @@ class Standard
           ambient_loop = model_get_or_add_ambient_water_loop(model)
         end
         ambient_loop.addDemandBranchForComponent(water_to_water_hp)
+      # Central Air Source Heat Pump
+      when 'AirSourceHeatPump', 'ASHP'
+        create_central_air_source_heat_pump(model, hot_water_loop)
       # Boiler
       when 'Electricity', 'Gas', 'NaturalGas', 'PropaneGas', 'FuelOil#1', 'FuelOil#2'
         if boiler_lvg_temp_dsgn.nil?
@@ -158,9 +161,9 @@ class Standard
     end
 
     # add hot water loop pipes
-    boiler_bypass_pipe = OpenStudio::Model::PipeAdiabatic.new(model)
-    boiler_bypass_pipe.setName("#{hot_water_loop.name} Boiler Bypass")
-    hot_water_loop.addSupplyBranchForComponent(boiler_bypass_pipe)
+    supply_equipment_bypass_pipe = OpenStudio::Model::PipeAdiabatic.new(model)
+    supply_equipment_bypass_pipe.setName("#{hot_water_loop.name} Supply Equipment Bypass")
+    hot_water_loop.addSupplyBranchForComponent(supply_equipment_bypass_pipe)
 
     coil_bypass_pipe = OpenStudio::Model::PipeAdiabatic.new(model)
     coil_bypass_pipe.setName("#{hot_water_loop.name} Coil Bypass")
@@ -1748,9 +1751,11 @@ class Standard
       hw_delta_t_k = hot_water_loop.sizingPlant.loopDesignTemperatureDifference
     end
 
-    # adjusted zone design heating temperature for pvav
-    dsgn_temps['zn_htg_dsgn_sup_air_temp_f'] = 122.0
-    dsgn_temps['zn_htg_dsgn_sup_air_temp_c'] = OpenStudio.convert(dsgn_temps['zn_htg_dsgn_sup_air_temp_f'], 'F', 'C').get
+    # adjusted zone design heating temperature for pvav unless it would cause a temperature higher than reheat water supply temperature
+    if hw_temp_c > OpenStudio.convert(140.0, 'F', 'C').get
+      dsgn_temps['zn_htg_dsgn_sup_air_temp_f'] = 122.0
+      dsgn_temps['zn_htg_dsgn_sup_air_temp_c'] = OpenStudio.convert(dsgn_temps['zn_htg_dsgn_sup_air_temp_f'], 'F', 'C').get
+    end
 
     # default design settings used across all air loops
     sizing_system = adjust_sizing_system(air_loop, dsgn_temps)
@@ -4542,6 +4547,10 @@ class Standard
         heating_type = 'Water'
         hot_water_loop = model_get_or_add_hot_water_loop(model, main_heat_fuel,
                                                          hot_water_loop_type: hot_water_loop_type)
+      when 'AirSourceHeatPump'
+        heating_type = 'Water'
+        hot_water_loop = model_get_or_add_hot_water_loop(model, main_heat_fuel,
+                                                         hot_water_loop_type: 'LowTemperature')
       when 'Electricity'
         heating_type = main_heat_fuel
         hot_water_loop = nil
@@ -4573,6 +4582,11 @@ class Standard
         supplemental_heating_type = 'Electricity'
         hot_water_loop = model_get_or_add_hot_water_loop(model, main_heat_fuel,
                                                          hot_water_loop_type: hot_water_loop_type)
+      when 'AirSourceHeatPump'
+        heating_type = 'Water'
+        supplemental_heating_type = 'Electricity'
+        hot_water_loop = model_get_or_add_hot_water_loop(model, main_heat_fuel,
+                                                         hot_water_loop_type: 'LowTemperature')
       when 'Electricity'
         heating_type = main_heat_fuel
         supplemental_heating_type = 'Electricity'
@@ -4633,6 +4647,9 @@ class Standard
       when 'NaturalGas', 'DistrictHeating', 'Electricity'
         hot_water_loop = model_get_or_add_hot_water_loop(model, main_heat_fuel,
                                                          hot_water_loop_type: hot_water_loop_type)
+      when 'AirSourceHeatPump'
+        hot_water_loop = model_get_or_add_hot_water_loop(model, main_heat_fuel,
+                                                         hot_water_loop_type: 'LowTemperature')
       else
         hot_water_loop = nil
       end
@@ -4656,6 +4673,9 @@ class Standard
       when 'NaturalGas', 'DistrictHeating'
         hot_water_loop = model_get_or_add_hot_water_loop(model, main_heat_fuel,
                                                          hot_water_loop_type: hot_water_loop_type)
+      when 'AirSourceHeatPump'
+        hot_water_loop = model_get_or_add_hot_water_loop(model, main_heat_fuel,
+                                                         hot_water_loop_type: 'LowTemperature')
       when 'Electricity'
         hot_water_loop = nil
       else
@@ -4714,6 +4734,10 @@ class Standard
         heating_type = main_heat_fuel
         hot_water_loop = model_get_or_add_hot_water_loop(model, main_heat_fuel,
                                                          hot_water_loop_type: hot_water_loop_type)
+      when 'AirSourceHeatPump'
+        heating_type = main_heat_fuel
+        hot_water_loop = model_get_or_add_hot_water_loop(model, main_heat_fuel,
+                                                         hot_water_loop_type: 'LowTemperature')
       else
         heating_type = 'Electricity'
         hot_water_loop = nil
@@ -4757,6 +4781,10 @@ class Standard
         heating_type = main_heat_fuel
         hot_water_loop = model_get_or_add_hot_water_loop(model, main_heat_fuel,
                                                          hot_water_loop_type: hot_water_loop_type)
+      when 'AirSourceHeatPump'
+        heating_type = main_heat_fuel
+        hot_water_loop = model_get_or_add_hot_water_loop(model, main_heat_fuel,
+                                                         hot_water_loop_type: 'LowTemperature')
       else
         heating_type = 'Electricity'
         hot_water_loop = nil
@@ -4795,20 +4823,29 @@ class Standard
                            fan_pressure_rise: 4.0)
 
     when 'PVAV Reheat'
-      hot_water_loop = model_get_or_add_hot_water_loop(model, main_heat_fuel,
-                                                       hot_water_loop_type: hot_water_loop_type)
-      chilled_water_loop = case cool_fuel
-                           when 'Electricity'
-                             nil
-                           else
-                             model_get_or_add_chilled_water_loop(model, cool_fuel,
+      case main_heat_fuel
+      when 'AirSourceHeatPump'
+        hot_water_loop = model_get_or_add_hot_water_loop(model, main_heat_fuel,
+                                                         hot_water_loop_type: 'LowTemperature')
+      else
+        hot_water_loop = model_get_or_add_hot_water_loop(model, main_heat_fuel,
+                                                         hot_water_loop_type: hot_water_loop_type)
+      end
+
+      case cool_fuel
+      when 'Electricity'
+        chilled_water_loop = nil
+      else
+        chilled_water_loop = model_get_or_add_chilled_water_loop(model, cool_fuel,
                                                                  chilled_water_loop_cooling_type: chilled_water_loop_cooling_type)
-                           end
+      end
+
       if zone_heat_fuel == 'Electricity'
         electric_reheat = true
       else
         electric_reheat = false
       end
+
       model_add_pvav(model,
                      zones,
                      hot_water_loop: hot_water_loop,
@@ -4870,8 +4907,14 @@ class Standard
 
     when 'DOAS'
       if air_loop_heating_type == 'Water'
-        hot_water_loop = model_get_or_add_hot_water_loop(model, main_heat_fuel,
-                                                         hot_water_loop_type: hot_water_loop_type)
+        case main_heat_fuel
+        when 'AirSourceHeatPump'
+          hot_water_loop = model_get_or_add_hot_water_loop(model, main_heat_fuel,
+                                                           hot_water_loop_type: 'LowTemperature')
+        else
+          hot_water_loop = model_get_or_add_hot_water_loop(model, main_heat_fuel,
+                                                           hot_water_loop_type: hot_water_loop_type)
+        end
       else
         hot_water_loop = nil
       end
@@ -4888,8 +4931,14 @@ class Standard
 
     when 'DOAS with DCV'
       if air_loop_heating_type == 'Water'
-        hot_water_loop = model_get_or_add_hot_water_loop(model, main_heat_fuel,
-                                                         hot_water_loop_type: hot_water_loop_type)
+        case main_heat_fuel
+        when 'AirSourceHeatPump'
+          hot_water_loop = model_get_or_add_hot_water_loop(model, main_heat_fuel,
+                                                           hot_water_loop_type: 'LowTemperature')
+        else
+          hot_water_loop = model_get_or_add_hot_water_loop(model, main_heat_fuel,
+                                                           hot_water_loop_type: hot_water_loop_type)
+        end
       else
         hot_water_loop = nil
       end
@@ -4908,8 +4957,14 @@ class Standard
 
     when 'DOAS with Economizing'
       if air_loop_heating_type == 'Water'
-        hot_water_loop = model_get_or_add_hot_water_loop(model, main_heat_fuel,
-                                                         hot_water_loop_type: hot_water_loop_type)
+        case main_heat_fuel
+        when 'AirSourceHeatPump'
+          hot_water_loop = model_get_or_add_hot_water_loop(model, main_heat_fuel,
+                                                           hot_water_loop_type: 'LowTemperature')
+        else
+          hot_water_loop = model_get_or_add_hot_water_loop(model, main_heat_fuel,
+                                                           hot_water_loop_type: hot_water_loop_type)
+        end
       else
         hot_water_loop = nil
       end
@@ -4928,8 +4983,14 @@ class Standard
 
     when 'DOAS with DCV and Economizing'
       if air_loop_heating_type == 'Water'
-        hot_water_loop = model_get_or_add_hot_water_loop(model, main_heat_fuel,
-                                                         hot_water_loop_type: hot_water_loop_type)
+        case main_heat_fuel
+        when 'AirSourceHeatPump'
+          hot_water_loop = model_get_or_add_hot_water_loop(model, main_heat_fuel,
+                                                           hot_water_loop_type: 'LowTemperature')
+        else
+          hot_water_loop = model_get_or_add_hot_water_loop(model, main_heat_fuel,
+                                                           hot_water_loop_type: hot_water_loop_type)
+        end
       else
         hot_water_loop = nil
       end

--- a/test/doe_prototype/test_add_hvac_systems.rb
+++ b/test/doe_prototype/test_add_hvac_systems.rb
@@ -36,6 +36,9 @@ class TestAddHVACSystems < Minitest::Test
       ['PVAV Reheat', 'DistrictHeating', 'DistrictHeating', 'Electricity'],
       ['VAV Reheat', 'DistrictHeating', 'DistrictHeating', 'Electricity'],
 
+      # Central Air Source Heat Pump plant object
+      ['VAV Reheat', 'AirSourceHeatPump', 'AirSourceHeatPump', 'Electricity'],
+
       # Ambient Loop, Ambient Loop, forced air
       ['PVAV Reheat', 'HeatPump', 'HeatPump', 'HeatPump'],
       ['VAV Reheat', 'HeatPump', 'HeatPump', 'HeatPump'],
@@ -70,6 +73,9 @@ class TestAddHVACSystems < Minitest::Test
       ['Fan Coil with DOAS', 'DistrictHeating', nil, 'Electricity'],
       ['Water Source Heat Pumps with DOAS', 'DistrictHeating', 'DistrictHeating', 'Electricity'],
       ['Fan Coil with DOAS', 'DistrictHeating', 'DistrictHeating', 'Electricity'],
+
+      # Central Air Source Heat Pump, hydronic
+      ['Fan Coil with DOAS', 'AirSourceHeatPump', nil, 'Electricity'],
 
       # Ambient Loop, Ambient Loop, hydronic
       ['Water Source Heat Pumps with ERVs', 'HeatPump', nil, 'HeatPump'],


### PR DESCRIPTION
Adds the ability to model air to water heat pumps on hot water loops in place of boilers.  The equipment is defined with the PlantComponentUserDefined object until a formal object exists in EnergyPlus/OpenStudio, which should happen in the next year.