### PR TITLE
Add Computer Rooms to All 90.1 Schools Templates

### DIFF
--- a/data/geometry/ASHRAEPrimarySchool.osm
+++ b/data/geometry/ASHRAEPrimarySchool.osm
@@ -76,7 +76,7 @@ OS:Connection,
 OS:Space,
   {6fb8450c-0f97-450e-95a8-2b09bde8ba0e}, !- Handle
   Library_Media_Center_ZN_1_FLR_1,        !- Name
-  {3ae0e4f0-0b6b-41f1-92bc-64c51ae1646c}, !- Space Type Name
+  {167ab0d2-fe39-46d4-bb03-41aa6d55af0a}, !- Space Type Name
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
@@ -322,7 +322,7 @@ OS:Connection,
 OS:Space,
   {597eb46d-eacc-454e-8b06-a06f770e9515}, !- Handle
   Computer_Class_ZN_1_FLR_1,              !- Name
-  {3ae0e4f0-0b6b-41f1-92bc-64c51ae1646c}, !- Space Type Name
+  {5fa21c44-72fb-4c23-8777-8205c75d81ce}, !- Space Type Name
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
@@ -6455,4 +6455,38 @@ OS:Rendering:Color,
   120,                                    !- Rendering Red Value
   230,                                    !- Rendering Green Value
   199;                                    !- Rendering Blue Value
+
+OS:SpaceType,
+  {5fa21c44-72fb-4c23-8777-8205c75d81ce}, !- Handle
+  PrimarySchool ComputerRoom,             !- Name
+  ,                                       !- Default Construction Set Name
+  ,                                       !- Default Schedule Set Name
+  {5523923f-6128-48f7-b361-279399792ff5}, !- Group Rendering Name
+  ,                                       !- Design Specification Outdoor Air Object Name
+  PrimarySchool,                          !- Standards Building Type
+  ComputerRoom;                           !- Standards Space Type
+
+OS:Rendering:Color,
+  {5523923f-6128-48f7-b361-279399792ff5}, !- Handle
+  PrimarySchool ComputerRoom,             !- Name
+  120,                                    !- Rendering Red Value
+  230,                                    !- Rendering Green Value
+  199;                                    !- Rendering Blue Value
+
+OS:SpaceType,
+  {167ab0d2-fe39-46d4-bb03-41aa6d55af0a}, !- Handle
+  PrimarySchool Library,                  !- Name
+  ,                                       !- Default Construction Set Name
+  ,                                       !- Default Schedule Set Name
+  {b36531a2-a0fd-4d78-a02d-531890427a29}, !- Group Rendering Name
+  ,                                       !- Design Specification Outdoor Air Object Name
+  PrimarySchool,                          !- Standards Building Type
+  Library;                                !- Standards Space Type
+
+OS:Rendering:Color,
+  {b36531a2-a0fd-4d78-a02d-531890427a29}, !- Handle
+  PrimarySchool Library,                  !- Name
+  230,                                    !- Rendering Red Value
+  196,                                    !- Rendering Green Value
+  120;                                    !- Rendering Blue Value
 

--- a/data/geometry/ASHRAESecondarySchool.osm
+++ b/data/geometry/ASHRAESecondarySchool.osm
@@ -521,7 +521,7 @@ OS:Connection,
 OS:Space,
   {dda8118e-5bf7-4453-bed7-34efb3eb3a63}, !- Handle
   Mult_Class_1_Pod_3_ZN_1_FLR_2,          !- Name
-  {3fbc61e2-5ba2-47f6-854e-20a037673eaa}, !- Space Type Name
+  {c73772b8-aa19-4b80-ab3c-a8d3178978d0}, !- Space Type Name
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
@@ -1035,7 +1035,7 @@ OS:Connection,
 OS:Space,
   {8c061ff2-4149-4bdf-95af-a72da9c80a3d}, !- Handle
   Mult_Class_2_Pod_3_ZN_1_FLR_2,          !- Name
-  {3fbc61e2-5ba2-47f6-854e-20a037673eaa}, !- Space Type Name
+  {c73772b8-aa19-4b80-ab3c-a8d3178978d0}, !- Space Type Name
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   0,                                      !- Direction of Relative North {deg}
@@ -13366,6 +13366,23 @@ OS:SpaceType,
 OS:Rendering:Color,
   {cb3854c6-e817-4be8-a30e-8daa0a5bf51f}, !- Handle
   SecondarySchool Classroom,              !- Name
+  120,                                    !- Rendering Red Value
+  230,                                    !- Rendering Green Value
+  199;                                    !- Rendering Blue Value
+
+OS:SpaceType,
+  {c73772b8-aa19-4b80-ab3c-a8d3178978d0}, !- Handle
+  SecondarySchool ComputerRoom,           !- Name
+  ,                                       !- Default Construction Set Name
+  ,                                       !- Default Schedule Set Name
+  {27d027f7-2a45-4c89-a187-5aae2be88f12}, !- Group Rendering Name
+  ,                                       !- Design Specification Outdoor Air Object Name
+  SecondarySchool,                        !- Standards Building Type
+  ComputerRoom;                           !- Standards Space Type
+
+OS:Rendering:Color,
+  {27d027f7-2a45-4c89-a187-5aae2be88f12}, !- Handle
+  SecondarySchool ComputerRoom,           !- Name
   120,                                    !- Rendering Red Value
   230,                                    !- Rendering Green Value
   199;                                    !- Rendering Blue Value


### PR DESCRIPTION
The `ComputerRoom` space type was missing from some of the schools templates but is already included in the space types json file.