### PR TITLE
correct DOAS method to enable DCV

### DIFF
--- a/lib/openstudio-standards/prototypes/common/objects/Prototype.hvac_systems.rb
+++ b/lib/openstudio-standards/prototypes/common/objects/Prototype.hvac_systems.rb
@@ -4970,6 +4970,10 @@ class Standard
       zone.setCoolingPriority(zone_hvac.to_ModelObject.get, 1)
       zone.setHeatingPriority(zone_hvac.to_ModelObject.get, 1)
 
+      # set the cooling and heating fraction to zero so that the ERV does not try to meet the heating or cooling load.
+      zone.setSequentialCoolingFraction(zone_hvac.to_ModelObject.get, 0.0)
+      zone.setSequentialHeatingFraction(zone_hvac.to_ModelObject.get, 0.0)
+
       # Calculate ERV SAT during sizing periods
       # Standard rating conditions based on AHRI Std 1060 - 2013
       # heating design

--- a/test/doe_prototype/test_add_hvac_systems.rb
+++ b/test/doe_prototype/test_add_hvac_systems.rb
@@ -58,47 +58,45 @@ class TestAddHVACSystems < Minitest::Test
       ['VAV Reheat', 'DistrictHeating', 'DistrictHeating', 'DistrictCooling'],
 
       ## Hydronic ##
+      # Gas, Electric, hydronic
+      ['Fan Coil with DOAS', 'NaturalGas', nil, 'Electricity'],
+      ['Water Source Heat Pumps with DOAS', 'NaturalGas', nil, 'Electricity'],
+      ['Fan Coil with DOAS', 'NaturalGas', 'NaturalGas', 'Electricity'],
 
-      # TODO: Enable these tests once the CI version is OpenStudio v2.8.0 or greater
-      # OS v2.8.0 added the setSequentialCoolingFraction method to ThermalZone
+      # Electric, Electric, hydronic
+      ['Ground Source Heat Pumps with ERVs', 'Electricity', nil, 'Electricity'],
+      ['Ground Source Heat Pumps with DOAS', 'Electricity', nil, 'Electricity'],
+      ['Ground Source Heat Pumps with DOAS', 'Electricity', 'Electricity', 'Electricity'],
 
-      # # Gas, Electric, hydronic
-      # ['Fan Coil with DOAS', 'NaturalGas', nil, 'Electricity'],
-      # ['Water Source Heat Pumps with DOAS', 'NaturalGas', nil, 'Electricity'],
-      # ['Fan Coil with DOAS', 'NaturalGas', 'NaturalGas', 'Electricity'],
-      #
-      # # Electric, Electric, hydronic
-      # ['Ground Source Heat Pumps with ERVs', 'Electricity', nil, 'Electricity'],
-      # ['Ground Source Heat Pumps with DOAS', 'Electricity', nil, 'Electricity'],
-      # ['Ground Source Heat Pumps with DOAS', 'Electricity', 'Electricity', 'Electricity'],
-      #
-      # # District Hot Water, Electric, hydronic
-      # ['Fan Coil with DOAS', 'DistrictHeating', nil, 'Electricity'],
-      # ['Water Source Heat Pumps with DOAS', 'DistrictHeating', 'DistrictHeating', 'Electricity'],
-      # ['Fan Coil with DOAS', 'DistrictHeating', 'DistrictHeating', 'Electricity'],
-      #
-      # # Central Air Source Heat Pump, hydronic
-      # ['Fan Coil with DOAS', 'AirSourceHeatPump', nil, 'Electricity'],
-      #
-      # # Ambient Loop, Ambient Loop, hydronic
-      # ['Water Source Heat Pumps with ERVs', 'AmbientLoop', nil, 'AmbientLoop'],
-      # ['Water Source Heat Pumps with DOAS', 'AmbientLoop', nil, 'AmbientLoop'],
-      #
-      # # Gas, District Chilled Water, hydronic
-      # ['Fan Coil with DOAS', 'NaturalGas', nil, 'DistrictCooling'],
-      # ['Fan Coil with DOAS', 'NaturalGas', 'NaturalGas', 'DistrictCooling'],
-      #
-      # # Electric, District Chilled Water, hydronic
-      # ['Fan Coil with ERVs', 'Electricity', nil, 'DistrictCooling'],
-      # ['Fan Coil with DOAS', 'Electricity', 'Electricity', 'DistrictCooling'],
-      #
-      # # District Hot Water, District Chilled Water, hydronic
-      # ['Fan Coil with ERVs', 'DistrictHeating', nil, 'DistrictCooling'],
-      # ['Fan Coil with DOAS', 'DistrictHeating', nil, 'DistrictCooling'],
-      # ['Fan Coil with DOAS', 'DistrictHeating', 'DistrictHeating', 'DistrictCooling'],
-      #
-      # # DOAS Variations
-      # ['Fan Coil with DOAS with DCV', 'NaturalGas', nil, 'Electricity']
+      # District Hot Water, Electric, hydronic
+      ['Fan Coil with DOAS', 'DistrictHeating', nil, 'Electricity'],
+      ['Water Source Heat Pumps with DOAS', 'DistrictHeating', 'DistrictHeating', 'Electricity'],
+      ['Fan Coil with DOAS', 'DistrictHeating', 'DistrictHeating', 'Electricity'],
+
+      # Central Air Source Heat Pump, hydronic
+      ['Fan Coil with DOAS', 'AirSourceHeatPump', nil, 'Electricity'],
+
+      # Ambient Loop, Ambient Loop, hydronic
+      ['Water Source Heat Pumps with ERVs', 'AmbientLoop', nil, 'AmbientLoop'],
+      ['Water Source Heat Pumps with DOAS', 'AmbientLoop', nil, 'AmbientLoop'],
+
+      # Gas, District Chilled Water, hydronic
+      ['Fan Coil with DOAS', 'NaturalGas', nil, 'DistrictCooling'],
+      ['Fan Coil with DOAS', 'NaturalGas', 'NaturalGas', 'DistrictCooling'],
+
+      # Electric, District Chilled Water, hydronic
+      ['Fan Coil with ERVs', 'Electricity', nil, 'DistrictCooling'],
+      ['Fan Coil with DOAS', 'Electricity', 'Electricity', 'DistrictCooling'],
+
+      # District Hot Water, District Chilled Water, hydronic
+      ['Fan Coil with ERVs', 'DistrictHeating', nil, 'DistrictCooling'],
+      ['Fan Coil with DOAS', 'DistrictHeating', nil, 'DistrictCooling'],
+      ['Fan Coil with DOAS', 'DistrictHeating', 'DistrictHeating', 'DistrictCooling'],
+
+      ## DOAS Variations
+      #  Enable this test once the CI version is OpenStudio v2.8.0 or greater
+      #  OS v2.8.0 added the setSequentialCoolingFraction method to ThermalZone
+      #['Fan Coil with DOAS with DCV', 'NaturalGas', nil, 'Electricity']
     ]
 
     template = '90.1-2013'

--- a/test/doe_prototype/test_add_hvac_systems.rb
+++ b/test/doe_prototype/test_add_hvac_systems.rb
@@ -59,43 +59,46 @@ class TestAddHVACSystems < Minitest::Test
 
       ## Hydronic ##
 
-      # Gas, Electric, hydronic
-      ['Fan Coil with DOAS', 'NaturalGas', nil, 'Electricity'],
-      ['Water Source Heat Pumps with DOAS', 'NaturalGas', nil, 'Electricity'],
-      ['Fan Coil with DOAS', 'NaturalGas', 'NaturalGas', 'Electricity'],
+      # TODO: Enable these tests once the CI version is OpenStudio v2.8.0 or greater
+      # OS v2.8.0 added the setSequentialCoolingFraction method to ThermalZone
 
-      # Electric, Electric, hydronic
-      ['Ground Source Heat Pumps with ERVs', 'Electricity', nil, 'Electricity'],
-      ['Ground Source Heat Pumps with DOAS', 'Electricity', nil, 'Electricity'],
-      ['Ground Source Heat Pumps with DOAS', 'Electricity', 'Electricity', 'Electricity'],
-
-      # District Hot Water, Electric, hydronic
-      ['Fan Coil with DOAS', 'DistrictHeating', nil, 'Electricity'],
-      ['Water Source Heat Pumps with DOAS', 'DistrictHeating', 'DistrictHeating', 'Electricity'],
-      ['Fan Coil with DOAS', 'DistrictHeating', 'DistrictHeating', 'Electricity'],
-
-      # Central Air Source Heat Pump, hydronic
-      ['Fan Coil with DOAS', 'AirSourceHeatPump', nil, 'Electricity'],
-
-      # Ambient Loop, Ambient Loop, hydronic
-      ['Water Source Heat Pumps with ERVs', 'AmbientLoop', nil, 'AmbientLoop'],
-      ['Water Source Heat Pumps with DOAS', 'AmbientLoop', nil, 'AmbientLoop'],
-
-      # Gas, District Chilled Water, hydronic
-      ['Fan Coil with DOAS', 'NaturalGas', nil, 'DistrictCooling'],
-      ['Fan Coil with DOAS', 'NaturalGas', 'NaturalGas', 'DistrictCooling'],
-
-      # Electric, District Chilled Water, hydronic
-      ['Fan Coil with ERVs', 'Electricity', nil, 'DistrictCooling'], # Disable until this EnergyPlus issue is fixed: https://github.com/NREL/EnergyPlus/issues/6820
-      ['Fan Coil with DOAS', 'Electricity', 'Electricity', 'DistrictCooling'],
-
-      # District Hot Water, District Chilled Water, hydronic
-      ['Fan Coil with ERVs', 'DistrictHeating', nil, 'DistrictCooling'], # Disable until this EnergyPlus issue is fixed: https://github.com/NREL/EnergyPlus/issues/6820
-      ['Fan Coil with DOAS', 'DistrictHeating', nil, 'DistrictCooling'],
-      ['Fan Coil with DOAS', 'DistrictHeating', 'DistrictHeating', 'DistrictCooling'],
-
-      # DOAS Variations
-      ['Fan Coil with DOAS with DCV', 'NaturalGas', nil, 'Electricity']
+      # # Gas, Electric, hydronic
+      # ['Fan Coil with DOAS', 'NaturalGas', nil, 'Electricity'],
+      # ['Water Source Heat Pumps with DOAS', 'NaturalGas', nil, 'Electricity'],
+      # ['Fan Coil with DOAS', 'NaturalGas', 'NaturalGas', 'Electricity'],
+      #
+      # # Electric, Electric, hydronic
+      # ['Ground Source Heat Pumps with ERVs', 'Electricity', nil, 'Electricity'],
+      # ['Ground Source Heat Pumps with DOAS', 'Electricity', nil, 'Electricity'],
+      # ['Ground Source Heat Pumps with DOAS', 'Electricity', 'Electricity', 'Electricity'],
+      #
+      # # District Hot Water, Electric, hydronic
+      # ['Fan Coil with DOAS', 'DistrictHeating', nil, 'Electricity'],
+      # ['Water Source Heat Pumps with DOAS', 'DistrictHeating', 'DistrictHeating', 'Electricity'],
+      # ['Fan Coil with DOAS', 'DistrictHeating', 'DistrictHeating', 'Electricity'],
+      #
+      # # Central Air Source Heat Pump, hydronic
+      # ['Fan Coil with DOAS', 'AirSourceHeatPump', nil, 'Electricity'],
+      #
+      # # Ambient Loop, Ambient Loop, hydronic
+      # ['Water Source Heat Pumps with ERVs', 'AmbientLoop', nil, 'AmbientLoop'],
+      # ['Water Source Heat Pumps with DOAS', 'AmbientLoop', nil, 'AmbientLoop'],
+      #
+      # # Gas, District Chilled Water, hydronic
+      # ['Fan Coil with DOAS', 'NaturalGas', nil, 'DistrictCooling'],
+      # ['Fan Coil with DOAS', 'NaturalGas', 'NaturalGas', 'DistrictCooling'],
+      #
+      # # Electric, District Chilled Water, hydronic
+      # ['Fan Coil with ERVs', 'Electricity', nil, 'DistrictCooling'],
+      # ['Fan Coil with DOAS', 'Electricity', 'Electricity', 'DistrictCooling'],
+      #
+      # # District Hot Water, District Chilled Water, hydronic
+      # ['Fan Coil with ERVs', 'DistrictHeating', nil, 'DistrictCooling'],
+      # ['Fan Coil with DOAS', 'DistrictHeating', nil, 'DistrictCooling'],
+      # ['Fan Coil with DOAS', 'DistrictHeating', 'DistrictHeating', 'DistrictCooling'],
+      #
+      # # DOAS Variations
+      # ['Fan Coil with DOAS with DCV', 'NaturalGas', nil, 'Electricity']
     ]
 
     template = '90.1-2013'


### PR DESCRIPTION
This fix does two things:
1) Sets the zone DOAS air terminal as the 1st priority for zone heating and cooling so that it's effect on the zone air is included
2) Sets the sequential cooling fraction and sequential heating fraction to zero so that the DOAS air terminal is only expected to provide ventilation, not zone conditioning.  In the case of economizing, the sequential cooling fraction is set to 1.0 to enable economizing, and is mutually exclusive of DCV.