### PR TITLE
change default condenser loop to follow OATwb with 7F approach

### DIFF
--- a/lib/openstudio-standards/prototypes/common/objects/Prototype.hvac_systems.rb
+++ b/lib/openstudio-standards/prototypes/common/objects/Prototype.hvac_systems.rb
@@ -424,11 +424,14 @@ class Standard
     sizing_plant.setLoopType('Condenser')
     sizing_plant.setDesignLoopExitTemperature(dsgn_sup_wtr_temp_c)
     sizing_plant.setLoopDesignTemperatureDifference(dsgn_sup_wtr_temp_delt_k)
-    cw_temp_sch = model_add_constant_schedule_ruleset(model,
-                                                      sup_wtr_temp_c,
-                                                      name = "#{condenser_water_loop.name} Temp - #{sup_wtr_temp.round(0)}F")
-    cw_stpt_manager = OpenStudio::Model::SetpointManagerScheduled.new(model, cw_temp_sch)
-    cw_stpt_manager.setName("#{condenser_water_loop.name} Setpoint Manager")
+
+    # follow outdoor air wetbulb with given approach temperature
+    cw_stpt_manager = OpenStudio::Model::SetpointManagerFollowOutdoorAirTemperature.new(model)
+    cw_stpt_manager.setName("#{condenser_water_loop.name} Setpoint Manager Follow OATwb with #{wet_bulb_approach}F Approach")
+    cw_stpt_manager.setReferenceTemperatureType('OutdoorAirWetBulb')
+    cw_stpt_manager.setMaximumSetpointTemperature(dsgn_sup_wtr_temp_c)
+    cw_stpt_manager.setMinimumSetpointTemperature(sup_wtr_temp_c)
+    cw_stpt_manager.setOffsetTemperatureDifference(wet_bulb_approach_k)
     cw_stpt_manager.addToNode(condenser_water_loop.supplyOutletNode)
 
     # create condenser water pump


### PR DESCRIPTION
While running QC/QC on the tenant star project, @mpraprost encountered several cooling towers operating near or at full-load for some of their run time, which indicates undersized equipment.

The default condenser loop in openstudio-standards uses an 85°F leaving water temperature for cooling tower design sizing and a constant 70°F temperature setpoint schedule at the condenser water supply outlet node.  This means the tower frequently operates at or near full capacity to meet the 70°F target, and operates at full capacity any time the wet bulb is over 70°F.

This pull request replaces the constant 70°F setpoint and instead uses a follow outdoor air temperature controller keyed to outdoor air wet bulb with a 7°F approach and 70°F min and 85°F max.

There is a [method in the prm section](https://github.com/NREL/openstudio-standards/blob/master/lib/openstudio-standards/standards/Standards.PlantLoop.rb#L318-L337) of standards to apply this sort of logic, but it is not in the default prototype condenser water loop constructor.

**Expected changes**
We should expect to non-prm models to have significantly lower cooling tower fan energy use (heat rejection) and slightly higher chiller energy use. 
