### PR TITLE
added vintage to Building Object StandardsBuildingType name

### DIFF
--- a/lib/openstudio-standards/standards/necb/NECB2011/data/geometry/FullServiceRestaurant.osm
+++ b/lib/openstudio-standards/standards/necb/NECB2011/data/geometry/FullServiceRestaurant.osm
@@ -434,7 +434,7 @@ OS:Surface,
 
 OS:Building,
   {57a0612b-80fa-4a4f-8704-b192e6d39f92}, !- Handle
-  NECB_2011FullServiceRestaurant,         !- Name
+  ,                                       !- Name
   ,                                       !- Building Sector Type
   0,                                      !- North Axis {deg}
   ,                                       !- Nominal Floor to Floor Height {m}

--- a/lib/openstudio-standards/standards/necb/NECB2011/data/geometry/HighriseApartment.osm
+++ b/lib/openstudio-standards/standards/necb/NECB2011/data/geometry/HighriseApartment.osm
@@ -11740,7 +11740,7 @@ OS:Surface,
 
 OS:Building,
   {586eee9f-0959-42dd-8f3c-7b61ed86bab5}, !- Handle
-  NECB_2011HighriseApartment,             !- Name
+  ,                               !- Name
   ,                                       !- Building Sector Type
   0,                                      !- North Axis {deg}
   ,                                       !- Nominal Floor to Floor Height {m}

--- a/lib/openstudio-standards/standards/necb/NECB2011/data/geometry/Hospital.osm
+++ b/lib/openstudio-standards/standards/necb/NECB2011/data/geometry/Hospital.osm
@@ -164,7 +164,7 @@ OS:ThermostatSetpoint:DualSetpoint,
 
 OS:Building,
   {161a51f0-9700-4aa1-8ba8-f2513d0eecae}, !- Handle
-  NECB_2011Hospital,                      !- Name
+  ,                                       !- Name
   ,                                       !- Building Sector Type
   ,                                       !- North Axis {deg}
   ,                                       !- Nominal Floor to Floor Height {m}

--- a/lib/openstudio-standards/standards/necb/NECB2011/data/geometry/LargeHotel.osm
+++ b/lib/openstudio-standards/standards/necb/NECB2011/data/geometry/LargeHotel.osm
@@ -266,7 +266,7 @@ OS:Space,
 
 OS:Building,
   {bb5b588d-ed54-4560-ae15-dfaff42d1cbb}, !- Handle
-  NECB_2011LargeHotel,                    !- Name
+  ,                                       !- Name
   ,                                       !- Building Sector Type
   0,                                      !- North Axis {deg}
   ,                                       !- Nominal Floor to Floor Height {m}

--- a/lib/openstudio-standards/standards/necb/NECB2011/data/geometry/LargeOffice.osm
+++ b/lib/openstudio-standards/standards/necb/NECB2011/data/geometry/LargeOffice.osm
@@ -2404,7 +2404,7 @@ OS:Surface,
 
 OS:Building,
   {9458e43b-b7b0-46f5-82b4-529de66fc6c8}, !- Handle
-  NECB_2011LargeOffice,                   !- Name
+  ,                                       !- Name
   ,                                       !- Building Sector Type
   0,                                      !- North Axis {deg}
   ,                                       !- Nominal Floor to Floor Height {m}

--- a/lib/openstudio-standards/standards/necb/NECB2011/data/geometry/MediumOffice.osm
+++ b/lib/openstudio-standards/standards/necb/NECB2011/data/geometry/MediumOffice.osm
@@ -2124,7 +2124,7 @@ OS:Surface,
 
 OS:Building,
   {ed36787e-0111-455c-a24c-be4262835f11}, !- Handle
-  NECB_2011MediumOffice,                  !- Name
+  ,                                       !- Name
   ,                                       !- Building Sector Type
   0,                                      !- North Axis {deg}
   ,                                       !- Nominal Floor to Floor Height {m}

--- a/lib/openstudio-standards/standards/necb/NECB2011/data/geometry/MidriseApartment.osm
+++ b/lib/openstudio-standards/standards/necb/NECB2011/data/geometry/MidriseApartment.osm
@@ -1090,7 +1090,7 @@ OS:Surface,
 
 OS:Building,
   {761ed503-73d7-48c5-8197-2a7009e22170}, !- Handle
-  NECB_2011MidriseApartment,              !- Name
+  ,                                       !- Name
   ,                                       !- Building Sector Type
   0,                                      !- North Axis {deg}
   ,                                       !- Nominal Floor to Floor Height {m}

--- a/lib/openstudio-standards/standards/necb/NECB2011/data/geometry/Outpatient.osm
+++ b/lib/openstudio-standards/standards/necb/NECB2011/data/geometry/Outpatient.osm
@@ -5157,7 +5157,7 @@ OS:Surface,
 
 OS:Building,
   {9e3e5eef-9590-4941-bdaa-4a05a47e12d6}, !- Handle
-  NECB_2011Outpatient,                    !- Name
+  ,                                       !- Name
   ,                                       !- Building Sector Type
   0,                                      !- North Axis {deg}
   ,                                       !- Nominal Floor to Floor Height {m}

--- a/lib/openstudio-standards/standards/necb/NECB2011/data/geometry/PrimarySchool.osm
+++ b/lib/openstudio-standards/standards/necb/NECB2011/data/geometry/PrimarySchool.osm
@@ -4125,7 +4125,7 @@ OS:SubSurface,
 
 OS:Building,
   {9a5048da-f51f-4a23-bf2e-fd970cdf8aae}, !- Handle
-  NECB_2011PrimarySchool,                 !- Name
+  ,                                       !- Name
   ,                                       !- Building Sector Type
   0,                                      !- North Axis {deg}
   ,                                       !- Nominal Floor to Floor Height {m}

--- a/lib/openstudio-standards/standards/necb/NECB2011/data/geometry/QuickServiceRestaurant.osm
+++ b/lib/openstudio-standards/standards/necb/NECB2011/data/geometry/QuickServiceRestaurant.osm
@@ -184,7 +184,7 @@ OS:HeatBalanceAlgorithm,
 
 OS:Building,
   {2359408b-6252-42dc-81e2-5632894e0032}, !- Handle
-  NECB_2011QuickServiceRestaurant,        !- Name
+  ,                                       !- Name
   ,                                       !- Building Sector Type
   0,                                      !- North Axis {deg}
   ,                                       !- Nominal Floor to Floor Height {m}

--- a/lib/openstudio-standards/standards/necb/NECB2011/data/geometry/RetailStandalone.osm
+++ b/lib/openstudio-standards/standards/necb/NECB2011/data/geometry/RetailStandalone.osm
@@ -929,7 +929,7 @@ OS:Timestep,
 
 OS:Building,
   {aa071399-e221-47e9-8f4a-f45735eb331f}, !- Handle
-  NECB_2011RetailStandalone,              !- Name
+  ,                                       !- Name
   ,                                       !- Building Sector Type
   0,                                      !- North Axis {deg}
   ,                                       !- Nominal Floor to Floor Height {m}

--- a/lib/openstudio-standards/standards/necb/NECB2011/data/geometry/RetailStripmall.osm
+++ b/lib/openstudio-standards/standards/necb/NECB2011/data/geometry/RetailStripmall.osm
@@ -2109,7 +2109,7 @@ OS:YearDescription,
 
 OS:Building,
   {2b0bfd6c-8754-4347-b436-1d7c3e63c79e}, !- Handle
-  NECB_2011RetailStripmall,               !- Name
+  ,                                       !- Name
   ,                                       !- Building Sector Type
   ,                                       !- North Axis {deg}
   ,                                       !- Nominal Floor to Floor Height {m}

--- a/lib/openstudio-standards/standards/necb/NECB2011/data/geometry/SecondarySchool.osm
+++ b/lib/openstudio-standards/standards/necb/NECB2011/data/geometry/SecondarySchool.osm
@@ -4718,7 +4718,7 @@ OS:SubSurface,
 
 OS:Building,
   {27c6b628-dd0b-4338-bf65-2883ce7ce3a0}, !- Handle
-  NECB_2011SecondarySchool,               !- Name
+  ,                                       !- Name
   ,                                       !- Building Sector Type
   0,                                      !- North Axis {deg}
   ,                                       !- Nominal Floor to Floor Height {m}

--- a/lib/openstudio-standards/standards/necb/NECB2011/data/geometry/SmallHotel.osm
+++ b/lib/openstudio-standards/standards/necb/NECB2011/data/geometry/SmallHotel.osm
@@ -5211,7 +5211,7 @@ OS:Surface,
 
 OS:Building,
   {d51e5796-e368-46e3-9443-963f0bbac6c9}, !- Handle
-  NECB_2011SmallHotel,                    !- Name
+  ,                                       !- Name
   ,                                       !- Building Sector Type
   180,                                    !- North Axis {deg}
   ,                                       !- Nominal Floor to Floor Height {m}

--- a/lib/openstudio-standards/standards/necb/NECB2011/data/geometry/SmallOffice.osm
+++ b/lib/openstudio-standards/standards/necb/NECB2011/data/geometry/SmallOffice.osm
@@ -1204,7 +1204,7 @@ OS:SubSurface,
 
 OS:Building,
   {6b25c3c7-39e4-4be7-84a9-17e80feecaf5}, !- Handle
-  NECB_2011SmallOffice,                   !- Name
+  ,                                       !- Name
   ,                                       !- Building Sector Type
   0,                                      !- North Axis {deg}
   ,                                       !- Nominal Floor to Floor Height {m}

--- a/lib/openstudio-standards/standards/necb/NECB2011/data/geometry/Warehouse.osm
+++ b/lib/openstudio-standards/standards/necb/NECB2011/data/geometry/Warehouse.osm
@@ -1614,7 +1614,7 @@ OS:YearDescription,
 
 OS:Building,
   {c23ded4b-6f18-4e30-b6db-cc00e1198751}, !- Handle
-  NECB_2011Warehouse,                     !- Name
+  ,                     !- Name
   ,                                       !- Building Sector Type
   ,                                       !- North Axis {deg}
   ,                                       !- Nominal Floor to Floor Height {m}

--- a/lib/openstudio-standards/standards/necb/NECB2011/necb_2011.rb
+++ b/lib/openstudio-standards/standards/necb/NECB2011/necb_2011.rb
@@ -185,6 +185,7 @@ class NECB2011 < Standard
     osm_model_path = File.absolute_path(File.join(__FILE__, '..', '..', '..', "necb/NECB2011/data/geometry/#{building_type}.osm"))
     model = BTAP::FileIO::load_osm(osm_model_path)
     model.getBuilding.setName("#{File.basename(osm_model_path, '.osm')}-#{epw_file} created: #{Time.new}")
+
     return model_apply_standard(model: model,
                                 epw_file: epw_file,
                                 x_scale: x_scale,
@@ -208,7 +209,8 @@ class NECB2011 < Standard
                            fdwr_set: 'MAXIMIZE',
                            ssr_set: 'MAXIMIZE'
   )
-
+    building_type =  model.getBuilding.standardsBuildingType.empty? ? "unknown" : model.getBuilding.standardsBuildingType.get
+    model.getBuilding.setStandardsBuildingType("#{self.class.name}_#{building_type}")
     climate_zone = 'NECB HDD Method'
 
     # prototype generation.I'm current


### PR DESCRIPTION
added vintage to buiding standardBuilding field so @ckirney and @jblake59 can access the vintage from a call like model.getBuilding.standardsBuildingType.get that will return the vintage_building_name