### PR TITLE
removed necb references from metaprogramming

### DIFF
--- a/lib/openstudio-standards/prototypes/common/prototype_metaprogramming.rb
+++ b/lib/openstudio-standards/prototypes/common/prototype_metaprogramming.rb
@@ -163,107 +163,6 @@ end
     end
   end
 
-  ['NECB2011',
-   'NECB2015',
-   'NECB2017'].each do |template|
-    # Create Prototype base class (May not be needed...)
-    # Ex: class NECB2011_Prototype < NECB2011
-    class_array << "
-  class #{template}_Prototype < #{template}
-  attr_reader :instvarbuilding_type
-  def initialize
-    super()
-  end
-end
-"
-
-    # Create Building Specific classes for each building.
-    # Example class NECB2011Hospital
-    prototype_buildings.each do |name|
-      class_array << "
-  # This class represents a prototypical #{template} #{name}.
-  class #{template}#{name} < #{template}
-    BUILDING_TYPE = \"#{name}\"
-    TEMPLATE =  \"#{template}\"
-    register_standard (\"\#{TEMPLATE}_\#{BUILDING_TYPE}\")
-    attr_accessor :prototype_database
-    attr_accessor :prototype_input
-    attr_accessor :lookup_building_type
-    attr_accessor :space_type_map
-    attr_accessor :geometry_file
-    attr_accessor :building_story_map
-    attr_accessor :system_to_space_map
-
-    def initialize
-      super()
-      @building_type = BUILDING_TYPE
-      @template = TEMPLATE
-      @instvarbuilding_type = @building_type
-      @prototype_input = self.standards_lookup_table_first(table_name: 'prototype_inputs', search_criteria: {'template' => \"#{template}\",'building_type' => \"#{name}\" })
-      if @prototype_input.nil?
-        OpenStudio.logFree(OpenStudio::Error, 'openstudio.standards.Model', \"Could not find prototype inputs for \#{{'template' => \"#{template}\",'building_type' => \"#{name}\" }}, cannot create model.\")
-        #puts JSON.pretty_generate(standards_data['prototype_inputs'])
-        raise(\"Could not find prototype inputs for #{template} #{name}, cannot create model.\")
-        return false
-      end
-      @lookup_building_type = self.model_get_lookup_name(@building_type)
-      #ideally we should map the data required to a instance variable.
-      @geometry_file = 'geometry/' + self.class.name + '.osm'
-      hvac_map_file =  'geometry/' + self.class.name + '.hvac_map.json'
-      # @system_to_space_map = load_hvac_map(hvac_map_file) # No HVAC map json files for NECB
-      self.set_variables()
-    end
-
-  # This method is used to extend the class with building-type-specific
-  # methods, as defined in Prototype.SomeBuildingType.rb.  Each building type
-  # has its own set of methods that change things which are not
-  # common across all prototype buildings, even within a given Standard.
-    def set_variables()
-    end
-
-  # Returns the mapping between the names of the spaces
-  # in the geometry .osm file and the space types
-  # available for this particular Standard.
-    def define_space_type_map(building_type, climate_zone)
-      return @space_type_map
-    end
-
-  # Returns the mapping between the names of the spaces
-  # in the geometry .osm file and the HVAC system that will
-  # be applied to those spaces.
-    def define_hvac_system_map(building_type, climate_zone)
-      return @system_to_space_map
-    end
-
-  # Returns the mapping between the names of the spaces
-  # in the geometry .osm file and the building story
-  # that they are located on.
-  def define_building_story_map(building_type, climate_zone)
-     return @building_story_map
-  end
-
-  # Does nothing unless implmented by the specific standard
-  def model_modify_oa_controller(model)
-  end
-
-  # Does nothing unless implmented by the specific standard
-  def model_reset_or_room_vav_minimum_damper(prototype_input, model)
-  end
-
-  # Does nothing unless implmented by the specific standard
-  def model_update_exhaust_fan_efficiency(model)
-  end
-
-  # Does nothing unless implmented by the specific standard
-  def model_update_fan_efficiency(model)
-  end
-
-end
-"
-    end
-  end
-
-
   return class_array
 end
 
@@ -483,7 +382,7 @@ def create_deer_class_array
       'SUn' => ['Unc'],
       'WRf' => ['DXGF']
   }
-  
+
   templates = ['DEERPRE1975',
                 'DEER1985',
                 'DEER1996',


### PR DESCRIPTION
changes to metaprogramming. NECB has no building specific classed to be used as it is now generalized for all building. 