### PR TITLE
allows btap results to run on 2011-17 vintages

### DIFF
--- a/lib/openstudio-standards/standards/necb/NECB2011/qaqc/necb_qaqc.rb
+++ b/lib/openstudio-standards/standards/necb/NECB2011/qaqc/necb_qaqc.rb
@@ -41,7 +41,8 @@ class NECB2011
   # generates full qaqc.json
   def init_qaqc(model)
     # load the qaqc.json files
-    @qaqc_data = self.load_qaqc_database_new()
+    # This is currently disabled as most tests are now done using regression and unit tests.. but we may bring this back.
+    # @qaqc_data = self.load_qaqc_database_new()
 
     # generate base qaqc hash
     qaqc = create_base_data(model)

--- a/test/necb/test_necb_qaqc_single.rb
+++ b/test/necb/test_necb_qaqc_single.rb
@@ -47,7 +47,9 @@ class TestNECBQAQC < CreateDOEPrototypeBuildingTest
     # "Warehouse"
     ]
 
-    templates = ['NECB2011']
+    templates = ['NECB2011',
+                 'NECB2015',
+                 'NECB2017']
     climate_zones = 'NECB HDD Method'
     epw_files = ['CAN_AB_Calgary.Intl.AP.718770_CWEC2016.epw']
 
@@ -56,7 +58,9 @@ class TestNECBQAQC < CreateDOEPrototypeBuildingTest
     building_types.each do |building|
       epw_files.each do |epw|
         templates.each {|template|
-          run_argument_array << {'building' => building, 'epw' => epw, 'template' => template}
+          run_argument_array << { 'building' => building,
+                                  'epw' => epw,
+                                  'template' => template}
         }
       end
     end


### PR DESCRIPTION
This is currently disabled as most tests are now done using regression and unit tests.. but we may bring this back, maybe for NECB checklist reporting.... so the method is commented out. 