### PR TITLE
move single controls to last method in air_loop_hvac_apply_standard_controls

### DIFF
--- a/lib/openstudio-standards/standards/Standards.AirLoopHVAC.rb
+++ b/lib/openstudio-standards/standards/Standards.AirLoopHVAC.rb
@@ -100,16 +100,6 @@ class Standard
       ## end
     end
 
-    # Single zone systems
-    if air_loop_hvac.thermalZones.size == 1
-      air_loop_hvac_supply_return_exhaust_relief_fans(air_loop_hvac).each do |fan|
-        if fan.to_FanVariableVolume.is_initialized
-          fan_variable_volume_set_control_type(fan, 'Single Zone VAV Fan')
-        end
-      end
-      air_loop_hvac_apply_single_zone_controls(air_loop_hvac, climate_zone)
-    end
-
     # DCV
     if air_loop_hvac_demand_control_ventilation_required?(air_loop_hvac, climate_zone)
       air_loop_hvac_enable_demand_control_ventilation(air_loop_hvac, climate_zone)
@@ -170,8 +160,16 @@ class Standard
     end
 
     # Optimum Start
-    if air_loop_hvac_optimum_start_required?(air_loop_hvac)
-      air_loop_hvac_enable_optimum_start(air_loop_hvac)
+    air_loop_hvac_enable_optimum_start(air_loop_hvac) if air_loop_hvac_optimum_start_required?(air_loop_hvac)
+
+    # Single zone systems
+    if air_loop_hvac.thermalZones.size == 1
+      air_loop_hvac_supply_return_exhaust_relief_fans(air_loop_hvac).each do |fan|
+        if fan.to_FanVariableVolume.is_initialized
+          fan_variable_volume_set_control_type(fan, 'Single Zone VAV Fan')
+        end
+      end
+      air_loop_hvac_apply_single_zone_controls(air_loop_hvac, climate_zone)
     end
   end
 


### PR DESCRIPTION
air_loop_hvac_apply_single_zone_controls adds EMS code that depends on the zone outdoor air schedule.  Previously, this schedule was getting adjusted by downstream measures per the zone occupancy schedules.  This invalidated the EMS controls in some climate zones with economizer controls.  This change moves the method to be applied last in the air_loop_hvac_apply_standard_controls method so that this EMS code isn't invalidated.