### PR TITLE
model_add_schedule return sch

### DIFF
--- a/lib/openstudio-standards/standards/Standards.Model.rb
+++ b/lib/openstudio-standards/standards/Standards.Model.rb
@@ -1864,7 +1864,7 @@ class Standard
     rules = model_find_objects(standards_data['schedules'], 'name' => schedule_name)
     if rules.size.zero?
       OpenStudio.logFree(OpenStudio::Error, 'openstudio.standards.Model', "Cannot find data for schedule: #{schedule_name}, will not be created.")
-      return false
+      return model.alwaysOnDiscreteSchedule
     end
 
     # Make a schedule ruleset


### PR DESCRIPTION
changes model_add_schedule to return an always on discrete schedule instead of false.  The code still throws an error message.

@asparke2 this needs to be merged into the LA100 branch too