### PR TITLE
Updating gemspec to fix the version of simplecov and simplecov-html w…

### DIFF
--- a/openstudio-standards.gemspec
+++ b/openstudio-standards.gemspec
@@ -34,6 +34,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'activesupport', '4.2.5' # pairs with google-api-client, > 5.0.0 does not work
   spec.add_development_dependency 'public_suffix', '3.0.3' # fixing version of google-api-client dependency
   spec.add_development_dependency 'google-api-client', '0.8.6' # to download Openstudio_Standards Google Spreadsheet
+  spec.add_development_dependency 'simplecov-html', '0.10.2' # fixing version of simplecov-html, simplecov dependency
+  spec.add_development_dependency 'simplecov', '0.17.1' # fixing version of simplecov, codecov dependency
   spec.add_development_dependency 'codecov' # to perform code coverage checking
   spec.add_development_dependency 'rest-client', '2.0.2'
   spec.add_development_dependency 'faraday', '0.15.4' # fixing version of google-api-client dependency


### PR DESCRIPTION
…hich can be used with the older version of Ruby.