### PR TITLE
[PSZ-AC] Autosizing minmium outdoor airflow rate so ERV can be created when necessary

### DIFF
--- a/lib/openstudio-standards/prototypes/common/objects/Prototype.hvac_systems.rb
+++ b/lib/openstudio-standards/prototypes/common/objects/Prototype.hvac_systems.rb
@@ -2431,6 +2431,7 @@ class Standard
       oa_controller = OpenStudio::Model::ControllerOutdoorAir.new(model)
       oa_controller.setName("#{air_loop.name} OA System Controller")
       oa_controller.setMinimumOutdoorAirSchedule(oa_damper_sch)
+      oa_controller.autosizeMinimumOutdoorAirFlowRate
       oa_controller.resetEconomizerMinimumLimitDryBulbTemperature
       oa_system = OpenStudio::Model::AirLoopHVACOutdoorAirSystem.new(model, oa_controller)
       oa_system.setName("#{air_loop.name} OA System")


### PR DESCRIPTION
The minimum outdoor airflow rate was never set to be autosized (the default value is 0) for PSZ-AC systems. One of the consequences is that no ERVs were created because, for most standards, the ERV requirement depends on the percentage of outdoor air flow rate to design flow rate which was always 0.

I will create another pull request to add tests to check that ERVs are created when required for a few known cases.