### PR TITLE
remove ems objects when calling model_create_prm_baseline_building

### DIFF
--- a/lib/openstudio-standards/standards/Standards.Model.rb
+++ b/lib/openstudio-standards/standards/Standards.Model.rb
@@ -90,6 +90,9 @@ class Standard
     # Remove all HVAC from model, excluding service water heating
     model_remove_prm_hvac(model)
 
+    # Remove all EMS objects from the model
+    model_remove_prm_ems_objects(model)
+
     # Modify the service water heating loops per the baseline rules
     OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.Model', '*** Cleaning up Service Water Heating Loops ***')
     model_apply_baseline_swh_loops(model, building_type)
@@ -3774,6 +3777,26 @@ class Standard
 
     # Outdoor VRF units (not in zone, not in loops)
     model.getAirConditionerVariableRefrigerantFlows.each(&:remove)
+
+    return true
+  end
+
+  # Remove EMS objects that may be orphaned from removing HVAC
+  #
+  # @return [Bool] true if successful, false if not
+  def model_remove_prm_ems_objects(model)
+    model.getEnergyManagementSystemActuators(&:remove)
+    model.getEnergyManagementSystemConstructionIndexVariables(&:remove)
+    model.getEnergyManagementSystemCurveOrTableIndexVariables(&:remove)
+    model.getEnergyManagementSystemGlobalVariables(&:remove)
+    model.getEnergyManagementSystemInternalVariables(&:remove)
+    model.getEnergyManagementSystemMeteredOutputVariables(&:remove)
+    model.getEnergyManagementSystemOutputVariables(&:remove)
+    model.getEnergyManagementSystemPrograms(&:remove)
+    model.getEnergyManagementSystemProgramCallingManagers(&:remove)
+    model.getEnergyManagementSystemSensors(&:remove)
+    model.getEnergyManagementSystemSubroutines(&:remove)
+    model.getEnergyManagementSystemTrendVariables(&:remove)
 
     return true
   end


### PR DESCRIPTION
If a user makes a prototype HVAC system, or otherwise uses EMS objects in their model, these may get orphaned when running the prm_baseline method which removes all HVAC and service water heating.

This method removes EMS objects so that the baseline model can be made cleanly.

Intends to fix [NREL/OpenStudio issue #3279](https://github.com/NREL/OpenStudio/issues/3279) and #688.