### PR TITLE
Ignore Exception b to Section 9.4.1.4 to 90.1-2010

### DIFF
--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2010/ashrae_90_1_2010.Space.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2010/ashrae_90_1_2010.Space.rb
@@ -39,7 +39,7 @@ class ASHRAE9012010 < ASHRAE901
       # Check effective sidelighted aperture
       sidelighted_effective_aperture = space_sidelighting_effective_aperture(space, areas['primary_sidelighted_area'])
       OpenStudio.logFree(OpenStudio::Debug, 'openstudio.model.Space', "sidelighted_effective_aperture_pri = #{sidelighted_effective_aperture}")
-      if sidelighted_effective_aperture < 0.1
+      if sidelighted_effective_aperture < 0.1 and @instvarbuilding_type.nil?
         OpenStudio.logFree(OpenStudio::Info, 'openstudio.model.Space', "For #{space.name}, primary sidelighting control not required because sidelighted effective aperture < 0.1 per 9.4.1.4 Exception b.")
         req_pri_ctrl = false
       end


### PR DESCRIPTION
Exception b to Section 9.4.1.4 to 90.1-2010 should be ignored when generating the DOE prototypes. There is no code requirement in 90.1-2010 for visible transmittance hence, the sidelighted effective aperture area for prototypes is not evaluated. The proposed change uses the `@instvarbuilding` variable, that is only defined when creating a prototype, to skip the sidelighted effective aperture exception test. This should not impact the baseline model creation for performance rating methods as the variable isn't defined and as a result `@instvarbuilding_type.nil?` should always be `true`.