### PR TITLE
Bump dependencies (OpenStudio-update-gems)

### DIFF
--- a/openstudio-standards.gemspec
+++ b/openstudio-standards.gemspec
@@ -23,24 +23,24 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest-parallel_fork'
   spec.add_development_dependency 'ruby-progressbar'
   spec.add_development_dependency 'parallel_tests'
-  spec.add_development_dependency 'nokogiri', '<= 1.6.8.1'
-  spec.add_development_dependency 'bundler', '~> 1.9'
-  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'nokogiri', '~> 1.8.2'
+  spec.add_development_dependency 'bundler', '~> 2.1'
+  spec.add_development_dependency 'rake', '~> 12.3.1'
   spec.add_development_dependency 'yard', '~> 0.9'
-  spec.add_development_dependency 'rubocop', '0.68.1'
-  spec.add_development_dependency 'rubocop-checkstyle_formatter', '~> 0.1.1'
-  spec.add_development_dependency 'minitest-ci', '<= 5.10.3'
-  spec.add_development_dependency 'rubyXL', '3.3.8' # install rubyXL gem to export excel files to json
-  spec.add_development_dependency 'activesupport', '4.2.5' # pairs with google-api-client, > 5.0.0 does not work
-  spec.add_development_dependency 'public_suffix', '3.0.3' # fixing version of google-api-client dependency
-  spec.add_development_dependency 'faraday', '0.15.4' # fixing version of google-api-client dependency
-  spec.add_development_dependency 'signet', '< 0.12.0' # development dependency for google-api-client
-  spec.add_development_dependency 'launchy', '< 2.5.0' # development dependency for google-api-client
-  spec.add_development_dependency 'google-api-client', '0.8.6' # to download Openstudio_Standards Google Spreadsheet
-  spec.add_development_dependency 'simplecov-html', '< 0.11.0'
+  spec.add_development_dependency 'rubocop', '~> 0.80.1'
+  spec.add_development_dependency 'rubocop-checkstyle_formatter', '~> 0.4.0'
+  spec.add_development_dependency 'minitest-ci', '~> 5.10.3'
+  spec.add_development_dependency 'rubyXL', '~> 3.3.8' # install rubyXL gem to export excel files to json
+  spec.add_development_dependency 'activesupport', '~> 4.2.5' # pairs with google-api-client, > 5.0.0 does not work
+  spec.add_development_dependency 'public_suffix', '~> 4.0.3' # fixing version of google-api-client dependency
+  spec.add_development_dependency 'faraday', '~> 0.15.4' # fixing version of google-api-client dependency
+  spec.add_development_dependency 'signet', '~> < 0.12.0' # development dependency for google-api-client
+  spec.add_development_dependency 'launchy', '~> < 2.5.0' # development dependency for google-api-client
+  spec.add_development_dependency 'google-api-client', '~> 0.8.6' # to download Openstudio_Standards Google Spreadsheet
+  spec.add_development_dependency 'simplecov-html', '~> 0.10.0'
   spec.add_development_dependency 'codecov' # to perform code coverage checking
-  spec.add_development_dependency 'rest-client', '2.0.2'
-  spec.add_development_dependency 'aes', '0.5.0'
-  spec.add_development_dependency 'roo', '2.7.1'
+  spec.add_development_dependency 'rest-client', '~> 2.0.2'
+  spec.add_development_dependency 'aes', '~> 0.5.0'
+  spec.add_development_dependency 'roo', '~> 2.7.1'
   spec.add_development_dependency 'openstudio-api-stubs'
 end


### PR DESCRIPTION
the rake & bundler lines are needed for 3.x*. For the rest including using pessimistic version constraints, up to you.


*Not really needed in the sense that it's a development_dependency, so it'll work for us, but since you'll be switching to ruby 2.5.5 soon, might as well update as well.