### PR TITLE
Correct surfaces 190, 515, and 516 in ASHRAELargeOfficeDetailed.osm

### DIFF
--- a/data/geometry/ASHRAE9012013MediumOfficeDetailed.osm
+++ b/data/geometry/ASHRAE9012013MediumOfficeDetailed.osm
@@ -1,7 +1,7 @@
 
 OS:Version,
-  {27ab0958-a306-456b-8ced-d6a42410ac31}, !- Handle
-  2.3.0;                                  !- Version Identifier
+  {d5cdc5f7-d600-4f3d-a305-b30ddc0b9ace}, !- Handle
+  2.7.1;                                  !- Version Identifier
 
 OS:Space,
   {dead6e0b-93b8-47d9-be64-14bafc65d3ed}, !- Handle
@@ -11,7 +11,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  -7.21911419532262e-016,                 !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {6ae3b0c2-4c48-48f5-899c-4535e4abda9b}, !- Building Story Name
   {3a7886cf-2a83-410c-b706-a9101db3432f}, !- Thermal Zone Name
@@ -21,7 +21,7 @@ OS:Space,
 
 OS:Surface,
   {4f6ce9ef-b8a0-47b3-9969-91dba85f795f}, !- Handle
-  Surface 1,                              !- Name
+  ConfRoom_Bot_1 - Floor_a,               !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {dead6e0b-93b8-47d9-be64-14bafc65d3ed}, !- Space Name
@@ -38,7 +38,7 @@ OS:Surface,
 
 OS:Surface,
   {ee216b85-e4fa-45dc-adf5-783ca88f1a36}, !- Handle
-  Surface 2,                              !- Name
+  ConfRoom_Bot_1 - Wall 180_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {dead6e0b-93b8-47d9-be64-14bafc65d3ed}, !- Space Name
@@ -55,7 +55,7 @@ OS:Surface,
 
 OS:Surface,
   {cbd6def7-e055-4b6a-88bf-bbe3cb1b13da}, !- Handle
-  Surface 3,                              !- Name
+  ConfRoom_Bot_1 - Wall 270_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {dead6e0b-93b8-47d9-be64-14bafc65d3ed}, !- Space Name
@@ -72,7 +72,7 @@ OS:Surface,
 
 OS:Surface,
   {dc55e7e1-f28e-4c44-9c0c-ae5c75980c3a}, !- Handle
-  Surface 4,                              !- Name
+  ConfRoom_Bot_1 - Wall 090_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {dead6e0b-93b8-47d9-be64-14bafc65d3ed}, !- Space Name
@@ -89,7 +89,7 @@ OS:Surface,
 
 OS:Surface,
   {d0520f38-85f4-4064-8058-2959a439f858}, !- Handle
-  Surface 5,                              !- Name
+  ConfRoom_Bot_1 - RoofCeiling_a,         !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {dead6e0b-93b8-47d9-be64-14bafc65d3ed}, !- Space Name
@@ -106,7 +106,7 @@ OS:Surface,
 
 OS:Surface,
   {8692d635-5bfc-4d4a-ab16-6d36862bfb62}, !- Handle
-  Surface 6,                              !- Name
+  ConfRoom_Bot_1 - Wall 000_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {dead6e0b-93b8-47d9-be64-14bafc65d3ed}, !- Space Name
@@ -129,7 +129,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {6ae3b0c2-4c48-48f5-899c-4535e4abda9b}, !- Building Story Name
   {50f269fe-e2e6-4649-9146-723f691a44fb}, !- Thermal Zone Name
@@ -139,7 +139,7 @@ OS:Space,
 
 OS:Surface,
   {06281163-a7c3-4bb2-8dfd-b2b1e724e646}, !- Handle
-  Surface 7,                              !- Name
+  EnclosedOffice_Bot_3 - Floor_a,         !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {3722a907-8e46-4db9-958e-74273550d93b}, !- Space Name
@@ -156,7 +156,7 @@ OS:Surface,
 
 OS:Surface,
   {14810237-4695-4b22-a6db-37edca1b81cb}, !- Handle
-  Surface 8,                              !- Name
+  EnclosedOffice_Bot_3 - Wall 090_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3722a907-8e46-4db9-958e-74273550d93b}, !- Space Name
@@ -173,7 +173,7 @@ OS:Surface,
 
 OS:Surface,
   {f08cc2cf-59e9-4ab3-9f31-736d2720d8ba}, !- Handle
-  Surface 9,                              !- Name
+  EnclosedOffice_Bot_3 - RoofCeiling_a,   !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {3722a907-8e46-4db9-958e-74273550d93b}, !- Space Name
@@ -190,7 +190,7 @@ OS:Surface,
 
 OS:Surface,
   {5c0cd1fa-0554-48ed-b89c-e2f023ca9f57}, !- Handle
-  Surface 10,                             !- Name
+  EnclosedOffice_Bot_3 - Wall 000_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3722a907-8e46-4db9-958e-74273550d93b}, !- Space Name
@@ -207,7 +207,7 @@ OS:Surface,
 
 OS:Surface,
   {461fd235-e5a3-4976-a758-86cdaae6c00b}, !- Handle
-  Surface 11,                             !- Name
+  EnclosedOffice_Bot_3 - Wall 180_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3722a907-8e46-4db9-958e-74273550d93b}, !- Space Name
@@ -224,7 +224,7 @@ OS:Surface,
 
 OS:Surface,
   {cf00a667-0aef-4d0e-931f-a1e797d33f2f}, !- Handle
-  Surface 12,                             !- Name
+  EnclosedOffice_Bot_3 - Wall 270_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3722a907-8e46-4db9-958e-74273550d93b}, !- Space Name
@@ -247,7 +247,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {6ae3b0c2-4c48-48f5-899c-4535e4abda9b}, !- Building Story Name
   {6ace123f-abf3-430c-a767-2511c188ec0c}, !- Thermal Zone Name
@@ -257,7 +257,7 @@ OS:Space,
 
 OS:Surface,
   {654c4941-8477-4724-af24-46237acf2edc}, !- Handle
-  Surface 13,                             !- Name
+  Lounge_Bot - Floor_a,                   !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {234ac46c-ffc3-4573-99a3-a40a78cb0ee7}, !- Space Name
@@ -274,7 +274,7 @@ OS:Surface,
 
 OS:Surface,
   {83f0b611-5859-48ed-9c67-7c6698f68579}, !- Handle
-  Surface 14,                             !- Name
+  Lounge_Bot - Wall 000_a,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {234ac46c-ffc3-4573-99a3-a40a78cb0ee7}, !- Space Name
@@ -291,7 +291,7 @@ OS:Surface,
 
 OS:Surface,
   {53730ee6-f809-471a-b8b7-bb05f9bb7849}, !- Handle
-  Surface 15,                             !- Name
+  Lounge_Bot - RoofCeiling_a,             !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {234ac46c-ffc3-4573-99a3-a40a78cb0ee7}, !- Space Name
@@ -308,7 +308,7 @@ OS:Surface,
 
 OS:Surface,
   {df65ba66-691a-4bc7-ab66-a62103c480e9}, !- Handle
-  Surface 16,                             !- Name
+  Lounge_Bot - Wall 270_a,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {234ac46c-ffc3-4573-99a3-a40a78cb0ee7}, !- Space Name
@@ -325,7 +325,7 @@ OS:Surface,
 
 OS:Surface,
   {9750e3db-ab55-4cb3-93f8-807563459cf0}, !- Handle
-  Surface 17,                             !- Name
+  Lounge_Bot - Wall 090_a,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {234ac46c-ffc3-4573-99a3-a40a78cb0ee7}, !- Space Name
@@ -342,7 +342,7 @@ OS:Surface,
 
 OS:Surface,
   {cc4872fe-0abd-4224-bdcd-434ba9df8fa0}, !- Handle
-  Surface 18,                             !- Name
+  Lounge_Bot - Wall 180_a,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {234ac46c-ffc3-4573-99a3-a40a78cb0ee7}, !- Space Name
@@ -365,7 +365,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {6ae3b0c2-4c48-48f5-899c-4535e4abda9b}, !- Building Story Name
   {dd8f204f-43c7-488b-aced-b516b7634775}, !- Thermal Zone Name
@@ -375,7 +375,7 @@ OS:Space,
 
 OS:Surface,
   {92e0bc99-320e-4c25-b0d7-2947c3d2731b}, !- Handle
-  Surface 19,                             !- Name
+  EnclosedOffice_Bot_4 - Floor_a,         !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {01b8e746-81ac-4927-8f78-0abadefcbe48}, !- Space Name
@@ -392,7 +392,7 @@ OS:Surface,
 
 OS:Surface,
   {5444054f-3e70-427a-8c65-6e1f92bef721}, !- Handle
-  Surface 20,                             !- Name
+  EnclosedOffice_Bot_4 - Wall 000_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {01b8e746-81ac-4927-8f78-0abadefcbe48}, !- Space Name
@@ -409,7 +409,7 @@ OS:Surface,
 
 OS:Surface,
   {90084885-6457-42a1-be13-9cb390c97b73}, !- Handle
-  Surface 21,                             !- Name
+  EnclosedOffice_Bot_4 - Wall 270_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {01b8e746-81ac-4927-8f78-0abadefcbe48}, !- Space Name
@@ -426,7 +426,7 @@ OS:Surface,
 
 OS:Surface,
   {7903bab5-19a0-47e1-93fa-88a1831c144e}, !- Handle
-  Surface 22,                             !- Name
+  EnclosedOffice_Bot_4 - Wall 090_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {01b8e746-81ac-4927-8f78-0abadefcbe48}, !- Space Name
@@ -443,7 +443,7 @@ OS:Surface,
 
 OS:Surface,
   {f3a3e826-998e-414f-b44e-d0d1c74c33ea}, !- Handle
-  Surface 23,                             !- Name
+  EnclosedOffice_Bot_4 - Wall 180_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {01b8e746-81ac-4927-8f78-0abadefcbe48}, !- Space Name
@@ -460,7 +460,7 @@ OS:Surface,
 
 OS:Surface,
   {165569b2-f724-479f-beb0-59ac81daf096}, !- Handle
-  Surface 24,                             !- Name
+  EnclosedOffice_Bot_4 - RoofCeiling_a,   !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {01b8e746-81ac-4927-8f78-0abadefcbe48}, !- Space Name
@@ -483,7 +483,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {6ae3b0c2-4c48-48f5-899c-4535e4abda9b}, !- Building Story Name
   {d7559f81-feff-4e7d-90a9-3719a14d60ee}, !- Thermal Zone Name
@@ -493,7 +493,7 @@ OS:Space,
 
 OS:Surface,
   {9e6124db-9389-46ec-a29e-99e5a93b8902}, !- Handle
-  Surface 25,                             !- Name
+  ConfRoom_Bot_2 - Floor_a,               !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {5c3f4599-a380-4a4b-9c7b-8ddf191cfd3c}, !- Space Name
@@ -510,7 +510,7 @@ OS:Surface,
 
 OS:Surface,
   {35b9daf8-42ba-4f2a-8154-7c9bea01af2a}, !- Handle
-  Surface 26,                             !- Name
+  ConfRoom_Bot_2 - RoofCeiling_a,         !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {5c3f4599-a380-4a4b-9c7b-8ddf191cfd3c}, !- Space Name
@@ -527,7 +527,7 @@ OS:Surface,
 
 OS:Surface,
   {483def8c-a833-4c12-82f0-d5efaf2c8d77}, !- Handle
-  Surface 27,                             !- Name
+  ConfRoom_Bot_2 - Wall 270_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {5c3f4599-a380-4a4b-9c7b-8ddf191cfd3c}, !- Space Name
@@ -544,7 +544,7 @@ OS:Surface,
 
 OS:Surface,
   {e951ea82-4724-418a-9414-4abe1b5613cc}, !- Handle
-  Surface 28,                             !- Name
+  ConfRoom_Bot_2 - Wall 180_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {5c3f4599-a380-4a4b-9c7b-8ddf191cfd3c}, !- Space Name
@@ -561,7 +561,7 @@ OS:Surface,
 
 OS:Surface,
   {3675566c-d679-4694-942d-baaa29068541}, !- Handle
-  Surface 29,                             !- Name
+  ConfRoom_Bot_2 - Wall 000_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {5c3f4599-a380-4a4b-9c7b-8ddf191cfd3c}, !- Space Name
@@ -578,7 +578,7 @@ OS:Surface,
 
 OS:Surface,
   {1c501ce7-9cbd-482b-9b37-9bdee8fb66d6}, !- Handle
-  Surface 30,                             !- Name
+  ConfRoom_Bot_2 - Wall 090_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {5c3f4599-a380-4a4b-9c7b-8ddf191cfd3c}, !- Space Name
@@ -601,7 +601,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {6ae3b0c2-4c48-48f5-899c-4535e4abda9b}, !- Building Story Name
   {fed42c3c-cef1-4c79-9b92-13675d5c52ae}, !- Thermal Zone Name
@@ -611,7 +611,7 @@ OS:Space,
 
 OS:Surface,
   {7d85d010-a6c5-4100-b914-5148f6051a07}, !- Handle
-  Surface 31,                             !- Name
+  EnclosedOffice_Bot_1 - Floor_a,         !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {fde173d0-3216-4c8c-81aa-f97765d7e07b}, !- Space Name
@@ -628,7 +628,7 @@ OS:Surface,
 
 OS:Surface,
   {71ca0ab1-a2ce-4b84-9cde-00e947add9c6}, !- Handle
-  Surface 32,                             !- Name
+  EnclosedOffice_Bot_1 - Wall 180_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {fde173d0-3216-4c8c-81aa-f97765d7e07b}, !- Space Name
@@ -645,7 +645,7 @@ OS:Surface,
 
 OS:Surface,
   {0d6d4e30-d5d6-4763-9ace-49b99d1fac51}, !- Handle
-  Surface 33,                             !- Name
+  EnclosedOffice_Bot_1 - Wall 090_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {fde173d0-3216-4c8c-81aa-f97765d7e07b}, !- Space Name
@@ -662,7 +662,7 @@ OS:Surface,
 
 OS:Surface,
   {f1f26603-9b76-4c89-8bd4-e59d6987d3c2}, !- Handle
-  Surface 34,                             !- Name
+  EnclosedOffice_Bot_1 - Wall 000_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {fde173d0-3216-4c8c-81aa-f97765d7e07b}, !- Space Name
@@ -679,7 +679,7 @@ OS:Surface,
 
 OS:Surface,
   {b04a2501-431a-4745-a51d-64230f66347d}, !- Handle
-  Surface 35,                             !- Name
+  EnclosedOffice_Bot_1 - Wall 270_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {fde173d0-3216-4c8c-81aa-f97765d7e07b}, !- Space Name
@@ -696,7 +696,7 @@ OS:Surface,
 
 OS:Surface,
   {74e9feca-a5b1-43ac-8cf4-70d0a10f0bb7}, !- Handle
-  Surface 36,                             !- Name
+  EnclosedOffice_Bot_1 - RoofCeiling_a,   !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {fde173d0-3216-4c8c-81aa-f97765d7e07b}, !- Space Name
@@ -719,7 +719,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {6ae3b0c2-4c48-48f5-899c-4535e4abda9b}, !- Building Story Name
   {8c0b6af5-fb91-4b2d-a4f7-84b0129c6bac}, !- Thermal Zone Name
@@ -729,7 +729,7 @@ OS:Space,
 
 OS:Surface,
   {73ed7be2-800f-4d4c-8eae-5fae5129d965}, !- Handle
-  Surface 37,                             !- Name
+  Corridor_Bot_1 - Floor_a,               !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {3582db20-b034-4500-9c2e-ddf83e8c51fb}, !- Space Name
@@ -750,7 +750,7 @@ OS:Surface,
 
 OS:Surface,
   {febc77dd-cf16-4297-afb5-7ff0ec153126}, !- Handle
-  Surface 38,                             !- Name
+  Corridor_Bot_1 - Wall 090_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3582db20-b034-4500-9c2e-ddf83e8c51fb}, !- Space Name
@@ -767,7 +767,7 @@ OS:Surface,
 
 OS:Surface,
   {15cc338b-8594-47e0-9990-08a1456cd676}, !- Handle
-  Surface 39,                             !- Name
+  Corridor_Bot_1 - RoofCeiling_a,         !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {3582db20-b034-4500-9c2e-ddf83e8c51fb}, !- Space Name
@@ -788,7 +788,7 @@ OS:Surface,
 
 OS:Surface,
   {aa703743-3fc8-46a8-9bac-9d5715a44ffc}, !- Handle
-  Surface 40,                             !- Name
+  Corridor_Bot_1 - Wall 000_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3582db20-b034-4500-9c2e-ddf83e8c51fb}, !- Space Name
@@ -805,7 +805,7 @@ OS:Surface,
 
 OS:Surface,
   {bd6e007f-ca8b-49e7-88b9-0422b18cbb55}, !- Handle
-  Surface 41,                             !- Name
+  Corridor_Bot_1 - Wall 000_c,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3582db20-b034-4500-9c2e-ddf83e8c51fb}, !- Space Name
@@ -822,7 +822,7 @@ OS:Surface,
 
 OS:Surface,
   {14ac1ab4-752d-45e9-afda-47d432cd3aa0}, !- Handle
-  Surface 42,                             !- Name
+  Corridor_Bot_1 - Wall 270_b,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3582db20-b034-4500-9c2e-ddf83e8c51fb}, !- Space Name
@@ -839,7 +839,7 @@ OS:Surface,
 
 OS:Surface,
   {eebe45c5-82e8-4b65-a1d3-4c10988bb014}, !- Handle
-  Surface 43,                             !- Name
+  Corridor_Bot_1 - Wall 000_b,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3582db20-b034-4500-9c2e-ddf83e8c51fb}, !- Space Name
@@ -856,7 +856,7 @@ OS:Surface,
 
 OS:Surface,
   {a4b3cc85-a4e4-40ff-a6da-f765063873ed}, !- Handle
-  Surface 44,                             !- Name
+  Corridor_Bot_1 - Wall 090_b,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3582db20-b034-4500-9c2e-ddf83e8c51fb}, !- Space Name
@@ -873,7 +873,7 @@ OS:Surface,
 
 OS:Surface,
   {14f75553-0faa-4095-adfa-11cde0946c50}, !- Handle
-  Surface 45,                             !- Name
+  Corridor_Bot_1 - Wall 180_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3582db20-b034-4500-9c2e-ddf83e8c51fb}, !- Space Name
@@ -890,7 +890,7 @@ OS:Surface,
 
 OS:Surface,
   {8dfddb87-bf60-4486-b9dd-549bf77ef6b8}, !- Handle
-  Surface 46,                             !- Name
+  Corridor_Bot_1 - Wall 270_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3582db20-b034-4500-9c2e-ddf83e8c51fb}, !- Space Name
@@ -913,7 +913,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {6ae3b0c2-4c48-48f5-899c-4535e4abda9b}, !- Building Story Name
   {40974fb9-e93b-44c4-a16d-088b59a37fa6}, !- Thermal Zone Name
@@ -923,7 +923,7 @@ OS:Space,
 
 OS:Surface,
   {588398bf-e4d7-4973-a353-4d05e8d28d64}, !- Handle
-  Surface 47,                             !- Name
+  OpenOffice_Bot_2 - Floor_a,             !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {71627c3d-b8bb-4822-94c6-e191f607c7c3}, !- Space Name
@@ -940,7 +940,7 @@ OS:Surface,
 
 OS:Surface,
   {77d4713f-bbef-48af-a4d5-15ac61e977d0}, !- Handle
-  Surface 48,                             !- Name
+  OpenOffice_Bot_2 - RoofCeiling_a,       !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {71627c3d-b8bb-4822-94c6-e191f607c7c3}, !- Space Name
@@ -957,7 +957,7 @@ OS:Surface,
 
 OS:Surface,
   {9cd7ae6a-0ffc-4f15-91c4-e5035c1a18ea}, !- Handle
-  Surface 49,                             !- Name
+  OpenOffice_Bot_2 - Wall 180_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {71627c3d-b8bb-4822-94c6-e191f607c7c3}, !- Space Name
@@ -974,7 +974,7 @@ OS:Surface,
 
 OS:Surface,
   {013ecd01-5927-4ede-b8b9-ba85a5d1762a}, !- Handle
-  Surface 50,                             !- Name
+  OpenOffice_Bot_2 - Wall 090_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {71627c3d-b8bb-4822-94c6-e191f607c7c3}, !- Space Name
@@ -991,7 +991,7 @@ OS:Surface,
 
 OS:Surface,
   {7622965e-11df-4604-83fd-d17ca1ed335e}, !- Handle
-  Surface 51,                             !- Name
+  OpenOffice_Bot_2 - Wall 270_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {71627c3d-b8bb-4822-94c6-e191f607c7c3}, !- Space Name
@@ -1008,7 +1008,7 @@ OS:Surface,
 
 OS:Surface,
   {d3fa7153-5c3d-4ae6-a4f0-cb8a271ca465}, !- Handle
-  Surface 52,                             !- Name
+  OpenOffice_Bot_2 - Wall 000_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {71627c3d-b8bb-4822-94c6-e191f607c7c3}, !- Space Name
@@ -1031,7 +1031,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {6ae3b0c2-4c48-48f5-899c-4535e4abda9b}, !- Building Story Name
   {b77be4f7-7476-403e-ba6b-617ed7b714c5}, !- Thermal Zone Name
@@ -1041,7 +1041,7 @@ OS:Space,
 
 OS:Surface,
   {49be1aab-20f6-4210-98f9-253d9e3a2401}, !- Handle
-  Surface 53,                             !- Name
+  ActiveStorage_Bot_2 - Floor_a,          !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {73402641-4d57-419b-a232-ecaadb97f818}, !- Space Name
@@ -1058,7 +1058,7 @@ OS:Surface,
 
 OS:Surface,
   {4708090f-a1ff-426d-a2c8-d392b07e4e1a}, !- Handle
-  Surface 54,                             !- Name
+  ActiveStorage_Bot_2 - RoofCeiling_a,    !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {73402641-4d57-419b-a232-ecaadb97f818}, !- Space Name
@@ -1075,7 +1075,7 @@ OS:Surface,
 
 OS:Surface,
   {ed16a6ba-6424-4d7b-a891-06738d6446ef}, !- Handle
-  Surface 55,                             !- Name
+  ActiveStorage_Bot_2 - Wall 270_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {73402641-4d57-419b-a232-ecaadb97f818}, !- Space Name
@@ -1092,7 +1092,7 @@ OS:Surface,
 
 OS:Surface,
   {51e3ae5c-95d7-4b3f-806e-082b4d366841}, !- Handle
-  Surface 56,                             !- Name
+  ActiveStorage_Bot_2 - Wall 180_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {73402641-4d57-419b-a232-ecaadb97f818}, !- Space Name
@@ -1109,7 +1109,7 @@ OS:Surface,
 
 OS:Surface,
   {802c6346-0180-4c32-981d-e7ad44ce080b}, !- Handle
-  Surface 57,                             !- Name
+  ActiveStorage_Bot_2 - Wall 000_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {73402641-4d57-419b-a232-ecaadb97f818}, !- Space Name
@@ -1126,7 +1126,7 @@ OS:Surface,
 
 OS:Surface,
   {4b769701-9cae-41e4-89ff-5c643f1f3026}, !- Handle
-  Surface 58,                             !- Name
+  ActiveStorage_Bot_2 - Wall 090_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {73402641-4d57-419b-a232-ecaadb97f818}, !- Space Name
@@ -1149,7 +1149,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {6ae3b0c2-4c48-48f5-899c-4535e4abda9b}, !- Building Story Name
   {1bd749a4-6837-49ff-a664-93c3d1862eff}, !- Thermal Zone Name
@@ -1159,7 +1159,7 @@ OS:Space,
 
 OS:Surface,
   {9995b598-8ee8-44b3-9b33-97412fe17105}, !- Handle
-  Surface 59,                             !- Name
+  Stair_Bot_2 - Floor_a,                  !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {476eb5f5-f393-4d58-86b4-d6124e4ec4ea}, !- Space Name
@@ -1176,7 +1176,7 @@ OS:Surface,
 
 OS:Surface,
   {7d4514f8-65bd-4ba1-b8ca-b9e532f9fbce}, !- Handle
-  Surface 60,                             !- Name
+  Stair_Bot_2 - Wall 180_a,               !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {476eb5f5-f393-4d58-86b4-d6124e4ec4ea}, !- Space Name
@@ -1193,7 +1193,7 @@ OS:Surface,
 
 OS:Surface,
   {e56244ef-2a13-4649-a4a3-16e4707bc2ca}, !- Handle
-  Surface 61,                             !- Name
+  Stair_Bot_2 - RoofCeiling_a,            !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {476eb5f5-f393-4d58-86b4-d6124e4ec4ea}, !- Space Name
@@ -1210,7 +1210,7 @@ OS:Surface,
 
 OS:Surface,
   {ed93d9e6-605e-40b1-a94f-eb477639ff74}, !- Handle
-  Surface 62,                             !- Name
+  Stair_Bot_2 - Wall 270_a,               !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {476eb5f5-f393-4d58-86b4-d6124e4ec4ea}, !- Space Name
@@ -1227,7 +1227,7 @@ OS:Surface,
 
 OS:Surface,
   {509ea674-504a-4cca-8040-0bfbc403e525}, !- Handle
-  Surface 63,                             !- Name
+  Stair_Bot_2 - Wall 000_a,               !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {476eb5f5-f393-4d58-86b4-d6124e4ec4ea}, !- Space Name
@@ -1244,7 +1244,7 @@ OS:Surface,
 
 OS:Surface,
   {654f8d9c-a95d-4e37-b0e1-551015914fa4}, !- Handle
-  Surface 64,                             !- Name
+  Stair_Bot_2 - Wall 090_a,               !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {476eb5f5-f393-4d58-86b4-d6124e4ec4ea}, !- Space Name
@@ -1267,7 +1267,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {6ae3b0c2-4c48-48f5-899c-4535e4abda9b}, !- Building Story Name
   {7590f5b7-76ad-4e98-bbf5-6f2ef605fba6}, !- Thermal Zone Name
@@ -1277,7 +1277,7 @@ OS:Space,
 
 OS:Surface,
   {99367583-ac99-45c4-9fcb-e9038c9913b4}, !- Handle
-  Surface 65,                             !- Name
+  ActiveStorage_Bot_3 - Floor_a,          !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {c79dfd8e-0c5f-468d-a862-3d8cfa5ecc3d}, !- Space Name
@@ -1294,7 +1294,7 @@ OS:Surface,
 
 OS:Surface,
   {17b7ddb2-ebc0-4b36-ac1f-ec3c69033fc4}, !- Handle
-  Surface 66,                             !- Name
+  ActiveStorage_Bot_3 - Wall 180_b,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c79dfd8e-0c5f-468d-a862-3d8cfa5ecc3d}, !- Space Name
@@ -1311,7 +1311,7 @@ OS:Surface,
 
 OS:Surface,
   {dcbac142-ed99-4b5e-bf65-ee4297cbbeed}, !- Handle
-  Surface 67,                             !- Name
+  ActiveStorage_Bot_3 - Wall 270_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c79dfd8e-0c5f-468d-a862-3d8cfa5ecc3d}, !- Space Name
@@ -1328,7 +1328,7 @@ OS:Surface,
 
 OS:Surface,
   {5da10b39-672b-4d24-81f6-e31368cfab69}, !- Handle
-  Surface 68,                             !- Name
+  ActiveStorage_Bot_3 - RoofCeiling_a,    !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {c79dfd8e-0c5f-468d-a862-3d8cfa5ecc3d}, !- Space Name
@@ -1345,7 +1345,7 @@ OS:Surface,
 
 OS:Surface,
   {d6cacc75-9c02-4976-87c1-1e383dffe58e}, !- Handle
-  Surface 69,                             !- Name
+  ActiveStorage_Bot_3 - Wall 000_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c79dfd8e-0c5f-468d-a862-3d8cfa5ecc3d}, !- Space Name
@@ -1362,7 +1362,7 @@ OS:Surface,
 
 OS:Surface,
   {792a0e12-4da8-4c2d-ba11-4f80114168ae}, !- Handle
-  Surface 70,                             !- Name
+  ActiveStorage_Bot_3 - Wall 090_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c79dfd8e-0c5f-468d-a862-3d8cfa5ecc3d}, !- Space Name
@@ -1385,7 +1385,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {6ae3b0c2-4c48-48f5-899c-4535e4abda9b}, !- Building Story Name
   {9235bed7-49c4-4f8c-a0f5-249682f43044}, !- Thermal Zone Name
@@ -1395,7 +1395,7 @@ OS:Space,
 
 OS:Surface,
   {25375090-3f83-4936-8246-a2158b75276d}, !- Handle
-  Surface 71,                             !- Name
+  Mechanical_Bot - Floor_a,               !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {a851ef72-3731-451e-8776-1a4d556b3063}, !- Space Name
@@ -1412,7 +1412,7 @@ OS:Surface,
 
 OS:Surface,
   {ac099415-a724-44f3-891c-858e0be1ec5d}, !- Handle
-  Surface 72,                             !- Name
+  Mechanical_Bot - Wall 000_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {a851ef72-3731-451e-8776-1a4d556b3063}, !- Space Name
@@ -1429,7 +1429,7 @@ OS:Surface,
 
 OS:Surface,
   {072d529f-7271-4293-adbe-e2920b701774}, !- Handle
-  Surface 73,                             !- Name
+  Mechanical_Bot - RoofCeiling_a,         !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {a851ef72-3731-451e-8776-1a4d556b3063}, !- Space Name
@@ -1446,7 +1446,7 @@ OS:Surface,
 
 OS:Surface,
   {8d889c50-6136-4cb2-9334-ecfcba868f24}, !- Handle
-  Surface 74,                             !- Name
+  Mechanical_Bot - Wall 090_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {a851ef72-3731-451e-8776-1a4d556b3063}, !- Space Name
@@ -1463,7 +1463,7 @@ OS:Surface,
 
 OS:Surface,
   {9c086a86-160c-46d9-bd97-1db0afb8a00e}, !- Handle
-  Surface 75,                             !- Name
+  Mechanical_Bot - Wall 180_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {a851ef72-3731-451e-8776-1a4d556b3063}, !- Space Name
@@ -1480,7 +1480,7 @@ OS:Surface,
 
 OS:Surface,
   {6f49b4a6-cb62-4462-b009-425c24c27f6b}, !- Handle
-  Surface 76,                             !- Name
+  Mechanical_Bot - Wall 270_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {a851ef72-3731-451e-8776-1a4d556b3063}, !- Space Name
@@ -1503,7 +1503,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {6ae3b0c2-4c48-48f5-899c-4535e4abda9b}, !- Building Story Name
   {2586f405-4f2a-4830-968b-a9e77efc1629}, !- Thermal Zone Name
@@ -1513,7 +1513,7 @@ OS:Space,
 
 OS:Surface,
   {5d140d5a-9fdc-43df-89d1-fcfcb147dd98}, !- Handle
-  Surface 77,                             !- Name
+  Lobby_Bot - Floor_a,                    !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {79e07745-0c54-4000-bd7b-056875fc02b7}, !- Space Name
@@ -1530,7 +1530,7 @@ OS:Surface,
 
 OS:Surface,
   {5bd425c0-21e4-4367-8706-52806aef9610}, !- Handle
-  Surface 78,                             !- Name
+  Lobby_Bot - RoofCeiling_a,              !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {79e07745-0c54-4000-bd7b-056875fc02b7}, !- Space Name
@@ -1540,14 +1540,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  26.4795, 6.5611375, 2.74319999999999,   !- X,Y,Z Vertex 1 {m}
-  26.4795, 26.71445, 2.74319999999999,    !- X,Y,Z Vertex 2 {m}
-  23.4315, 26.71445, 2.74319999999999,    !- X,Y,Z Vertex 3 {m}
-  23.4315, 6.5611375, 2.74319999999999;   !- X,Y,Z Vertex 4 {m}
+  26.4795, 6.5611375, 2.7432,             !- X,Y,Z Vertex 1 {m}
+  26.4795, 26.71445, 2.7432,              !- X,Y,Z Vertex 2 {m}
+  23.4315, 26.71445, 2.7432,              !- X,Y,Z Vertex 3 {m}
+  23.4315, 6.5611375, 2.7432;             !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {076aa603-edf3-48ac-b887-cd25c90c30f9}, !- Handle
-  Surface 79,                             !- Name
+  Lobby_Bot - Wall 180_a,                 !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {79e07745-0c54-4000-bd7b-056875fc02b7}, !- Space Name
@@ -1557,14 +1557,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 6.5611375, 2.74319999999999,   !- X,Y,Z Vertex 1 {m}
+  23.4315, 6.5611375, 2.7432,             !- X,Y,Z Vertex 1 {m}
   23.4315, 6.5611375, 0,                  !- X,Y,Z Vertex 2 {m}
   26.4795, 6.5611375, 0,                  !- X,Y,Z Vertex 3 {m}
-  26.4795, 6.5611375, 2.74319999999999;   !- X,Y,Z Vertex 4 {m}
+  26.4795, 6.5611375, 2.7432;             !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {1b7eae37-e019-4cb4-9309-a3080abb3831}, !- Handle
-  Surface 80,                             !- Name
+  Lobby_Bot - Wall 270_a,                 !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {79e07745-0c54-4000-bd7b-056875fc02b7}, !- Space Name
@@ -1574,14 +1574,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 26.71445, 2.74319999999999,    !- X,Y,Z Vertex 1 {m}
+  23.4315, 26.71445, 2.7432,              !- X,Y,Z Vertex 1 {m}
   23.4315, 26.71445, 0,                   !- X,Y,Z Vertex 2 {m}
   23.4315, 22.234525, 0,                  !- X,Y,Z Vertex 3 {m}
-  23.4315, 22.234525, 2.74319999999999;   !- X,Y,Z Vertex 4 {m}
+  23.4315, 22.234525, 2.7432;             !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {49b154bd-608a-4706-8da3-327d7901cd2e}, !- Handle
-  Surface 81,                             !- Name
+  Lobby_Bot - Wall 000_a,                 !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {79e07745-0c54-4000-bd7b-056875fc02b7}, !- Space Name
@@ -1591,14 +1591,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  26.4795, 26.71445, 2.74319999999999,    !- X,Y,Z Vertex 1 {m}
+  26.4795, 26.71445, 2.7432,              !- X,Y,Z Vertex 1 {m}
   26.4795, 26.71445, 0,                   !- X,Y,Z Vertex 2 {m}
   23.4315, 26.71445, 0,                   !- X,Y,Z Vertex 3 {m}
-  23.4315, 26.71445, 2.74319999999999;    !- X,Y,Z Vertex 4 {m}
+  23.4315, 26.71445, 2.7432;              !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {3d14bc77-292a-406d-a12c-e778fde62235}, !- Handle
-  Surface 82,                             !- Name
+  Lobby_Bot - Wall 090_a,                 !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {79e07745-0c54-4000-bd7b-056875fc02b7}, !- Space Name
@@ -1608,10 +1608,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  26.4795, 22.234525, 2.74319999999999,   !- X,Y,Z Vertex 1 {m}
+  26.4795, 22.234525, 2.7432,             !- X,Y,Z Vertex 1 {m}
   26.4795, 22.234525, 0,                  !- X,Y,Z Vertex 2 {m}
   26.4795, 26.71445, 0,                   !- X,Y,Z Vertex 3 {m}
-  26.4795, 26.71445, 2.74319999999999;    !- X,Y,Z Vertex 4 {m}
+  26.4795, 26.71445, 2.7432;              !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {e33b76f2-d31e-486a-ba0e-68c11e5dc618}, !- Handle
@@ -1621,7 +1621,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {6ae3b0c2-4c48-48f5-899c-4535e4abda9b}, !- Building Story Name
   {565b61f6-2e86-41f6-aae0-b9a531aa9bb0}, !- Thermal Zone Name
@@ -1631,7 +1631,7 @@ OS:Space,
 
 OS:Surface,
   {1488437a-b050-4d6d-9277-a84894338986}, !- Handle
-  Surface 83,                             !- Name
+  Dining_Bot - Floor_a,                   !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {e33b76f2-d31e-486a-ba0e-68c11e5dc618}, !- Space Name
@@ -1648,7 +1648,7 @@ OS:Surface,
 
 OS:Surface,
   {e2873024-97eb-4378-9a70-b58a7b7f8085}, !- Handle
-  Surface 84,                             !- Name
+  Dining_Bot - RoofCeiling_a,             !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {e33b76f2-d31e-486a-ba0e-68c11e5dc618}, !- Space Name
@@ -1658,14 +1658,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 22.234525, 2.74319999999999,   !- X,Y,Z Vertex 1 {m}
-  23.4315, 26.71445, 2.74319999999999,    !- X,Y,Z Vertex 2 {m}
-  18.310225, 26.71445, 2.74319999999999,  !- X,Y,Z Vertex 3 {m}
-  18.310225, 22.234525, 2.74319999999999; !- X,Y,Z Vertex 4 {m}
+  23.4315, 22.234525, 2.7432,             !- X,Y,Z Vertex 1 {m}
+  23.4315, 26.71445, 2.7432,              !- X,Y,Z Vertex 2 {m}
+  18.310225, 26.71445, 2.7432,            !- X,Y,Z Vertex 3 {m}
+  18.310225, 22.234525, 2.7432;           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {c74c42f8-8302-4e5a-8062-c08008b71f4f}, !- Handle
-  Surface 85,                             !- Name
+  Dining_Bot - Wall 000_a,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e33b76f2-d31e-486a-ba0e-68c11e5dc618}, !- Space Name
@@ -1675,14 +1675,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 26.71445, 2.74319999999999,    !- X,Y,Z Vertex 1 {m}
+  23.4315, 26.71445, 2.7432,              !- X,Y,Z Vertex 1 {m}
   23.4315, 26.71445, 0,                   !- X,Y,Z Vertex 2 {m}
   18.310225, 26.71445, 0,                 !- X,Y,Z Vertex 3 {m}
-  18.310225, 26.71445, 2.74319999999999;  !- X,Y,Z Vertex 4 {m}
+  18.310225, 26.71445, 2.7432;            !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {eb302358-b2f9-4755-9d45-0cf972252a64}, !- Handle
-  Surface 86,                             !- Name
+  Dining_Bot - Wall 270_a,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e33b76f2-d31e-486a-ba0e-68c11e5dc618}, !- Space Name
@@ -1692,14 +1692,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  18.310225, 26.71445, 2.74319999999999,  !- X,Y,Z Vertex 1 {m}
+  18.310225, 26.71445, 2.7432,            !- X,Y,Z Vertex 1 {m}
   18.310225, 26.71445, 0,                 !- X,Y,Z Vertex 2 {m}
   18.310225, 22.234525, 0,                !- X,Y,Z Vertex 3 {m}
-  18.310225, 22.234525, 2.74319999999999; !- X,Y,Z Vertex 4 {m}
+  18.310225, 22.234525, 2.7432;           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {3a220190-f1ff-4821-a3c8-56876712aad2}, !- Handle
-  Surface 87,                             !- Name
+  Dining_Bot - Wall 180_a,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e33b76f2-d31e-486a-ba0e-68c11e5dc618}, !- Space Name
@@ -1709,14 +1709,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  18.310225, 22.234525, 2.74319999999999, !- X,Y,Z Vertex 1 {m}
+  18.310225, 22.234525, 2.7432,           !- X,Y,Z Vertex 1 {m}
   18.310225, 22.234525, 0,                !- X,Y,Z Vertex 2 {m}
   23.4315, 22.234525, 0,                  !- X,Y,Z Vertex 3 {m}
-  23.4315, 22.234525, 2.74319999999999;   !- X,Y,Z Vertex 4 {m}
+  23.4315, 22.234525, 2.7432;             !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {3d96e6d7-792e-47b0-93dd-9f8666b893ac}, !- Handle
-  Surface 88,                             !- Name
+  Dining_Bot - Wall 090_a,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e33b76f2-d31e-486a-ba0e-68c11e5dc618}, !- Space Name
@@ -1726,10 +1726,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 22.234525, 2.74319999999999,   !- X,Y,Z Vertex 1 {m}
+  23.4315, 22.234525, 2.7432,             !- X,Y,Z Vertex 1 {m}
   23.4315, 22.234525, 0,                  !- X,Y,Z Vertex 2 {m}
   23.4315, 26.71445, 0,                   !- X,Y,Z Vertex 3 {m}
-  23.4315, 26.71445, 2.74319999999999;    !- X,Y,Z Vertex 4 {m}
+  23.4315, 26.71445, 2.7432;              !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {3eecb187-413f-4cee-a5c8-613f53ea8a9a}, !- Handle
@@ -1739,7 +1739,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {6ae3b0c2-4c48-48f5-899c-4535e4abda9b}, !- Building Story Name
   {bd69f731-f897-40c0-9bbc-da49b08fa43c}, !- Thermal Zone Name
@@ -1749,7 +1749,7 @@ OS:Space,
 
 OS:Surface,
   {b81c3311-59da-4fc4-96d5-3b6c17aa4a8c}, !- Handle
-  Surface 89,                             !- Name
+  Restroom_Bot - Floor_a,                 !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {3eecb187-413f-4cee-a5c8-613f53ea8a9a}, !- Space Name
@@ -1766,7 +1766,7 @@ OS:Surface,
 
 OS:Surface,
   {1c8bce2d-a1c4-41e4-aa39-657179bc9a71}, !- Handle
-  Surface 90,                             !- Name
+  Restroom_Bot - Wall 090_a,              !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3eecb187-413f-4cee-a5c8-613f53ea8a9a}, !- Space Name
@@ -1776,14 +1776,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 11.0410625, 2.74319999999999,  !- X,Y,Z Vertex 1 {m}
+  23.4315, 11.0410625, 2.7432,            !- X,Y,Z Vertex 1 {m}
   23.4315, 11.0410625, 0,                 !- X,Y,Z Vertex 2 {m}
   23.4315, 22.234525, 0,                  !- X,Y,Z Vertex 3 {m}
-  23.4315, 22.234525, 2.74319999999999;   !- X,Y,Z Vertex 4 {m}
+  23.4315, 22.234525, 2.7432;             !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {453ad57b-d5ea-40bb-ae09-27b1ae3681b5}, !- Handle
-  Surface 91,                             !- Name
+  Restroom_Bot - RoofCeiling_a,           !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {3eecb187-413f-4cee-a5c8-613f53ea8a9a}, !- Space Name
@@ -1793,14 +1793,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 11.0410625, 2.74319999999999,  !- X,Y,Z Vertex 1 {m}
-  23.4315, 22.234525, 2.74319999999999,   !- X,Y,Z Vertex 2 {m}
-  18.0975, 22.234525, 2.74319999999999,   !- X,Y,Z Vertex 3 {m}
-  18.0975, 11.0410625, 2.74319999999999;  !- X,Y,Z Vertex 4 {m}
+  23.4315, 11.0410625, 2.7432,            !- X,Y,Z Vertex 1 {m}
+  23.4315, 22.234525, 2.7432,             !- X,Y,Z Vertex 2 {m}
+  18.0975, 22.234525, 2.7432,             !- X,Y,Z Vertex 3 {m}
+  18.0975, 11.0410625, 2.7432;            !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {70b62726-059e-471f-8242-9a9e4257729f}, !- Handle
-  Surface 92,                             !- Name
+  Restroom_Bot - Wall 180_a,              !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3eecb187-413f-4cee-a5c8-613f53ea8a9a}, !- Space Name
@@ -1810,14 +1810,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  18.0975, 11.0410625, 2.74319999999999,  !- X,Y,Z Vertex 1 {m}
+  18.0975, 11.0410625, 2.7432,            !- X,Y,Z Vertex 1 {m}
   18.0975, 11.0410625, 0,                 !- X,Y,Z Vertex 2 {m}
   23.4315, 11.0410625, 0,                 !- X,Y,Z Vertex 3 {m}
-  23.4315, 11.0410625, 2.74319999999999;  !- X,Y,Z Vertex 4 {m}
+  23.4315, 11.0410625, 2.7432;            !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {75170074-3fc4-45a9-bae3-e29713f9b795}, !- Handle
-  Surface 93,                             !- Name
+  Restroom_Bot - Wall 000_a,              !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3eecb187-413f-4cee-a5c8-613f53ea8a9a}, !- Space Name
@@ -1827,14 +1827,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  18.310225, 22.234525, 2.74319999999999, !- X,Y,Z Vertex 1 {m}
+  18.310225, 22.234525, 2.7432,           !- X,Y,Z Vertex 1 {m}
   18.310225, 22.234525, 0,                !- X,Y,Z Vertex 2 {m}
   18.0975, 22.234525, 0,                  !- X,Y,Z Vertex 3 {m}
-  18.0975, 22.234525, 2.74319999999999;   !- X,Y,Z Vertex 4 {m}
+  18.0975, 22.234525, 2.7432;             !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {53d29c93-45bb-4f3a-b401-f644d26cc010}, !- Handle
-  Surface 94,                             !- Name
+  Restroom_Bot - Wall 270_a,              !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3eecb187-413f-4cee-a5c8-613f53ea8a9a}, !- Space Name
@@ -1844,10 +1844,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  18.0975, 22.234525, 2.74319999999999,   !- X,Y,Z Vertex 1 {m}
+  18.0975, 22.234525, 2.7432,             !- X,Y,Z Vertex 1 {m}
   18.0975, 22.234525, 0,                  !- X,Y,Z Vertex 2 {m}
   18.0975, 11.0410625, 0,                 !- X,Y,Z Vertex 3 {m}
-  18.0975, 11.0410625, 2.74319999999999;  !- X,Y,Z Vertex 4 {m}
+  18.0975, 11.0410625, 2.7432;            !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {8bfa1513-dde5-445d-b5af-69b547f9fed4}, !- Handle
@@ -1857,7 +1857,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {6ae3b0c2-4c48-48f5-899c-4535e4abda9b}, !- Building Story Name
   {aefed899-7bbf-40b3-83e8-48f3aa1ab1f4}, !- Thermal Zone Name
@@ -1867,7 +1867,7 @@ OS:Space,
 
 OS:Surface,
   {85efcb0c-ec74-4c7d-bba7-8b656f565c19}, !- Handle
-  Surface 95,                             !- Name
+  ActiveStorage_Bot_1 - Floor_a,          !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {8bfa1513-dde5-445d-b5af-69b547f9fed4}, !- Space Name
@@ -1884,7 +1884,7 @@ OS:Surface,
 
 OS:Surface,
   {d81fd8a9-dfc6-4c0b-a0b6-b3ed13527483}, !- Handle
-  Surface 96,                             !- Name
+  ActiveStorage_Bot_1 - Wall 270_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {8bfa1513-dde5-445d-b5af-69b547f9fed4}, !- Space Name
@@ -1901,7 +1901,7 @@ OS:Surface,
 
 OS:Surface,
   {b5e22fab-2aba-4231-a9dd-cefc89f8f25a}, !- Handle
-  Surface 97,                             !- Name
+  ActiveStorage_Bot_1 - Wall 180_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {8bfa1513-dde5-445d-b5af-69b547f9fed4}, !- Space Name
@@ -1918,7 +1918,7 @@ OS:Surface,
 
 OS:Surface,
   {f2ed0a02-aaa0-431b-8d10-7f9de6c57b18}, !- Handle
-  Surface 98,                             !- Name
+  ActiveStorage_Bot_1 - Wall 090_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {8bfa1513-dde5-445d-b5af-69b547f9fed4}, !- Space Name
@@ -1935,7 +1935,7 @@ OS:Surface,
 
 OS:Surface,
   {1e5f03c6-7168-43c2-a56a-808bf06f3087}, !- Handle
-  Surface 99,                             !- Name
+  ActiveStorage_Bot_1 - RoofCeiling_a,    !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {8bfa1513-dde5-445d-b5af-69b547f9fed4}, !- Space Name
@@ -1952,7 +1952,7 @@ OS:Surface,
 
 OS:Surface,
   {2a921ed2-6fd3-400c-89dc-984d881a7eb4}, !- Handle
-  Surface 100,                            !- Name
+  ActiveStorage_Bot_1 - Wall 000_b,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {8bfa1513-dde5-445d-b5af-69b547f9fed4}, !- Space Name
@@ -1975,7 +1975,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {6ae3b0c2-4c48-48f5-899c-4535e4abda9b}, !- Building Story Name
   {8b6a66f3-1dc1-484b-82fc-1495af27d153}, !- Thermal Zone Name
@@ -1985,7 +1985,7 @@ OS:Space,
 
 OS:Surface,
   {e7844b0a-a6d2-42c2-b978-524e916b9d90}, !- Handle
-  Surface 101,                            !- Name
+  Stair_Bot_1 - Floor_a,                  !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {34daa9fc-c3a7-4661-b303-855b08b13084}, !- Space Name
@@ -2002,7 +2002,7 @@ OS:Surface,
 
 OS:Surface,
   {1e973de6-74f1-49bc-b560-9e384fc3105e}, !- Handle
-  Surface 102,                            !- Name
+  Stair_Bot_1 - RoofCeiling_a,            !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {34daa9fc-c3a7-4661-b303-855b08b13084}, !- Space Name
@@ -2019,7 +2019,7 @@ OS:Surface,
 
 OS:Surface,
   {221b9d25-9dcb-4e48-bd17-0b216fa5c729}, !- Handle
-  Surface 103,                            !- Name
+  Stair_Bot_1 - Wall 180_a,               !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {34daa9fc-c3a7-4661-b303-855b08b13084}, !- Space Name
@@ -2036,7 +2036,7 @@ OS:Surface,
 
 OS:Surface,
   {bce80bcb-f0fa-4fb9-bb74-449f6680dad8}, !- Handle
-  Surface 104,                            !- Name
+  Stair_Bot_1 - Wall 270_a,               !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {34daa9fc-c3a7-4661-b303-855b08b13084}, !- Space Name
@@ -2053,7 +2053,7 @@ OS:Surface,
 
 OS:Surface,
   {04829833-a2f0-4323-a72d-bb6d5bda080b}, !- Handle
-  Surface 105,                            !- Name
+  Stair_Bot_1 - Wall 090_a,               !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {34daa9fc-c3a7-4661-b303-855b08b13084}, !- Space Name
@@ -2070,7 +2070,7 @@ OS:Surface,
 
 OS:Surface,
   {47e7ecc0-5fa9-4c6d-952f-eb438815279a}, !- Handle
-  Surface 106,                            !- Name
+  Stair_Bot_1 - Wall 000_a,               !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {34daa9fc-c3a7-4661-b303-855b08b13084}, !- Space Name
@@ -2093,7 +2093,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {6ae3b0c2-4c48-48f5-899c-4535e4abda9b}, !- Building Story Name
   {4d141c4e-7af4-412e-910f-e17d39945991}, !- Thermal Zone Name
@@ -2103,7 +2103,7 @@ OS:Space,
 
 OS:Surface,
   {187d46d4-05af-427f-ba69-597a58d547fb}, !- Handle
-  Surface 107,                            !- Name
+  ActiveStorage_Bot_4 - Floor_a,          !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {28928794-2be1-4844-8cbb-7e9a5135b712}, !- Space Name
@@ -2120,7 +2120,7 @@ OS:Surface,
 
 OS:Surface,
   {f663f55e-9b08-472b-91e3-c6c85938e1fb}, !- Handle
-  Surface 108,                            !- Name
+  ActiveStorage_Bot_4 - Wall 090_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {28928794-2be1-4844-8cbb-7e9a5135b712}, !- Space Name
@@ -2137,7 +2137,7 @@ OS:Surface,
 
 OS:Surface,
   {db07646d-b36a-402c-96bd-1709bc8834c8}, !- Handle
-  Surface 109,                            !- Name
+  ActiveStorage_Bot_4 - Wall 180_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {28928794-2be1-4844-8cbb-7e9a5135b712}, !- Space Name
@@ -2154,7 +2154,7 @@ OS:Surface,
 
 OS:Surface,
   {075d7a7e-4365-47e7-8017-23c153e4fb3f}, !- Handle
-  Surface 110,                            !- Name
+  ActiveStorage_Bot_4 - Wall 270_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {28928794-2be1-4844-8cbb-7e9a5135b712}, !- Space Name
@@ -2171,7 +2171,7 @@ OS:Surface,
 
 OS:Surface,
   {3e8a3608-12a8-4bb3-aead-edbb574fd2a9}, !- Handle
-  Surface 111,                            !- Name
+  ActiveStorage_Bot_4 - Wall 000_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {28928794-2be1-4844-8cbb-7e9a5135b712}, !- Space Name
@@ -2188,7 +2188,7 @@ OS:Surface,
 
 OS:Surface,
   {0ef91d51-8b82-4f1c-902a-0defd7cbbb33}, !- Handle
-  Surface 112,                            !- Name
+  ActiveStorage_Bot_4 - RoofCeiling_a,    !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {28928794-2be1-4844-8cbb-7e9a5135b712}, !- Space Name
@@ -2211,7 +2211,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {6ae3b0c2-4c48-48f5-899c-4535e4abda9b}, !- Building Story Name
   {189c8ddc-f078-4a70-b892-259857f77f05}, !- Thermal Zone Name
@@ -2221,7 +2221,7 @@ OS:Space,
 
 OS:Surface,
   {9711055e-3c8d-4812-8733-72cd6af27c51}, !- Handle
-  Surface 113,                            !- Name
+  Corridor_Bot_2 - Floor_a,               !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {93f9b288-ab23-4aeb-92d3-0f31119c425c}, !- Space Name
@@ -2242,7 +2242,7 @@ OS:Surface,
 
 OS:Surface,
   {5cb714c5-2e2c-4364-8a0a-21d356853357}, !- Handle
-  Surface 114,                            !- Name
+  Corridor_Bot_2 - RoofCeiling_a,         !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {93f9b288-ab23-4aeb-92d3-0f31119c425c}, !- Space Name
@@ -2263,7 +2263,7 @@ OS:Surface,
 
 OS:Surface,
   {5a43a854-4864-4560-aeca-489600726240}, !- Handle
-  Surface 115,                            !- Name
+  Corridor_Bot_2 - Wall 270_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {93f9b288-ab23-4aeb-92d3-0f31119c425c}, !- Space Name
@@ -2280,7 +2280,7 @@ OS:Surface,
 
 OS:Surface,
   {5eefd0f8-d729-4be9-9aa9-2283754fe331}, !- Handle
-  Surface 116,                            !- Name
+  Corridor_Bot_2 - Wall 180_b,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {93f9b288-ab23-4aeb-92d3-0f31119c425c}, !- Space Name
@@ -2297,7 +2297,7 @@ OS:Surface,
 
 OS:Surface,
   {34d50455-c1b6-4277-8864-758169de4a92}, !- Handle
-  Surface 117,                            !- Name
+  Corridor_Bot_2 - Wall 000_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {93f9b288-ab23-4aeb-92d3-0f31119c425c}, !- Space Name
@@ -2314,7 +2314,7 @@ OS:Surface,
 
 OS:Surface,
   {c3feea21-e6c9-48a7-8d76-6d0d26f7e766}, !- Handle
-  Surface 118,                            !- Name
+  Corridor_Bot_2 - Wall 090_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {93f9b288-ab23-4aeb-92d3-0f31119c425c}, !- Space Name
@@ -2331,7 +2331,7 @@ OS:Surface,
 
 OS:Surface,
   {60dd1cca-e70f-4c26-bca8-050e22b29e94}, !- Handle
-  Surface 119,                            !- Name
+  Corridor_Bot_2 - Wall 180_c,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {93f9b288-ab23-4aeb-92d3-0f31119c425c}, !- Space Name
@@ -2348,7 +2348,7 @@ OS:Surface,
 
 OS:Surface,
   {2f9fc9b0-685f-4949-9d4b-21f5bea04783}, !- Handle
-  Surface 120,                            !- Name
+  Corridor_Bot_2 - Wall 270_b,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {93f9b288-ab23-4aeb-92d3-0f31119c425c}, !- Space Name
@@ -2365,7 +2365,7 @@ OS:Surface,
 
 OS:Surface,
   {9bfadcf8-9419-4535-b8c7-fbc1ac3d565d}, !- Handle
-  Surface 121,                            !- Name
+  Corridor_Bot_2 - Wall 180_d,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {93f9b288-ab23-4aeb-92d3-0f31119c425c}, !- Space Name
@@ -2382,7 +2382,7 @@ OS:Surface,
 
 OS:Surface,
   {0798a52b-4bd7-4318-8d42-23a7090f3717}, !- Handle
-  Surface 122,                            !- Name
+  Corridor_Bot_2 - Wall 090_b,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {93f9b288-ab23-4aeb-92d3-0f31119c425c}, !- Space Name
@@ -2399,7 +2399,7 @@ OS:Surface,
 
 OS:Surface,
   {969c55ce-31cc-44b0-bc85-89b3787945a2}, !- Handle
-  Surface 123,                            !- Name
+  Corridor_Bot_2 - Wall 180_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {93f9b288-ab23-4aeb-92d3-0f31119c425c}, !- Space Name
@@ -2422,7 +2422,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {6ae3b0c2-4c48-48f5-899c-4535e4abda9b}, !- Building Story Name
   {41cd6239-97fc-4edf-9fb2-e6e6b420e09f}, !- Thermal Zone Name
@@ -2432,7 +2432,7 @@ OS:Space,
 
 OS:Surface,
   {a1ddf0a1-79b1-4403-97fc-be7bc4505e13}, !- Handle
-  Surface 124,                            !- Name
+  OpenOffice_Bot_1 - Floor_a,             !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {d3b80d82-0387-4e18-a970-84ace3573794}, !- Space Name
@@ -2449,7 +2449,7 @@ OS:Surface,
 
 OS:Surface,
   {80072c6c-b7d4-438b-940d-29b5a7ad3904}, !- Handle
-  Surface 125,                            !- Name
+  OpenOffice_Bot_1 - Wall 270_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d3b80d82-0387-4e18-a970-84ace3573794}, !- Space Name
@@ -2466,7 +2466,7 @@ OS:Surface,
 
 OS:Surface,
   {ec36b517-d3c1-48e5-8fb4-a83048db001c}, !- Handle
-  Surface 126,                            !- Name
+  OpenOffice_Bot_1 - RoofCeiling_a,       !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {d3b80d82-0387-4e18-a970-84ace3573794}, !- Space Name
@@ -2483,7 +2483,7 @@ OS:Surface,
 
 OS:Surface,
   {4b25dd2b-e073-49c1-ae34-a3f18f50ff99}, !- Handle
-  Surface 127,                            !- Name
+  OpenOffice_Bot_1 - Wall 180_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d3b80d82-0387-4e18-a970-84ace3573794}, !- Space Name
@@ -2500,7 +2500,7 @@ OS:Surface,
 
 OS:Surface,
   {d609d0cf-5da6-4ff3-a4c1-c66bd2dadae4}, !- Handle
-  Surface 128,                            !- Name
+  OpenOffice_Bot_1 - Wall 000_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d3b80d82-0387-4e18-a970-84ace3573794}, !- Space Name
@@ -2517,7 +2517,7 @@ OS:Surface,
 
 OS:Surface,
   {8c3ecf28-33e4-4349-be96-476895d0c9cb}, !- Handle
-  Surface 129,                            !- Name
+  OpenOffice_Bot_1 - Wall 090_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d3b80d82-0387-4e18-a970-84ace3573794}, !- Space Name
@@ -2540,7 +2540,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {6ae3b0c2-4c48-48f5-899c-4535e4abda9b}, !- Building Story Name
   {4db7eee2-73e2-4fff-9953-3af33d6ba40d}, !- Thermal Zone Name
@@ -2550,7 +2550,7 @@ OS:Space,
 
 OS:Surface,
   {e53a1f42-6949-45c8-a194-35e9e38bed23}, !- Handle
-  Surface 130,                            !- Name
+  ClassRoom_Bot - Floor_a,                !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {20a72fcc-8f53-4254-a663-0a1e83c54121}, !- Space Name
@@ -2567,7 +2567,7 @@ OS:Surface,
 
 OS:Surface,
   {26c38f2f-9f85-4386-95da-8a6f2e81785f}, !- Handle
-  Surface 131,                            !- Name
+  ClassRoom_Bot - RoofCeiling_a,          !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {20a72fcc-8f53-4254-a663-0a1e83c54121}, !- Space Name
@@ -2584,7 +2584,7 @@ OS:Surface,
 
 OS:Surface,
   {511f210f-bd8d-4fb6-88f0-a6e5a2146ac5}, !- Handle
-  Surface 132,                            !- Name
+  ClassRoom_Bot - Wall 270_a,             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {20a72fcc-8f53-4254-a663-0a1e83c54121}, !- Space Name
@@ -2601,7 +2601,7 @@ OS:Surface,
 
 OS:Surface,
   {4a2ecd01-d744-4305-bad1-f5777e64dbaf}, !- Handle
-  Surface 133,                            !- Name
+  ClassRoom_Bot - Wall 180_a,             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {20a72fcc-8f53-4254-a663-0a1e83c54121}, !- Space Name
@@ -2618,7 +2618,7 @@ OS:Surface,
 
 OS:Surface,
   {49438c66-0fae-4b1f-8971-6c704cbb323e}, !- Handle
-  Surface 134,                            !- Name
+  ClassRoom_Bot - Wall 000_a,             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {20a72fcc-8f53-4254-a663-0a1e83c54121}, !- Space Name
@@ -2635,7 +2635,7 @@ OS:Surface,
 
 OS:Surface,
   {29ce2893-6048-4640-a5b0-5129f75e9048}, !- Handle
-  Surface 135,                            !- Name
+  ClassRoom_Bot - Wall 090_a,             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {20a72fcc-8f53-4254-a663-0a1e83c54121}, !- Space Name
@@ -2658,7 +2658,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {6ae3b0c2-4c48-48f5-899c-4535e4abda9b}, !- Building Story Name
   {af46f94b-979f-4baf-a003-e6a733d39a41}, !- Thermal Zone Name
@@ -2668,7 +2668,7 @@ OS:Space,
 
 OS:Surface,
   {d804fcb2-bdc1-435a-b560-283411697fdc}, !- Handle
-  Surface 136,                            !- Name
+  OpenOffice_Bot_3 - Floor_a,             !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {22813b20-9643-4e5e-ac1b-ca71f74c398b}, !- Space Name
@@ -2685,7 +2685,7 @@ OS:Surface,
 
 OS:Surface,
   {a322ede9-16bb-4afe-8521-28a263651911}, !- Handle
-  Surface 137,                            !- Name
+  OpenOffice_Bot_3 - RoofCeiling_a,       !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {22813b20-9643-4e5e-ac1b-ca71f74c398b}, !- Space Name
@@ -2702,7 +2702,7 @@ OS:Surface,
 
 OS:Surface,
   {4a3411b7-f72e-459d-8f8c-d7f59440853b}, !- Handle
-  Surface 138,                            !- Name
+  OpenOffice_Bot_3 - Wall 180_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {22813b20-9643-4e5e-ac1b-ca71f74c398b}, !- Space Name
@@ -2719,7 +2719,7 @@ OS:Surface,
 
 OS:Surface,
   {760b961f-fda9-4e5c-b46e-e95c97659ac9}, !- Handle
-  Surface 139,                            !- Name
+  OpenOffice_Bot_3 - Wall 000_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {22813b20-9643-4e5e-ac1b-ca71f74c398b}, !- Space Name
@@ -2736,7 +2736,7 @@ OS:Surface,
 
 OS:Surface,
   {6879ed9a-2909-4bcf-a5d3-4ec2733b6363}, !- Handle
-  Surface 140,                            !- Name
+  OpenOffice_Bot_3 - Wall 090_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {22813b20-9643-4e5e-ac1b-ca71f74c398b}, !- Space Name
@@ -2753,7 +2753,7 @@ OS:Surface,
 
 OS:Surface,
   {5fce64b2-aedc-4858-aa95-fc6191a831ad}, !- Handle
-  Surface 141,                            !- Name
+  OpenOffice_Bot_3 - Wall 270_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {22813b20-9643-4e5e-ac1b-ca71f74c398b}, !- Space Name
@@ -2776,7 +2776,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {6ae3b0c2-4c48-48f5-899c-4535e4abda9b}, !- Building Story Name
   {e45c6c6a-d922-4d61-a121-4f32dbc6de11}, !- Thermal Zone Name
@@ -2786,7 +2786,7 @@ OS:Space,
 
 OS:Surface,
   {c919cb30-b4a9-4371-9cf8-044cecc8541b}, !- Handle
-  Surface 142,                            !- Name
+  EnclosedOffice_Bot_2 - Floor_a,         !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {597c73f0-ba11-4097-8b84-21dbfe0e3af0}, !- Space Name
@@ -2803,7 +2803,7 @@ OS:Surface,
 
 OS:Surface,
   {85cefc1a-7279-4ed5-8774-e414b076b756}, !- Handle
-  Surface 143,                            !- Name
+  EnclosedOffice_Bot_2 - Wall 000_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {597c73f0-ba11-4097-8b84-21dbfe0e3af0}, !- Space Name
@@ -2820,7 +2820,7 @@ OS:Surface,
 
 OS:Surface,
   {18e89e67-920b-451e-84a3-b7057863b1de}, !- Handle
-  Surface 144,                            !- Name
+  EnclosedOffice_Bot_2 - RoofCeiling_a,   !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {597c73f0-ba11-4097-8b84-21dbfe0e3af0}, !- Space Name
@@ -2837,7 +2837,7 @@ OS:Surface,
 
 OS:Surface,
   {b9ded477-a976-45fb-b9b9-9cb6c12d56b8}, !- Handle
-  Surface 145,                            !- Name
+  EnclosedOffice_Bot_2 - Wall 090_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {597c73f0-ba11-4097-8b84-21dbfe0e3af0}, !- Space Name
@@ -2854,7 +2854,7 @@ OS:Surface,
 
 OS:Surface,
   {d393b4bd-4068-401e-a094-d335fef45f68}, !- Handle
-  Surface 146,                            !- Name
+  EnclosedOffice_Bot_2 - Wall 270_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {597c73f0-ba11-4097-8b84-21dbfe0e3af0}, !- Space Name
@@ -2871,7 +2871,7 @@ OS:Surface,
 
 OS:Surface,
   {fbfa89a6-8cc7-41c6-909c-b506dfab37ed}, !- Handle
-  Surface 147,                            !- Name
+  EnclosedOffice_Bot_2 - Wall 180_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {597c73f0-ba11-4097-8b84-21dbfe0e3af0}, !- Space Name
@@ -2888,7 +2888,7 @@ OS:Surface,
 
 OS:Surface,
   {0f29dc6c-1e78-4fe1-8347-733f37238828}, !- Handle
-  Surface 148,                            !- Name
+  ConfRoom_Bot_1 - Wall 000_b,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {dead6e0b-93b8-47d9-be64-14bafc65d3ed}, !- Space Name
@@ -2905,7 +2905,7 @@ OS:Surface,
 
 OS:Surface,
   {f99fee31-b37a-4880-a9cc-b1184ce941ea}, !- Handle
-  Surface 149,                            !- Name
+  ConfRoom_Bot_2 - Wall 000_b,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {5c3f4599-a380-4a4b-9c7b-8ddf191cfd3c}, !- Space Name
@@ -2922,7 +2922,7 @@ OS:Surface,
 
 OS:Surface,
   {5e3d753e-73d2-4e28-a19c-0bec1b46b68d}, !- Handle
-  Surface 150,                            !- Name
+  EnclosedOffice_Bot_1 - Wall 090_b,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {fde173d0-3216-4c8c-81aa-f97765d7e07b}, !- Space Name
@@ -2939,7 +2939,7 @@ OS:Surface,
 
 OS:Surface,
   {6dd6f4f2-071f-446b-a5f3-d745d459a45c}, !- Handle
-  Surface 151,                            !- Name
+  EnclosedOffice_Bot_1 - Wall 090_c,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {fde173d0-3216-4c8c-81aa-f97765d7e07b}, !- Space Name
@@ -2956,7 +2956,7 @@ OS:Surface,
 
 OS:Surface,
   {ed4ddc6c-52d3-498c-a203-218fbd2d8f0a}, !- Handle
-  Surface 152,                            !- Name
+  Corridor_Bot_1 - Wall 000_d,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3582db20-b034-4500-9c2e-ddf83e8c51fb}, !- Space Name
@@ -2973,7 +2973,7 @@ OS:Surface,
 
 OS:Surface,
   {e620d739-762c-42d0-b7ff-4c42b717dc9b}, !- Handle
-  Surface 153,                            !- Name
+  Corridor_Bot_1 - Wall 180_b,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3582db20-b034-4500-9c2e-ddf83e8c51fb}, !- Space Name
@@ -2990,7 +2990,7 @@ OS:Surface,
 
 OS:Surface,
   {15e54436-e188-4b13-bfb4-25843701c8c5}, !- Handle
-  Surface 154,                            !- Name
+  Corridor_Bot_1 - Wall 180_c,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3582db20-b034-4500-9c2e-ddf83e8c51fb}, !- Space Name
@@ -3007,7 +3007,7 @@ OS:Surface,
 
 OS:Surface,
   {66b8f5d0-5b92-4f75-af67-dbb349e16c44}, !- Handle
-  Surface 155,                            !- Name
+  Corridor_Bot_1 - Wall 000_e,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3582db20-b034-4500-9c2e-ddf83e8c51fb}, !- Space Name
@@ -3024,7 +3024,7 @@ OS:Surface,
 
 OS:Surface,
   {7af40f9c-3e7b-49b6-8759-017df8520c2a}, !- Handle
-  Surface 156,                            !- Name
+  Corridor_Bot_1 - Wall 180_d,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3582db20-b034-4500-9c2e-ddf83e8c51fb}, !- Space Name
@@ -3041,7 +3041,7 @@ OS:Surface,
 
 OS:Surface,
   {7feaf36c-d0f7-4046-8c04-f701bba82db8}, !- Handle
-  Surface 157,                            !- Name
+  Corridor_Bot_1 - Wall 000_f,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3582db20-b034-4500-9c2e-ddf83e8c51fb}, !- Space Name
@@ -3058,7 +3058,7 @@ OS:Surface,
 
 OS:Surface,
   {e4658aac-febd-4032-82bf-10873b28c77b}, !- Handle
-  Surface 158,                            !- Name
+  Corridor_Bot_1 - Wall 180_e,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3582db20-b034-4500-9c2e-ddf83e8c51fb}, !- Space Name
@@ -3075,7 +3075,7 @@ OS:Surface,
 
 OS:Surface,
   {3d7066bd-332f-4bbc-b414-3f6ee840c5b7}, !- Handle
-  Surface 159,                            !- Name
+  Corridor_Bot_1 - Wall 000_g,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3582db20-b034-4500-9c2e-ddf83e8c51fb}, !- Space Name
@@ -3092,7 +3092,7 @@ OS:Surface,
 
 OS:Surface,
   {43521a05-d481-489d-aff6-804ff3908cdd}, !- Handle
-  Surface 160,                            !- Name
+  OpenOffice_Bot_2 - Wall 270_c,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {71627c3d-b8bb-4822-94c6-e191f607c7c3}, !- Space Name
@@ -3109,7 +3109,7 @@ OS:Surface,
 
 OS:Surface,
   {10b686bb-2b2e-4a28-9a7a-6b754bfdd7f5}, !- Handle
-  Surface 161,                            !- Name
+  OpenOffice_Bot_2 - Wall 270_b,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {71627c3d-b8bb-4822-94c6-e191f607c7c3}, !- Space Name
@@ -3126,7 +3126,7 @@ OS:Surface,
 
 OS:Surface,
   {ccc59777-a50e-4801-9093-588ea8dcf3fe}, !- Handle
-  Surface 162,                            !- Name
+  OpenOffice_Bot_2 - Wall 090_b,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {71627c3d-b8bb-4822-94c6-e191f607c7c3}, !- Space Name
@@ -3143,7 +3143,7 @@ OS:Surface,
 
 OS:Surface,
   {4bd90679-9151-4eb9-ba79-07676983aa8a}, !- Handle
-  Surface 163,                            !- Name
+  ActiveStorage_Bot_2 - Wall 000_b,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {73402641-4d57-419b-a232-ecaadb97f818}, !- Space Name
@@ -3160,7 +3160,7 @@ OS:Surface,
 
 OS:Surface,
   {13541e31-cd53-4fbf-8fa0-d3efd83d43fd}, !- Handle
-  Surface 164,                            !- Name
+  ActiveStorage_Bot_3 - Wall 180_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c79dfd8e-0c5f-468d-a862-3d8cfa5ecc3d}, !- Space Name
@@ -3177,7 +3177,7 @@ OS:Surface,
 
 OS:Surface,
   {d2c27731-6e08-4d3c-80c0-ad71536d5ae2}, !- Handle
-  Surface 165,                            !- Name
+  Lobby_Bot - Wall 270_b,                 !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {79e07745-0c54-4000-bd7b-056875fc02b7}, !- Space Name
@@ -3187,14 +3187,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 11.0410625, 2.74319999999999,  !- X,Y,Z Vertex 1 {m}
+  23.4315, 11.0410625, 2.7432,            !- X,Y,Z Vertex 1 {m}
   23.4315, 11.0410625, 0,                 !- X,Y,Z Vertex 2 {m}
   23.4315, 6.5611375, 0,                  !- X,Y,Z Vertex 3 {m}
-  23.4315, 6.5611375, 2.74319999999999;   !- X,Y,Z Vertex 4 {m}
+  23.4315, 6.5611375, 2.7432;             !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {30b1412a-8a60-4a48-b84a-ead36555eb5c}, !- Handle
-  Surface 166,                            !- Name
+  Lobby_Bot - Wall 090_b,                 !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {79e07745-0c54-4000-bd7b-056875fc02b7}, !- Space Name
@@ -3204,14 +3204,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  26.4795, 11.0410625, 2.74319999999999,  !- X,Y,Z Vertex 1 {m}
+  26.4795, 11.0410625, 2.7432,            !- X,Y,Z Vertex 1 {m}
   26.4795, 11.0410625, 0,                 !- X,Y,Z Vertex 2 {m}
   26.4795, 22.234525, 0,                  !- X,Y,Z Vertex 3 {m}
-  26.4795, 22.234525, 2.74319999999999;   !- X,Y,Z Vertex 4 {m}
+  26.4795, 22.234525, 2.7432;             !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {4a2df7dc-e4c6-4a5f-b43b-b1c0dd382a04}, !- Handle
-  Surface 167,                            !- Name
+  Lobby_Bot - Wall 090_c,                 !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {79e07745-0c54-4000-bd7b-056875fc02b7}, !- Space Name
@@ -3221,14 +3221,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  26.4795, 6.5611375, 2.74319999999999,   !- X,Y,Z Vertex 1 {m}
+  26.4795, 6.5611375, 2.7432,             !- X,Y,Z Vertex 1 {m}
   26.4795, 6.5611375, 0,                  !- X,Y,Z Vertex 2 {m}
   26.4795, 11.0410625, 0,                 !- X,Y,Z Vertex 3 {m}
-  26.4795, 11.0410625, 2.74319999999999;  !- X,Y,Z Vertex 4 {m}
+  26.4795, 11.0410625, 2.7432;            !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {cf806425-bd04-413c-b002-77865c749901}, !- Handle
-  Surface 168,                            !- Name
+  Lobby_Bot - Wall 270_c,                 !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {79e07745-0c54-4000-bd7b-056875fc02b7}, !- Space Name
@@ -3238,14 +3238,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 22.234525, 2.74319999999999,   !- X,Y,Z Vertex 1 {m}
+  23.4315, 22.234525, 2.7432,             !- X,Y,Z Vertex 1 {m}
   23.4315, 22.234525, 0,                  !- X,Y,Z Vertex 2 {m}
   23.4315, 11.0410625, 0,                 !- X,Y,Z Vertex 3 {m}
-  23.4315, 11.0410625, 2.74319999999999;  !- X,Y,Z Vertex 4 {m}
+  23.4315, 11.0410625, 2.7432;            !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {6cd6b3d6-34d2-4fb0-a649-a5a224843367}, !- Handle
-  Surface 169,                            !- Name
+  Restroom_Bot - Wall 000_b,              !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3eecb187-413f-4cee-a5c8-613f53ea8a9a}, !- Space Name
@@ -3255,14 +3255,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 22.234525, 2.74319999999999,   !- X,Y,Z Vertex 1 {m}
+  23.4315, 22.234525, 2.7432,             !- X,Y,Z Vertex 1 {m}
   23.4315, 22.234525, 0,                  !- X,Y,Z Vertex 2 {m}
   18.310225, 22.234525, 0,                !- X,Y,Z Vertex 3 {m}
-  18.310225, 22.234525, 2.74319999999999; !- X,Y,Z Vertex 4 {m}
+  18.310225, 22.234525, 2.7432;           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {6da7c73a-cf17-4901-855b-14f71cc18f51}, !- Handle
-  Surface 170,                            !- Name
+  ActiveStorage_Bot_1 - Wall 000_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {8bfa1513-dde5-445d-b5af-69b547f9fed4}, !- Space Name
@@ -3279,7 +3279,7 @@ OS:Surface,
 
 OS:Surface,
   {e8058ef7-9442-4ab9-b937-d7a786a5c489}, !- Handle
-  Surface 171,                            !- Name
+  ActiveStorage_Bot_4 - Wall 180_b,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {28928794-2be1-4844-8cbb-7e9a5135b712}, !- Space Name
@@ -3296,7 +3296,7 @@ OS:Surface,
 
 OS:Surface,
   {ac1a0acc-0ecd-494f-b1ca-a9c9de0ee8ae}, !- Handle
-  Surface 172,                            !- Name
+  Corridor_Bot_2 - Wall 180_e,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {93f9b288-ab23-4aeb-92d3-0f31119c425c}, !- Space Name
@@ -3313,7 +3313,7 @@ OS:Surface,
 
 OS:Surface,
   {613ea5db-8d1a-408b-91a6-956b34d6d724}, !- Handle
-  Surface 173,                            !- Name
+  Corridor_Bot_2 - Wall 000_b,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {93f9b288-ab23-4aeb-92d3-0f31119c425c}, !- Space Name
@@ -3330,7 +3330,7 @@ OS:Surface,
 
 OS:Surface,
   {065c988d-7355-4efc-81a9-234d7e16bd44}, !- Handle
-  Surface 174,                            !- Name
+  Corridor_Bot_2 - Wall 180_f,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {93f9b288-ab23-4aeb-92d3-0f31119c425c}, !- Space Name
@@ -3347,7 +3347,7 @@ OS:Surface,
 
 OS:Surface,
   {d22b320f-7852-4141-a449-e0735ee09e66}, !- Handle
-  Surface 175,                            !- Name
+  Corridor_Bot_2 - Wall 180_g,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {93f9b288-ab23-4aeb-92d3-0f31119c425c}, !- Space Name
@@ -3364,7 +3364,7 @@ OS:Surface,
 
 OS:Surface,
   {f131bfc5-286e-4230-b5b6-e2fbb3bc9d76}, !- Handle
-  Surface 176,                            !- Name
+  Corridor_Bot_2 - Wall 180_h,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {93f9b288-ab23-4aeb-92d3-0f31119c425c}, !- Space Name
@@ -3381,7 +3381,7 @@ OS:Surface,
 
 OS:Surface,
   {0c30e32c-3adb-46ab-b9da-524f3eed2df0}, !- Handle
-  Surface 177,                            !- Name
+  OpenOffice_Bot_1 - Wall 090_b,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d3b80d82-0387-4e18-a970-84ace3573794}, !- Space Name
@@ -3398,7 +3398,7 @@ OS:Surface,
 
 OS:Surface,
   {94a4c742-1f30-4c48-8dff-45d9dcf9d881}, !- Handle
-  Surface 178,                            !- Name
+  OpenOffice_Bot_1 - Wall 270_b,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d3b80d82-0387-4e18-a970-84ace3573794}, !- Space Name
@@ -3415,7 +3415,7 @@ OS:Surface,
 
 OS:Surface,
   {528cd941-26ec-4eda-9155-b422f0900bc0}, !- Handle
-  Surface 179,                            !- Name
+  OpenOffice_Bot_1 - Wall 090_c,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d3b80d82-0387-4e18-a970-84ace3573794}, !- Space Name
@@ -3432,7 +3432,7 @@ OS:Surface,
 
 OS:Surface,
   {b955f122-db70-48f9-bd32-e5a77470c474}, !- Handle
-  Surface 180,                            !- Name
+  EnclosedOffice_Bot_2 - Wall 270_b,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {597c73f0-ba11-4097-8b84-21dbfe0e3af0}, !- Space Name
@@ -3449,7 +3449,7 @@ OS:Surface,
 
 OS:Surface,
   {14ab2a28-5129-49d9-a67d-528a02b18f14}, !- Handle
-  Surface 181,                            !- Name
+  EnclosedOffice_Bot_2 - Wall 270_c,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {597c73f0-ba11-4097-8b84-21dbfe0e3af0}, !- Space Name
@@ -3471,7 +3471,7 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
+  0,                                      !- X Origin {m}
   0,                                      !- Y Origin {m}
   2.7432,                                 !- Z Origin {m}
   {6ae3b0c2-4c48-48f5-899c-4535e4abda9b}, !- Building Story Name
@@ -3482,7 +3482,7 @@ OS:Space,
 
 OS:Surface,
   {5f67475b-8b60-42e5-8eb1-cc631dca0676}, !- Handle
-  Surface 182,                            !- Name
+  FirstFloor_Plenum - Floor_g,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -3499,7 +3499,7 @@ OS:Surface,
 
 OS:Surface,
   {863e08ab-9859-4c60-8698-9c9411286b27}, !- Handle
-  Surface 183,                            !- Name
+  FirstFloor_Plenum - Wall 090_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -3516,7 +3516,7 @@ OS:Surface,
 
 OS:Surface,
   {1d490495-37fa-4ce2-9a2f-8112fdf702e7}, !- Handle
-  Surface 184,                            !- Name
+  FirstFloor_Plenum - RoofCeiling_d,      !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -3533,7 +3533,7 @@ OS:Surface,
 
 OS:Surface,
   {21b1990d-04db-4cf5-8ba5-2d8bb4604caa}, !- Handle
-  Surface 185,                            !- Name
+  FirstFloor_Plenum - Wall 000_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -3550,7 +3550,7 @@ OS:Surface,
 
 OS:Surface,
   {84df663a-62ce-4246-82fc-b560895943f7}, !- Handle
-  Surface 186,                            !- Name
+  FirstFloor_Plenum - Wall 270_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -3567,7 +3567,7 @@ OS:Surface,
 
 OS:Surface,
   {300f01f2-ed5d-4904-a70d-d16296d79acc}, !- Handle
-  Surface 187,                            !- Name
+  FirstFloor_Plenum - Wall 180_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -3584,7 +3584,7 @@ OS:Surface,
 
 OS:Surface,
   {e17c644a-21f7-494c-a40f-2899a4152ed3}, !- Handle
-  Surface 188,                            !- Name
+  FirstFloor_Plenum - Floor_h,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -3594,14 +3594,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  33.6724625, 11.0410625, 1.80477854883065e-015, !- X,Y,Z Vertex 1 {m}
-  33.6724625, 6.5611375, -3.60955709766142e-016, !- X,Y,Z Vertex 2 {m}
-  26.4795, 6.5611375, -3.97051280742745e-015, !- X,Y,Z Vertex 3 {m}
-  26.4795, 11.0410625, -1.80477854883066e-015; !- X,Y,Z Vertex 4 {m}
+  33.6724625, 11.0410625, 0,              !- X,Y,Z Vertex 1 {m}
+  33.6724625, 6.5611375, 0,               !- X,Y,Z Vertex 2 {m}
+  26.4795, 6.5611375, 0,                  !- X,Y,Z Vertex 3 {m}
+  26.4795, 11.0410625, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {8d25bb95-10d8-41e8-96d4-014ffa639085}, !- Handle
-  Surface 189,                            !- Name
+  FirstFloor_Plenum - Floor_b,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -3618,7 +3618,7 @@ OS:Surface,
 
 OS:Surface,
   {b942a384-68c6-4508-a059-35eb642dd1e4}, !- Handle
-  Surface 190,                            !- Name
+  FirstFloor_Plenum - Floor_j,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -3628,14 +3628,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  18.310225, 26.71445, 7.21911419532262e-016, !- X,Y,Z Vertex 1 {m}
-  18.310225, 22.234525, -7.21911419532262e-016, !- X,Y,Z Vertex 2 {m}
-  15.3543, 22.234525, -7.21911419532262e-016, !- X,Y,Z Vertex 3 {m}
-  15.3543, 26.71445, 7.21911419532262e-016; !- X,Y,Z Vertex 4 {m}
+  18.310225, 26.71445, 0,                 !- X,Y,Z Vertex 1 {m}
+  18.310225, 22.234525, 0,                !- X,Y,Z Vertex 2 {m}
+  15.3543, 22.234525, 0,                  !- X,Y,Z Vertex 3 {m}
+  15.3543, 26.71445, 0;                   !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {f67f3364-0404-4268-9dec-5e566497e972}, !- Handle
-  Surface 191,                            !- Name
+  FirstFloor_Plenum - Floor_k,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -3652,7 +3652,7 @@ OS:Surface,
 
 OS:Surface,
   {229790ec-45aa-4146-82ba-a93c85581061}, !- Handle
-  Surface 192,                            !- Name
+  FirstFloor_Plenum - Floor_l,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -3662,14 +3662,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  18.0975, 22.234525, -7.21911419532262e-016, !- X,Y,Z Vertex 1 {m}
-  18.0975, 11.0410625, 7.21911419532262e-016, !- X,Y,Z Vertex 2 {m}
-  15.3543, 11.0410625, 7.21911419532262e-016, !- X,Y,Z Vertex 3 {m}
-  15.3543, 22.234525, -7.21911419532262e-016; !- X,Y,Z Vertex 4 {m}
+  18.0975, 22.234525, 0,                  !- X,Y,Z Vertex 1 {m}
+  18.0975, 11.0410625, 0,                 !- X,Y,Z Vertex 2 {m}
+  15.3543, 11.0410625, 0,                 !- X,Y,Z Vertex 3 {m}
+  15.3543, 22.234525, 0;                  !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {5f64776d-9382-4f3c-b7b7-601dca746ea6}, !- Handle
-  Surface 193,                            !- Name
+  FirstFloor_Plenum - Floor_f,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -3686,7 +3686,7 @@ OS:Surface,
 
 OS:Surface,
   {9316e7eb-b921-4ac3-ac25-d329788eb285}, !- Handle
-  Surface 194,                            !- Name
+  FirstFloor_Plenum - Floor_m,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -3707,7 +3707,7 @@ OS:Surface,
 
 OS:Surface,
   {8c5e2a86-41ec-4af7-befe-d5190c827a9c}, !- Handle
-  Surface 195,                            !- Name
+  FirstFloor_Plenum - Floor_n,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -3717,14 +3717,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 26.71445, -7.21911419532262e-016, !- X,Y,Z Vertex 1 {m}
-  23.4315, 22.234525, -2.16573425859679e-015, !- X,Y,Z Vertex 2 {m}
-  18.310225, 22.234525, -7.21911419532262e-016, !- X,Y,Z Vertex 3 {m}
-  18.310225, 26.71445, 7.21911419532265e-016; !- X,Y,Z Vertex 4 {m}
+  23.4315, 26.71445, 0,                   !- X,Y,Z Vertex 1 {m}
+  23.4315, 22.234525, 0,                  !- X,Y,Z Vertex 2 {m}
+  18.310225, 22.234525, 0,                !- X,Y,Z Vertex 3 {m}
+  18.310225, 26.71445, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {f4c4bbe1-25cb-45da-9cc8-b86db24f396f}, !- Handle
-  Surface 196,                            !- Name
+  FirstFloor_Plenum - Floor_o,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -3741,7 +3741,7 @@ OS:Surface,
 
 OS:Surface,
   {f7df5124-9fae-4704-8532-1aded0d593be}, !- Handle
-  Surface 197,                            !- Name
+  FirstFloor_Plenum - Floor_q,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -3762,7 +3762,7 @@ OS:Surface,
 
 OS:Surface,
   {ff0a2cb5-59da-4ddb-84e8-cc8080749976}, !- Handle
-  Surface 198,                            !- Name
+  FirstFloor_Plenum - Floor_s,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -3772,14 +3772,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  30.9292625, 22.234525, 8.12150346973795e-016, !- X,Y,Z Vertex 1 {m}
-  30.9292625, 11.0410625, -8.12150346973793e-016, !- X,Y,Z Vertex 2 {m}
-  26.4795, 11.0410625, -1.71453962138912e-015, !- X,Y,Z Vertex 3 {m}
-  26.4795, 22.234525, -9.02389274415328e-017; !- X,Y,Z Vertex 4 {m}
+  30.9292625, 22.234525, 0,               !- X,Y,Z Vertex 1 {m}
+  30.9292625, 11.0410625, 0,              !- X,Y,Z Vertex 2 {m}
+  26.4795, 11.0410625, 0,                 !- X,Y,Z Vertex 3 {m}
+  26.4795, 22.234525, 0;                  !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {588ab4e2-6191-42c7-91ea-77eea532f014}, !- Handle
-  Surface 199,                            !- Name
+  FirstFloor_Plenum - Floor_c,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -3789,14 +3789,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  26.4795, 26.71445, -2.70716782324596e-016, !- X,Y,Z Vertex 1 {m}
-  26.4795, 6.5611375, -3.69979602510284e-015, !- X,Y,Z Vertex 2 {m}
-  23.4315, 6.5611375, -3.88027387998591e-015, !- X,Y,Z Vertex 3 {m}
-  23.4315, 26.71445, -4.51194637207666e-016; !- X,Y,Z Vertex 4 {m}
+  26.4795, 26.71445, 0,                   !- X,Y,Z Vertex 1 {m}
+  26.4795, 6.5611375, 0,                  !- X,Y,Z Vertex 2 {m}
+  23.4315, 6.5611375, 0,                  !- X,Y,Z Vertex 3 {m}
+  23.4315, 26.71445, 0;                   !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {e4b4dc62-f283-414a-ac0b-adb41b720f80}, !- Handle
-  Surface 200,                            !- Name
+  FirstFloor_Plenum - Floor_t,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -3813,7 +3813,7 @@ OS:Surface,
 
 OS:Surface,
   {05d3820d-212c-4fe8-bc6b-61ab09afe9da}, !- Handle
-  Surface 201,                            !- Name
+  FirstFloor_Plenum - Floor_p,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -3830,7 +3830,7 @@ OS:Surface,
 
 OS:Surface,
   {ce6e2852-c3ac-4029-84ef-f5ca1af2265b}, !- Handle
-  Surface 202,                            !- Name
+  FirstFloor_Plenum - Floor_e,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -3840,14 +3840,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 22.234525, -2.25597318603832e-015, !- X,Y,Z Vertex 1 {m}
-  23.4315, 11.0410625, -9.9262820185686e-016, !- X,Y,Z Vertex 2 {m}
-  18.0975, 11.0410625, 6.31672492090729e-016, !- X,Y,Z Vertex 3 {m}
-  18.0975, 22.234525, -6.31672492090731e-016; !- X,Y,Z Vertex 4 {m}
+  23.4315, 22.234525, 0,                  !- X,Y,Z Vertex 1 {m}
+  23.4315, 11.0410625, 0,                 !- X,Y,Z Vertex 2 {m}
+  18.0975, 11.0410625, 0,                 !- X,Y,Z Vertex 3 {m}
+  18.0975, 22.234525, 0;                  !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {42ef1f73-58bf-4ce2-bbcd-4fbd18c866a7}, !- Handle
-  Surface 203,                            !- Name
+  FirstFloor_Plenum - Floor_u,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -3864,7 +3864,7 @@ OS:Surface,
 
 OS:Surface,
   {a888b100-622d-42f4-9371-e8c3ace13ccd}, !- Handle
-  Surface 204,                            !- Name
+  FirstFloor_Plenum - Floor_v,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -3874,14 +3874,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 11.0410625, -1.44382283906452e-015, !- X,Y,Z Vertex 1 {m}
-  23.4315, 6.5611375, -3.24860138789518e-015, !- X,Y,Z Vertex 2 {m}
-  15.3543, 6.5611375, -7.21911419532266e-016, !- X,Y,Z Vertex 3 {m}
-  15.3543, 11.0410625, 1.08286712929839e-015; !- X,Y,Z Vertex 4 {m}
+  23.4315, 11.0410625, 0,                 !- X,Y,Z Vertex 1 {m}
+  23.4315, 6.5611375, 0,                  !- X,Y,Z Vertex 2 {m}
+  15.3543, 6.5611375, 0,                  !- X,Y,Z Vertex 3 {m}
+  15.3543, 11.0410625, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {6c01a919-bb8e-43b9-bae4-85061210bdb2}, !- Handle
-  Surface 205,                            !- Name
+  FirstFloor_Plenum - Floor_a,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -3891,14 +3891,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  33.6724625, 22.234525, 8.12150346973791e-016, !- X,Y,Z Vertex 1 {m}
-  33.6724625, 11.0410625, 9.92628201856854e-016, !- X,Y,Z Vertex 2 {m}
-  30.9292625, 11.0410625, 9.02389274415274e-017, !- X,Y,Z Vertex 3 {m}
-  30.9292625, 22.234525, -9.02389274415352e-017; !- X,Y,Z Vertex 4 {m}
+  33.6724625, 22.234525, 0,               !- X,Y,Z Vertex 1 {m}
+  33.6724625, 11.0410625, 0,              !- X,Y,Z Vertex 2 {m}
+  30.9292625, 11.0410625, 0,              !- X,Y,Z Vertex 3 {m}
+  30.9292625, 22.234525, 0;               !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {6c67b581-3bea-4e54-b675-851ec03efb32}, !- Handle
-  Surface 206,                            !- Name
+  FirstFloor_Plenum - Floor_w,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -3915,7 +3915,7 @@ OS:Surface,
 
 OS:Surface,
   {cd30b8b8-78fe-434e-8ff8-bb0bbbf23844}, !- Handle
-  Surface 207,                            !- Name
+  FirstFloor_Plenum - Floor_r,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -3925,14 +3925,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  44.1880625, 26.71445, 9.02389274415329e-017, !- X,Y,Z Vertex 1 {m}
-  44.1880625, 6.5611375, -9.02389274415325e-017, !- X,Y,Z Vertex 2 {m}
-  33.6724625, 6.5611375, -2.70716782324598e-016, !- X,Y,Z Vertex 3 {m}
-  33.6724625, 26.71445, -9.02389274415324e-017; !- X,Y,Z Vertex 4 {m}
+  44.1880625, 26.71445, 0,                !- X,Y,Z Vertex 1 {m}
+  44.1880625, 6.5611375, 0,               !- X,Y,Z Vertex 2 {m}
+  33.6724625, 6.5611375, 0,               !- X,Y,Z Vertex 3 {m}
+  33.6724625, 26.71445, 0;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {43049827-cd30-496b-8983-cc7a97635ffc}, !- Handle
-  Surface 208,                            !- Name
+  FirstFloor_Plenum - Floor_d,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -3949,7 +3949,7 @@ OS:Surface,
 
 OS:Surface,
   {20becf71-cbfe-4124-b276-afcc76bb4c4e}, !- Handle
-  Surface 209,                            !- Name
+  FirstFloor_Plenum - Floor_i,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -3959,10 +3959,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  15.3543, 26.71445, 4.51194637207664e-016, !- X,Y,Z Vertex 1 {m}
-  15.3543, 6.5611375, -9.02389274415324e-017, !- X,Y,Z Vertex 2 {m}
-  5.7229375, 6.5611375, -2.70716782324598e-016, !- X,Y,Z Vertex 3 {m}
-  5.7229375, 26.71445, 2.70716782324598e-016; !- X,Y,Z Vertex 4 {m}
+  15.3543, 26.71445, 0,                   !- X,Y,Z Vertex 1 {m}
+  15.3543, 6.5611375, 0,                  !- X,Y,Z Vertex 2 {m}
+  5.7229375, 6.5611375, 0,                !- X,Y,Z Vertex 3 {m}
+  5.7229375, 26.71445, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {4e389877-72d6-482c-9f41-78c8947f9391}, !- Handle
@@ -3971,8 +3971,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   3.9624,                                 !- Z Origin {m}
   {78fc9da4-4d1f-40ea-abef-42e2fc17fcf7}, !- Building Story Name
   {4e496989-a555-48b1-8271-e070772f4120}, !- Thermal Zone Name
@@ -3982,7 +3982,7 @@ OS:Space,
 
 OS:Surface,
   {8d13ee4b-c100-480f-9795-eefebcfda61f}, !- Handle
-  Surface 216,                            !- Name
+  ActiveStorage_Mid_1 - Wall 000_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {4e389877-72d6-482c-9f41-78c8947f9391}, !- Space Name
@@ -3999,7 +3999,7 @@ OS:Surface,
 
 OS:Surface,
   {4b0fe52c-111e-4135-9180-48d3dad025ce}, !- Handle
-  Surface 217,                            !- Name
+  ActiveStorage_Mid_1 - Floor_a,          !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {4e389877-72d6-482c-9f41-78c8947f9391}, !- Space Name
@@ -4016,7 +4016,7 @@ OS:Surface,
 
 OS:Surface,
   {def672f3-e468-4bce-af0f-71a20b744087}, !- Handle
-  Surface 218,                            !- Name
+  ActiveStorage_Mid_1 - Wall 270_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {4e389877-72d6-482c-9f41-78c8947f9391}, !- Space Name
@@ -4033,7 +4033,7 @@ OS:Surface,
 
 OS:Surface,
   {accd6328-53f0-4421-8f5f-ddcb02867660}, !- Handle
-  Surface 219,                            !- Name
+  ActiveStorage_Mid_1 - Wall 180_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {4e389877-72d6-482c-9f41-78c8947f9391}, !- Space Name
@@ -4050,7 +4050,7 @@ OS:Surface,
 
 OS:Surface,
   {3bb21499-2f8d-4777-8c31-37d03d385d0e}, !- Handle
-  Surface 220,                            !- Name
+  ActiveStorage_Mid_1 - Wall 090_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {4e389877-72d6-482c-9f41-78c8947f9391}, !- Space Name
@@ -4067,7 +4067,7 @@ OS:Surface,
 
 OS:Surface,
   {b628aeb5-10b3-48d1-b5f2-95a05a364441}, !- Handle
-  Surface 221,                            !- Name
+  ActiveStorage_Mid_1 - RoofCeiling_a,    !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {4e389877-72d6-482c-9f41-78c8947f9391}, !- Space Name
@@ -4084,7 +4084,7 @@ OS:Surface,
 
 OS:Surface,
   {77646783-bfec-4b8e-a55f-c342a113e86c}, !- Handle
-  Surface 222,                            !- Name
+  ActiveStorage_Mid_1 - Wall 000_b,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {4e389877-72d6-482c-9f41-78c8947f9391}, !- Space Name
@@ -4106,8 +4106,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   3.9624,                                 !- Z Origin {m}
   {78fc9da4-4d1f-40ea-abef-42e2fc17fcf7}, !- Building Story Name
   {f5662b78-3bfa-482a-a1b9-0364a539e96a}, !- Thermal Zone Name
@@ -4117,7 +4117,7 @@ OS:Space,
 
 OS:Surface,
   {a0e62f09-a39d-4d6b-b04c-8065ab8b7dec}, !- Handle
-  Surface 223,                            !- Name
+  EnclosedOffice_Mid_1 - Wall 090_b,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f0a6c979-b679-4887-8c3e-fd2959a4c252}, !- Space Name
@@ -4134,7 +4134,7 @@ OS:Surface,
 
 OS:Surface,
   {24172482-44be-482d-9a3f-e126d32437f8}, !- Handle
-  Surface 224,                            !- Name
+  EnclosedOffice_Mid_1 - Wall 090_c,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f0a6c979-b679-4887-8c3e-fd2959a4c252}, !- Space Name
@@ -4151,7 +4151,7 @@ OS:Surface,
 
 OS:Surface,
   {a15b0901-00ad-4d3a-9e7c-692e8d8aa338}, !- Handle
-  Surface 225,                            !- Name
+  EnclosedOffice_Mid_1 - Floor_a,         !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {f0a6c979-b679-4887-8c3e-fd2959a4c252}, !- Space Name
@@ -4168,7 +4168,7 @@ OS:Surface,
 
 OS:Surface,
   {8c3445de-922a-4f65-879f-0c59700b0920}, !- Handle
-  Surface 226,                            !- Name
+  EnclosedOffice_Mid_1 - Wall 180_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f0a6c979-b679-4887-8c3e-fd2959a4c252}, !- Space Name
@@ -4185,7 +4185,7 @@ OS:Surface,
 
 OS:Surface,
   {800ceafa-f348-4a91-86ec-673a59177c6e}, !- Handle
-  Surface 227,                            !- Name
+  EnclosedOffice_Mid_1 - Wall 090_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f0a6c979-b679-4887-8c3e-fd2959a4c252}, !- Space Name
@@ -4202,7 +4202,7 @@ OS:Surface,
 
 OS:Surface,
   {aa741c95-947f-4828-a165-c636e6a497b8}, !- Handle
-  Surface 228,                            !- Name
+  EnclosedOffice_Mid_1 - Wall 000_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f0a6c979-b679-4887-8c3e-fd2959a4c252}, !- Space Name
@@ -4219,7 +4219,7 @@ OS:Surface,
 
 OS:Surface,
   {1d081beb-e1b0-4f68-ae07-bf494d782507}, !- Handle
-  Surface 229,                            !- Name
+  EnclosedOffice_Mid_1 - Wall 270_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f0a6c979-b679-4887-8c3e-fd2959a4c252}, !- Space Name
@@ -4236,7 +4236,7 @@ OS:Surface,
 
 OS:Surface,
   {d5103abf-63e7-43c1-8162-10544d341158}, !- Handle
-  Surface 230,                            !- Name
+  EnclosedOffice_Mid_1 - RoofCeiling_a,   !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {f0a6c979-b679-4887-8c3e-fd2959a4c252}, !- Space Name
@@ -4258,8 +4258,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   3.9624,                                 !- Z Origin {m}
   {78fc9da4-4d1f-40ea-abef-42e2fc17fcf7}, !- Building Story Name
   {a9e78f84-bbf7-4eb0-b4f0-996f80cefed9}, !- Thermal Zone Name
@@ -4269,7 +4269,7 @@ OS:Space,
 
 OS:Surface,
   {a3f51059-5f63-49a9-bec7-3a2c80ba30c1}, !- Handle
-  Surface 231,                            !- Name
+  Corridor_Mid_1 - Wall 000_d,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {78b6dd7f-2610-4461-8eef-6df2e285809a}, !- Space Name
@@ -4286,7 +4286,7 @@ OS:Surface,
 
 OS:Surface,
   {fbaa7c4a-a9d4-4fa3-963d-d92f5d0cf7ad}, !- Handle
-  Surface 232,                            !- Name
+  Corridor_Mid_1 - Wall 180_c,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {78b6dd7f-2610-4461-8eef-6df2e285809a}, !- Space Name
@@ -4303,7 +4303,7 @@ OS:Surface,
 
 OS:Surface,
   {2bcc89bd-5502-4dd2-bc4f-8f725af4041e}, !- Handle
-  Surface 233,                            !- Name
+  Corridor_Mid_1 - Wall 000_b,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {78b6dd7f-2610-4461-8eef-6df2e285809a}, !- Space Name
@@ -4320,7 +4320,7 @@ OS:Surface,
 
 OS:Surface,
   {1bedf937-ce18-414d-ad99-190acc93546c}, !- Handle
-  Surface 234,                            !- Name
+  Corridor_Mid_1 - Wall 180_b,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {78b6dd7f-2610-4461-8eef-6df2e285809a}, !- Space Name
@@ -4337,7 +4337,7 @@ OS:Surface,
 
 OS:Surface,
   {5059baaf-debe-4369-bc22-f4a680ea0e26}, !- Handle
-  Surface 235,                            !- Name
+  Corridor_Mid_1 - Wall 000_c,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {78b6dd7f-2610-4461-8eef-6df2e285809a}, !- Space Name
@@ -4354,7 +4354,7 @@ OS:Surface,
 
 OS:Surface,
   {1aa3a40e-8249-482a-881d-60812e0fcfa6}, !- Handle
-  Surface 236,                            !- Name
+  Corridor_Mid_1 - Wall 180_d,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {78b6dd7f-2610-4461-8eef-6df2e285809a}, !- Space Name
@@ -4371,7 +4371,7 @@ OS:Surface,
 
 OS:Surface,
   {705b9311-5fbb-47f3-8ea8-085c0c435838}, !- Handle
-  Surface 237,                            !- Name
+  Corridor_Mid_1 - Wall 180_e,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {78b6dd7f-2610-4461-8eef-6df2e285809a}, !- Space Name
@@ -4388,7 +4388,7 @@ OS:Surface,
 
 OS:Surface,
   {45766433-1385-44cc-b385-308b69cca913}, !- Handle
-  Surface 238,                            !- Name
+  Corridor_Mid_1 - Wall 000_e,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {78b6dd7f-2610-4461-8eef-6df2e285809a}, !- Space Name
@@ -4405,7 +4405,7 @@ OS:Surface,
 
 OS:Surface,
   {523b3e51-8238-4f2f-8392-f38cea440ed6}, !- Handle
-  Surface 239,                            !- Name
+  Corridor_Mid_1 - Floor_a,               !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {78b6dd7f-2610-4461-8eef-6df2e285809a}, !- Space Name
@@ -4426,7 +4426,7 @@ OS:Surface,
 
 OS:Surface,
   {ca6afb79-69de-40dc-8b26-ab995b28e91e}, !- Handle
-  Surface 240,                            !- Name
+  Corridor_Mid_1 - Wall 090_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {78b6dd7f-2610-4461-8eef-6df2e285809a}, !- Space Name
@@ -4443,7 +4443,7 @@ OS:Surface,
 
 OS:Surface,
   {b613aea9-ea0d-4e86-9597-8fc0b00a1603}, !- Handle
-  Surface 241,                            !- Name
+  Corridor_Mid_1 - RoofCeiling_a,         !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {78b6dd7f-2610-4461-8eef-6df2e285809a}, !- Space Name
@@ -4464,7 +4464,7 @@ OS:Surface,
 
 OS:Surface,
   {e905fcac-06d1-4338-a605-88ce10d060f9}, !- Handle
-  Surface 242,                            !- Name
+  Corridor_Mid_1 - Wall 000_f,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {78b6dd7f-2610-4461-8eef-6df2e285809a}, !- Space Name
@@ -4481,7 +4481,7 @@ OS:Surface,
 
 OS:Surface,
   {2a493c40-c251-4d6d-8265-975585970da5}, !- Handle
-  Surface 243,                            !- Name
+  Corridor_Mid_1 - Wall 000_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {78b6dd7f-2610-4461-8eef-6df2e285809a}, !- Space Name
@@ -4498,7 +4498,7 @@ OS:Surface,
 
 OS:Surface,
   {94ac5bf5-ef64-4e5a-8458-3452615f0554}, !- Handle
-  Surface 244,                            !- Name
+  Corridor_Mid_1 - Wall 270_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {78b6dd7f-2610-4461-8eef-6df2e285809a}, !- Space Name
@@ -4515,7 +4515,7 @@ OS:Surface,
 
 OS:Surface,
   {dda6f93d-19e4-45d8-bcec-a2f4d8b34680}, !- Handle
-  Surface 245,                            !- Name
+  Corridor_Mid_1 - Wall 000_g,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {78b6dd7f-2610-4461-8eef-6df2e285809a}, !- Space Name
@@ -4532,7 +4532,7 @@ OS:Surface,
 
 OS:Surface,
   {06c0ab92-4595-4f04-8a03-4e86186dddce}, !- Handle
-  Surface 246,                            !- Name
+  Corridor_Mid_1 - Wall 090_b,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {78b6dd7f-2610-4461-8eef-6df2e285809a}, !- Space Name
@@ -4549,7 +4549,7 @@ OS:Surface,
 
 OS:Surface,
   {843950c9-3da7-4b61-ab23-aa079ee7cb04}, !- Handle
-  Surface 247,                            !- Name
+  Corridor_Mid_1 - Wall 180_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {78b6dd7f-2610-4461-8eef-6df2e285809a}, !- Space Name
@@ -4566,7 +4566,7 @@ OS:Surface,
 
 OS:Surface,
   {c44eb5b8-095f-4706-9e27-82b0692b5120}, !- Handle
-  Surface 248,                            !- Name
+  Corridor_Mid_1 - Wall 270_b,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {78b6dd7f-2610-4461-8eef-6df2e285809a}, !- Space Name
@@ -4588,8 +4588,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   3.9624,                                 !- Z Origin {m}
   {78fc9da4-4d1f-40ea-abef-42e2fc17fcf7}, !- Building Story Name
   {21213f5c-925d-448d-b9a4-22723892e069}, !- Thermal Zone Name
@@ -4599,7 +4599,7 @@ OS:Space,
 
 OS:Surface,
   {b7eae8ae-8192-4ae4-9fca-bc06b0f771ea}, !- Handle
-  Surface 249,                            !- Name
+  OpenOffice_Mid_2 - Wall 090_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {df413531-d117-43e3-9eff-bc366114d051}, !- Space Name
@@ -4616,7 +4616,7 @@ OS:Surface,
 
 OS:Surface,
   {7ce93590-cf07-4b57-b3d4-cd1d6209ac31}, !- Handle
-  Surface 250,                            !- Name
+  OpenOffice_Mid_2 - Wall 270_b,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {df413531-d117-43e3-9eff-bc366114d051}, !- Space Name
@@ -4633,7 +4633,7 @@ OS:Surface,
 
 OS:Surface,
   {ed2b5fd9-38e9-47a6-8f05-0194724702c7}, !- Handle
-  Surface 251,                            !- Name
+  OpenOffice_Mid_2 - Wall 270_c,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {df413531-d117-43e3-9eff-bc366114d051}, !- Space Name
@@ -4650,7 +4650,7 @@ OS:Surface,
 
 OS:Surface,
   {ef24add5-7eb8-4f50-988f-153d04b09403}, !- Handle
-  Surface 252,                            !- Name
+  OpenOffice_Mid_2 - Floor_a,             !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {df413531-d117-43e3-9eff-bc366114d051}, !- Space Name
@@ -4667,7 +4667,7 @@ OS:Surface,
 
 OS:Surface,
   {ab9884d1-1fb8-43d4-867c-edb22710260f}, !- Handle
-  Surface 253,                            !- Name
+  OpenOffice_Mid_2 - RoofCeiling_a,       !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {df413531-d117-43e3-9eff-bc366114d051}, !- Space Name
@@ -4684,7 +4684,7 @@ OS:Surface,
 
 OS:Surface,
   {f9d282dd-b3de-4fe6-ae2a-72bc19b5ef09}, !- Handle
-  Surface 254,                            !- Name
+  OpenOffice_Mid_2 - Wall 180_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {df413531-d117-43e3-9eff-bc366114d051}, !- Space Name
@@ -4701,7 +4701,7 @@ OS:Surface,
 
 OS:Surface,
   {5af875f0-e630-45ce-876c-8b7163d16ec6}, !- Handle
-  Surface 255,                            !- Name
+  OpenOffice_Mid_2 - Wall 090_b,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {df413531-d117-43e3-9eff-bc366114d051}, !- Space Name
@@ -4718,7 +4718,7 @@ OS:Surface,
 
 OS:Surface,
   {0e975ad3-a19a-4fc6-bf73-c8f81177ef02}, !- Handle
-  Surface 256,                            !- Name
+  OpenOffice_Mid_2 - Wall 270_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {df413531-d117-43e3-9eff-bc366114d051}, !- Space Name
@@ -4735,7 +4735,7 @@ OS:Surface,
 
 OS:Surface,
   {88bf7f70-d7f3-4a3c-9d3a-5990ff43ae38}, !- Handle
-  Surface 257,                            !- Name
+  OpenOffice_Mid_2 - Wall 000_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {df413531-d117-43e3-9eff-bc366114d051}, !- Space Name
@@ -4757,8 +4757,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   3.9624,                                 !- Z Origin {m}
   {78fc9da4-4d1f-40ea-abef-42e2fc17fcf7}, !- Building Story Name
   {3f26caba-10b2-48c4-a6e2-5f74653bbc44}, !- Thermal Zone Name
@@ -4768,7 +4768,7 @@ OS:Space,
 
 OS:Surface,
   {73c49e8b-31d4-46c7-87db-6e2462c7c9ea}, !- Handle
-  Surface 258,                            !- Name
+  ActiveStorage_Mid_2 - Wall 000_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {9e41e3d2-92f3-42bd-89c8-6609dddb08bc}, !- Space Name
@@ -4785,7 +4785,7 @@ OS:Surface,
 
 OS:Surface,
   {a329fab7-97e7-47d2-bdea-a72a6fde1768}, !- Handle
-  Surface 259,                            !- Name
+  ActiveStorage_Mid_2 - Floor_a,          !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {9e41e3d2-92f3-42bd-89c8-6609dddb08bc}, !- Space Name
@@ -4802,7 +4802,7 @@ OS:Surface,
 
 OS:Surface,
   {d8661755-9584-4833-9c6e-1498f38e34b1}, !- Handle
-  Surface 260,                            !- Name
+  ActiveStorage_Mid_2 - RoofCeiling_a,    !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {9e41e3d2-92f3-42bd-89c8-6609dddb08bc}, !- Space Name
@@ -4819,7 +4819,7 @@ OS:Surface,
 
 OS:Surface,
   {698cfe51-b3b6-48e5-8d47-7306d3f4d140}, !- Handle
-  Surface 261,                            !- Name
+  ActiveStorage_Mid_2 - Wall 270_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {9e41e3d2-92f3-42bd-89c8-6609dddb08bc}, !- Space Name
@@ -4836,7 +4836,7 @@ OS:Surface,
 
 OS:Surface,
   {3a5587c4-d1f9-47f4-b4f3-162fd88625e1}, !- Handle
-  Surface 262,                            !- Name
+  ActiveStorage_Mid_2 - Wall 180_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {9e41e3d2-92f3-42bd-89c8-6609dddb08bc}, !- Space Name
@@ -4853,7 +4853,7 @@ OS:Surface,
 
 OS:Surface,
   {82e5a564-2465-4fea-9077-ee69c2f2d524}, !- Handle
-  Surface 263,                            !- Name
+  ActiveStorage_Mid_2 - Wall 000_b,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {9e41e3d2-92f3-42bd-89c8-6609dddb08bc}, !- Space Name
@@ -4870,7 +4870,7 @@ OS:Surface,
 
 OS:Surface,
   {b3476387-e36b-4c1f-948f-c6bda46bfd3e}, !- Handle
-  Surface 264,                            !- Name
+  ActiveStorage_Mid_2 - Wall 090_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {9e41e3d2-92f3-42bd-89c8-6609dddb08bc}, !- Space Name
@@ -4892,8 +4892,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   3.9624,                                 !- Z Origin {m}
   {78fc9da4-4d1f-40ea-abef-42e2fc17fcf7}, !- Building Story Name
   {34e2116a-bc2e-4145-914c-ee5402691877}, !- Thermal Zone Name
@@ -4903,7 +4903,7 @@ OS:Space,
 
 OS:Surface,
   {27843e1f-58bb-4a51-8234-a22b44da797b}, !- Handle
-  Surface 265,                            !- Name
+  Stair_Mid_2 - Floor_a,                  !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {043c1bed-f3c5-4d34-8a90-734e65850131}, !- Space Name
@@ -4920,7 +4920,7 @@ OS:Surface,
 
 OS:Surface,
   {2b764aa9-840e-47d9-b238-d2076bda30f6}, !- Handle
-  Surface 266,                            !- Name
+  Stair_Mid_2 - Wall 180_a,               !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {043c1bed-f3c5-4d34-8a90-734e65850131}, !- Space Name
@@ -4937,7 +4937,7 @@ OS:Surface,
 
 OS:Surface,
   {c62814a8-1612-4a53-af5f-72c4a9ce824c}, !- Handle
-  Surface 267,                            !- Name
+  Stair_Mid_2 - RoofCeiling_a,            !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {043c1bed-f3c5-4d34-8a90-734e65850131}, !- Space Name
@@ -4954,7 +4954,7 @@ OS:Surface,
 
 OS:Surface,
   {c3d0e0cf-3ca6-4fd6-b9a4-7a3efcafb954}, !- Handle
-  Surface 268,                            !- Name
+  Stair_Mid_2 - Wall 270_a,               !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {043c1bed-f3c5-4d34-8a90-734e65850131}, !- Space Name
@@ -4971,7 +4971,7 @@ OS:Surface,
 
 OS:Surface,
   {9fe1679a-e740-418f-91a0-157116a3225a}, !- Handle
-  Surface 269,                            !- Name
+  Stair_Mid_2 - Wall 000_a,               !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {043c1bed-f3c5-4d34-8a90-734e65850131}, !- Space Name
@@ -4988,7 +4988,7 @@ OS:Surface,
 
 OS:Surface,
   {b18de3ee-fa7a-4a2b-8203-0dc9a8c01be2}, !- Handle
-  Surface 270,                            !- Name
+  Stair_Mid_2 - Wall 090_a,               !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {043c1bed-f3c5-4d34-8a90-734e65850131}, !- Space Name
@@ -5010,8 +5010,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   3.9624,                                 !- Z Origin {m}
   {78fc9da4-4d1f-40ea-abef-42e2fc17fcf7}, !- Building Story Name
   {05d36b9e-f449-426c-b8eb-b5032321d155}, !- Thermal Zone Name
@@ -5021,7 +5021,7 @@ OS:Space,
 
 OS:Surface,
   {901a3483-3b8c-4be0-9d90-115bfc46dc69}, !- Handle
-  Surface 271,                            !- Name
+  ActiveStorage_Mid_3 - Wall 180_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {07c2c681-44df-453e-824e-dbf9410b3f66}, !- Space Name
@@ -5038,7 +5038,7 @@ OS:Surface,
 
 OS:Surface,
   {2ef10164-9b1d-4cdd-a29a-9a8871307619}, !- Handle
-  Surface 272,                            !- Name
+  ActiveStorage_Mid_3 - Floor_a,          !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {07c2c681-44df-453e-824e-dbf9410b3f66}, !- Space Name
@@ -5055,7 +5055,7 @@ OS:Surface,
 
 OS:Surface,
   {39261352-34a7-43f9-b109-8991058e0535}, !- Handle
-  Surface 273,                            !- Name
+  ActiveStorage_Mid_3 - Wall 180_b,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {07c2c681-44df-453e-824e-dbf9410b3f66}, !- Space Name
@@ -5072,7 +5072,7 @@ OS:Surface,
 
 OS:Surface,
   {27852ba4-4913-4686-84e7-f5e0eab1145a}, !- Handle
-  Surface 274,                            !- Name
+  ActiveStorage_Mid_3 - Wall 270_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {07c2c681-44df-453e-824e-dbf9410b3f66}, !- Space Name
@@ -5089,7 +5089,7 @@ OS:Surface,
 
 OS:Surface,
   {7d06b329-226b-4dd9-a519-f0cbc70ea2a9}, !- Handle
-  Surface 275,                            !- Name
+  ActiveStorage_Mid_3 - RoofCeiling_a,    !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {07c2c681-44df-453e-824e-dbf9410b3f66}, !- Space Name
@@ -5106,7 +5106,7 @@ OS:Surface,
 
 OS:Surface,
   {4dffcf8b-1c09-4685-abb2-7bfa22ef3377}, !- Handle
-  Surface 276,                            !- Name
+  ActiveStorage_Mid_3 - Wall 000_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {07c2c681-44df-453e-824e-dbf9410b3f66}, !- Space Name
@@ -5123,7 +5123,7 @@ OS:Surface,
 
 OS:Surface,
   {58e57424-20ac-4e08-9d92-8a1da509248b}, !- Handle
-  Surface 277,                            !- Name
+  ActiveStorage_Mid_3 - Wall 090_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {07c2c681-44df-453e-824e-dbf9410b3f66}, !- Space Name
@@ -5145,8 +5145,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   3.9624,                                 !- Z Origin {m}
   {78fc9da4-4d1f-40ea-abef-42e2fc17fcf7}, !- Building Story Name
   {774bfcef-ec77-49e6-8be7-6fdfdd560d07}, !- Thermal Zone Name
@@ -5156,7 +5156,7 @@ OS:Space,
 
 OS:Surface,
   {d38f5f06-3cbf-4d6e-b704-5045b8d943db}, !- Handle
-  Surface 278,                            !- Name
+  Lobby_Mid - Wall 270_b,                 !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {99514813-db6d-4470-adca-b6b0ff5d6f50}, !- Space Name
@@ -5166,14 +5166,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 22.234525, 2.74319999999999,   !- X,Y,Z Vertex 1 {m}
+  23.4315, 22.234525, 2.7432,             !- X,Y,Z Vertex 1 {m}
   23.4315, 22.234525, 0,                  !- X,Y,Z Vertex 2 {m}
   23.4315, 11.0410625, 0,                 !- X,Y,Z Vertex 3 {m}
-  23.4315, 11.0410625, 2.74319999999999;  !- X,Y,Z Vertex 4 {m}
+  23.4315, 11.0410625, 2.7432;            !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {e9fc9f96-121e-4f6e-a68c-afe05459db9a}, !- Handle
-  Surface 279,                            !- Name
+  Lobby_Mid - Wall 090_b,                 !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {99514813-db6d-4470-adca-b6b0ff5d6f50}, !- Space Name
@@ -5183,14 +5183,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  26.4795, 6.5611375, 2.74319999999999,   !- X,Y,Z Vertex 1 {m}
+  26.4795, 6.5611375, 2.7432,             !- X,Y,Z Vertex 1 {m}
   26.4795, 6.5611375, 0,                  !- X,Y,Z Vertex 2 {m}
   26.4795, 11.0410625, 0,                 !- X,Y,Z Vertex 3 {m}
-  26.4795, 11.0410625, 2.74319999999999;  !- X,Y,Z Vertex 4 {m}
+  26.4795, 11.0410625, 2.7432;            !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {1886a733-b872-4701-b5f9-b99184c05f2a}, !- Handle
-  Surface 280,                            !- Name
+  Lobby_Mid - Wall 090_a,                 !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {99514813-db6d-4470-adca-b6b0ff5d6f50}, !- Space Name
@@ -5200,14 +5200,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  26.4795, 11.0410625, 2.74319999999999,  !- X,Y,Z Vertex 1 {m}
+  26.4795, 11.0410625, 2.7432,            !- X,Y,Z Vertex 1 {m}
   26.4795, 11.0410625, 0,                 !- X,Y,Z Vertex 2 {m}
   26.4795, 22.234525, 0,                  !- X,Y,Z Vertex 3 {m}
-  26.4795, 22.234525, 2.74319999999999;   !- X,Y,Z Vertex 4 {m}
+  26.4795, 22.234525, 2.7432;             !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {989ea5b9-3f1f-4851-bb8f-858c98aca08c}, !- Handle
-  Surface 281,                            !- Name
+  Lobby_Mid - Floor_a,                    !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {99514813-db6d-4470-adca-b6b0ff5d6f50}, !- Space Name
@@ -5224,7 +5224,7 @@ OS:Surface,
 
 OS:Surface,
   {e6f3e681-40b0-442d-bfec-535ad7aae1e7}, !- Handle
-  Surface 282,                            !- Name
+  Lobby_Mid - RoofCeiling_a,              !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {99514813-db6d-4470-adca-b6b0ff5d6f50}, !- Space Name
@@ -5234,14 +5234,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  26.4795, 6.5611375, 2.74319999999999,   !- X,Y,Z Vertex 1 {m}
-  26.4795, 26.71445, 2.74319999999999,    !- X,Y,Z Vertex 2 {m}
-  23.4315, 26.71445, 2.74319999999999,    !- X,Y,Z Vertex 3 {m}
-  23.4315, 6.5611375, 2.74319999999999;   !- X,Y,Z Vertex 4 {m}
+  26.4795, 6.5611375, 2.7432,             !- X,Y,Z Vertex 1 {m}
+  26.4795, 26.71445, 2.7432,              !- X,Y,Z Vertex 2 {m}
+  23.4315, 26.71445, 2.7432,              !- X,Y,Z Vertex 3 {m}
+  23.4315, 6.5611375, 2.7432;             !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {04ebcefc-e70c-48f7-ae01-1ec7a17ab4ac}, !- Handle
-  Surface 283,                            !- Name
+  Lobby_Mid - Wall 180_a,                 !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {99514813-db6d-4470-adca-b6b0ff5d6f50}, !- Space Name
@@ -5251,14 +5251,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 6.5611375, 2.74319999999999,   !- X,Y,Z Vertex 1 {m}
+  23.4315, 6.5611375, 2.7432,             !- X,Y,Z Vertex 1 {m}
   23.4315, 6.5611375, 0,                  !- X,Y,Z Vertex 2 {m}
   26.4795, 6.5611375, 0,                  !- X,Y,Z Vertex 3 {m}
-  26.4795, 6.5611375, 2.74319999999999;   !- X,Y,Z Vertex 4 {m}
+  26.4795, 6.5611375, 2.7432;             !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {12d642bb-1ebb-4cce-9bed-fce43fcd8cd3}, !- Handle
-  Surface 284,                            !- Name
+  Lobby_Mid - Wall 270_a,                 !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {99514813-db6d-4470-adca-b6b0ff5d6f50}, !- Space Name
@@ -5268,14 +5268,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 26.71445, 2.74319999999999,    !- X,Y,Z Vertex 1 {m}
+  23.4315, 26.71445, 2.7432,              !- X,Y,Z Vertex 1 {m}
   23.4315, 26.71445, 0,                   !- X,Y,Z Vertex 2 {m}
   23.4315, 22.234525, 0,                  !- X,Y,Z Vertex 3 {m}
-  23.4315, 22.234525, 2.74319999999999;   !- X,Y,Z Vertex 4 {m}
+  23.4315, 22.234525, 2.7432;             !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {e94cee82-a89c-412c-b80b-347b891cf935}, !- Handle
-  Surface 285,                            !- Name
+  Lobby_Mid - Wall 000_a,                 !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {99514813-db6d-4470-adca-b6b0ff5d6f50}, !- Space Name
@@ -5285,14 +5285,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  26.4795, 26.71445, 2.74319999999999,    !- X,Y,Z Vertex 1 {m}
+  26.4795, 26.71445, 2.7432,              !- X,Y,Z Vertex 1 {m}
   26.4795, 26.71445, 0,                   !- X,Y,Z Vertex 2 {m}
   23.4315, 26.71445, 0,                   !- X,Y,Z Vertex 3 {m}
-  23.4315, 26.71445, 2.74319999999999;    !- X,Y,Z Vertex 4 {m}
+  23.4315, 26.71445, 2.7432;              !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {30c514f8-de4e-40b6-8b6f-d7e7a14c6fdd}, !- Handle
-  Surface 286,                            !- Name
+  Lobby_Mid - Wall 090_c,                 !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {99514813-db6d-4470-adca-b6b0ff5d6f50}, !- Space Name
@@ -5302,14 +5302,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  26.4795, 22.234525, 2.74319999999999,   !- X,Y,Z Vertex 1 {m}
+  26.4795, 22.234525, 2.7432,             !- X,Y,Z Vertex 1 {m}
   26.4795, 22.234525, 0,                  !- X,Y,Z Vertex 2 {m}
   26.4795, 26.71445, 0,                   !- X,Y,Z Vertex 3 {m}
-  26.4795, 26.71445, 2.74319999999999;    !- X,Y,Z Vertex 4 {m}
+  26.4795, 26.71445, 2.7432;              !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {d859326b-58b9-4680-b56b-946909729f67}, !- Handle
-  Surface 287,                            !- Name
+  Lobby_Mid - Wall 270_c,                 !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {99514813-db6d-4470-adca-b6b0ff5d6f50}, !- Space Name
@@ -5319,10 +5319,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 11.0410625, 2.74319999999999,  !- X,Y,Z Vertex 1 {m}
+  23.4315, 11.0410625, 2.7432,            !- X,Y,Z Vertex 1 {m}
   23.4315, 11.0410625, 0,                 !- X,Y,Z Vertex 2 {m}
   23.4315, 6.5611375, 0,                  !- X,Y,Z Vertex 3 {m}
-  23.4315, 6.5611375, 2.74319999999999;   !- X,Y,Z Vertex 4 {m}
+  23.4315, 6.5611375, 2.7432;             !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {57f3f5b2-5b72-4b03-a755-cfb36254100f}, !- Handle
@@ -5331,8 +5331,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   3.9624,                                 !- Z Origin {m}
   {34c2b3a4-b93e-443b-9867-ce24d7c61c21}, !- Building Story Name
   {80a3580d-b968-449c-a5cc-d3b35a0abc8f}, !- Thermal Zone Name
@@ -5342,7 +5342,7 @@ OS:Space,
 
 OS:Surface,
   {ba9d2fce-bc21-4b7b-b29e-3d02ed301468}, !- Handle
-  Surface 288,                            !- Name
+  Dining_Mid - Floor_a,                   !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {57f3f5b2-5b72-4b03-a755-cfb36254100f}, !- Space Name
@@ -5359,7 +5359,7 @@ OS:Surface,
 
 OS:Surface,
   {60a7d649-cd8d-4d88-9112-3c857dcb83cb}, !- Handle
-  Surface 289,                            !- Name
+  Dining_Mid - RoofCeiling_a,             !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {57f3f5b2-5b72-4b03-a755-cfb36254100f}, !- Space Name
@@ -5369,14 +5369,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 22.234525, 2.74319999999999,   !- X,Y,Z Vertex 1 {m}
-  23.4315, 26.71445, 2.74319999999999,    !- X,Y,Z Vertex 2 {m}
-  18.310225, 26.71445, 2.74319999999999,  !- X,Y,Z Vertex 3 {m}
-  18.310225, 22.234525, 2.74319999999999; !- X,Y,Z Vertex 4 {m}
+  23.4315, 22.234525, 2.7432,             !- X,Y,Z Vertex 1 {m}
+  23.4315, 26.71445, 2.7432,              !- X,Y,Z Vertex 2 {m}
+  18.310225, 26.71445, 2.7432,            !- X,Y,Z Vertex 3 {m}
+  18.310225, 22.234525, 2.7432;           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {75fb4cf4-660b-455a-ad02-52f2de5ecb09}, !- Handle
-  Surface 290,                            !- Name
+  Dining_Mid - Wall 000_a,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {57f3f5b2-5b72-4b03-a755-cfb36254100f}, !- Space Name
@@ -5386,14 +5386,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 26.71445, 2.74319999999999,    !- X,Y,Z Vertex 1 {m}
+  23.4315, 26.71445, 2.7432,              !- X,Y,Z Vertex 1 {m}
   23.4315, 26.71445, 0,                   !- X,Y,Z Vertex 2 {m}
   18.310225, 26.71445, 0,                 !- X,Y,Z Vertex 3 {m}
-  18.310225, 26.71445, 2.74319999999999;  !- X,Y,Z Vertex 4 {m}
+  18.310225, 26.71445, 2.7432;            !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {6cef89df-7578-40ad-a5e8-a5bcb07c96b1}, !- Handle
-  Surface 291,                            !- Name
+  Dining_Mid - Wall 270_a,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {57f3f5b2-5b72-4b03-a755-cfb36254100f}, !- Space Name
@@ -5403,14 +5403,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  18.310225, 26.71445, 2.74319999999999,  !- X,Y,Z Vertex 1 {m}
+  18.310225, 26.71445, 2.7432,            !- X,Y,Z Vertex 1 {m}
   18.310225, 26.71445, 0,                 !- X,Y,Z Vertex 2 {m}
   18.310225, 22.234525, 0,                !- X,Y,Z Vertex 3 {m}
-  18.310225, 22.234525, 2.74319999999999; !- X,Y,Z Vertex 4 {m}
+  18.310225, 22.234525, 2.7432;           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {40d3059e-13a8-4a46-96bc-706f4deb52ad}, !- Handle
-  Surface 292,                            !- Name
+  Dining_Mid - Wall 180_a,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {57f3f5b2-5b72-4b03-a755-cfb36254100f}, !- Space Name
@@ -5420,14 +5420,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  18.310225, 22.234525, 2.74319999999999, !- X,Y,Z Vertex 1 {m}
+  18.310225, 22.234525, 2.7432,           !- X,Y,Z Vertex 1 {m}
   18.310225, 22.234525, 0,                !- X,Y,Z Vertex 2 {m}
   23.4315, 22.234525, 0,                  !- X,Y,Z Vertex 3 {m}
-  23.4315, 22.234525, 2.74319999999999;   !- X,Y,Z Vertex 4 {m}
+  23.4315, 22.234525, 2.7432;             !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {a12a8bc2-80b7-488c-a112-0fc5c29a9eda}, !- Handle
-  Surface 293,                            !- Name
+  Dining_Mid - Wall 090_a,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {57f3f5b2-5b72-4b03-a755-cfb36254100f}, !- Space Name
@@ -5437,10 +5437,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 22.234525, 2.74319999999999,   !- X,Y,Z Vertex 1 {m}
+  23.4315, 22.234525, 2.7432,             !- X,Y,Z Vertex 1 {m}
   23.4315, 22.234525, 0,                  !- X,Y,Z Vertex 2 {m}
   23.4315, 26.71445, 0,                   !- X,Y,Z Vertex 3 {m}
-  23.4315, 26.71445, 2.74319999999999;    !- X,Y,Z Vertex 4 {m}
+  23.4315, 26.71445, 2.7432;              !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {97d239e3-2f93-4f66-88a2-7167dc152e5a}, !- Handle
@@ -5449,8 +5449,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   3.9624,                                 !- Z Origin {m}
   {78fc9da4-4d1f-40ea-abef-42e2fc17fcf7}, !- Building Story Name
   {02b55a4a-a5ec-4d4b-9841-96aad4cca002}, !- Thermal Zone Name
@@ -5460,7 +5460,7 @@ OS:Space,
 
 OS:Surface,
   {1630725c-f163-4ca4-91cc-88950cd4f164}, !- Handle
-  Surface 294,                            !- Name
+  ConfRoom_Mid_2 - Wall 000_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {97d239e3-2f93-4f66-88a2-7167dc152e5a}, !- Space Name
@@ -5477,7 +5477,7 @@ OS:Surface,
 
 OS:Surface,
   {ed1b2bc4-1d2a-4327-97df-49b494b81ae3}, !- Handle
-  Surface 295,                            !- Name
+  ConfRoom_Mid_2 - Floor_a,               !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {97d239e3-2f93-4f66-88a2-7167dc152e5a}, !- Space Name
@@ -5494,7 +5494,7 @@ OS:Surface,
 
 OS:Surface,
   {29c142b6-4f3b-4f13-8075-52d74812945b}, !- Handle
-  Surface 296,                            !- Name
+  ConfRoom_Mid_2 - RoofCeiling_a,         !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {97d239e3-2f93-4f66-88a2-7167dc152e5a}, !- Space Name
@@ -5511,7 +5511,7 @@ OS:Surface,
 
 OS:Surface,
   {848d376d-f805-4000-8d39-88e68ff22991}, !- Handle
-  Surface 297,                            !- Name
+  ConfRoom_Mid_2 - Wall 270_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {97d239e3-2f93-4f66-88a2-7167dc152e5a}, !- Space Name
@@ -5528,7 +5528,7 @@ OS:Surface,
 
 OS:Surface,
   {0876207b-490b-4e82-8079-196239528827}, !- Handle
-  Surface 299,                            !- Name
+  ConfRoom_Mid_2 - Wall 000_b,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {97d239e3-2f93-4f66-88a2-7167dc152e5a}, !- Space Name
@@ -5550,8 +5550,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   3.9624,                                 !- Z Origin {m}
   {78fc9da4-4d1f-40ea-abef-42e2fc17fcf7}, !- Building Story Name
   {ecd7832e-2da2-481c-8cda-24c6441f4211}, !- Thermal Zone Name
@@ -5561,7 +5561,7 @@ OS:Space,
 
 OS:Surface,
   {4b0e967e-42d1-449a-9932-5a25e3d3fe9f}, !- Handle
-  Surface 301,                            !- Name
+  Restroom_Mid - Wall 000_a,              !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {7c677a4d-94d0-45a0-ba23-55916435b088}, !- Space Name
@@ -5571,14 +5571,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 22.234525, 2.74319999999999,   !- X,Y,Z Vertex 1 {m}
+  23.4315, 22.234525, 2.7432,             !- X,Y,Z Vertex 1 {m}
   23.4315, 22.234525, 0,                  !- X,Y,Z Vertex 2 {m}
   18.310225, 22.234525, 0,                !- X,Y,Z Vertex 3 {m}
-  18.310225, 22.234525, 2.74319999999999; !- X,Y,Z Vertex 4 {m}
+  18.310225, 22.234525, 2.7432;           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {af19bd74-c144-4dad-b003-5fed5c156bed}, !- Handle
-  Surface 302,                            !- Name
+  Restroom_Mid - Floor_a,                 !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {7c677a4d-94d0-45a0-ba23-55916435b088}, !- Space Name
@@ -5595,7 +5595,7 @@ OS:Surface,
 
 OS:Surface,
   {97a882d3-b5b6-4276-9d3d-b3879b3a92a3}, !- Handle
-  Surface 303,                            !- Name
+  Restroom_Mid - Wall 090_a,              !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {7c677a4d-94d0-45a0-ba23-55916435b088}, !- Space Name
@@ -5605,14 +5605,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 11.0410625, 2.74319999999999,  !- X,Y,Z Vertex 1 {m}
+  23.4315, 11.0410625, 2.7432,            !- X,Y,Z Vertex 1 {m}
   23.4315, 11.0410625, 0,                 !- X,Y,Z Vertex 2 {m}
   23.4315, 22.234525, 0,                  !- X,Y,Z Vertex 3 {m}
-  23.4315, 22.234525, 2.74319999999999;   !- X,Y,Z Vertex 4 {m}
+  23.4315, 22.234525, 2.7432;             !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {846c3b96-38db-4725-8c05-5205575c7a28}, !- Handle
-  Surface 304,                            !- Name
+  Restroom_Mid - RoofCeiling_a,           !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {7c677a4d-94d0-45a0-ba23-55916435b088}, !- Space Name
@@ -5622,14 +5622,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 11.0410625, 2.74319999999999,  !- X,Y,Z Vertex 1 {m}
-  23.4315, 22.234525, 2.74319999999999,   !- X,Y,Z Vertex 2 {m}
-  18.0975, 22.234525, 2.74319999999999,   !- X,Y,Z Vertex 3 {m}
-  18.0975, 11.0410625, 2.74319999999999;  !- X,Y,Z Vertex 4 {m}
+  23.4315, 11.0410625, 2.7432,            !- X,Y,Z Vertex 1 {m}
+  23.4315, 22.234525, 2.7432,             !- X,Y,Z Vertex 2 {m}
+  18.0975, 22.234525, 2.7432,             !- X,Y,Z Vertex 3 {m}
+  18.0975, 11.0410625, 2.7432;            !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {558337d1-5505-4060-84cf-f57857601d4e}, !- Handle
-  Surface 305,                            !- Name
+  Restroom_Mid - Wall 180_a,              !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {7c677a4d-94d0-45a0-ba23-55916435b088}, !- Space Name
@@ -5639,14 +5639,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  18.0975, 11.0410625, 2.74319999999999,  !- X,Y,Z Vertex 1 {m}
+  18.0975, 11.0410625, 2.7432,            !- X,Y,Z Vertex 1 {m}
   18.0975, 11.0410625, 0,                 !- X,Y,Z Vertex 2 {m}
   23.4315, 11.0410625, 0,                 !- X,Y,Z Vertex 3 {m}
-  23.4315, 11.0410625, 2.74319999999999;  !- X,Y,Z Vertex 4 {m}
+  23.4315, 11.0410625, 2.7432;            !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {0acc55b6-f15a-4089-8cec-2a12b9445323}, !- Handle
-  Surface 306,                            !- Name
+  Restroom_Mid - Wall 000_b,              !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {7c677a4d-94d0-45a0-ba23-55916435b088}, !- Space Name
@@ -5656,14 +5656,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  18.310225, 22.234525, 2.74319999999999, !- X,Y,Z Vertex 1 {m}
+  18.310225, 22.234525, 2.7432,           !- X,Y,Z Vertex 1 {m}
   18.310225, 22.234525, 0,                !- X,Y,Z Vertex 2 {m}
   18.0975, 22.234525, 0,                  !- X,Y,Z Vertex 3 {m}
-  18.0975, 22.234525, 2.74319999999999;   !- X,Y,Z Vertex 4 {m}
+  18.0975, 22.234525, 2.7432;             !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {287b2b64-fd66-4077-b7b7-66157987ac6d}, !- Handle
-  Surface 307,                            !- Name
+  Restroom_Mid - Wall 270_a,              !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {7c677a4d-94d0-45a0-ba23-55916435b088}, !- Space Name
@@ -5673,10 +5673,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  18.0975, 22.234525, 2.74319999999999,   !- X,Y,Z Vertex 1 {m}
+  18.0975, 22.234525, 2.7432,             !- X,Y,Z Vertex 1 {m}
   18.0975, 22.234525, 0,                  !- X,Y,Z Vertex 2 {m}
   18.0975, 11.0410625, 0,                 !- X,Y,Z Vertex 3 {m}
-  18.0975, 11.0410625, 2.74319999999999;  !- X,Y,Z Vertex 4 {m}
+  18.0975, 11.0410625, 2.7432;            !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {ac3c829e-9b67-4edf-bc90-a35d87f91269}, !- Handle
@@ -5685,8 +5685,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   3.9624,                                 !- Z Origin {m}
   {78fc9da4-4d1f-40ea-abef-42e2fc17fcf7}, !- Building Story Name
   {def599db-7c71-497c-8a7e-0f727c3b6089}, !- Thermal Zone Name
@@ -5696,7 +5696,7 @@ OS:Space,
 
 OS:Surface,
   {f75a439e-f365-49ac-93c0-08091e3027c6}, !- Handle
-  Surface 308,                            !- Name
+  Mechanical_Mid - Wall 180_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {ac3c829e-9b67-4edf-bc90-a35d87f91269}, !- Space Name
@@ -5713,7 +5713,7 @@ OS:Surface,
 
 OS:Surface,
   {6fc0e25a-ef94-4068-b916-81f09e02966b}, !- Handle
-  Surface 309,                            !- Name
+  Mechanical_Mid - Floor_a,               !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {ac3c829e-9b67-4edf-bc90-a35d87f91269}, !- Space Name
@@ -5730,7 +5730,7 @@ OS:Surface,
 
 OS:Surface,
   {f75e26e1-6525-45f1-aa85-654c3e06c1af}, !- Handle
-  Surface 310,                            !- Name
+  Mechanical_Mid - Wall 000_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {ac3c829e-9b67-4edf-bc90-a35d87f91269}, !- Space Name
@@ -5747,7 +5747,7 @@ OS:Surface,
 
 OS:Surface,
   {d7911a43-5fad-4144-9f0b-6b1160ff1052}, !- Handle
-  Surface 311,                            !- Name
+  Mechanical_Mid - RoofCeiling_a,         !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {ac3c829e-9b67-4edf-bc90-a35d87f91269}, !- Space Name
@@ -5764,7 +5764,7 @@ OS:Surface,
 
 OS:Surface,
   {a89ee92d-e90a-421d-b3e8-aae7428da66e}, !- Handle
-  Surface 312,                            !- Name
+  Mechanical_Mid - Wall 090_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {ac3c829e-9b67-4edf-bc90-a35d87f91269}, !- Space Name
@@ -5781,7 +5781,7 @@ OS:Surface,
 
 OS:Surface,
   {4612af34-b536-4825-817c-28bdc45c4386}, !- Handle
-  Surface 313,                            !- Name
+  Mechanical_Mid - Wall 270_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {ac3c829e-9b67-4edf-bc90-a35d87f91269}, !- Space Name
@@ -5803,8 +5803,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   3.9624,                                 !- Z Origin {m}
   {78fc9da4-4d1f-40ea-abef-42e2fc17fcf7}, !- Building Story Name
   {67ed0980-f2da-40fd-994a-63fb55b9c564}, !- Thermal Zone Name
@@ -5814,7 +5814,7 @@ OS:Space,
 
 OS:Surface,
   {bc39b1de-10d5-4f0c-8067-2d845e960f0b}, !- Handle
-  Surface 326,                            !- Name
+  ConfRoom_Mid_1 - Wall 000_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {a2f42132-0f39-42fb-a9bc-1b029ba5c56d}, !- Space Name
@@ -5831,7 +5831,7 @@ OS:Surface,
 
 OS:Surface,
   {45cf57e1-806c-4a6c-9d4c-3976c988291f}, !- Handle
-  Surface 327,                            !- Name
+  ConfRoom_Mid_1 - Floor_a,               !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {a2f42132-0f39-42fb-a9bc-1b029ba5c56d}, !- Space Name
@@ -5848,7 +5848,7 @@ OS:Surface,
 
 OS:Surface,
   {0a981bab-79b7-4a02-a06a-97a9181484e6}, !- Handle
-  Surface 328,                            !- Name
+  ConfRoom_Mid_1 - Wall 180_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {a2f42132-0f39-42fb-a9bc-1b029ba5c56d}, !- Space Name
@@ -5865,7 +5865,7 @@ OS:Surface,
 
 OS:Surface,
   {f2c323f4-4141-4d95-8e8f-7f7e7c1ae483}, !- Handle
-  Surface 330,                            !- Name
+  ConfRoom_Mid_1 - Wall 090_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {a2f42132-0f39-42fb-a9bc-1b029ba5c56d}, !- Space Name
@@ -5882,7 +5882,7 @@ OS:Surface,
 
 OS:Surface,
   {3f2c6949-9aac-4135-913c-476046b89010}, !- Handle
-  Surface 331,                            !- Name
+  ConfRoom_Mid_1 - RoofCeiling_a,         !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {a2f42132-0f39-42fb-a9bc-1b029ba5c56d}, !- Space Name
@@ -5899,7 +5899,7 @@ OS:Surface,
 
 OS:Surface,
   {aaef4127-649b-44d5-b0a5-793c1c5d1aa1}, !- Handle
-  Surface 332,                            !- Name
+  ConfRoom_Mid_1 - Wall 000_b,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {a2f42132-0f39-42fb-a9bc-1b029ba5c56d}, !- Space Name
@@ -5921,8 +5921,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   3.9624,                                 !- Z Origin {m}
   {78fc9da4-4d1f-40ea-abef-42e2fc17fcf7}, !- Building Story Name
   {67de5769-0be9-4996-820e-fffc469a52b0}, !- Thermal Zone Name
@@ -5932,7 +5932,7 @@ OS:Space,
 
 OS:Surface,
   {d2516ba5-9e30-472f-83fa-418e4f893746}, !- Handle
-  Surface 333,                            !- Name
+  ActiveStorage_Mid_4 - Wall 180_b,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f1c0bfcc-53e0-4195-b145-b5e99dda47cc}, !- Space Name
@@ -5949,7 +5949,7 @@ OS:Surface,
 
 OS:Surface,
   {86167355-730b-48ca-bc8d-a9c53bc6a59b}, !- Handle
-  Surface 334,                            !- Name
+  ActiveStorage_Mid_4 - RoofCeiling_a,    !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {f1c0bfcc-53e0-4195-b145-b5e99dda47cc}, !- Space Name
@@ -5966,7 +5966,7 @@ OS:Surface,
 
 OS:Surface,
   {e0016b53-40e9-426f-9d3e-a4fd16c2db40}, !- Handle
-  Surface 335,                            !- Name
+  ActiveStorage_Mid_4 - Wall 000_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f1c0bfcc-53e0-4195-b145-b5e99dda47cc}, !- Space Name
@@ -5983,7 +5983,7 @@ OS:Surface,
 
 OS:Surface,
   {93d17fe3-fa33-482a-94a2-5e7ebd2ba822}, !- Handle
-  Surface 336,                            !- Name
+  ActiveStorage_Mid_4 - Wall 270_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f1c0bfcc-53e0-4195-b145-b5e99dda47cc}, !- Space Name
@@ -6000,7 +6000,7 @@ OS:Surface,
 
 OS:Surface,
   {4c7d66d1-69ad-4dc5-8b69-8a1aa2c5765f}, !- Handle
-  Surface 337,                            !- Name
+  ActiveStorage_Mid_4 - Wall 180_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f1c0bfcc-53e0-4195-b145-b5e99dda47cc}, !- Space Name
@@ -6017,7 +6017,7 @@ OS:Surface,
 
 OS:Surface,
   {20a6cb7e-5687-4e6f-b3f3-75ddfd63d76e}, !- Handle
-  Surface 338,                            !- Name
+  ActiveStorage_Mid_4 - Wall 090_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f1c0bfcc-53e0-4195-b145-b5e99dda47cc}, !- Space Name
@@ -6034,7 +6034,7 @@ OS:Surface,
 
 OS:Surface,
   {b76dd97c-30bc-4841-b0f9-b618afb5d09a}, !- Handle
-  Surface 339,                            !- Name
+  ActiveStorage_Mid_4 - Floor_a,          !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {f1c0bfcc-53e0-4195-b145-b5e99dda47cc}, !- Space Name
@@ -6056,8 +6056,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   3.9624,                                 !- Z Origin {m}
   {78fc9da4-4d1f-40ea-abef-42e2fc17fcf7}, !- Building Story Name
   {cfe70983-ff7f-498a-a553-eae07d8e721f}, !- Thermal Zone Name
@@ -6067,7 +6067,7 @@ OS:Space,
 
 OS:Surface,
   {64feb8c7-2285-4cca-b262-38ad3a23fd32}, !- Handle
-  Surface 340,                            !- Name
+  Corridor_Mid_2 - Wall 180_c,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {8ac827fd-9254-438e-a8da-229b190abbc7}, !- Space Name
@@ -6084,7 +6084,7 @@ OS:Surface,
 
 OS:Surface,
   {82f77e2e-e8b4-470f-8c62-ccf8552895b7}, !- Handle
-  Surface 341,                            !- Name
+  Corridor_Mid_2 - Wall 180_d,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {8ac827fd-9254-438e-a8da-229b190abbc7}, !- Space Name
@@ -6101,7 +6101,7 @@ OS:Surface,
 
 OS:Surface,
   {92449a80-8cd7-4752-88a2-94e96552ba66}, !- Handle
-  Surface 342,                            !- Name
+  Corridor_Mid_2 - Wall 180_e,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {8ac827fd-9254-438e-a8da-229b190abbc7}, !- Space Name
@@ -6118,7 +6118,7 @@ OS:Surface,
 
 OS:Surface,
   {11043709-e96a-452b-a042-8e5d13fe02c1}, !- Handle
-  Surface 343,                            !- Name
+  Corridor_Mid_2 - Wall 000_b,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {8ac827fd-9254-438e-a8da-229b190abbc7}, !- Space Name
@@ -6135,7 +6135,7 @@ OS:Surface,
 
 OS:Surface,
   {20e57d23-32ff-4d8c-8439-eaba6e14e3fb}, !- Handle
-  Surface 344,                            !- Name
+  Corridor_Mid_2 - Wall 180_f,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {8ac827fd-9254-438e-a8da-229b190abbc7}, !- Space Name
@@ -6152,7 +6152,7 @@ OS:Surface,
 
 OS:Surface,
   {e48385e2-8dc3-4e3b-8c2c-dfe1783347b6}, !- Handle
-  Surface 345,                            !- Name
+  Corridor_Mid_2 - Wall 180_g,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {8ac827fd-9254-438e-a8da-229b190abbc7}, !- Space Name
@@ -6169,7 +6169,7 @@ OS:Surface,
 
 OS:Surface,
   {bcf46479-380f-48ac-be00-e4463d070607}, !- Handle
-  Surface 346,                            !- Name
+  Corridor_Mid_2 - Wall 090_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {8ac827fd-9254-438e-a8da-229b190abbc7}, !- Space Name
@@ -6186,7 +6186,7 @@ OS:Surface,
 
 OS:Surface,
   {6bc5e52c-cb94-4912-bc55-3f5d0a4fbabe}, !- Handle
-  Surface 347,                            !- Name
+  Corridor_Mid_2 - Wall 180_h,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {8ac827fd-9254-438e-a8da-229b190abbc7}, !- Space Name
@@ -6203,7 +6203,7 @@ OS:Surface,
 
 OS:Surface,
   {a6f96998-7832-4e9a-89bd-a1d58b5a7974}, !- Handle
-  Surface 348,                            !- Name
+  Corridor_Mid_2 - Wall 270_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {8ac827fd-9254-438e-a8da-229b190abbc7}, !- Space Name
@@ -6220,7 +6220,7 @@ OS:Surface,
 
 OS:Surface,
   {39076209-d29d-47aa-acc4-2606d40da458}, !- Handle
-  Surface 349,                            !- Name
+  Corridor_Mid_2 - Wall 180_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {8ac827fd-9254-438e-a8da-229b190abbc7}, !- Space Name
@@ -6237,7 +6237,7 @@ OS:Surface,
 
 OS:Surface,
   {2e32b126-9001-49df-80ab-abdc42060f5f}, !- Handle
-  Surface 350,                            !- Name
+  Corridor_Mid_2 - Wall 090_b,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {8ac827fd-9254-438e-a8da-229b190abbc7}, !- Space Name
@@ -6254,7 +6254,7 @@ OS:Surface,
 
 OS:Surface,
   {aa9db808-2608-4d3c-8c49-0aeaaabaf7d8}, !- Handle
-  Surface 351,                            !- Name
+  Corridor_Mid_2 - Wall 000_c,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {8ac827fd-9254-438e-a8da-229b190abbc7}, !- Space Name
@@ -6271,7 +6271,7 @@ OS:Surface,
 
 OS:Surface,
   {68df71c4-fab6-4ed9-868d-b41696a3e858}, !- Handle
-  Surface 352,                            !- Name
+  Corridor_Mid_2 - Wall 180_b,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {8ac827fd-9254-438e-a8da-229b190abbc7}, !- Space Name
@@ -6288,7 +6288,7 @@ OS:Surface,
 
 OS:Surface,
   {ad71dc82-f192-4084-bada-281603cacb2d}, !- Handle
-  Surface 353,                            !- Name
+  Corridor_Mid_2 - Wall 270_b,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {8ac827fd-9254-438e-a8da-229b190abbc7}, !- Space Name
@@ -6305,7 +6305,7 @@ OS:Surface,
 
 OS:Surface,
   {79588968-d14a-4890-bd51-a99f7e05f9e2}, !- Handle
-  Surface 354,                            !- Name
+  Corridor_Mid_2 - RoofCeiling_a,         !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {8ac827fd-9254-438e-a8da-229b190abbc7}, !- Space Name
@@ -6326,7 +6326,7 @@ OS:Surface,
 
 OS:Surface,
   {e053199b-3a0f-4dae-ba0f-6041de0d5e81}, !- Handle
-  Surface 355,                            !- Name
+  Corridor_Mid_2 - Floor_a,               !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {8ac827fd-9254-438e-a8da-229b190abbc7}, !- Space Name
@@ -6352,8 +6352,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   3.9624,                                 !- Z Origin {m}
   {78fc9da4-4d1f-40ea-abef-42e2fc17fcf7}, !- Building Story Name
   {58a6dd06-bc3c-43f1-9705-cfcdd57e5995}, !- Thermal Zone Name
@@ -6363,7 +6363,7 @@ OS:Space,
 
 OS:Surface,
   {169b1485-f15c-44a3-a432-a41881f3d912}, !- Handle
-  Surface 356,                            !- Name
+  OpenOffice_Mid_1 - Wall 090_c,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {cbc7e64c-309f-482e-b2a4-75d926545811}, !- Space Name
@@ -6380,7 +6380,7 @@ OS:Surface,
 
 OS:Surface,
   {42cfdc94-b424-468f-ab82-493b4e10e945}, !- Handle
-  Surface 357,                            !- Name
+  OpenOffice_Mid_1 - Wall 270_b,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {cbc7e64c-309f-482e-b2a4-75d926545811}, !- Space Name
@@ -6397,7 +6397,7 @@ OS:Surface,
 
 OS:Surface,
   {75959681-4c59-4316-b375-67b08b75b5d8}, !- Handle
-  Surface 358,                            !- Name
+  OpenOffice_Mid_1 - Wall 090_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {cbc7e64c-309f-482e-b2a4-75d926545811}, !- Space Name
@@ -6414,7 +6414,7 @@ OS:Surface,
 
 OS:Surface,
   {1b1c91a3-f2fe-4359-88b5-350640779612}, !- Handle
-  Surface 359,                            !- Name
+  OpenOffice_Mid_1 - Wall 090_b,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {cbc7e64c-309f-482e-b2a4-75d926545811}, !- Space Name
@@ -6431,7 +6431,7 @@ OS:Surface,
 
 OS:Surface,
   {1f64b26a-60f0-4032-a55d-6bda158007e8}, !- Handle
-  Surface 360,                            !- Name
+  OpenOffice_Mid_1 - Wall 000_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {cbc7e64c-309f-482e-b2a4-75d926545811}, !- Space Name
@@ -6448,7 +6448,7 @@ OS:Surface,
 
 OS:Surface,
   {bef73890-8ae9-48a2-8413-33d455c241f4}, !- Handle
-  Surface 361,                            !- Name
+  OpenOffice_Mid_1 - Wall 180_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {cbc7e64c-309f-482e-b2a4-75d926545811}, !- Space Name
@@ -6465,7 +6465,7 @@ OS:Surface,
 
 OS:Surface,
   {f05d8223-eb62-40a0-aa98-80b72c86a6b5}, !- Handle
-  Surface 362,                            !- Name
+  OpenOffice_Mid_1 - RoofCeiling_a,       !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {cbc7e64c-309f-482e-b2a4-75d926545811}, !- Space Name
@@ -6482,7 +6482,7 @@ OS:Surface,
 
 OS:Surface,
   {c4cfc101-3250-4c42-bb23-c62e55f3fe58}, !- Handle
-  Surface 363,                            !- Name
+  OpenOffice_Mid_1 - Wall 270_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {cbc7e64c-309f-482e-b2a4-75d926545811}, !- Space Name
@@ -6499,7 +6499,7 @@ OS:Surface,
 
 OS:Surface,
   {c69a87ab-14f2-43fd-9ff6-1c6ab002ad97}, !- Handle
-  Surface 364,                            !- Name
+  OpenOffice_Mid_1 - Floor_a,             !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {cbc7e64c-309f-482e-b2a4-75d926545811}, !- Space Name
@@ -6521,8 +6521,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   3.9624,                                 !- Z Origin {m}
   {78fc9da4-4d1f-40ea-abef-42e2fc17fcf7}, !- Building Story Name
   {3f5d3178-72bf-4636-a11d-c5edb98cbc19}, !- Thermal Zone Name
@@ -6532,7 +6532,7 @@ OS:Space,
 
 OS:Surface,
   {0b1bff4b-2638-419e-be51-c2d1d09537ae}, !- Handle
-  Surface 365,                            !- Name
+  EnclosedOffice_Mid_3 - Wall 090_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {33539362-7b43-49a3-9a0d-5f008832b087}, !- Space Name
@@ -6549,7 +6549,7 @@ OS:Surface,
 
 OS:Surface,
   {cd903760-09fd-4136-8816-159cdd837f3e}, !- Handle
-  Surface 366,                            !- Name
+  EnclosedOffice_Mid_3 - Wall 000_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {33539362-7b43-49a3-9a0d-5f008832b087}, !- Space Name
@@ -6566,7 +6566,7 @@ OS:Surface,
 
 OS:Surface,
   {0b9f3a3b-32a9-414a-b967-6ec87524d695}, !- Handle
-  Surface 367,                            !- Name
+  EnclosedOffice_Mid_3 - Wall 180_b,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {33539362-7b43-49a3-9a0d-5f008832b087}, !- Space Name
@@ -6583,7 +6583,7 @@ OS:Surface,
 
 OS:Surface,
   {62a29ade-333a-4f56-9607-ecb1cf4881ed}, !- Handle
-  Surface 368,                            !- Name
+  EnclosedOffice_Mid_3 - Wall 270_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {33539362-7b43-49a3-9a0d-5f008832b087}, !- Space Name
@@ -6600,7 +6600,7 @@ OS:Surface,
 
 OS:Surface,
   {706dd5ba-ce1c-46e8-92f5-07d4c69efc29}, !- Handle
-  Surface 369,                            !- Name
+  EnclosedOffice_Mid_3 - RoofCeiling_a,   !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {33539362-7b43-49a3-9a0d-5f008832b087}, !- Space Name
@@ -6617,7 +6617,7 @@ OS:Surface,
 
 OS:Surface,
   {f7d77da6-88c0-46db-92f1-2f81104dd262}, !- Handle
-  Surface 370,                            !- Name
+  EnclosedOffice_Mid_3 - Floor_a,         !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {33539362-7b43-49a3-9a0d-5f008832b087}, !- Space Name
@@ -6639,8 +6639,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   3.9624,                                 !- Z Origin {m}
   {78fc9da4-4d1f-40ea-abef-42e2fc17fcf7}, !- Building Story Name
   {e57a208a-d0a0-483c-834b-83f1b15670ba}, !- Thermal Zone Name
@@ -6650,7 +6650,7 @@ OS:Space,
 
 OS:Surface,
   {0ec9bb12-1220-4140-88c5-07a0bff1e85f}, !- Handle
-  Surface 371,                            !- Name
+  OpenOffice_Mid_3 - Wall 270_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {52646ffd-e7f7-4b4f-9543-312ced0a6bae}, !- Space Name
@@ -6667,7 +6667,7 @@ OS:Surface,
 
 OS:Surface,
   {44da1640-8d93-4a46-9955-0ca786e6ac43}, !- Handle
-  Surface 372,                            !- Name
+  OpenOffice_Mid_3 - Wall 090_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {52646ffd-e7f7-4b4f-9543-312ced0a6bae}, !- Space Name
@@ -6684,7 +6684,7 @@ OS:Surface,
 
 OS:Surface,
   {83ea213b-fb53-4b2a-96d3-537b60825b58}, !- Handle
-  Surface 373,                            !- Name
+  OpenOffice_Mid_3 - Wall 000_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {52646ffd-e7f7-4b4f-9543-312ced0a6bae}, !- Space Name
@@ -6701,7 +6701,7 @@ OS:Surface,
 
 OS:Surface,
   {c7ba3eb2-f20e-42b7-9a08-e7b02403dabc}, !- Handle
-  Surface 374,                            !- Name
+  OpenOffice_Mid_3 - Wall 180_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {52646ffd-e7f7-4b4f-9543-312ced0a6bae}, !- Space Name
@@ -6718,7 +6718,7 @@ OS:Surface,
 
 OS:Surface,
   {088b56ae-6db9-40d6-b8f3-797dcd0b6a52}, !- Handle
-  Surface 375,                            !- Name
+  OpenOffice_Mid_3 - RoofCeiling_a,       !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {52646ffd-e7f7-4b4f-9543-312ced0a6bae}, !- Space Name
@@ -6735,7 +6735,7 @@ OS:Surface,
 
 OS:Surface,
   {a04fe17f-54d2-46bc-b58e-9dc20320e537}, !- Handle
-  Surface 376,                            !- Name
+  OpenOffice_Mid_3 - Floor_a,             !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {52646ffd-e7f7-4b4f-9543-312ced0a6bae}, !- Space Name
@@ -6757,8 +6757,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   3.9624,                                 !- Z Origin {m}
   {78fc9da4-4d1f-40ea-abef-42e2fc17fcf7}, !- Building Story Name
   {c1a15444-a578-4521-8793-433c820bcd9c}, !- Thermal Zone Name
@@ -6768,7 +6768,7 @@ OS:Space,
 
 OS:Surface,
   {7b533b22-edd8-411f-980f-bc1c69fb42c8}, !- Handle
-  Surface 377,                            !- Name
+  EnclosedOffice_Mid_2 - Wall 270_c,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {5ce85006-2881-44f2-8075-2f399d15ba10}, !- Space Name
@@ -6785,7 +6785,7 @@ OS:Surface,
 
 OS:Surface,
   {8563e8ee-b726-4194-90dd-0671d42018f8}, !- Handle
-  Surface 378,                            !- Name
+  EnclosedOffice_Mid_2 - Wall 270_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {5ce85006-2881-44f2-8075-2f399d15ba10}, !- Space Name
@@ -6802,7 +6802,7 @@ OS:Surface,
 
 OS:Surface,
   {2e39909e-81d0-4ad2-9668-d2b99f6be80b}, !- Handle
-  Surface 379,                            !- Name
+  EnclosedOffice_Mid_2 - Wall 180_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {5ce85006-2881-44f2-8075-2f399d15ba10}, !- Space Name
@@ -6819,7 +6819,7 @@ OS:Surface,
 
 OS:Surface,
   {253b5007-e611-4a79-a17e-6b1ebad0ae35}, !- Handle
-  Surface 380,                            !- Name
+  EnclosedOffice_Mid_2 - Wall 270_b,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {5ce85006-2881-44f2-8075-2f399d15ba10}, !- Space Name
@@ -6836,7 +6836,7 @@ OS:Surface,
 
 OS:Surface,
   {ddacbdb9-4067-4b7c-8554-a393595dbeb8}, !- Handle
-  Surface 382,                            !- Name
+  EnclosedOffice_Mid_2 - RoofCeiling_a,   !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {5ce85006-2881-44f2-8075-2f399d15ba10}, !- Space Name
@@ -6853,7 +6853,7 @@ OS:Surface,
 
 OS:Surface,
   {5e554606-98a6-4c91-99fc-fd673f4051f1}, !- Handle
-  Surface 384,                            !- Name
+  EnclosedOffice_Mid_2 - Floor_a,         !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {5ce85006-2881-44f2-8075-2f399d15ba10}, !- Space Name
@@ -6875,8 +6875,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   3.9624,                                 !- Z Origin {m}
   {78fc9da4-4d1f-40ea-abef-42e2fc17fcf7}, !- Building Story Name
   {5f9749b4-9adf-40cf-baf8-218be7eb55e4}, !- Thermal Zone Name
@@ -6886,7 +6886,7 @@ OS:Space,
 
 OS:Surface,
   {5343b9f5-5af0-4d72-b421-a0de7a8ebcb7}, !- Handle
-  Surface 385,                            !- Name
+  Stair_Mid_1 - Wall 000_a,               !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f90cece3-70e9-447e-b482-e9cbe5a23e4d}, !- Space Name
@@ -6903,7 +6903,7 @@ OS:Surface,
 
 OS:Surface,
   {24a042d3-60fe-439e-adcd-9a93b63530f4}, !- Handle
-  Surface 386,                            !- Name
+  Stair_Mid_1 - Wall 090_a,               !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f90cece3-70e9-447e-b482-e9cbe5a23e4d}, !- Space Name
@@ -6920,7 +6920,7 @@ OS:Surface,
 
 OS:Surface,
   {728613d7-e5ae-4831-a849-da4e9c128fd1}, !- Handle
-  Surface 387,                            !- Name
+  Stair_Mid_1 - Wall 270_a,               !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f90cece3-70e9-447e-b482-e9cbe5a23e4d}, !- Space Name
@@ -6937,7 +6937,7 @@ OS:Surface,
 
 OS:Surface,
   {c1aaf4a8-4a33-4831-a5d6-2b4b33a557e6}, !- Handle
-  Surface 388,                            !- Name
+  Stair_Mid_1 - Wall 180_a,               !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f90cece3-70e9-447e-b482-e9cbe5a23e4d}, !- Space Name
@@ -6954,7 +6954,7 @@ OS:Surface,
 
 OS:Surface,
   {306030c9-ac82-44ba-81ca-a8948e8a283f}, !- Handle
-  Surface 389,                            !- Name
+  Stair_Mid_1 - RoofCeiling_a,            !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {f90cece3-70e9-447e-b482-e9cbe5a23e4d}, !- Space Name
@@ -6971,7 +6971,7 @@ OS:Surface,
 
 OS:Surface,
   {80135390-5964-49e2-a981-e3fe80ffac11}, !- Handle
-  Surface 390,                            !- Name
+  Stair_Mid_1 - Floor_a,                  !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {f90cece3-70e9-447e-b482-e9cbe5a23e4d}, !- Space Name
@@ -6993,8 +6993,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   3.9624,                                 !- Z Origin {m}
   {78fc9da4-4d1f-40ea-abef-42e2fc17fcf7}, !- Building Story Name
   {61acd950-16f4-4c9f-9bf5-f6ac94f01c7c}, !- Thermal Zone Name
@@ -7004,7 +7004,7 @@ OS:Space,
 
 OS:Surface,
   {f2ae63c5-d9ad-4b5c-8bc6-8bfd3c517e86}, !- Handle
-  Surface 210,                            !- Name
+  OpenOffice_Mid_4 - Floor_a,             !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {d760da4e-d075-4ad8-8f56-c8f324e1c9c9}, !- Space Name
@@ -7014,14 +7014,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  41.8417375, 5.34193749999998, 0,        !- X,Y,Z Vertex 1 {m}
+  41.8417375, 5.3419375, 0,               !- X,Y,Z Vertex 1 {m}
   41.8417375, 0, 0,                       !- X,Y,Z Vertex 2 {m}
   8.0692625, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  8.0692625, 5.34193749999998, 0;         !- X,Y,Z Vertex 4 {m}
+  8.0692625, 5.3419375, 0;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {b1949ba7-1aa6-4c3e-a8b4-7c2006e9d2af}, !- Handle
-  Surface 211,                            !- Name
+  OpenOffice_Mid_4 - Wall 270_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d760da4e-d075-4ad8-8f56-c8f324e1c9c9}, !- Space Name
@@ -7031,14 +7031,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  8.0692625, 5.34193749999998, 2.7432,    !- X,Y,Z Vertex 1 {m}
-  8.0692625, 5.34193749999998, 0,         !- X,Y,Z Vertex 2 {m}
+  8.0692625, 5.3419375, 2.7432,           !- X,Y,Z Vertex 1 {m}
+  8.0692625, 5.3419375, 0,                !- X,Y,Z Vertex 2 {m}
   8.0692625, 0, 0,                        !- X,Y,Z Vertex 3 {m}
   8.0692625, 0, 2.7432;                   !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {b2b77bd1-cc2c-49a8-ad61-796c147d3e7d}, !- Handle
-  Surface 212,                            !- Name
+  OpenOffice_Mid_4 - Wall 090_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d760da4e-d075-4ad8-8f56-c8f324e1c9c9}, !- Space Name
@@ -7050,12 +7050,12 @@ OS:Surface,
   ,                                       !- Number of Vertices
   41.8417375, 0, 2.7432,                  !- X,Y,Z Vertex 1 {m}
   41.8417375, 0, 0,                       !- X,Y,Z Vertex 2 {m}
-  41.8417375, 5.34193749999998, 0,        !- X,Y,Z Vertex 3 {m}
-  41.8417375, 5.34193749999998, 2.7432;   !- X,Y,Z Vertex 4 {m}
+  41.8417375, 5.3419375, 0,               !- X,Y,Z Vertex 3 {m}
+  41.8417375, 5.3419375, 2.7432;          !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {d1927d2b-4630-48f8-8e2b-d3d427798232}, !- Handle
-  Surface 213,                            !- Name
+  OpenOffice_Mid_4 - Wall 180_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d760da4e-d075-4ad8-8f56-c8f324e1c9c9}, !- Space Name
@@ -7072,7 +7072,7 @@ OS:Surface,
 
 OS:Surface,
   {63eb00cc-72d6-4f9b-88bd-c8a31ea3acae}, !- Handle
-  Surface 214,                            !- Name
+  OpenOffice_Mid_4 - RoofCeiling_a,       !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {d760da4e-d075-4ad8-8f56-c8f324e1c9c9}, !- Space Name
@@ -7083,13 +7083,13 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   41.8417375, 0, 2.7432,                  !- X,Y,Z Vertex 1 {m}
-  41.8417375, 5.34193749999998, 2.7432,   !- X,Y,Z Vertex 2 {m}
-  8.0692625, 5.34193749999998, 2.7432,    !- X,Y,Z Vertex 3 {m}
+  41.8417375, 5.3419375, 2.7432,          !- X,Y,Z Vertex 2 {m}
+  8.0692625, 5.3419375, 2.7432,           !- X,Y,Z Vertex 3 {m}
   8.0692625, 0, 2.7432;                   !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {589fcc57-d278-4770-b9de-cd499fe4712a}, !- Handle
-  Surface 215,                            !- Name
+  OpenOffice_Mid_4 - Wall 0_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d760da4e-d075-4ad8-8f56-c8f324e1c9c9}, !- Space Name
@@ -7101,8 +7101,8 @@ OS:Surface,
   ,                                       !- Number of Vertices
   16.5735, 5.3419375, 2.7432,             !- X,Y,Z Vertex 1 {m}
   16.5735, 5.3419375, 0,                  !- X,Y,Z Vertex 2 {m}
-  8.0692625, 5.34193749999998, 0,         !- X,Y,Z Vertex 3 {m}
-  8.0692625, 5.34193749999998, 2.7432;    !- X,Y,Z Vertex 4 {m}
+  8.0692625, 5.3419375, 0,                !- X,Y,Z Vertex 3 {m}
+  8.0692625, 5.3419375, 2.7432;           !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Handle
@@ -7111,8 +7111,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  7.21911419532262e-016,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   3.9624,                                 !- Z Origin {m}
   {78fc9da4-4d1f-40ea-abef-42e2fc17fcf7}, !- Building Story Name
   {0d120da8-0d40-4a9f-92e4-6351ebfc47c1}, !- Thermal Zone Name
@@ -7122,7 +7122,7 @@ OS:Space,
 
 OS:Surface,
   {933f2ec8-bbaf-4f85-9621-15ae4df08a1b}, !- Handle
-  Surface 314,                            !- Name
+  MidFloor_Plenum - Floor_c,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -7139,7 +7139,7 @@ OS:Surface,
 
 OS:Surface,
   {e78b7c4f-8e89-4a1a-ad89-b823eb533cd5}, !- Handle
-  Surface 315,                            !- Name
+  MidFloor_Plenum - Wall 000_a,           !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -7156,7 +7156,7 @@ OS:Surface,
 
 OS:Surface,
   {e74d1bbc-92e9-4eb2-902d-21a98566c0ef}, !- Handle
-  Surface 316,                            !- Name
+  MidFloor_Plenum - Wall 180_a,           !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -7173,7 +7173,7 @@ OS:Surface,
 
 OS:Surface,
   {e56f7b18-4662-4dfa-ba78-158c92f5e944}, !- Handle
-  Surface 317,                            !- Name
+  MidFloor_Plenum - RoofCeiling_i,        !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -7190,7 +7190,7 @@ OS:Surface,
 
 OS:Surface,
   {1789f81f-6b62-4a95-9fa6-7967d092e9c2}, !- Handle
-  Surface 318,                            !- Name
+  MidFloor_Plenum - Wall 270_a,           !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -7207,7 +7207,7 @@ OS:Surface,
 
 OS:Surface,
   {f3f5add7-f5e4-44b6-9f2e-7198f53ed153}, !- Handle
-  Surface 319,                            !- Name
+  MidFloor_Plenum - Wall 090_a,           !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -7224,7 +7224,7 @@ OS:Surface,
 
 OS:Surface,
   {2d913b5d-b8d4-463b-928f-e28c6965bf87}, !- Handle
-  Surface 391,                            !- Name
+  Corridor_Mid_2 - Wall 000_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {8ac827fd-9254-438e-a8da-229b190abbc7}, !- Space Name
@@ -7241,7 +7241,7 @@ OS:Surface,
 
 OS:Surface,
   {eb72b64b-20a2-4417-8313-1dfeecbb4dd4}, !- Handle
-  Surface 392,                            !- Name
+  EnclosedOffice_Mid_3 - Wall 180_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {33539362-7b43-49a3-9a0d-5f008832b087}, !- Space Name
@@ -7258,7 +7258,7 @@ OS:Surface,
 
 OS:Surface,
   {af24cb05-6f1d-428d-aede-40185d08fac8}, !- Handle
-  Surface 393,                            !- Name
+  OpenOffice_Mid_4 - Wall 000_b,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d760da4e-d075-4ad8-8f56-c8f324e1c9c9}, !- Space Name
@@ -7268,14 +7268,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  41.8417375, 5.34193749999998, 2.7432,   !- X,Y,Z Vertex 1 {m}
-  41.8417375, 5.34193749999998, 0,        !- X,Y,Z Vertex 2 {m}
+  41.8417375, 5.3419375, 2.7432,          !- X,Y,Z Vertex 1 {m}
+  41.8417375, 5.3419375, 0,               !- X,Y,Z Vertex 2 {m}
   33.3375, 5.3419375, 0,                  !- X,Y,Z Vertex 3 {m}
   33.3375, 5.3419375, 2.7432;             !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {75335b96-f655-460b-86ea-55a62bf15741}, !- Handle
-  Surface 394,                            !- Name
+  OpenOffice_Mid_4 - Wall 000_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d760da4e-d075-4ad8-8f56-c8f324e1c9c9}, !- Space Name
@@ -7292,7 +7292,7 @@ OS:Surface,
 
 OS:Surface,
   {f32190ad-852c-45b6-a84e-3eb1775bfe2b}, !- Handle
-  Surface 395,                            !- Name
+  MidFloor_Plenum - Floor_n,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -7302,14 +7302,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 11.0410625, 2.74319999999999,  !- X,Y,Z Vertex 1 {m}
-  23.4315, 6.5611375, 2.74319999999999,   !- X,Y,Z Vertex 2 {m}
+  23.4315, 11.0410625, 2.7432,            !- X,Y,Z Vertex 1 {m}
+  23.4315, 6.5611375, 2.7432,             !- X,Y,Z Vertex 2 {m}
   15.3543, 6.5611375, 2.7432,             !- X,Y,Z Vertex 3 {m}
   15.3543, 11.0410625, 2.7432;            !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {7366e4e4-c72d-4015-bd7a-d717dbf72933}, !- Handle
-  Surface 396,                            !- Name
+  MidFloor_Plenum - Floor_o,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -7326,7 +7326,7 @@ OS:Surface,
 
 OS:Surface,
   {d5f2ffd2-4889-4af4-ba52-caaf2fa1e9d6}, !- Handle
-  Surface 397,                            !- Name
+  MidFloor_Plenum - Floor_k,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -7343,7 +7343,7 @@ OS:Surface,
 
 OS:Surface,
   {46f64adc-d065-44bf-84f3-be5ed6132aa3}, !- Handle
-  Surface 398,                            !- Name
+  MidFloor_Plenum - Floor_a,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -7360,7 +7360,7 @@ OS:Surface,
 
 OS:Surface,
   {f44c1b70-4843-46d5-95b1-50196dc10696}, !- Handle
-  Surface 399,                            !- Name
+  MidFloor_Plenum - Floor_l,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -7377,7 +7377,7 @@ OS:Surface,
 
 OS:Surface,
   {e4194949-7da1-4491-b979-d49ac4867c61}, !- Handle
-  Surface 400,                            !- Name
+  MidFloor_Plenum - Floor_g,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -7394,7 +7394,7 @@ OS:Surface,
 
 OS:Surface,
   {9b4f91d6-a39c-496e-a4f8-35a8a435d8f1}, !- Handle
-  Surface 401,                            !- Name
+  MidFloor_Plenum - Floor_m,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -7415,7 +7415,7 @@ OS:Surface,
 
 OS:Surface,
   {790b6dec-5689-4302-9f97-dc8d199f86dd}, !- Handle
-  Surface 402,                            !- Name
+  MidFloor_Plenum - Floor_p,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -7426,13 +7426,13 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   23.4315, 26.71445, 2.7432,              !- X,Y,Z Vertex 1 {m}
-  23.4315, 22.234525, 2.74319999999999,   !- X,Y,Z Vertex 2 {m}
+  23.4315, 22.234525, 2.7432,             !- X,Y,Z Vertex 2 {m}
   18.310225, 22.234525, 2.7432,           !- X,Y,Z Vertex 3 {m}
   18.310225, 26.71445, 2.7432;            !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {b2c53ae3-ce4a-4cc4-a4d9-60eb50aed1f3}, !- Handle
-  Surface 403,                            !- Name
+  MidFloor_Plenum - Floor_q,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -7449,7 +7449,7 @@ OS:Surface,
 
 OS:Surface,
   {3faf1d14-7c37-4d1a-985f-1ca512bb978e}, !- Handle
-  Surface 404,                            !- Name
+  MidFloor_Plenum - Floor_e,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -7466,7 +7466,7 @@ OS:Surface,
 
 OS:Surface,
   {ef393780-2d03-4035-b320-480c92c51cee}, !- Handle
-  Surface 405,                            !- Name
+  MidFloor_Plenum - Floor_r,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -7483,7 +7483,7 @@ OS:Surface,
 
 OS:Surface,
   {ecdffcb6-d21c-4547-ad70-21be89552cbf}, !- Handle
-  Surface 406,                            !- Name
+  MidFloor_Plenum - Floor_i,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -7500,7 +7500,7 @@ OS:Surface,
 
 OS:Surface,
   {a88c72aa-845e-44bc-a065-15c1405f2803}, !- Handle
-  Surface 407,                            !- Name
+  MidFloor_Plenum - Floor_f,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -7521,7 +7521,7 @@ OS:Surface,
 
 OS:Surface,
   {65738bd1-1a90-42dc-9fb4-c9fa58baf804}, !- Handle
-  Surface 408,                            !- Name
+  MidFloor_Plenum - Floor_s,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -7531,14 +7531,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 22.234525, 2.74319999999999,   !- X,Y,Z Vertex 1 {m}
-  23.4315, 11.0410625, 2.74319999999999,  !- X,Y,Z Vertex 2 {m}
+  23.4315, 22.234525, 2.7432,             !- X,Y,Z Vertex 1 {m}
+  23.4315, 11.0410625, 2.7432,            !- X,Y,Z Vertex 2 {m}
   18.0975, 11.0410625, 2.7432,            !- X,Y,Z Vertex 3 {m}
   18.0975, 22.234525, 2.7432;             !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {0dcd1069-c8bd-4939-92ca-b08a43745c14}, !- Handle
-  Surface 409,                            !- Name
+  MidFloor_Plenum - Floor_h,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -7555,7 +7555,7 @@ OS:Surface,
 
 OS:Surface,
   {bfe9b452-d0e1-4256-8fa3-731a89643d37}, !- Handle
-  Surface 410,                            !- Name
+  MidFloor_Plenum - Floor_j,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -7572,7 +7572,7 @@ OS:Surface,
 
 OS:Surface,
   {abcfd959-fb40-4b6c-8e22-dd187f6aad6b}, !- Handle
-  Surface 411,                            !- Name
+  MidFloor_Plenum - Floor_b,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -7583,13 +7583,13 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   26.4795, 26.71445, 2.7432,              !- X,Y,Z Vertex 1 {m}
-  26.4795, 6.5611375, 2.74319999999999,   !- X,Y,Z Vertex 2 {m}
-  23.4315, 6.5611375, 2.74319999999999,   !- X,Y,Z Vertex 3 {m}
+  26.4795, 6.5611375, 2.7432,             !- X,Y,Z Vertex 2 {m}
+  23.4315, 6.5611375, 2.7432,             !- X,Y,Z Vertex 3 {m}
   23.4315, 26.71445, 2.7432;              !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {ab9582bc-d893-4ada-899a-2ad4acd8eced}, !- Handle
-  Surface 412,                            !- Name
+  MidFloor_Plenum - Floor_d,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -7606,7 +7606,7 @@ OS:Surface,
 
 OS:Surface,
   {9ac3a9d2-c928-4ee0-b7d0-940fc071a8e2}, !- Handle
-  Surface 413,                            !- Name
+  MidFloor_Plenum - Floor_t,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -7618,12 +7618,12 @@ OS:Surface,
   ,                                       !- Number of Vertices
   33.6724625, 11.0410625, 2.7432,         !- X,Y,Z Vertex 1 {m}
   33.6724625, 6.5611375, 2.7432,          !- X,Y,Z Vertex 2 {m}
-  26.4795, 6.5611375, 2.74319999999999,   !- X,Y,Z Vertex 3 {m}
+  26.4795, 6.5611375, 2.7432,             !- X,Y,Z Vertex 3 {m}
   26.4795, 11.0410625, 2.7432;            !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {a4c3c222-3d22-4a45-b2c5-421b2686d0f0}, !- Handle
-  Surface 414,                            !- Name
+  MidFloor_Plenum - Floor_u,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -7645,8 +7645,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  7.21911419532262e-016,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   7.9248,                                 !- Z Origin {m}
   {34c2b3a4-b93e-443b-9867-ce24d7c61c21}, !- Building Story Name
   {c6b78f1d-6990-419f-accd-c9dcaa76d920}, !- Thermal Zone Name
@@ -7656,7 +7656,7 @@ OS:Space,
 
 OS:Surface,
   {34443c0b-326e-4913-bcc5-e091e59f28ec}, !- Handle
-  Surface 419,                            !- Name
+  Corridor_Top_2 - Floor_a,               !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {684d765c-071b-490a-b181-4f80e0572fd5}, !- Space Name
@@ -7677,7 +7677,7 @@ OS:Surface,
 
 OS:Surface,
   {025468d1-0b2c-4c3a-928b-0dda2a075c3a}, !- Handle
-  Surface 420,                            !- Name
+  Corridor_Top_2 - RoofCeiling_a,         !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {684d765c-071b-490a-b181-4f80e0572fd5}, !- Space Name
@@ -7698,7 +7698,7 @@ OS:Surface,
 
 OS:Surface,
   {58a77044-64b8-41e3-8255-08e9e6b811f5}, !- Handle
-  Surface 421,                            !- Name
+  Corridor_Top_2 - Wall 270_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {684d765c-071b-490a-b181-4f80e0572fd5}, !- Space Name
@@ -7715,7 +7715,7 @@ OS:Surface,
 
 OS:Surface,
   {daf90dda-bf36-4193-98b5-ad6666a02bc7}, !- Handle
-  Surface 422,                            !- Name
+  Corridor_Top_2 - Wall 180_f,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {684d765c-071b-490a-b181-4f80e0572fd5}, !- Space Name
@@ -7732,7 +7732,7 @@ OS:Surface,
 
 OS:Surface,
   {ed96633c-1096-4b8d-b0fe-054f163b127d}, !- Handle
-  Surface 423,                            !- Name
+  Corridor_Top_2 - Wall 000_b,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {684d765c-071b-490a-b181-4f80e0572fd5}, !- Space Name
@@ -7749,7 +7749,7 @@ OS:Surface,
 
 OS:Surface,
   {e91faf45-846e-4226-8ed8-3c0354c451ec}, !- Handle
-  Surface 424,                            !- Name
+  Corridor_Top_2 - Wall 090_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {684d765c-071b-490a-b181-4f80e0572fd5}, !- Space Name
@@ -7766,7 +7766,7 @@ OS:Surface,
 
 OS:Surface,
   {c1fbc202-5aac-4014-81d6-80f1ffad47cb}, !- Handle
-  Surface 425,                            !- Name
+  Corridor_Top_2 - Wall 180_g,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {684d765c-071b-490a-b181-4f80e0572fd5}, !- Space Name
@@ -7783,7 +7783,7 @@ OS:Surface,
 
 OS:Surface,
   {e24fc624-0095-423b-b0a0-6b8a56d56e48}, !- Handle
-  Surface 426,                            !- Name
+  Corridor_Top_2 - Wall 270_b,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {684d765c-071b-490a-b181-4f80e0572fd5}, !- Space Name
@@ -7800,7 +7800,7 @@ OS:Surface,
 
 OS:Surface,
   {82f4421e-560e-4a77-969a-4e8b68d449ce}, !- Handle
-  Surface 427,                            !- Name
+  Corridor_Top_2 - Wall 180_e,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {684d765c-071b-490a-b181-4f80e0572fd5}, !- Space Name
@@ -7817,7 +7817,7 @@ OS:Surface,
 
 OS:Surface,
   {1ea2566d-d8ea-4dcb-a262-0e2a2ac28d46}, !- Handle
-  Surface 428,                            !- Name
+  Corridor_Top_2 - Wall 090_b,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {684d765c-071b-490a-b181-4f80e0572fd5}, !- Space Name
@@ -7834,7 +7834,7 @@ OS:Surface,
 
 OS:Surface,
   {7965761c-ebcf-4ded-aaf6-a86734b1ad81}, !- Handle
-  Surface 429,                            !- Name
+  Corridor_Top_2 - Wall 180_h,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {684d765c-071b-490a-b181-4f80e0572fd5}, !- Space Name
@@ -7851,7 +7851,7 @@ OS:Surface,
 
 OS:Surface,
   {cf01e91f-c43a-4320-ac0b-108bd73d8083}, !- Handle
-  Surface 430,                            !- Name
+  Corridor_Top_2 - Wall 180_b,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {684d765c-071b-490a-b181-4f80e0572fd5}, !- Space Name
@@ -7868,7 +7868,7 @@ OS:Surface,
 
 OS:Surface,
   {123e7a62-eb04-4448-a9bd-b13405432bed}, !- Handle
-  Surface 431,                            !- Name
+  Corridor_Top_2 - Wall 000_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {684d765c-071b-490a-b181-4f80e0572fd5}, !- Space Name
@@ -7885,7 +7885,7 @@ OS:Surface,
 
 OS:Surface,
   {c9024bcd-01cf-4af4-abcb-fddb3cfd0672}, !- Handle
-  Surface 432,                            !- Name
+  Corridor_Top_2 - Wall 180_c,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {684d765c-071b-490a-b181-4f80e0572fd5}, !- Space Name
@@ -7902,7 +7902,7 @@ OS:Surface,
 
 OS:Surface,
   {05a21aa6-4400-4970-b98e-2dc807617027}, !- Handle
-  Surface 433,                            !- Name
+  Corridor_Top_2 - Wall 180_d,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {684d765c-071b-490a-b181-4f80e0572fd5}, !- Space Name
@@ -7919,7 +7919,7 @@ OS:Surface,
 
 OS:Surface,
   {aa14458e-4ff1-4910-87a7-a3edb26d9748}, !- Handle
-  Surface 434,                            !- Name
+  Corridor_Top_2 - Wall 180_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {684d765c-071b-490a-b181-4f80e0572fd5}, !- Space Name
@@ -7936,7 +7936,7 @@ OS:Surface,
 
 OS:Surface,
   {f9d2a1ee-3ed4-444f-b4e4-f35644adfdbf}, !- Handle
-  Surface 435,                            !- Name
+  Corridor_Top_2 - Wall 000_c,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {684d765c-071b-490a-b181-4f80e0572fd5}, !- Space Name
@@ -7958,8 +7958,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  7.21911419532262e-016,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   7.9248,                                 !- Z Origin {m}
   {34c2b3a4-b93e-443b-9867-ce24d7c61c21}, !- Building Story Name
   {355e4c73-cb17-4378-ba21-8644519dfb5a}, !- Thermal Zone Name
@@ -7969,7 +7969,7 @@ OS:Space,
 
 OS:Surface,
   {26446060-329b-4523-9658-4e127a0bdcea}, !- Handle
-  Surface 462,                            !- Name
+  OpenOffice_Top_1 - Floor_a,             !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {012df538-0e9f-408a-b54c-c013737bb521}, !- Space Name
@@ -7986,7 +7986,7 @@ OS:Surface,
 
 OS:Surface,
   {e69bca5d-d4b1-4be7-83e2-445725daf1e8}, !- Handle
-  Surface 463,                            !- Name
+  OpenOffice_Top_1 - Wall 270_b,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {012df538-0e9f-408a-b54c-c013737bb521}, !- Space Name
@@ -8003,7 +8003,7 @@ OS:Surface,
 
 OS:Surface,
   {fbd39b0f-d023-4894-baf3-33a0db34e045}, !- Handle
-  Surface 464,                            !- Name
+  OpenOffice_Top_1 - RoofCeiling_a,       !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {012df538-0e9f-408a-b54c-c013737bb521}, !- Space Name
@@ -8020,7 +8020,7 @@ OS:Surface,
 
 OS:Surface,
   {6ffc3269-e2a2-45b5-b969-f9a2f0634c15}, !- Handle
-  Surface 465,                            !- Name
+  OpenOffice_Top_1 - Wall 180_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {012df538-0e9f-408a-b54c-c013737bb521}, !- Space Name
@@ -8037,7 +8037,7 @@ OS:Surface,
 
 OS:Surface,
   {d17a96e2-eac9-4f77-82df-0b5144efd671}, !- Handle
-  Surface 466,                            !- Name
+  OpenOffice_Top_1 - Wall 000_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {012df538-0e9f-408a-b54c-c013737bb521}, !- Space Name
@@ -8054,7 +8054,7 @@ OS:Surface,
 
 OS:Surface,
   {a966c9e4-3978-457e-aec2-0b83b6ff3686}, !- Handle
-  Surface 467,                            !- Name
+  OpenOffice_Top_1 - Wall 090_b,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {012df538-0e9f-408a-b54c-c013737bb521}, !- Space Name
@@ -8071,7 +8071,7 @@ OS:Surface,
 
 OS:Surface,
   {f7d3fca9-0a73-4e26-a243-91fa67e0717e}, !- Handle
-  Surface 468,                            !- Name
+  OpenOffice_Top_1 - Wall 090_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {012df538-0e9f-408a-b54c-c013737bb521}, !- Space Name
@@ -8088,7 +8088,7 @@ OS:Surface,
 
 OS:Surface,
   {07626e3b-b4c6-4a86-ae2c-77fae2d38eb4}, !- Handle
-  Surface 469,                            !- Name
+  OpenOffice_Top_1 - Wall 270_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {012df538-0e9f-408a-b54c-c013737bb521}, !- Space Name
@@ -8105,7 +8105,7 @@ OS:Surface,
 
 OS:Surface,
   {0ead78fb-558d-4a7c-91e2-9f11f9fab7e9}, !- Handle
-  Surface 470,                            !- Name
+  OpenOffice_Top_1 - Wall 090_c,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {012df538-0e9f-408a-b54c-c013737bb521}, !- Space Name
@@ -8127,8 +8127,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  7.21911419532262e-016,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   7.9248,                                 !- Z Origin {m}
   {34c2b3a4-b93e-443b-9867-ce24d7c61c21}, !- Building Story Name
   {eb3fcf73-8d14-45e9-ad6e-a3a1445d6895}, !- Thermal Zone Name
@@ -8138,7 +8138,7 @@ OS:Space,
 
 OS:Surface,
   {21ba42ce-e881-499e-88e6-2ba41f0b436d}, !- Handle
-  Surface 471,                            !- Name
+  EnclosedOffice_Top_3 - Floor_a,         !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {088fff13-3245-46c2-bd01-90dce95d2d32}, !- Space Name
@@ -8155,7 +8155,7 @@ OS:Surface,
 
 OS:Surface,
   {627d1435-67c5-400e-aacc-ea0892a1edd7}, !- Handle
-  Surface 472,                            !- Name
+  EnclosedOffice_Top_3 - RoofCeiling_a,   !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {088fff13-3245-46c2-bd01-90dce95d2d32}, !- Space Name
@@ -8172,7 +8172,7 @@ OS:Surface,
 
 OS:Surface,
   {3157b624-dcb4-4363-93bb-2269cc2e0a61}, !- Handle
-  Surface 473,                            !- Name
+  EnclosedOffice_Top_3 - Wall 270_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {088fff13-3245-46c2-bd01-90dce95d2d32}, !- Space Name
@@ -8189,7 +8189,7 @@ OS:Surface,
 
 OS:Surface,
   {56c286b1-05b5-4857-8497-2a7d50a3a4dd}, !- Handle
-  Surface 475,                            !- Name
+  EnclosedOffice_Top_3 - Wall 090_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {088fff13-3245-46c2-bd01-90dce95d2d32}, !- Space Name
@@ -8206,7 +8206,7 @@ OS:Surface,
 
 OS:Surface,
   {88631b6b-9c10-4571-b461-718c45f97d42}, !- Handle
-  Surface 476,                            !- Name
+  EnclosedOffice_Top_3 - Wall 180_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {088fff13-3245-46c2-bd01-90dce95d2d32}, !- Space Name
@@ -8223,7 +8223,7 @@ OS:Surface,
 
 OS:Surface,
   {28c05385-483a-411a-8faf-d42d3ea90852}, !- Handle
-  Surface 477,                            !- Name
+  EnclosedOffice_Top_3 - Wall 180_b,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {088fff13-3245-46c2-bd01-90dce95d2d32}, !- Space Name
@@ -8245,8 +8245,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  7.21911419532262e-016,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   7.9248,                                 !- Z Origin {m}
   {34c2b3a4-b93e-443b-9867-ce24d7c61c21}, !- Building Story Name
   {26a377b7-4408-48d2-bf23-ba3ca649317e}, !- Thermal Zone Name
@@ -8256,7 +8256,7 @@ OS:Space,
 
 OS:Surface,
   {610a922f-0df1-41ce-a85d-9f7ca6402772}, !- Handle
-  Surface 478,                            !- Name
+  OpenOffice_Top_3 - Floor_a,             !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {cd57e5c2-5023-4058-b2a8-752285324e5c}, !- Space Name
@@ -8273,7 +8273,7 @@ OS:Surface,
 
 OS:Surface,
   {d513d23b-d820-418d-b4ad-3007315a4207}, !- Handle
-  Surface 479,                            !- Name
+  OpenOffice_Top_3 - RoofCeiling_a,       !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {cd57e5c2-5023-4058-b2a8-752285324e5c}, !- Space Name
@@ -8290,7 +8290,7 @@ OS:Surface,
 
 OS:Surface,
   {ae3a5181-efed-41ff-a750-7572cc4f12f4}, !- Handle
-  Surface 480,                            !- Name
+  OpenOffice_Top_3 - Wall 180_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {cd57e5c2-5023-4058-b2a8-752285324e5c}, !- Space Name
@@ -8307,7 +8307,7 @@ OS:Surface,
 
 OS:Surface,
   {31aaa649-a714-467a-ad54-52a464a4091d}, !- Handle
-  Surface 481,                            !- Name
+  OpenOffice_Top_3 - Wall 000_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {cd57e5c2-5023-4058-b2a8-752285324e5c}, !- Space Name
@@ -8324,7 +8324,7 @@ OS:Surface,
 
 OS:Surface,
   {cb789a33-3145-473e-ad3a-7255de79addb}, !- Handle
-  Surface 482,                            !- Name
+  OpenOffice_Top_3 - Wall 090_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {cd57e5c2-5023-4058-b2a8-752285324e5c}, !- Space Name
@@ -8341,7 +8341,7 @@ OS:Surface,
 
 OS:Surface,
   {c2a4007c-804b-40c7-b5ea-800f3c5f11ce}, !- Handle
-  Surface 483,                            !- Name
+  OpenOffice_Top_3 - Wall 270_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {cd57e5c2-5023-4058-b2a8-752285324e5c}, !- Space Name
@@ -8363,8 +8363,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  7.21911419532262e-016,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   7.9248,                                 !- Z Origin {m}
   {34c2b3a4-b93e-443b-9867-ce24d7c61c21}, !- Building Story Name
   {1ce45898-8a87-4247-875d-8b2234ad4cd1}, !- Thermal Zone Name
@@ -8374,7 +8374,7 @@ OS:Space,
 
 OS:Surface,
   {a4a8ef25-0d55-4b9d-a5a6-4411a3d07617}, !- Handle
-  Surface 484,                            !- Name
+  EnclosedOffice_Top_2 - Floor_a,         !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {9a8fdf16-17b3-4e90-9f33-f4e710f4b4af}, !- Space Name
@@ -8391,7 +8391,7 @@ OS:Surface,
 
 OS:Surface,
   {b077d97e-9c8a-4261-9da8-c1a47d93f40a}, !- Handle
-  Surface 485,                            !- Name
+  EnclosedOffice_Top_2 - Wall 000_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {9a8fdf16-17b3-4e90-9f33-f4e710f4b4af}, !- Space Name
@@ -8408,7 +8408,7 @@ OS:Surface,
 
 OS:Surface,
   {f4044ebb-ceff-4513-b7b8-b00275cf59e0}, !- Handle
-  Surface 486,                            !- Name
+  EnclosedOffice_Top_2 - RoofCeiling_a,   !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {9a8fdf16-17b3-4e90-9f33-f4e710f4b4af}, !- Space Name
@@ -8425,7 +8425,7 @@ OS:Surface,
 
 OS:Surface,
   {92bd749b-a0f8-4c85-9dd8-2a3845c85a89}, !- Handle
-  Surface 487,                            !- Name
+  EnclosedOffice_Top_2 - Wall 090_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {9a8fdf16-17b3-4e90-9f33-f4e710f4b4af}, !- Space Name
@@ -8442,7 +8442,7 @@ OS:Surface,
 
 OS:Surface,
   {d82e57dc-fa0c-419c-b046-51f8e23fee27}, !- Handle
-  Surface 488,                            !- Name
+  EnclosedOffice_Top_2 - Wall 270_b,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {9a8fdf16-17b3-4e90-9f33-f4e710f4b4af}, !- Space Name
@@ -8459,7 +8459,7 @@ OS:Surface,
 
 OS:Surface,
   {d32a2fbc-0fac-4bb4-a6a4-8e894d9097a5}, !- Handle
-  Surface 489,                            !- Name
+  EnclosedOffice_Top_2 - Wall 180_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {9a8fdf16-17b3-4e90-9f33-f4e710f4b4af}, !- Space Name
@@ -8476,7 +8476,7 @@ OS:Surface,
 
 OS:Surface,
   {5e54d1de-060c-4e8c-949e-4dbb88ce2cd5}, !- Handle
-  Surface 490,                            !- Name
+  EnclosedOffice_Top_2 - Wall 270_c,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {9a8fdf16-17b3-4e90-9f33-f4e710f4b4af}, !- Space Name
@@ -8493,7 +8493,7 @@ OS:Surface,
 
 OS:Surface,
   {d0e7d1e0-3e4d-4660-bb2f-f2d6b349b183}, !- Handle
-  Surface 491,                            !- Name
+  EnclosedOffice_Top_2 - Wall 270_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {9a8fdf16-17b3-4e90-9f33-f4e710f4b4af}, !- Space Name
@@ -8515,8 +8515,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  7.21911419532262e-016,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   7.9248,                                 !- Z Origin {m}
   {34c2b3a4-b93e-443b-9867-ce24d7c61c21}, !- Building Story Name
   {a1add966-6ea6-4014-95f8-f7eea197b91c}, !- Thermal Zone Name
@@ -8526,7 +8526,7 @@ OS:Space,
 
 OS:Surface,
   {c4234dbd-9126-4443-8a52-0694d7547d60}, !- Handle
-  Surface 492,                            !- Name
+  Stair_Top_1 - Floor_a,                  !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {f30b4347-26f3-4bab-9859-c9e3ec113927}, !- Space Name
@@ -8543,7 +8543,7 @@ OS:Surface,
 
 OS:Surface,
   {8026faba-7f82-4141-9fee-7969c64fe35f}, !- Handle
-  Surface 493,                            !- Name
+  Stair_Top_1 - RoofCeiling_a,            !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {f30b4347-26f3-4bab-9859-c9e3ec113927}, !- Space Name
@@ -8560,7 +8560,7 @@ OS:Surface,
 
 OS:Surface,
   {1869b770-8ade-4539-8dc3-5f37d7ce1189}, !- Handle
-  Surface 494,                            !- Name
+  Stair_Top_1 - Wall 180_a,               !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f30b4347-26f3-4bab-9859-c9e3ec113927}, !- Space Name
@@ -8577,7 +8577,7 @@ OS:Surface,
 
 OS:Surface,
   {7907f205-f202-4271-bc71-c988cc039c35}, !- Handle
-  Surface 495,                            !- Name
+  Stair_Top_1 - Wall 270_a,               !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f30b4347-26f3-4bab-9859-c9e3ec113927}, !- Space Name
@@ -8594,7 +8594,7 @@ OS:Surface,
 
 OS:Surface,
   {de2adcf9-01e2-41bd-9f3f-5616e147bc92}, !- Handle
-  Surface 496,                            !- Name
+  Stair_Top_1 - Wall 090_a,               !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f30b4347-26f3-4bab-9859-c9e3ec113927}, !- Space Name
@@ -8611,7 +8611,7 @@ OS:Surface,
 
 OS:Surface,
   {f32893e1-e9ef-4f04-99e0-4fc5f739c979}, !- Handle
-  Surface 497,                            !- Name
+  Stair_Top_1 - Wall 000_a,               !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f30b4347-26f3-4bab-9859-c9e3ec113927}, !- Space Name
@@ -8633,8 +8633,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  7.21911419532262e-016,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   7.9248,                                 !- Z Origin {m}
   {34c2b3a4-b93e-443b-9867-ce24d7c61c21}, !- Building Story Name
   {8ead2b82-5479-452a-ae97-540bbed210f8}, !- Thermal Zone Name
@@ -8644,7 +8644,7 @@ OS:Space,
 
 OS:Surface,
   {28e01bac-bd7b-4f2c-935e-94fc93aa20f5}, !- Handle
-  Surface 498,                            !- Name
+  OpenOffice_Top_4 - Wall 270_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {2c570dca-0fd4-41ad-8bd7-f645979bf614}, !- Space Name
@@ -8654,14 +8654,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  8.0692625, 5.34193749999998, 2.7432,    !- X,Y,Z Vertex 1 {m}
-  8.0692625, 5.34193749999998, 0,         !- X,Y,Z Vertex 2 {m}
+  8.0692625, 5.3419375, 2.7432,           !- X,Y,Z Vertex 1 {m}
+  8.0692625, 5.3419375, 0,                !- X,Y,Z Vertex 2 {m}
   8.0692625, 0, 0,                        !- X,Y,Z Vertex 3 {m}
   8.0692625, 0, 2.7432;                   !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {4be46ab5-a4d5-4786-ab71-d82d8578bd7f}, !- Handle
-  Surface 499,                            !- Name
+  OpenOffice_Top_4 - Wall 090_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {2c570dca-0fd4-41ad-8bd7-f645979bf614}, !- Space Name
@@ -8673,12 +8673,12 @@ OS:Surface,
   ,                                       !- Number of Vertices
   41.8417375, 0, 2.7432,                  !- X,Y,Z Vertex 1 {m}
   41.8417375, 0, 0,                       !- X,Y,Z Vertex 2 {m}
-  41.8417375, 5.34193749999998, 0,        !- X,Y,Z Vertex 3 {m}
-  41.8417375, 5.34193749999998, 2.7432;   !- X,Y,Z Vertex 4 {m}
+  41.8417375, 5.3419375, 0,               !- X,Y,Z Vertex 3 {m}
+  41.8417375, 5.3419375, 2.7432;          !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {201a37ea-f8ed-42fb-9b65-f07245801d17}, !- Handle
-  Surface 500,                            !- Name
+  OpenOffice_Top_4 - Wall 180_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {2c570dca-0fd4-41ad-8bd7-f645979bf614}, !- Space Name
@@ -8695,7 +8695,7 @@ OS:Surface,
 
 OS:Surface,
   {e8fec8d9-a74a-4177-a1c2-a3c97d67bf03}, !- Handle
-  Surface 501,                            !- Name
+  OpenOffice_Top_4 - RoofCeiling_a,       !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {2c570dca-0fd4-41ad-8bd7-f645979bf614}, !- Space Name
@@ -8706,13 +8706,13 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   41.8417375, 0, 2.7432,                  !- X,Y,Z Vertex 1 {m}
-  41.8417375, 5.34193749999998, 2.7432,   !- X,Y,Z Vertex 2 {m}
-  8.0692625, 5.34193749999998, 2.7432,    !- X,Y,Z Vertex 3 {m}
+  41.8417375, 5.3419375, 2.7432,          !- X,Y,Z Vertex 2 {m}
+  8.0692625, 5.3419375, 2.7432,           !- X,Y,Z Vertex 3 {m}
   8.0692625, 0, 2.7432;                   !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {52e9d5da-0644-4492-b567-69362441a487}, !- Handle
-  Surface 502,                            !- Name
+  OpenOffice_Top_4 - Wall 0_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {2c570dca-0fd4-41ad-8bd7-f645979bf614}, !- Space Name
@@ -8724,12 +8724,12 @@ OS:Surface,
   ,                                       !- Number of Vertices
   16.5735, 5.3419375, 2.7432,             !- X,Y,Z Vertex 1 {m}
   16.5735, 5.3419375, 0,                  !- X,Y,Z Vertex 2 {m}
-  8.0692625, 5.34193749999998, 0,         !- X,Y,Z Vertex 3 {m}
-  8.0692625, 5.34193749999998, 2.7432;    !- X,Y,Z Vertex 4 {m}
+  8.0692625, 5.3419375, 0,                !- X,Y,Z Vertex 3 {m}
+  8.0692625, 5.3419375, 2.7432;           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {af6c7172-6e84-4c02-bec5-561668aae843}, !- Handle
-  Surface 503,                            !- Name
+  OpenOffice_Top_4 - Wall 000_b,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {2c570dca-0fd4-41ad-8bd7-f645979bf614}, !- Space Name
@@ -8739,14 +8739,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  41.8417375, 5.34193749999998, 2.7432,   !- X,Y,Z Vertex 1 {m}
-  41.8417375, 5.34193749999998, 0,        !- X,Y,Z Vertex 2 {m}
+  41.8417375, 5.3419375, 2.7432,          !- X,Y,Z Vertex 1 {m}
+  41.8417375, 5.3419375, 0,               !- X,Y,Z Vertex 2 {m}
   33.3375, 5.3419375, 0,                  !- X,Y,Z Vertex 3 {m}
   33.3375, 5.3419375, 2.7432;             !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {fac9b4c0-ef0d-44f6-b2d1-6badd33c9ff9}, !- Handle
-  Surface 504,                            !- Name
+  OpenOffice_Top_4 - Wall 000_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {2c570dca-0fd4-41ad-8bd7-f645979bf614}, !- Space Name
@@ -8763,7 +8763,7 @@ OS:Surface,
 
 OS:Surface,
   {4c8fd388-921d-4d35-a1f2-7c3caeb5cd57}, !- Handle
-  Surface 505,                            !- Name
+  OpenOffice_Top_4 - Floor_a,             !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {2c570dca-0fd4-41ad-8bd7-f645979bf614}, !- Space Name
@@ -8773,10 +8773,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  41.8417375, 5.34193749999998, 0,        !- X,Y,Z Vertex 1 {m}
+  41.8417375, 5.3419375, 0,               !- X,Y,Z Vertex 1 {m}
   41.8417375, 0, 0,                       !- X,Y,Z Vertex 2 {m}
   8.0692625, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  8.0692625, 5.34193749999998, 0;         !- X,Y,Z Vertex 4 {m}
+  8.0692625, 5.3419375, 0;                !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {d259cafd-e505-4a7c-9fd3-92dde1140f3b}, !- Handle
@@ -8785,8 +8785,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  7.21911419532262e-016,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   7.9248,                                 !- Z Origin {m}
   {34c2b3a4-b93e-443b-9867-ce24d7c61c21}, !- Building Story Name
   {a752b066-febb-43d6-8ce7-a33016318c0b}, !- Thermal Zone Name
@@ -8796,7 +8796,7 @@ OS:Space,
 
 OS:Surface,
   {372c7b69-f3b6-4d62-9eed-f72c3840d150}, !- Handle
-  Surface 506,                            !- Name
+  Mechanical_Top - Wall 270_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d259cafd-e505-4a7c-9fd3-92dde1140f3b}, !- Space Name
@@ -8813,7 +8813,7 @@ OS:Surface,
 
 OS:Surface,
   {9342cbfb-0ca3-42dc-ac2e-24bbfbbe706f}, !- Handle
-  Surface 507,                            !- Name
+  Mechanical_Top - Wall 090_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d259cafd-e505-4a7c-9fd3-92dde1140f3b}, !- Space Name
@@ -8830,7 +8830,7 @@ OS:Surface,
 
 OS:Surface,
   {26d961ec-4398-480d-81d5-31fd87c80c75}, !- Handle
-  Surface 508,                            !- Name
+  Mechanical_Top - Wall 180_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d259cafd-e505-4a7c-9fd3-92dde1140f3b}, !- Space Name
@@ -8847,7 +8847,7 @@ OS:Surface,
 
 OS:Surface,
   {3ae9a62b-b68c-433b-ab05-19521fab75c6}, !- Handle
-  Surface 509,                            !- Name
+  Mechanical_Top - Floor_a,               !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {d259cafd-e505-4a7c-9fd3-92dde1140f3b}, !- Space Name
@@ -8864,7 +8864,7 @@ OS:Surface,
 
 OS:Surface,
   {fe4632ff-93bd-4f26-8c63-acec482cec5c}, !- Handle
-  Surface 510,                            !- Name
+  Mechanical_Top - Wall 000_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d259cafd-e505-4a7c-9fd3-92dde1140f3b}, !- Space Name
@@ -8881,7 +8881,7 @@ OS:Surface,
 
 OS:Surface,
   {90cf54a6-2b82-4d57-b088-32a2d1bdc7cd}, !- Handle
-  Surface 511,                            !- Name
+  Mechanical_Top - RoofCeiling_a,         !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {d259cafd-e505-4a7c-9fd3-92dde1140f3b}, !- Space Name
@@ -8903,8 +8903,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  7.21911419532262e-016,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   7.9248,                                 !- Z Origin {m}
   {34c2b3a4-b93e-443b-9867-ce24d7c61c21}, !- Building Story Name
   {5d45a573-f58e-4d13-be4b-0a4f4540251e}, !- Thermal Zone Name
@@ -8914,7 +8914,7 @@ OS:Space,
 
 OS:Surface,
   {9553c862-a57e-458a-be6f-f7a5c098dc65}, !- Handle
-  Surface 512,                            !- Name
+  ActiveStorage_Top_4 - Floor_a,          !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {e5b9b64e-a463-490d-aace-ded47cbf2d97}, !- Space Name
@@ -8931,7 +8931,7 @@ OS:Surface,
 
 OS:Surface,
   {e5ab432b-8d38-44e4-82f6-6f29ad2b7e3e}, !- Handle
-  Surface 513,                            !- Name
+  ActiveStorage_Top_4 - Wall 090_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e5b9b64e-a463-490d-aace-ded47cbf2d97}, !- Space Name
@@ -8948,7 +8948,7 @@ OS:Surface,
 
 OS:Surface,
   {662f91e2-d8d2-4ff8-8171-91f0dc84a77a}, !- Handle
-  Surface 514,                            !- Name
+  ActiveStorage_Top_4 - Wall 180_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e5b9b64e-a463-490d-aace-ded47cbf2d97}, !- Space Name
@@ -8965,7 +8965,7 @@ OS:Surface,
 
 OS:Surface,
   {ed3d7ef5-f621-4188-aad5-659f7c2169a5}, !- Handle
-  Surface 515,                            !- Name
+  ActiveStorage_Top_4 - Wall 270_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e5b9b64e-a463-490d-aace-ded47cbf2d97}, !- Space Name
@@ -8982,7 +8982,7 @@ OS:Surface,
 
 OS:Surface,
   {f83eaf56-1007-4d3a-87da-f5bd1a6ea6c7}, !- Handle
-  Surface 516,                            !- Name
+  ActiveStorage_Top_4 - Wall 000_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e5b9b64e-a463-490d-aace-ded47cbf2d97}, !- Space Name
@@ -8999,7 +8999,7 @@ OS:Surface,
 
 OS:Surface,
   {6ce08d29-9d0e-48b5-ab65-63b63b5483f3}, !- Handle
-  Surface 517,                            !- Name
+  ActiveStorage_Top_4 - RoofCeiling_a,    !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {e5b9b64e-a463-490d-aace-ded47cbf2d97}, !- Space Name
@@ -9016,7 +9016,7 @@ OS:Surface,
 
 OS:Surface,
   {ed83b7b3-425c-4c64-8e58-609c4b37dabf}, !- Handle
-  Surface 518,                            !- Name
+  ActiveStorage_Top_4 - Wall 180_b,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e5b9b64e-a463-490d-aace-ded47cbf2d97}, !- Space Name
@@ -9038,8 +9038,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  7.21911419532262e-016,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   7.9248,                                 !- Z Origin {m}
   {34c2b3a4-b93e-443b-9867-ce24d7c61c21}, !- Building Story Name
   {020322ec-6c5c-48ec-b5df-b99f6ad2cca5}, !- Thermal Zone Name
@@ -9049,7 +9049,7 @@ OS:Space,
 
 OS:Surface,
   {b24289ab-7566-494c-be40-8fd0feb2f146}, !- Handle
-  Surface 519,                            !- Name
+  Lobby_Top - Wall 270_b,                 !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3ec26761-c667-4167-89c1-197f22b958f4}, !- Space Name
@@ -9059,14 +9059,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 22.234525, 2.74319999999999,   !- X,Y,Z Vertex 1 {m}
+  23.4315, 22.234525, 2.7432,             !- X,Y,Z Vertex 1 {m}
   23.4315, 22.234525, 0,                  !- X,Y,Z Vertex 2 {m}
   23.4315, 11.0410625, 0,                 !- X,Y,Z Vertex 3 {m}
-  23.4315, 11.0410625, 2.74319999999999;  !- X,Y,Z Vertex 4 {m}
+  23.4315, 11.0410625, 2.7432;            !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {113dbbc5-d8b3-46d7-b427-2c152f53393e}, !- Handle
-  Surface 520,                            !- Name
+  Lobby_Top - Wall 090_c,                 !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3ec26761-c667-4167-89c1-197f22b958f4}, !- Space Name
@@ -9076,14 +9076,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  26.4795, 6.5611375, 2.74319999999999,   !- X,Y,Z Vertex 1 {m}
+  26.4795, 6.5611375, 2.7432,             !- X,Y,Z Vertex 1 {m}
   26.4795, 6.5611375, 0,                  !- X,Y,Z Vertex 2 {m}
   26.4795, 11.0410625, 0,                 !- X,Y,Z Vertex 3 {m}
-  26.4795, 11.0410625, 2.74319999999999;  !- X,Y,Z Vertex 4 {m}
+  26.4795, 11.0410625, 2.7432;            !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {36bd1ecd-632a-41e4-ac74-331d85be41f8}, !- Handle
-  Surface 521,                            !- Name
+  Lobby_Top - Wall 090_b,                 !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3ec26761-c667-4167-89c1-197f22b958f4}, !- Space Name
@@ -9093,14 +9093,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  26.4795, 11.0410625, 2.74319999999999,  !- X,Y,Z Vertex 1 {m}
+  26.4795, 11.0410625, 2.7432,            !- X,Y,Z Vertex 1 {m}
   26.4795, 11.0410625, 0,                 !- X,Y,Z Vertex 2 {m}
   26.4795, 22.234525, 0,                  !- X,Y,Z Vertex 3 {m}
-  26.4795, 22.234525, 2.74319999999999;   !- X,Y,Z Vertex 4 {m}
+  26.4795, 22.234525, 2.7432;             !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {7dc13738-a352-4962-b955-5f70acaf4d4f}, !- Handle
-  Surface 522,                            !- Name
+  Lobby_Top - Floor_a,                    !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {3ec26761-c667-4167-89c1-197f22b958f4}, !- Space Name
@@ -9117,7 +9117,7 @@ OS:Surface,
 
 OS:Surface,
   {c4c3e5d5-3fe1-49f5-bed2-1d73531bf661}, !- Handle
-  Surface 523,                            !- Name
+  Lobby_Top - RoofCeiling_a,              !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {3ec26761-c667-4167-89c1-197f22b958f4}, !- Space Name
@@ -9127,14 +9127,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  26.4795, 6.5611375, 2.74319999999999,   !- X,Y,Z Vertex 1 {m}
-  26.4795, 26.71445, 2.74319999999999,    !- X,Y,Z Vertex 2 {m}
-  23.4315, 26.71445, 2.74319999999999,    !- X,Y,Z Vertex 3 {m}
-  23.4315, 6.5611375, 2.74319999999999;   !- X,Y,Z Vertex 4 {m}
+  26.4795, 6.5611375, 2.7432,             !- X,Y,Z Vertex 1 {m}
+  26.4795, 26.71445, 2.7432,              !- X,Y,Z Vertex 2 {m}
+  23.4315, 26.71445, 2.7432,              !- X,Y,Z Vertex 3 {m}
+  23.4315, 6.5611375, 2.7432;             !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {a14b015d-2fb1-4d83-97f1-0324da95d7a4}, !- Handle
-  Surface 524,                            !- Name
+  Lobby_Top - Wall 180_a,                 !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3ec26761-c667-4167-89c1-197f22b958f4}, !- Space Name
@@ -9144,14 +9144,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 6.5611375, 2.74319999999999,   !- X,Y,Z Vertex 1 {m}
+  23.4315, 6.5611375, 2.7432,             !- X,Y,Z Vertex 1 {m}
   23.4315, 6.5611375, 0,                  !- X,Y,Z Vertex 2 {m}
   26.4795, 6.5611375, 0,                  !- X,Y,Z Vertex 3 {m}
-  26.4795, 6.5611375, 2.74319999999999;   !- X,Y,Z Vertex 4 {m}
+  26.4795, 6.5611375, 2.7432;             !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {68dcf7b9-19ef-4d35-b093-e14f7edea749}, !- Handle
-  Surface 525,                            !- Name
+  Lobby_Top - Wall 270_c,                 !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3ec26761-c667-4167-89c1-197f22b958f4}, !- Space Name
@@ -9161,14 +9161,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 26.71445, 2.74319999999999,    !- X,Y,Z Vertex 1 {m}
+  23.4315, 26.71445, 2.7432,              !- X,Y,Z Vertex 1 {m}
   23.4315, 26.71445, 0,                   !- X,Y,Z Vertex 2 {m}
   23.4315, 22.234525, 0,                  !- X,Y,Z Vertex 3 {m}
-  23.4315, 22.234525, 2.74319999999999;   !- X,Y,Z Vertex 4 {m}
+  23.4315, 22.234525, 2.7432;             !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {c83dfe71-e51a-4233-8311-627becb22c27}, !- Handle
-  Surface 526,                            !- Name
+  Lobby_Top - Wall 000_a,                 !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3ec26761-c667-4167-89c1-197f22b958f4}, !- Space Name
@@ -9178,14 +9178,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  26.4795, 26.71445, 2.74319999999999,    !- X,Y,Z Vertex 1 {m}
+  26.4795, 26.71445, 2.7432,              !- X,Y,Z Vertex 1 {m}
   26.4795, 26.71445, 0,                   !- X,Y,Z Vertex 2 {m}
   23.4315, 26.71445, 0,                   !- X,Y,Z Vertex 3 {m}
-  23.4315, 26.71445, 2.74319999999999;    !- X,Y,Z Vertex 4 {m}
+  23.4315, 26.71445, 2.7432;              !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {bf6edb97-47d4-4614-9e5d-ce8564bdc413}, !- Handle
-  Surface 527,                            !- Name
+  Lobby_Top - Wall 090_a,                 !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3ec26761-c667-4167-89c1-197f22b958f4}, !- Space Name
@@ -9195,14 +9195,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  26.4795, 22.234525, 2.74319999999999,   !- X,Y,Z Vertex 1 {m}
+  26.4795, 22.234525, 2.7432,             !- X,Y,Z Vertex 1 {m}
   26.4795, 22.234525, 0,                  !- X,Y,Z Vertex 2 {m}
   26.4795, 26.71445, 0,                   !- X,Y,Z Vertex 3 {m}
-  26.4795, 26.71445, 2.74319999999999;    !- X,Y,Z Vertex 4 {m}
+  26.4795, 26.71445, 2.7432;              !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {cefd0999-1c41-4340-9f9c-4cc0c6a3782f}, !- Handle
-  Surface 528,                            !- Name
+  Lobby_Top - Wall 270_a,                 !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3ec26761-c667-4167-89c1-197f22b958f4}, !- Space Name
@@ -9212,10 +9212,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 11.0410625, 2.74319999999999,  !- X,Y,Z Vertex 1 {m}
+  23.4315, 11.0410625, 2.7432,            !- X,Y,Z Vertex 1 {m}
   23.4315, 11.0410625, 0,                 !- X,Y,Z Vertex 2 {m}
   23.4315, 6.5611375, 0,                  !- X,Y,Z Vertex 3 {m}
-  23.4315, 6.5611375, 2.74319999999999;   !- X,Y,Z Vertex 4 {m}
+  23.4315, 6.5611375, 2.7432;             !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {253908e5-6fa9-4d28-aa23-cf9123080b33}, !- Handle
@@ -9224,8 +9224,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  7.21911419532262e-016,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   7.9248,                                 !- Z Origin {m}
   {34c2b3a4-b93e-443b-9867-ce24d7c61c21}, !- Building Story Name
   {e5aaa50b-0c4f-4b64-9f0f-68e37b10c8e6}, !- Thermal Zone Name
@@ -9235,7 +9235,7 @@ OS:Space,
 
 OS:Surface,
   {2ee0a8f7-031b-4e64-9b0b-3548feac6365}, !- Handle
-  Surface 529,                            !- Name
+  Dining_Top - Floor_a,                   !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {253908e5-6fa9-4d28-aa23-cf9123080b33}, !- Space Name
@@ -9252,7 +9252,7 @@ OS:Surface,
 
 OS:Surface,
   {0b13002b-1ab4-44f9-9695-f3d57c1dc533}, !- Handle
-  Surface 530,                            !- Name
+  Dining_Top - RoofCeiling_a,             !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {253908e5-6fa9-4d28-aa23-cf9123080b33}, !- Space Name
@@ -9262,14 +9262,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 22.234525, 2.74319999999999,   !- X,Y,Z Vertex 1 {m}
-  23.4315, 26.71445, 2.74319999999999,    !- X,Y,Z Vertex 2 {m}
-  18.310225, 26.71445, 2.74319999999999,  !- X,Y,Z Vertex 3 {m}
-  18.310225, 22.234525, 2.74319999999999; !- X,Y,Z Vertex 4 {m}
+  23.4315, 22.234525, 2.7432,             !- X,Y,Z Vertex 1 {m}
+  23.4315, 26.71445, 2.7432,              !- X,Y,Z Vertex 2 {m}
+  18.310225, 26.71445, 2.7432,            !- X,Y,Z Vertex 3 {m}
+  18.310225, 22.234525, 2.7432;           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {31db377a-3ed4-44b7-af06-1237ec0bc296}, !- Handle
-  Surface 531,                            !- Name
+  Dining_Top - Wall 000_a,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {253908e5-6fa9-4d28-aa23-cf9123080b33}, !- Space Name
@@ -9279,14 +9279,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 26.71445, 2.74319999999999,    !- X,Y,Z Vertex 1 {m}
+  23.4315, 26.71445, 2.7432,              !- X,Y,Z Vertex 1 {m}
   23.4315, 26.71445, 0,                   !- X,Y,Z Vertex 2 {m}
   18.310225, 26.71445, 0,                 !- X,Y,Z Vertex 3 {m}
-  18.310225, 26.71445, 2.74319999999999;  !- X,Y,Z Vertex 4 {m}
+  18.310225, 26.71445, 2.7432;            !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {f6ff6b3a-1666-4ef1-b71c-dfad4bf16652}, !- Handle
-  Surface 532,                            !- Name
+  Dining_Top - Wall 270_a,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {253908e5-6fa9-4d28-aa23-cf9123080b33}, !- Space Name
@@ -9296,14 +9296,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  18.310225, 26.71445, 2.74319999999999,  !- X,Y,Z Vertex 1 {m}
+  18.310225, 26.71445, 2.7432,            !- X,Y,Z Vertex 1 {m}
   18.310225, 26.71445, 0,                 !- X,Y,Z Vertex 2 {m}
   18.310225, 22.234525, 0,                !- X,Y,Z Vertex 3 {m}
-  18.310225, 22.234525, 2.74319999999999; !- X,Y,Z Vertex 4 {m}
+  18.310225, 22.234525, 2.7432;           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {3127f17f-ae40-4109-ad58-05367a0870e2}, !- Handle
-  Surface 533,                            !- Name
+  Dining_Top - Wall 180_a,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {253908e5-6fa9-4d28-aa23-cf9123080b33}, !- Space Name
@@ -9313,14 +9313,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  18.310225, 22.234525, 2.74319999999999, !- X,Y,Z Vertex 1 {m}
+  18.310225, 22.234525, 2.7432,           !- X,Y,Z Vertex 1 {m}
   18.310225, 22.234525, 0,                !- X,Y,Z Vertex 2 {m}
   23.4315, 22.234525, 0,                  !- X,Y,Z Vertex 3 {m}
-  23.4315, 22.234525, 2.74319999999999;   !- X,Y,Z Vertex 4 {m}
+  23.4315, 22.234525, 2.7432;             !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {7052584a-13df-4b38-8257-6d011ed9255c}, !- Handle
-  Surface 534,                            !- Name
+  Dining_Top - Wall 090_a,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {253908e5-6fa9-4d28-aa23-cf9123080b33}, !- Space Name
@@ -9330,10 +9330,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 22.234525, 2.74319999999999,   !- X,Y,Z Vertex 1 {m}
+  23.4315, 22.234525, 2.7432,             !- X,Y,Z Vertex 1 {m}
   23.4315, 22.234525, 0,                  !- X,Y,Z Vertex 2 {m}
   23.4315, 26.71445, 0,                   !- X,Y,Z Vertex 3 {m}
-  23.4315, 26.71445, 2.74319999999999;    !- X,Y,Z Vertex 4 {m}
+  23.4315, 26.71445, 2.7432;              !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {c078e3bf-4616-455a-910d-4eb58ddc485b}, !- Handle
@@ -9342,8 +9342,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  7.21911419532262e-016,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   7.9248,                                 !- Z Origin {m}
   {34c2b3a4-b93e-443b-9867-ce24d7c61c21}, !- Building Story Name
   {54cfb823-762b-47e6-8778-e96443e8f870}, !- Thermal Zone Name
@@ -9353,7 +9353,7 @@ OS:Space,
 
 OS:Surface,
   {063d7d54-13a8-4440-afc7-11cf88a6f957}, !- Handle
-  Surface 535,                            !- Name
+  Restroom_Top - Wall 000_a,              !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c078e3bf-4616-455a-910d-4eb58ddc485b}, !- Space Name
@@ -9363,14 +9363,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 22.234525, 2.74319999999999,   !- X,Y,Z Vertex 1 {m}
+  23.4315, 22.234525, 2.7432,             !- X,Y,Z Vertex 1 {m}
   23.4315, 22.234525, 0,                  !- X,Y,Z Vertex 2 {m}
   18.310225, 22.234525, 0,                !- X,Y,Z Vertex 3 {m}
-  18.310225, 22.234525, 2.74319999999999; !- X,Y,Z Vertex 4 {m}
+  18.310225, 22.234525, 2.7432;           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {0c8a6f03-5551-45cc-a4ee-ef35a0936616}, !- Handle
-  Surface 536,                            !- Name
+  Restroom_Top - Floor_a,                 !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {c078e3bf-4616-455a-910d-4eb58ddc485b}, !- Space Name
@@ -9387,7 +9387,7 @@ OS:Surface,
 
 OS:Surface,
   {5e529cac-8c2c-4bb6-aac1-1395802c78db}, !- Handle
-  Surface 537,                            !- Name
+  Restroom_Top - Wall 090_a,              !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c078e3bf-4616-455a-910d-4eb58ddc485b}, !- Space Name
@@ -9397,14 +9397,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 11.0410625, 2.74319999999999,  !- X,Y,Z Vertex 1 {m}
+  23.4315, 11.0410625, 2.7432,            !- X,Y,Z Vertex 1 {m}
   23.4315, 11.0410625, 0,                 !- X,Y,Z Vertex 2 {m}
   23.4315, 22.234525, 0,                  !- X,Y,Z Vertex 3 {m}
-  23.4315, 22.234525, 2.74319999999999;   !- X,Y,Z Vertex 4 {m}
+  23.4315, 22.234525, 2.7432;             !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {f3860240-9d00-49b3-8828-5ff508201c3f}, !- Handle
-  Surface 538,                            !- Name
+  Restroom_Top - RoofCeiling_a,           !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {c078e3bf-4616-455a-910d-4eb58ddc485b}, !- Space Name
@@ -9414,14 +9414,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 11.0410625, 2.74319999999999,  !- X,Y,Z Vertex 1 {m}
-  23.4315, 22.234525, 2.74319999999999,   !- X,Y,Z Vertex 2 {m}
-  18.0975, 22.234525, 2.74319999999999,   !- X,Y,Z Vertex 3 {m}
-  18.0975, 11.0410625, 2.74319999999999;  !- X,Y,Z Vertex 4 {m}
+  23.4315, 11.0410625, 2.7432,            !- X,Y,Z Vertex 1 {m}
+  23.4315, 22.234525, 2.7432,             !- X,Y,Z Vertex 2 {m}
+  18.0975, 22.234525, 2.7432,             !- X,Y,Z Vertex 3 {m}
+  18.0975, 11.0410625, 2.7432;            !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {a65e549c-7a92-482e-8d8f-adc73f9b5ddd}, !- Handle
-  Surface 539,                            !- Name
+  Restroom_Top - Wall 180_a,              !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c078e3bf-4616-455a-910d-4eb58ddc485b}, !- Space Name
@@ -9431,14 +9431,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  18.0975, 11.0410625, 2.74319999999999,  !- X,Y,Z Vertex 1 {m}
+  18.0975, 11.0410625, 2.7432,            !- X,Y,Z Vertex 1 {m}
   18.0975, 11.0410625, 0,                 !- X,Y,Z Vertex 2 {m}
   23.4315, 11.0410625, 0,                 !- X,Y,Z Vertex 3 {m}
-  23.4315, 11.0410625, 2.74319999999999;  !- X,Y,Z Vertex 4 {m}
+  23.4315, 11.0410625, 2.7432;            !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {5c392262-6df6-43c8-ba57-ab0e8baf72cd}, !- Handle
-  Surface 540,                            !- Name
+  Restroom_Top - Wall 000_b,              !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c078e3bf-4616-455a-910d-4eb58ddc485b}, !- Space Name
@@ -9448,14 +9448,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  18.310225, 22.234525, 2.74319999999999, !- X,Y,Z Vertex 1 {m}
+  18.310225, 22.234525, 2.7432,           !- X,Y,Z Vertex 1 {m}
   18.310225, 22.234525, 0,                !- X,Y,Z Vertex 2 {m}
   18.0975, 22.234525, 0,                  !- X,Y,Z Vertex 3 {m}
-  18.0975, 22.234525, 2.74319999999999;   !- X,Y,Z Vertex 4 {m}
+  18.0975, 22.234525, 2.7432;             !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {e6be93c6-a554-4444-9a99-5002c31ea0d8}, !- Handle
-  Surface 541,                            !- Name
+  Restroom_Top - Wall 270_a,              !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c078e3bf-4616-455a-910d-4eb58ddc485b}, !- Space Name
@@ -9465,10 +9465,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  18.0975, 22.234525, 2.74319999999999,   !- X,Y,Z Vertex 1 {m}
+  18.0975, 22.234525, 2.7432,             !- X,Y,Z Vertex 1 {m}
   18.0975, 22.234525, 0,                  !- X,Y,Z Vertex 2 {m}
   18.0975, 11.0410625, 0,                 !- X,Y,Z Vertex 3 {m}
-  18.0975, 11.0410625, 2.74319999999999;  !- X,Y,Z Vertex 4 {m}
+  18.0975, 11.0410625, 2.7432;            !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {532a76a3-a007-4347-afed-4f4aa3e41419}, !- Handle
@@ -9477,8 +9477,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  7.21911419532262e-016,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   7.9248,                                 !- Z Origin {m}
   {34c2b3a4-b93e-443b-9867-ce24d7c61c21}, !- Building Story Name
   {bf624746-7178-45e3-b173-e4653888d0fd}, !- Thermal Zone Name
@@ -9488,7 +9488,7 @@ OS:Space,
 
 OS:Surface,
   {e3aa26e4-aadd-47cf-948a-67324b20585c}, !- Handle
-  Surface 542,                            !- Name
+  ConfRoom_Top_2 - Wall 000_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {532a76a3-a007-4347-afed-4f4aa3e41419}, !- Space Name
@@ -9505,7 +9505,7 @@ OS:Surface,
 
 OS:Surface,
   {90779e80-b6ad-4509-bed1-fa9f5df04a48}, !- Handle
-  Surface 543,                            !- Name
+  ConfRoom_Top_2 - Floor_a,               !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {532a76a3-a007-4347-afed-4f4aa3e41419}, !- Space Name
@@ -9522,7 +9522,7 @@ OS:Surface,
 
 OS:Surface,
   {9507f26b-d73e-4583-bddd-201f0b648079}, !- Handle
-  Surface 544,                            !- Name
+  ConfRoom_Top_2 - RoofCeiling_a,         !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {532a76a3-a007-4347-afed-4f4aa3e41419}, !- Space Name
@@ -9539,7 +9539,7 @@ OS:Surface,
 
 OS:Surface,
   {5f3e099e-570d-4b77-8450-80cb1bc848cd}, !- Handle
-  Surface 545,                            !- Name
+  ConfRoom_Top_2 - Wall 270_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {532a76a3-a007-4347-afed-4f4aa3e41419}, !- Space Name
@@ -9556,7 +9556,7 @@ OS:Surface,
 
 OS:Surface,
   {e4674b9e-70bf-41f9-828b-87c7a218e496}, !- Handle
-  Surface 546,                            !- Name
+  ConfRoom_Top_2 - Wall 180_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {532a76a3-a007-4347-afed-4f4aa3e41419}, !- Space Name
@@ -9573,7 +9573,7 @@ OS:Surface,
 
 OS:Surface,
   {eafe3f27-66c9-4191-a48a-8ed4e697bd62}, !- Handle
-  Surface 547,                            !- Name
+  ConfRoom_Top_2 - Wall 000_b,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {532a76a3-a007-4347-afed-4f4aa3e41419}, !- Space Name
@@ -9595,8 +9595,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  7.21911419532262e-016,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   7.9248,                                 !- Z Origin {m}
   {34c2b3a4-b93e-443b-9867-ce24d7c61c21}, !- Building Story Name
   {2ec9e0b6-744b-4acf-82ff-75ba8fd8d44f}, !- Thermal Zone Name
@@ -9606,7 +9606,7 @@ OS:Space,
 
 OS:Surface,
   {578b1df3-4922-4e67-8839-15c1841d9e12}, !- Handle
-  Surface 549,                            !- Name
+  ActiveStorage_Top_3 - Wall 180_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {ed4c4f3d-97af-4aee-8dd1-e5c7e0c1156f}, !- Space Name
@@ -9623,7 +9623,7 @@ OS:Surface,
 
 OS:Surface,
   {7a8d9e88-1668-44d7-9ef9-469bd5c5a14e}, !- Handle
-  Surface 550,                            !- Name
+  ActiveStorage_Top_3 - Floor_a,          !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {ed4c4f3d-97af-4aee-8dd1-e5c7e0c1156f}, !- Space Name
@@ -9640,7 +9640,7 @@ OS:Surface,
 
 OS:Surface,
   {d002babc-bc34-42b7-ac75-6c3a89e05ae1}, !- Handle
-  Surface 551,                            !- Name
+  ActiveStorage_Top_3 - Wall 180_b,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {ed4c4f3d-97af-4aee-8dd1-e5c7e0c1156f}, !- Space Name
@@ -9657,7 +9657,7 @@ OS:Surface,
 
 OS:Surface,
   {1e64584d-c3f3-41a6-a3ae-8e0be3b8d26b}, !- Handle
-  Surface 552,                            !- Name
+  ActiveStorage_Top_3 - Wall 270_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {ed4c4f3d-97af-4aee-8dd1-e5c7e0c1156f}, !- Space Name
@@ -9674,7 +9674,7 @@ OS:Surface,
 
 OS:Surface,
   {0d40073a-b648-4d72-ba4d-77f6df381666}, !- Handle
-  Surface 553,                            !- Name
+  ActiveStorage_Top_3 - RoofCeiling_a,    !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {ed4c4f3d-97af-4aee-8dd1-e5c7e0c1156f}, !- Space Name
@@ -9691,7 +9691,7 @@ OS:Surface,
 
 OS:Surface,
   {a261eba1-cd92-44f7-aaa6-9452988b12fe}, !- Handle
-  Surface 554,                            !- Name
+  ActiveStorage_Top_3 - Wall 000_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {ed4c4f3d-97af-4aee-8dd1-e5c7e0c1156f}, !- Space Name
@@ -9708,7 +9708,7 @@ OS:Surface,
 
 OS:Surface,
   {62e4f4ea-9f50-4ede-adbd-2b59bbc86224}, !- Handle
-  Surface 555,                            !- Name
+  ActiveStorage_Top_3 - Wall 090_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {ed4c4f3d-97af-4aee-8dd1-e5c7e0c1156f}, !- Space Name
@@ -9730,8 +9730,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  7.21911419532262e-016,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   7.9248,                                 !- Z Origin {m}
   {34c2b3a4-b93e-443b-9867-ce24d7c61c21}, !- Building Story Name
   {8994d32d-4b2e-4b58-a451-e239a7a6cd26}, !- Thermal Zone Name
@@ -9741,7 +9741,7 @@ OS:Space,
 
 OS:Surface,
   {2f983573-ea91-4229-b74e-11c3b8114a9e}, !- Handle
-  Surface 556,                            !- Name
+  Stair_Top_2 - Floor_a,                  !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {415020a7-0ebc-479d-817d-7158b9d145ae}, !- Space Name
@@ -9758,7 +9758,7 @@ OS:Surface,
 
 OS:Surface,
   {5d1c1b23-7a87-48d6-8ad2-b82c69108f81}, !- Handle
-  Surface 557,                            !- Name
+  Stair_Top_2 - Wall 180_a,               !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {415020a7-0ebc-479d-817d-7158b9d145ae}, !- Space Name
@@ -9775,7 +9775,7 @@ OS:Surface,
 
 OS:Surface,
   {29156c50-3095-4d02-8686-fb36c00ad6c7}, !- Handle
-  Surface 558,                            !- Name
+  Stair_Top_2 - RoofCeiling_a,            !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {415020a7-0ebc-479d-817d-7158b9d145ae}, !- Space Name
@@ -9792,7 +9792,7 @@ OS:Surface,
 
 OS:Surface,
   {5f96bebc-fcce-47e6-9d4f-99efb05b6f5b}, !- Handle
-  Surface 559,                            !- Name
+  Stair_Top_2 - Wall 270_a,               !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {415020a7-0ebc-479d-817d-7158b9d145ae}, !- Space Name
@@ -9809,7 +9809,7 @@ OS:Surface,
 
 OS:Surface,
   {fa524c05-b7e6-4e8a-86e4-cd95b225feeb}, !- Handle
-  Surface 560,                            !- Name
+  Stair_Top_2 - Wall 000_a,               !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {415020a7-0ebc-479d-817d-7158b9d145ae}, !- Space Name
@@ -9826,7 +9826,7 @@ OS:Surface,
 
 OS:Surface,
   {b11a8329-1911-4f5b-8688-77ea6e56dd6b}, !- Handle
-  Surface 561,                            !- Name
+  Stair_Top_2 - Wall 090_a,               !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {415020a7-0ebc-479d-817d-7158b9d145ae}, !- Space Name
@@ -9848,8 +9848,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  7.21911419532262e-016,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   7.9248,                                 !- Z Origin {m}
   {34c2b3a4-b93e-443b-9867-ce24d7c61c21}, !- Building Story Name
   {c09d0857-b8ca-46fc-9eb8-5192fa1a16a7}, !- Thermal Zone Name
@@ -9859,7 +9859,7 @@ OS:Space,
 
 OS:Surface,
   {fe9cbea3-885e-4493-8bce-2b4a0da280d2}, !- Handle
-  Surface 562,                            !- Name
+  ActiveStorage_Top_2 - Wall 270_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e6819e9b-a5fa-4fba-9afa-e362ffb236e0}, !- Space Name
@@ -9876,7 +9876,7 @@ OS:Surface,
 
 OS:Surface,
   {f42ffa35-9903-48b3-8358-57c85c798dfc}, !- Handle
-  Surface 563,                            !- Name
+  ActiveStorage_Top_2 - Wall 000_b,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e6819e9b-a5fa-4fba-9afa-e362ffb236e0}, !- Space Name
@@ -9893,7 +9893,7 @@ OS:Surface,
 
 OS:Surface,
   {800f1369-839f-4fd9-83ea-6fbd969b7bce}, !- Handle
-  Surface 564,                            !- Name
+  ActiveStorage_Top_2 - Floor_a,          !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {e6819e9b-a5fa-4fba-9afa-e362ffb236e0}, !- Space Name
@@ -9910,7 +9910,7 @@ OS:Surface,
 
 OS:Surface,
   {50f108d8-f2a8-4793-980c-e1ff149e1d55}, !- Handle
-  Surface 565,                            !- Name
+  ActiveStorage_Top_2 - RoofCeiling_a,    !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {e6819e9b-a5fa-4fba-9afa-e362ffb236e0}, !- Space Name
@@ -9927,7 +9927,7 @@ OS:Surface,
 
 OS:Surface,
   {9ba38eb3-66ac-4af3-a3c4-d864be170974}, !- Handle
-  Surface 566,                            !- Name
+  ActiveStorage_Top_2 - Wall 180_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e6819e9b-a5fa-4fba-9afa-e362ffb236e0}, !- Space Name
@@ -9944,7 +9944,7 @@ OS:Surface,
 
 OS:Surface,
   {22781793-7e5e-4781-be45-96e641fe132b}, !- Handle
-  Surface 567,                            !- Name
+  ActiveStorage_Top_2 - Wall 090_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e6819e9b-a5fa-4fba-9afa-e362ffb236e0}, !- Space Name
@@ -9961,7 +9961,7 @@ OS:Surface,
 
 OS:Surface,
   {6af0b48f-b640-4119-b2b0-86d8611ebac5}, !- Handle
-  Surface 568,                            !- Name
+  ActiveStorage_Top_2 - Wall 000_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e6819e9b-a5fa-4fba-9afa-e362ffb236e0}, !- Space Name
@@ -9983,8 +9983,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  7.21911419532262e-016,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   7.9248,                                 !- Z Origin {m}
   {34c2b3a4-b93e-443b-9867-ce24d7c61c21}, !- Building Story Name
   {37181995-c697-4566-b686-e314123b3060}, !- Thermal Zone Name
@@ -9994,7 +9994,7 @@ OS:Space,
 
 OS:Surface,
   {80572af9-2659-4bfc-80d0-dd3f8f7f1cb0}, !- Handle
-  Surface 569,                            !- Name
+  OpenOffice_Top_2 - Wall 090_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {39644eab-0d0f-4e37-ba13-07a4b9cb84ca}, !- Space Name
@@ -10011,7 +10011,7 @@ OS:Surface,
 
 OS:Surface,
   {96efa079-8210-4b4f-ab0a-d941631a6ed3}, !- Handle
-  Surface 570,                            !- Name
+  OpenOffice_Top_2 - Wall 270_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {39644eab-0d0f-4e37-ba13-07a4b9cb84ca}, !- Space Name
@@ -10028,7 +10028,7 @@ OS:Surface,
 
 OS:Surface,
   {a617c7ef-4fb6-45e7-bb71-a73d31f949db}, !- Handle
-  Surface 571,                            !- Name
+  OpenOffice_Top_2 - Wall 270_b,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {39644eab-0d0f-4e37-ba13-07a4b9cb84ca}, !- Space Name
@@ -10045,7 +10045,7 @@ OS:Surface,
 
 OS:Surface,
   {47b41bc0-745c-433e-bea4-6b2bff532f92}, !- Handle
-  Surface 572,                            !- Name
+  OpenOffice_Top_2 - Floor_a,             !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {39644eab-0d0f-4e37-ba13-07a4b9cb84ca}, !- Space Name
@@ -10062,7 +10062,7 @@ OS:Surface,
 
 OS:Surface,
   {a3f8b734-371f-4eb6-8a87-563b5547a87b}, !- Handle
-  Surface 573,                            !- Name
+  OpenOffice_Top_2 - RoofCeiling_a,       !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {39644eab-0d0f-4e37-ba13-07a4b9cb84ca}, !- Space Name
@@ -10079,7 +10079,7 @@ OS:Surface,
 
 OS:Surface,
   {b5367eb0-6fff-4776-82d7-ec7f50d745cb}, !- Handle
-  Surface 574,                            !- Name
+  OpenOffice_Top_2 - Wall 180_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {39644eab-0d0f-4e37-ba13-07a4b9cb84ca}, !- Space Name
@@ -10096,7 +10096,7 @@ OS:Surface,
 
 OS:Surface,
   {47d1260f-bc81-409a-af87-e65a7a4cbcc3}, !- Handle
-  Surface 575,                            !- Name
+  OpenOffice_Top_2 - Wall 090_b,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {39644eab-0d0f-4e37-ba13-07a4b9cb84ca}, !- Space Name
@@ -10113,7 +10113,7 @@ OS:Surface,
 
 OS:Surface,
   {ac2bbc6b-3789-4493-99e9-ae9a00829934}, !- Handle
-  Surface 576,                            !- Name
+  OpenOffice_Top_2 - Wall 270_c,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {39644eab-0d0f-4e37-ba13-07a4b9cb84ca}, !- Space Name
@@ -10130,7 +10130,7 @@ OS:Surface,
 
 OS:Surface,
   {9704e587-e453-4be7-800a-481e944ad190}, !- Handle
-  Surface 577,                            !- Name
+  OpenOffice_Top_2 - Wall 000_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {39644eab-0d0f-4e37-ba13-07a4b9cb84ca}, !- Space Name
@@ -10152,8 +10152,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  7.21911419532262e-016,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   7.9248,                                 !- Z Origin {m}
   {34c2b3a4-b93e-443b-9867-ce24d7c61c21}, !- Building Story Name
   {645c4cf5-8c36-4b5c-8c01-fb7daf9dd828}, !- Thermal Zone Name
@@ -10163,7 +10163,7 @@ OS:Space,
 
 OS:Surface,
   {8a3ff373-fc58-4c86-b714-fb85252c9a1f}, !- Handle
-  Surface 578,                            !- Name
+  Corridor_Top_1 - Wall 000_c,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3c299b5c-1e29-4d6b-b2ed-07d32ab6602a}, !- Space Name
@@ -10180,7 +10180,7 @@ OS:Surface,
 
 OS:Surface,
   {396bd8cc-a206-4032-8947-dcdb4fc46105}, !- Handle
-  Surface 579,                            !- Name
+  Corridor_Top_1 - Wall 180_b,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3c299b5c-1e29-4d6b-b2ed-07d32ab6602a}, !- Space Name
@@ -10197,7 +10197,7 @@ OS:Surface,
 
 OS:Surface,
   {c9a56c47-6d09-4469-aca0-6d86a42ebdd6}, !- Handle
-  Surface 580,                            !- Name
+  Corridor_Top_1 - Wall 000_d,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3c299b5c-1e29-4d6b-b2ed-07d32ab6602a}, !- Space Name
@@ -10214,7 +10214,7 @@ OS:Surface,
 
 OS:Surface,
   {95a87223-4f69-4b4d-b85c-db93b6d7f77c}, !- Handle
-  Surface 581,                            !- Name
+  Corridor_Top_1 - Wall 180_c,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3c299b5c-1e29-4d6b-b2ed-07d32ab6602a}, !- Space Name
@@ -10231,7 +10231,7 @@ OS:Surface,
 
 OS:Surface,
   {14e1e93c-e807-416a-a845-7e50afa90223}, !- Handle
-  Surface 582,                            !- Name
+  Corridor_Top_1 - Wall 000_e,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3c299b5c-1e29-4d6b-b2ed-07d32ab6602a}, !- Space Name
@@ -10248,7 +10248,7 @@ OS:Surface,
 
 OS:Surface,
   {731efc66-9eda-4319-9eac-6a56144836da}, !- Handle
-  Surface 583,                            !- Name
+  Corridor_Top_1 - Wall 180_d,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3c299b5c-1e29-4d6b-b2ed-07d32ab6602a}, !- Space Name
@@ -10265,7 +10265,7 @@ OS:Surface,
 
 OS:Surface,
   {c64ebd7d-3b83-428e-a294-c3c7d0d7b253}, !- Handle
-  Surface 584,                            !- Name
+  Corridor_Top_1 - Wall 180_e,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3c299b5c-1e29-4d6b-b2ed-07d32ab6602a}, !- Space Name
@@ -10282,7 +10282,7 @@ OS:Surface,
 
 OS:Surface,
   {33fda864-ddd5-4e25-b45a-afde95fe562f}, !- Handle
-  Surface 585,                            !- Name
+  Corridor_Top_1 - Wall 000_f,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3c299b5c-1e29-4d6b-b2ed-07d32ab6602a}, !- Space Name
@@ -10299,7 +10299,7 @@ OS:Surface,
 
 OS:Surface,
   {2034b553-7374-4ec6-affc-621a91fa983f}, !- Handle
-  Surface 586,                            !- Name
+  Corridor_Top_1 - Floor_a,               !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {3c299b5c-1e29-4d6b-b2ed-07d32ab6602a}, !- Space Name
@@ -10320,7 +10320,7 @@ OS:Surface,
 
 OS:Surface,
   {955851d9-ee71-43cf-8ef6-c6104107ba9c}, !- Handle
-  Surface 587,                            !- Name
+  Corridor_Top_1 - Wall 090_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3c299b5c-1e29-4d6b-b2ed-07d32ab6602a}, !- Space Name
@@ -10337,7 +10337,7 @@ OS:Surface,
 
 OS:Surface,
   {8274a349-2cb8-436c-8a39-9e486f8a3601}, !- Handle
-  Surface 588,                            !- Name
+  Corridor_Top_1 - RoofCeiling_a,         !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {3c299b5c-1e29-4d6b-b2ed-07d32ab6602a}, !- Space Name
@@ -10358,7 +10358,7 @@ OS:Surface,
 
 OS:Surface,
   {abfff3db-2dd7-4744-b56f-2aee25096a00}, !- Handle
-  Surface 589,                            !- Name
+  Corridor_Top_1 - Wall 000_b,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3c299b5c-1e29-4d6b-b2ed-07d32ab6602a}, !- Space Name
@@ -10375,7 +10375,7 @@ OS:Surface,
 
 OS:Surface,
   {76ab4cd6-e74e-41b1-8aab-56a049c46e6b}, !- Handle
-  Surface 590,                            !- Name
+  Corridor_Top_1 - Wall 000_g,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3c299b5c-1e29-4d6b-b2ed-07d32ab6602a}, !- Space Name
@@ -10392,7 +10392,7 @@ OS:Surface,
 
 OS:Surface,
   {cbd0a088-edb5-4279-b7b4-59635dd29e6b}, !- Handle
-  Surface 591,                            !- Name
+  Corridor_Top_1 - Wall 270_b,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3c299b5c-1e29-4d6b-b2ed-07d32ab6602a}, !- Space Name
@@ -10409,7 +10409,7 @@ OS:Surface,
 
 OS:Surface,
   {aea01a8d-5247-40cd-b5e8-3df2c9da7f1c}, !- Handle
-  Surface 592,                            !- Name
+  Corridor_Top_1 - Wall 000_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3c299b5c-1e29-4d6b-b2ed-07d32ab6602a}, !- Space Name
@@ -10426,7 +10426,7 @@ OS:Surface,
 
 OS:Surface,
   {dae2ed93-f705-4edb-b01d-91af6dd58a20}, !- Handle
-  Surface 593,                            !- Name
+  Corridor_Top_1 - Wall 090_b,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3c299b5c-1e29-4d6b-b2ed-07d32ab6602a}, !- Space Name
@@ -10443,7 +10443,7 @@ OS:Surface,
 
 OS:Surface,
   {ecd25b38-69aa-4309-a58d-a2fea2676806}, !- Handle
-  Surface 594,                            !- Name
+  Corridor_Top_1 - Wall 180_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3c299b5c-1e29-4d6b-b2ed-07d32ab6602a}, !- Space Name
@@ -10460,7 +10460,7 @@ OS:Surface,
 
 OS:Surface,
   {d41d2384-1794-4f1e-ba23-b5944afb6660}, !- Handle
-  Surface 595,                            !- Name
+  Corridor_Top_1 - Wall 270_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3c299b5c-1e29-4d6b-b2ed-07d32ab6602a}, !- Space Name
@@ -10482,8 +10482,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  7.21911419532262e-016,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   7.9248,                                 !- Z Origin {m}
   {34c2b3a4-b93e-443b-9867-ce24d7c61c21}, !- Building Story Name
   {0d1bd9b9-16d1-4378-ba7a-4ac952440963}, !- Thermal Zone Name
@@ -10493,7 +10493,7 @@ OS:Space,
 
 OS:Surface,
   {e5cff3bd-7984-48bb-9c87-25c7da34938e}, !- Handle
-  Surface 596,                            !- Name
+  EnclosedOffice_Top_1 - Wall 090_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {2b598676-3558-42cf-ab42-7bf228720330}, !- Space Name
@@ -10510,7 +10510,7 @@ OS:Surface,
 
 OS:Surface,
   {baf4a3c5-dc75-420c-a394-3e2a8232c102}, !- Handle
-  Surface 597,                            !- Name
+  EnclosedOffice_Top_1 - Wall 090_b,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {2b598676-3558-42cf-ab42-7bf228720330}, !- Space Name
@@ -10527,7 +10527,7 @@ OS:Surface,
 
 OS:Surface,
   {80b07503-bf66-4da9-a8bf-da867c86459f}, !- Handle
-  Surface 598,                            !- Name
+  EnclosedOffice_Top_1 - Floor_a,         !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {2b598676-3558-42cf-ab42-7bf228720330}, !- Space Name
@@ -10544,7 +10544,7 @@ OS:Surface,
 
 OS:Surface,
   {a82b5eef-8de4-4fea-91f8-491f1cc825b3}, !- Handle
-  Surface 599,                            !- Name
+  EnclosedOffice_Top_1 - Wall 180_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {2b598676-3558-42cf-ab42-7bf228720330}, !- Space Name
@@ -10561,7 +10561,7 @@ OS:Surface,
 
 OS:Surface,
   {9944ab9c-d147-4548-a446-9915276c205a}, !- Handle
-  Surface 600,                            !- Name
+  EnclosedOffice_Top_1 - Wall 090_c,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {2b598676-3558-42cf-ab42-7bf228720330}, !- Space Name
@@ -10578,7 +10578,7 @@ OS:Surface,
 
 OS:Surface,
   {fdfd425e-9e85-4d74-bc81-281d983f8a70}, !- Handle
-  Surface 602,                            !- Name
+  EnclosedOffice_Top_1 - Wall 270_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {2b598676-3558-42cf-ab42-7bf228720330}, !- Space Name
@@ -10595,7 +10595,7 @@ OS:Surface,
 
 OS:Surface,
   {118c98bd-4067-420a-ac41-04ba8ba22c6d}, !- Handle
-  Surface 603,                            !- Name
+  EnclosedOffice_Top_1 - RoofCeiling_a,   !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {2b598676-3558-42cf-ab42-7bf228720330}, !- Space Name
@@ -10617,8 +10617,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  7.21911419532262e-016,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   7.9248,                                 !- Z Origin {m}
   {34c2b3a4-b93e-443b-9867-ce24d7c61c21}, !- Building Story Name
   {5d11a456-633f-4fdf-91e9-14d4dabfa08b}, !- Thermal Zone Name
@@ -10628,7 +10628,7 @@ OS:Space,
 
 OS:Surface,
   {43480694-90ca-49a9-aab0-cfb8694956fb}, !- Handle
-  Surface 604,                            !- Name
+  ActiveStorage_Top_1 - Wall 000_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {81d663af-05fb-46d2-8207-a345ceb974c3}, !- Space Name
@@ -10645,7 +10645,7 @@ OS:Surface,
 
 OS:Surface,
   {878337ad-6cf9-45cf-9258-03d2a6b04d9f}, !- Handle
-  Surface 605,                            !- Name
+  ActiveStorage_Top_1 - Floor_a,          !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {81d663af-05fb-46d2-8207-a345ceb974c3}, !- Space Name
@@ -10662,7 +10662,7 @@ OS:Surface,
 
 OS:Surface,
   {ed47f1e0-2856-4a90-86c7-d62e029f0052}, !- Handle
-  Surface 606,                            !- Name
+  ActiveStorage_Top_1 - Wall 270_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {81d663af-05fb-46d2-8207-a345ceb974c3}, !- Space Name
@@ -10679,7 +10679,7 @@ OS:Surface,
 
 OS:Surface,
   {a9d77a06-3c37-4aad-9d2a-4e714bb481a6}, !- Handle
-  Surface 607,                            !- Name
+  ActiveStorage_Top_1 - Wall 180_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {81d663af-05fb-46d2-8207-a345ceb974c3}, !- Space Name
@@ -10696,7 +10696,7 @@ OS:Surface,
 
 OS:Surface,
   {4535834d-83cb-4227-b478-ba8bd46752b6}, !- Handle
-  Surface 608,                            !- Name
+  ActiveStorage_Top_1 - Wall 090_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {81d663af-05fb-46d2-8207-a345ceb974c3}, !- Space Name
@@ -10713,7 +10713,7 @@ OS:Surface,
 
 OS:Surface,
   {3ffa9711-961b-4b71-a2ea-1e6c5fe14755}, !- Handle
-  Surface 609,                            !- Name
+  ActiveStorage_Top_1 - RoofCeiling_a,    !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {81d663af-05fb-46d2-8207-a345ceb974c3}, !- Space Name
@@ -10730,7 +10730,7 @@ OS:Surface,
 
 OS:Surface,
   {0491859b-308c-4553-8f17-116946fc4668}, !- Handle
-  Surface 610,                            !- Name
+  ActiveStorage_Top_1 - Wall 000_b,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {81d663af-05fb-46d2-8207-a345ceb974c3}, !- Space Name
@@ -10752,8 +10752,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  7.21911419532262e-016,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   7.9248,                                 !- Z Origin {m}
   {34c2b3a4-b93e-443b-9867-ce24d7c61c21}, !- Building Story Name
   {3456fdaf-1ee8-4a3e-9844-127f74ff3c5a}, !- Thermal Zone Name
@@ -10763,7 +10763,7 @@ OS:Space,
 
 OS:Surface,
   {0da0da04-6579-4a9e-8569-c8b552e9e00b}, !- Handle
-  Surface 611,                            !- Name
+  ConfRoom_Top_1 - Wall 180_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {680a1f37-2b9f-44fa-b9d1-5ca9ea50a35b}, !- Space Name
@@ -10780,7 +10780,7 @@ OS:Surface,
 
 OS:Surface,
   {4982263f-c322-4d19-842a-79ddff827e9c}, !- Handle
-  Surface 612,                            !- Name
+  ConfRoom_Top_1 - Wall 000_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {680a1f37-2b9f-44fa-b9d1-5ca9ea50a35b}, !- Space Name
@@ -10797,7 +10797,7 @@ OS:Surface,
 
 OS:Surface,
   {6b9307b4-027d-44cf-afdc-0d03726a5264}, !- Handle
-  Surface 613,                            !- Name
+  ConfRoom_Top_1 - RoofCeiling_a,         !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {680a1f37-2b9f-44fa-b9d1-5ca9ea50a35b}, !- Space Name
@@ -10814,7 +10814,7 @@ OS:Surface,
 
 OS:Surface,
   {c0b96d1c-3110-49c5-ae41-a8c0547b31d9}, !- Handle
-  Surface 614,                            !- Name
+  ConfRoom_Top_1 - Wall 090_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {680a1f37-2b9f-44fa-b9d1-5ca9ea50a35b}, !- Space Name
@@ -10831,7 +10831,7 @@ OS:Surface,
 
 OS:Surface,
   {804b67bd-5780-4d6b-9472-6268e44431ac}, !- Handle
-  Surface 615,                            !- Name
+  ConfRoom_Top_1 - Wall 270_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {680a1f37-2b9f-44fa-b9d1-5ca9ea50a35b}, !- Space Name
@@ -10848,7 +10848,7 @@ OS:Surface,
 
 OS:Surface,
   {5f3a36b7-e112-476c-8554-929cc90085fa}, !- Handle
-  Surface 616,                            !- Name
+  ConfRoom_Top_1 - Wall 000_b,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {680a1f37-2b9f-44fa-b9d1-5ca9ea50a35b}, !- Space Name
@@ -10865,7 +10865,7 @@ OS:Surface,
 
 OS:Surface,
   {8e5fa34c-2355-43d2-8003-21ab2f44f143}, !- Handle
-  Surface 617,                            !- Name
+  ConfRoom_Top_1 - Floor_a,               !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {680a1f37-2b9f-44fa-b9d1-5ca9ea50a35b}, !- Space Name
@@ -10882,7 +10882,7 @@ OS:Surface,
 
 OS:Surface,
   {bf77f057-3768-4b34-8c6f-b38f7a94b562}, !- Handle
-  Surface 618,                            !- Name
+  FirstFloor_Plenum - RoofCeiling_i,      !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -10899,7 +10899,7 @@ OS:Surface,
 
 OS:Surface,
   {255e6293-0c97-4e6a-b3ed-fbed66d5aa1e}, !- Handle
-  Surface 619,                            !- Name
+  FirstFloor_Plenum - RoofCeiling_h,      !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -10916,7 +10916,7 @@ OS:Surface,
 
 OS:Surface,
   {d9d26bcd-6f00-4429-b945-2c9d363a5e2a}, !- Handle
-  Surface 620,                            !- Name
+  FirstFloor_Plenum - RoofCeiling_j,      !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -10937,7 +10937,7 @@ OS:Surface,
 
 OS:Surface,
   {090702bd-5ece-4d62-bca4-bd91634b8059}, !- Handle
-  Surface 621,                            !- Name
+  FirstFloor_Plenum - RoofCeiling_g,      !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -10954,7 +10954,7 @@ OS:Surface,
 
 OS:Surface,
   {92962ce7-207c-4a9c-a8f6-6ed97415c6da}, !- Handle
-  Surface 622,                            !- Name
+  FirstFloor_Plenum - RoofCeiling_c,      !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -10975,7 +10975,7 @@ OS:Surface,
 
 OS:Surface,
   {aa26130c-2a3f-4bdc-82a5-68078e97a011}, !- Handle
-  Surface 623,                            !- Name
+  FirstFloor_Plenum - RoofCeiling_e,      !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -10992,7 +10992,7 @@ OS:Surface,
 
 OS:Surface,
   {09cfb8ab-607d-417b-98dd-6d5db7d5c8d2}, !- Handle
-  Surface 624,                            !- Name
+  FirstFloor_Plenum - RoofCeiling_f,      !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -11009,7 +11009,7 @@ OS:Surface,
 
 OS:Surface,
   {9a7d8440-b43d-4303-b12a-2ff9b088ae72}, !- Handle
-  Surface 625,                            !- Name
+  FirstFloor_Plenum - RoofCeiling_k,      !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -11026,7 +11026,7 @@ OS:Surface,
 
 OS:Surface,
   {1ac23c69-201f-480c-b624-3a1fec897f76}, !- Handle
-  Surface 626,                            !- Name
+  FirstFloor_Plenum - RoofCeiling_l,      !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -11043,7 +11043,7 @@ OS:Surface,
 
 OS:Surface,
   {f4b200d5-e029-4abb-bb7b-ac82ee7f5ca9}, !- Handle
-  Surface 627,                            !- Name
+  FirstFloor_Plenum - RoofCeiling_m,      !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -11060,7 +11060,7 @@ OS:Surface,
 
 OS:Surface,
   {5037d9cc-d55c-4885-a7ef-c0b3cde2a55e}, !- Handle
-  Surface 628,                            !- Name
+  FirstFloor_Plenum - RoofCeiling_a,      !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -11077,7 +11077,7 @@ OS:Surface,
 
 OS:Surface,
   {9c2f5683-fccb-4073-8e0f-757d2596088d}, !- Handle
-  Surface 629,                            !- Name
+  FirstFloor_Plenum - RoofCeiling_n,      !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -11094,7 +11094,7 @@ OS:Surface,
 
 OS:Surface,
   {ed23d168-0b04-4a97-8880-05a5a51e3ad8}, !- Handle
-  Surface 630,                            !- Name
+  FirstFloor_Plenum - RoofCeiling_o,      !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -11111,7 +11111,7 @@ OS:Surface,
 
 OS:Surface,
   {1209aeac-8dc1-4e78-859c-21058a213a0d}, !- Handle
-  Surface 631,                            !- Name
+  FirstFloor_Plenum - RoofCeiling_p,      !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -11128,7 +11128,7 @@ OS:Surface,
 
 OS:Surface,
   {1c604607-39d2-4b88-80ad-300e2a34e74d}, !- Handle
-  Surface 632,                            !- Name
+  FirstFloor_Plenum - RoofCeiling_q,      !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -11145,7 +11145,7 @@ OS:Surface,
 
 OS:Surface,
   {3e052829-749a-4062-b03c-d4374ccc1d05}, !- Handle
-  Surface 633,                            !- Name
+  FirstFloor_Plenum - RoofCeiling_b,      !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -11162,7 +11162,7 @@ OS:Surface,
 
 OS:Surface,
   {08999080-f73d-420c-817c-147b50cdad06}, !- Handle
-  Surface 634,                            !- Name
+  MidFloor_Plenum - RoofCeiling_m,        !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -11179,7 +11179,7 @@ OS:Surface,
 
 OS:Surface,
   {37dc8fff-4432-49c2-9907-6a16b290b162}, !- Handle
-  Surface 635,                            !- Name
+  MidFloor_Plenum - RoofCeiling_n,        !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -11200,7 +11200,7 @@ OS:Surface,
 
 OS:Surface,
   {fe7c62c5-4ccd-45e1-84aa-cfcfeabcfd68}, !- Handle
-  Surface 636,                            !- Name
+  MidFloor_Plenum - RoofCeiling_o,        !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -11217,7 +11217,7 @@ OS:Surface,
 
 OS:Surface,
   {a655bbc0-8f33-4fa8-b3a7-b7324a45d4c4}, !- Handle
-  Surface 637,                            !- Name
+  MidFloor_Plenum - RoofCeiling_p,        !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -11238,7 +11238,7 @@ OS:Surface,
 
 OS:Surface,
   {a16f17d6-8fdc-4121-bd56-4726f5246c13}, !- Handle
-  Surface 638,                            !- Name
+  MidFloor_Plenum - RoofCeiling_q,        !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -11255,7 +11255,7 @@ OS:Surface,
 
 OS:Surface,
   {aec3822b-8e65-42cf-9bf1-0b94efa9cd06}, !- Handle
-  Surface 639,                            !- Name
+  MidFloor_Plenum - RoofCeiling_a,        !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -11272,7 +11272,7 @@ OS:Surface,
 
 OS:Surface,
   {4300d475-eb99-4ba4-b94d-99b9227a9e34}, !- Handle
-  Surface 640,                            !- Name
+  MidFloor_Plenum - RoofCeiling_r,        !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -11289,7 +11289,7 @@ OS:Surface,
 
 OS:Surface,
   {d4c3f039-b20e-4ef8-b2df-064d4dbb85e3}, !- Handle
-  Surface 641,                            !- Name
+  MidFloor_Plenum - RoofCeiling_c,        !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -11306,7 +11306,7 @@ OS:Surface,
 
 OS:Surface,
   {dbe28d2f-afa0-4290-a0ac-6c7b16c8253c}, !- Handle
-  Surface 642,                            !- Name
+  MidFloor_Plenum - RoofCeiling_h,        !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -11323,7 +11323,7 @@ OS:Surface,
 
 OS:Surface,
   {270a4493-20cb-4188-b3a9-c6d1913624ad}, !- Handle
-  Surface 643,                            !- Name
+  MidFloor_Plenum - RoofCeiling_s,        !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -11340,7 +11340,7 @@ OS:Surface,
 
 OS:Surface,
   {138a209e-3cba-4633-8e9a-96c77637194e}, !- Handle
-  Surface 644,                            !- Name
+  MidFloor_Plenum - RoofCeiling_j,        !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -11357,7 +11357,7 @@ OS:Surface,
 
 OS:Surface,
   {4de35918-6944-4f52-bda7-b433e5391a6c}, !- Handle
-  Surface 645,                            !- Name
+  MidFloor_Plenum - RoofCeiling_b,        !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -11374,7 +11374,7 @@ OS:Surface,
 
 OS:Surface,
   {e68f7529-b4e3-45cd-bc77-07f9ecbd1e94}, !- Handle
-  Surface 646,                            !- Name
+  MidFloor_Plenum - RoofCeiling_g,        !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -11391,7 +11391,7 @@ OS:Surface,
 
 OS:Surface,
   {22d46c33-6c9b-45d3-9fab-9e701b4da87d}, !- Handle
-  Surface 647,                            !- Name
+  MidFloor_Plenum - RoofCeiling_e,        !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -11408,7 +11408,7 @@ OS:Surface,
 
 OS:Surface,
   {c0d5f4f9-17dc-41e0-9c18-c6c3d4ecde08}, !- Handle
-  Surface 648,                            !- Name
+  MidFloor_Plenum - RoofCeiling_k,        !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -11425,7 +11425,7 @@ OS:Surface,
 
 OS:Surface,
   {75f79cb6-4452-46e4-a7be-56f414f48c89}, !- Handle
-  Surface 649,                            !- Name
+  MidFloor_Plenum - RoofCeiling_l,        !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -11442,7 +11442,7 @@ OS:Surface,
 
 OS:Surface,
   {75dc7635-47ac-4038-9a40-e8f28a325e93}, !- Handle
-  Surface 650,                            !- Name
+  MidFloor_Plenum - RoofCeiling_t,        !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -11459,7 +11459,7 @@ OS:Surface,
 
 OS:Surface,
   {521eaaa9-b63b-4e59-9c5a-5dd4807bf043}, !- Handle
-  Surface 651,                            !- Name
+  MidFloor_Plenum - RoofCeiling_f,        !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -11476,7 +11476,7 @@ OS:Surface,
 
 OS:Surface,
   {8977562c-488b-4c95-99be-3add660687a4}, !- Handle
-  Surface 652,                            !- Name
+  MidFloor_Plenum - RoofCeiling_u,        !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -11493,7 +11493,7 @@ OS:Surface,
 
 OS:Surface,
   {050cba94-a406-449d-b6fc-02f427df7233}, !- Handle
-  Surface 653,                            !- Name
+  MidFloor_Plenum - RoofCeiling_d,        !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -11510,7 +11510,7 @@ OS:Surface,
 
 OS:Surface,
   {f1a48f62-a034-4d14-91c4-9499fe4ab574}, !- Handle
-  Surface 664,                            !- Name
+  ConfRoom_Mid_1 - Wall 270_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {a2f42132-0f39-42fb-a9bc-1b029ba5c56d}, !- Space Name
@@ -11565,7 +11565,7 @@ OS:RunPeriod,
 
 OS:Surface,
   {6dc27b80-4c27-40c6-b73e-3cb23e75c3ed}, !- Handle
-  Surface 686,                            !- Name
+  FirstFloor_Plenum - RoofCeiling_r,      !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -11582,7 +11582,7 @@ OS:Surface,
 
 OS:Surface,
   {57711ff8-c713-4dfa-b70c-37c70ea1c477}, !- Handle
-  Surface 685,                            !- Name
+  FirstFloor_Plenum - RoofCeiling_s,      !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -11599,7 +11599,7 @@ OS:Surface,
 
 OS:Surface,
   {63d8ee76-703c-4f39-840a-d16b781cf42e}, !- Handle
-  Surface 687,                            !- Name
+  FirstFloor_Plenum - RoofCeiling_t,      !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -11616,7 +11616,7 @@ OS:Surface,
 
 OS:Surface,
   {0da17fee-e6ea-49e6-91fc-217835e5edcd}, !- Handle
-  Surface 321,                            !- Name
+  FirstFloor_Plenum - RoofCeiling_u,      !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -11638,8 +11638,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  -1.02589783002182e-029,                 !- X Origin {m}
-  1.44377485810546e-015,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {34c2b3a4-b93e-443b-9867-ce24d7c61c21}, !- Building Story Name
   {009ccf37-480b-4fd7-94ba-1bef9b6d6975}, !- Thermal Zone Name
@@ -11649,7 +11649,7 @@ OS:Space,
 
 OS:Surface,
   {b578ad87-bf45-49d9-9648-3bd7978643f1}, !- Handle
-  Surface 322,                            !- Name
+  TopFloor_Plenum - Floor_i,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {79ab5ef1-6729-4240-b9f0-4a689066e545}, !- Space Name
@@ -11659,14 +11659,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  4.50373750000001, 33.274, 10.668,       !- X,Y,Z Vertex 1 {m}
-  4.50373750000001, 5.3419375, 10.668,    !- X,Y,Z Vertex 2 {m}
-  5.7752913562581e-015, 5.3419375, 10.668, !- X,Y,Z Vertex 3 {m}
-  5.7752913562581e-015, 33.274, 10.668;   !- X,Y,Z Vertex 4 {m}
+  4.5037375, 33.274, 10.668,              !- X,Y,Z Vertex 1 {m}
+  4.5037375, 5.3419375, 10.668,           !- X,Y,Z Vertex 2 {m}
+  0, 5.3419375, 10.668,                   !- X,Y,Z Vertex 3 {m}
+  0, 33.274, 10.668;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {923dc1a4-8e00-4bce-9f79-26158f6bc2ab}, !- Handle
-  Surface 323,                            !- Name
+  TopFloor_Plenum - Wall 270_a,           !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {79ab5ef1-6729-4240-b9f0-4a689066e545}, !- Space Name
@@ -11676,14 +11676,14 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  5.7752913562581e-015, 33.274, 11.8872,  !- X,Y,Z Vertex 1 {m}
-  5.7752913562581e-015, 33.274, 10.668,   !- X,Y,Z Vertex 2 {m}
-  5.7752913562581e-015, 7.21911419532262e-016, 10.668, !- X,Y,Z Vertex 3 {m}
-  5.7752913562581e-015, 7.21911419532262e-016, 11.8872; !- X,Y,Z Vertex 4 {m}
+  0, 33.274, 11.8872,                     !- X,Y,Z Vertex 1 {m}
+  0, 33.274, 10.668,                      !- X,Y,Z Vertex 2 {m}
+  0, 0, 10.668,                           !- X,Y,Z Vertex 3 {m}
+  0, 0, 11.8872;                          !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {28e11e15-0b2d-442e-bd9a-9bdfb193b283}, !- Handle
-  Surface 324,                            !- Name
+  TopFloor_Plenum - RoofCeiling_a,        !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {79ab5ef1-6729-4240-b9f0-4a689066e545}, !- Space Name
@@ -11693,14 +11693,14 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  49.911, 7.21911419532262e-016, 11.8872, !- X,Y,Z Vertex 1 {m}
+  49.911, 0, 11.8872,                     !- X,Y,Z Vertex 1 {m}
   49.911, 33.274, 11.8872,                !- X,Y,Z Vertex 2 {m}
-  5.7752913562581e-015, 33.274, 11.8872,  !- X,Y,Z Vertex 3 {m}
-  5.7752913562581e-015, 7.21911419532262e-016, 11.8872; !- X,Y,Z Vertex 4 {m}
+  0, 33.274, 11.8872,                     !- X,Y,Z Vertex 3 {m}
+  0, 0, 11.8872;                          !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {a7a0f2a7-8052-4615-8e5f-5758587d8464}, !- Handle
-  Surface 325,                            !- Name
+  TopFloor_Plenum - Wall 000_a,           !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {79ab5ef1-6729-4240-b9f0-4a689066e545}, !- Space Name
@@ -11712,12 +11712,12 @@ OS:Surface,
   ,                                       !- Number of Vertices
   49.911, 33.274, 11.8872,                !- X,Y,Z Vertex 1 {m}
   49.911, 33.274, 10.668,                 !- X,Y,Z Vertex 2 {m}
-  5.7752913562581e-015, 33.274, 10.668,   !- X,Y,Z Vertex 3 {m}
-  5.7752913562581e-015, 33.274, 11.8872;  !- X,Y,Z Vertex 4 {m}
+  0, 33.274, 10.668,                      !- X,Y,Z Vertex 3 {m}
+  0, 33.274, 11.8872;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {5765faec-c253-4987-87f7-ef507061a066}, !- Handle
-  Surface 436,                            !- Name
+  TopFloor_Plenum - Wall 090_a,           !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {79ab5ef1-6729-4240-b9f0-4a689066e545}, !- Space Name
@@ -11727,14 +11727,14 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  49.911, 7.21911419532262e-016, 11.8872, !- X,Y,Z Vertex 1 {m}
-  49.911, 7.21911419532262e-016, 10.668,  !- X,Y,Z Vertex 2 {m}
+  49.911, 0, 11.8872,                     !- X,Y,Z Vertex 1 {m}
+  49.911, 0, 10.668,                      !- X,Y,Z Vertex 2 {m}
   49.911, 33.274, 10.668,                 !- X,Y,Z Vertex 3 {m}
   49.911, 33.274, 11.8872;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {0b34d370-cc13-4ffa-968d-b1587c96b20b}, !- Handle
-  Surface 437,                            !- Name
+  TopFloor_Plenum - Wall 180_a,           !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {79ab5ef1-6729-4240-b9f0-4a689066e545}, !- Space Name
@@ -11744,14 +11744,14 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  5.7752913562581e-015, 7.21911419532262e-016, 11.8872, !- X,Y,Z Vertex 1 {m}
-  5.7752913562581e-015, 7.21911419532262e-016, 10.668, !- X,Y,Z Vertex 2 {m}
-  49.911, 7.21911419532262e-016, 10.668,  !- X,Y,Z Vertex 3 {m}
-  49.911, 7.21911419532262e-016, 11.8872; !- X,Y,Z Vertex 4 {m}
+  0, 0, 11.8872,                          !- X,Y,Z Vertex 1 {m}
+  0, 0, 10.668,                           !- X,Y,Z Vertex 2 {m}
+  49.911, 0, 10.668,                      !- X,Y,Z Vertex 3 {m}
+  49.911, 0, 11.8872;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {539281e9-eb56-47d9-900b-5ec9fb197941}, !- Handle
-  Surface 688,                            !- Name
+  TopFloor_Plenum - Floor_j,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {79ab5ef1-6729-4240-b9f0-4a689066e545}, !- Space Name
@@ -11768,7 +11768,7 @@ OS:Surface,
 
 OS:Surface,
   {d2998121-9ea8-472f-a152-52df171d1f8b}, !- Handle
-  Surface 689,                            !- Name
+  TopFloor_Plenum - Floor_d,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {79ab5ef1-6729-4240-b9f0-4a689066e545}, !- Space Name
@@ -11780,16 +11780,16 @@ OS:Surface,
   ,                                       !- Number of Vertices
   45.4072625, 16.63779375, 10.668,        !- X,Y,Z Vertex 1 {m}
   45.4072625, 5.3419375, 10.668,          !- X,Y,Z Vertex 2 {m}
-  4.50373750000001, 5.3419375, 10.668,    !- X,Y,Z Vertex 3 {m}
-  4.50373750000001, 16.63779375, 10.668,  !- X,Y,Z Vertex 4 {m}
-  5.72293750000001, 16.63779375, 10.668,  !- X,Y,Z Vertex 5 {m}
-  5.72293750000001, 6.5611375, 10.668,    !- X,Y,Z Vertex 6 {m}
+  4.5037375, 5.3419375, 10.668,           !- X,Y,Z Vertex 3 {m}
+  4.5037375, 16.63779375, 10.668,         !- X,Y,Z Vertex 4 {m}
+  5.7229375, 16.63779375, 10.668,         !- X,Y,Z Vertex 5 {m}
+  5.7229375, 6.5611375, 10.668,           !- X,Y,Z Vertex 6 {m}
   44.1880625, 6.5611375, 10.668,          !- X,Y,Z Vertex 7 {m}
   44.1880625, 16.63779375, 10.668;        !- X,Y,Z Vertex 8 {m}
 
 OS:Surface,
   {f4ae91de-00c1-47b5-b061-5be67b38514e}, !- Handle
-  Surface 690,                            !- Name
+  TopFloor_Plenum - Floor_k,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {79ab5ef1-6729-4240-b9f0-4a689066e545}, !- Space Name
@@ -11803,14 +11803,14 @@ OS:Surface,
   45.4072625, 16.63779375, 10.668,        !- X,Y,Z Vertex 2 {m}
   44.1880625, 16.63779375, 10.668,        !- X,Y,Z Vertex 3 {m}
   44.1880625, 26.71445, 10.668,           !- X,Y,Z Vertex 4 {m}
-  5.72293750000001, 26.71445, 10.668,     !- X,Y,Z Vertex 5 {m}
-  5.72293750000001, 16.63779375, 10.668,  !- X,Y,Z Vertex 6 {m}
-  4.50373750000001, 16.63779375, 10.668,  !- X,Y,Z Vertex 7 {m}
-  4.50373750000001, 27.93365, 10.668;     !- X,Y,Z Vertex 8 {m}
+  5.7229375, 26.71445, 10.668,            !- X,Y,Z Vertex 5 {m}
+  5.7229375, 16.63779375, 10.668,         !- X,Y,Z Vertex 6 {m}
+  4.5037375, 16.63779375, 10.668,         !- X,Y,Z Vertex 7 {m}
+  4.5037375, 27.93365, 10.668;            !- X,Y,Z Vertex 8 {m}
 
 OS:Surface,
   {49c721cd-4cff-4df9-a06b-cce0bab554cf}, !- Handle
-  Surface 691,                            !- Name
+  TopFloor_Plenum - Floor_l,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {79ab5ef1-6729-4240-b9f0-4a689066e545}, !- Space Name
@@ -11827,7 +11827,7 @@ OS:Surface,
 
 OS:Surface,
   {c60fee28-a290-4e60-9b8f-280af482fc3d}, !- Handle
-  Surface 692,                            !- Name
+  TopFloor_Plenum - Floor_m,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {79ab5ef1-6729-4240-b9f0-4a689066e545}, !- Space Name
@@ -11839,12 +11839,12 @@ OS:Surface,
   ,                                       !- Number of Vertices
   15.3543, 26.71445, 10.668,              !- X,Y,Z Vertex 1 {m}
   15.3543, 6.5611375, 10.668,             !- X,Y,Z Vertex 2 {m}
-  5.72293750000001, 6.5611375, 10.668,    !- X,Y,Z Vertex 3 {m}
-  5.72293750000001, 26.71445, 10.668;     !- X,Y,Z Vertex 4 {m}
+  5.7229375, 6.5611375, 10.668,           !- X,Y,Z Vertex 3 {m}
+  5.7229375, 26.71445, 10.668;            !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {f815fd67-2859-4728-9037-4d3d48c86e39}, !- Handle
-  Surface 693,                            !- Name
+  TopFloor_Plenum - Floor_e,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {79ab5ef1-6729-4240-b9f0-4a689066e545}, !- Space Name
@@ -11861,7 +11861,7 @@ OS:Surface,
 
 OS:Surface,
   {e12c9e45-1b62-4e7f-ada1-816a881a2e4e}, !- Handle
-  Surface 694,                            !- Name
+  TopFloor_Plenum - Floor_n,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {79ab5ef1-6729-4240-b9f0-4a689066e545}, !- Space Name
@@ -11873,12 +11873,12 @@ OS:Surface,
   ,                                       !- Number of Vertices
   12.392025, 33.274, 10.668,              !- X,Y,Z Vertex 1 {m}
   12.392025, 27.93365, 10.668,            !- X,Y,Z Vertex 2 {m}
-  4.50373750000001, 27.93365, 10.668,     !- X,Y,Z Vertex 3 {m}
-  4.50373750000001, 33.274, 10.668;       !- X,Y,Z Vertex 4 {m}
+  4.5037375, 27.93365, 10.668,            !- X,Y,Z Vertex 3 {m}
+  4.5037375, 33.274, 10.668;              !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {51492ad7-078f-47af-b886-80ecd32ed976}, !- Handle
-  Surface 695,                            !- Name
+  TopFloor_Plenum - Floor_b,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {79ab5ef1-6729-4240-b9f0-4a689066e545}, !- Space Name
@@ -11895,7 +11895,7 @@ OS:Surface,
 
 OS:Surface,
   {75fb18c5-6c9a-47b1-96f6-b80e4946ba02}, !- Handle
-  Surface 696,                            !- Name
+  TopFloor_Plenum - Floor_o,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {79ab5ef1-6729-4240-b9f0-4a689066e545}, !- Space Name
@@ -11906,13 +11906,13 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   41.8417375, 5.3419375, 10.668,          !- X,Y,Z Vertex 1 {m}
-  41.8417375, 7.21911419532262e-016, 10.668, !- X,Y,Z Vertex 2 {m}
-  8.06926250000001, 7.21911419532262e-016, 10.668, !- X,Y,Z Vertex 3 {m}
-  8.06926250000001, 5.3419375, 10.668;    !- X,Y,Z Vertex 4 {m}
+  41.8417375, 0, 10.668,                  !- X,Y,Z Vertex 2 {m}
+  8.0692625, 0, 10.668,                   !- X,Y,Z Vertex 3 {m}
+  8.0692625, 5.3419375, 10.668;           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {cbf443a5-8667-4610-aa5d-10192eeedb9e}, !- Handle
-  Surface 697,                            !- Name
+  TopFloor_Plenum - Floor_g,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {79ab5ef1-6729-4240-b9f0-4a689066e545}, !- Space Name
@@ -11929,7 +11929,7 @@ OS:Surface,
 
 OS:Surface,
   {0e4f053f-d77d-4053-ad85-bd16d0ebc430}, !- Handle
-  Surface 698,                            !- Name
+  TopFloor_Plenum - Floor_h,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {79ab5ef1-6729-4240-b9f0-4a689066e545}, !- Space Name
@@ -11940,13 +11940,13 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   49.911, 5.3419375, 10.668,              !- X,Y,Z Vertex 1 {m}
-  49.911, 7.21911419532262e-016, 10.668,  !- X,Y,Z Vertex 2 {m}
-  41.8417375, 7.21911419532262e-016, 10.668, !- X,Y,Z Vertex 3 {m}
+  49.911, 0, 10.668,                      !- X,Y,Z Vertex 2 {m}
+  41.8417375, 0, 10.668,                  !- X,Y,Z Vertex 3 {m}
   41.8417375, 5.3419375, 10.668;          !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {7ef96b26-638a-4b45-aff1-a3498308b364}, !- Handle
-  Surface 699,                            !- Name
+  TopFloor_Plenum - Floor_p,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {79ab5ef1-6729-4240-b9f0-4a689066e545}, !- Space Name
@@ -11963,7 +11963,7 @@ OS:Surface,
 
 OS:Surface,
   {1d47453d-01d8-495e-8d0e-e8e3c7436933}, !- Handle
-  Surface 700,                            !- Name
+  TopFloor_Plenum - Floor_q,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {79ab5ef1-6729-4240-b9f0-4a689066e545}, !- Space Name
@@ -11980,7 +11980,7 @@ OS:Surface,
 
 OS:Surface,
   {1b81c0ed-6983-48a9-b85d-59966dbd9456}, !- Handle
-  Surface 701,                            !- Name
+  TopFloor_Plenum - Floor_a,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {79ab5ef1-6729-4240-b9f0-4a689066e545}, !- Space Name
@@ -11997,7 +11997,7 @@ OS:Surface,
 
 OS:Surface,
   {65258233-7b2b-4199-a722-9c16d79ec952}, !- Handle
-  Surface 702,                            !- Name
+  TopFloor_Plenum - Floor_r,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {79ab5ef1-6729-4240-b9f0-4a689066e545}, !- Space Name
@@ -12014,7 +12014,7 @@ OS:Surface,
 
 OS:Surface,
   {b9109bbd-8886-4fa6-9d23-2d2fb43e5c2c}, !- Handle
-  Surface 703,                            !- Name
+  TopFloor_Plenum - Floor_s,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {79ab5ef1-6729-4240-b9f0-4a689066e545}, !- Space Name
@@ -12031,7 +12031,7 @@ OS:Surface,
 
 OS:Surface,
   {3346d3ca-f82e-4978-a5b4-df637aa8730b}, !- Handle
-  Surface 704,                            !- Name
+  TopFloor_Plenum - Floor_f,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {79ab5ef1-6729-4240-b9f0-4a689066e545}, !- Space Name
@@ -12048,7 +12048,7 @@ OS:Surface,
 
 OS:Surface,
   {388c0b36-8cee-4be0-883a-4c9382f98460}, !- Handle
-  Surface 705,                            !- Name
+  TopFloor_Plenum - Floor_t,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {79ab5ef1-6729-4240-b9f0-4a689066e545}, !- Space Name
@@ -12065,7 +12065,7 @@ OS:Surface,
 
 OS:Surface,
   {1c3f7e13-f455-4836-bef5-93510e82bacc}, !- Handle
-  Surface 706,                            !- Name
+  TopFloor_Plenum - Floor_u,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {79ab5ef1-6729-4240-b9f0-4a689066e545}, !- Space Name
@@ -12082,7 +12082,7 @@ OS:Surface,
 
 OS:Surface,
   {7649d764-c94e-46cc-b092-3f1b854be18b}, !- Handle
-  Surface 438,                            !- Name
+  TopFloor_Plenum - Floor_c,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {79ab5ef1-6729-4240-b9f0-4a689066e545}, !- Space Name
@@ -12092,14 +12092,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  8.06926250000001, 5.3419375, 10.668,    !- X,Y,Z Vertex 1 {m}
-  8.06926250000001, 7.21911419532262e-016, 10.668, !- X,Y,Z Vertex 2 {m}
-  5.7752913562581e-015, 7.21911419532262e-016, 10.668, !- X,Y,Z Vertex 3 {m}
-  5.7752913562581e-015, 5.3419375, 10.668; !- X,Y,Z Vertex 4 {m}
+  8.0692625, 5.3419375, 10.668,           !- X,Y,Z Vertex 1 {m}
+  8.0692625, 0, 10.668,                   !- X,Y,Z Vertex 2 {m}
+  0, 0, 10.668,                           !- X,Y,Z Vertex 3 {m}
+  0, 5.3419375, 10.668;                   !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {bb2b7e0d-439e-42fd-8468-48a775da8188}, !- Handle
-  Surface 298,                            !- Name
+  ConfRoom_Mid_2 - Wall 090_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {97d239e3-2f93-4f66-88a2-7167dc152e5a}, !- Space Name
@@ -12116,7 +12116,7 @@ OS:Surface,
 
 OS:Surface,
   {7c5ce8a2-d811-4570-933e-3488543af5b1}, !- Handle
-  Surface 300,                            !- Name
+  ConfRoom_Mid_2 - Wall 180_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {97d239e3-2f93-4f66-88a2-7167dc152e5a}, !- Space Name
@@ -12133,7 +12133,7 @@ OS:Surface,
 
 OS:Surface,
   {aa7ae702-3c5f-4dcd-8834-a851262a154b}, !- Handle
-  Surface 329,                            !- Name
+  EnclosedOffice_Mid_2 - Wall 000_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {5ce85006-2881-44f2-8075-2f399d15ba10}, !- Space Name
@@ -12150,7 +12150,7 @@ OS:Surface,
 
 OS:Surface,
   {aa8ea45f-e806-442c-82c4-6fbcd8c01f9c}, !- Handle
-  Surface 381,                            !- Name
+  EnclosedOffice_Mid_2 - Wall 090_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {5ce85006-2881-44f2-8075-2f399d15ba10}, !- Space Name
@@ -12167,7 +12167,7 @@ OS:Surface,
 
 OS:Surface,
   {3ad91f30-1874-45bf-826f-4de126ebc76a}, !- Handle
-  Surface 383,                            !- Name
+  ConfRoom_Top_2 - Wall 090_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {532a76a3-a007-4347-afed-4f4aa3e41419}, !- Space Name
@@ -12184,7 +12184,7 @@ OS:Surface,
 
 OS:Surface,
   {de02315f-5f2f-4d6f-bc9d-3c43a65f9775}, !- Handle
-  Surface 415,                            !- Name
+  EnclosedOffice_Top_1 - Wall 000_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {2b598676-3558-42cf-ab42-7bf228720330}, !- Space Name
@@ -12201,7 +12201,7 @@ OS:Surface,
 
 OS:Surface,
   {94b17f05-9f1f-420d-94db-abda53a2e5e9}, !- Handle
-  Surface 416,                            !- Name
+  EnclosedOffice_Top_3 - Wall 000_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {088fff13-3245-46c2-bd01-90dce95d2d32}, !- Space Name
@@ -12218,7 +12218,7 @@ OS:Surface,
 
 OS:SubSurface,
   {dc9147cc-463a-468d-a031-6ca2c2913868}, !- Handle
-  Sub Surface 1,                          !- Name
+  ConfRoom_Bot_1 - Wall 180_a - Sub:a,    !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {ee216b85-e4fa-45dc-adf5-783ca88f1a36}, !- Surface Name
@@ -12235,7 +12235,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {bcf30908-6803-49f7-b237-1e69f1fb6d70}, !- Handle
-  Sub Surface 2,                          !- Name
+  ConfRoom_Bot_1 - Wall 270_a - Sub:a,    !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {cbd6def7-e055-4b6a-88bf-bbe3cb1b13da}, !- Surface Name
@@ -12252,7 +12252,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {c166dc1a-dbaa-46f0-92f1-f5616b1bc37f}, !- Handle
-  Sub Surface 4,                          !- Name
+  ConfRoom_Bot_2 - Wall 090_a - Sub:a,    !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {1c501ce7-9cbd-482b-9b37-9bdee8fb66d6}, !- Surface Name
@@ -12269,7 +12269,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {a5834a56-649d-4555-b4f5-75ee0186f42f}, !- Handle
-  Sub Surface 5,                          !- Name
+  EnclosedOffice_Bot_3 - Wall 180_a - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {461fd235-e5a3-4976-a758-86cdaae6c00b}, !- Surface Name
@@ -12286,7 +12286,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {624079ad-085a-4aef-a887-454029ae125c}, !- Handle
-  Sub Surface 6,                          !- Name
+  EnclosedOffice_Bot_4 - Wall 180_a - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {f3a3e826-998e-414f-b44e-d0d1c74c33ea}, !- Surface Name
@@ -12303,7 +12303,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {f7ebe4e8-abf7-4452-be8a-5b0c9aadfc45}, !- Handle
-  Sub Surface 7,                          !- Name
+  EnclosedOffice_Mid_3 - Wall 000_a - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {cd903760-09fd-4136-8816-159cdd837f3e}, !- Surface Name
@@ -12320,7 +12320,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {e7054e25-4a82-408a-ae8d-bf753e55ed7e}, !- Handle
-  Sub Surface 8,                          !- Name
+  Lounge_Bot - Wall 180_a - Sub:a,        !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {cc4872fe-0abd-4224-bdcd-434ba9df8fa0}, !- Surface Name
@@ -12337,7 +12337,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {36748563-03df-4d5a-9056-d7a3743704cb}, !- Handle
-  Sub Surface 9,                          !- Name
+  ConfRoom_Bot_2 - Wall 180_a - Sub:a,    !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {e951ea82-4724-418a-9414-4abe1b5613cc}, !- Surface Name
@@ -12354,7 +12354,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {99a87b34-6e7d-4450-8177-fa8e2b5d0ec8}, !- Handle
-  Sub Surface 10,                         !- Name
+  EnclosedOffice_Bot_1 - Wall 000_a - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {f1f26603-9b76-4c89-8bd4-e59d6987d3c2}, !- Surface Name
@@ -12371,7 +12371,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {a11d76d6-8ee6-4155-964f-6302902c9fb1}, !- Handle
-  Sub Surface 11,                         !- Name
+  EnclosedOffice_Bot_1 - Wall 270_a - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {b04a2501-431a-4745-a51d-64230f66347d}, !- Surface Name
@@ -12388,7 +12388,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {7be38074-a682-4d75-8ba6-a804199fbe3e}, !- Handle
-  Sub Surface 13,                         !- Name
+  EnclosedOffice_Bot_2 - Wall 090_a - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {b9ded477-a976-45fb-b9b9-9cb6c12d56b8}, !- Surface Name
@@ -12405,7 +12405,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {12d0740c-5b48-4e62-8885-083a2e9a82d8}, !- Handle
-  Sub Surface 14,                         !- Name
+  EnclosedOffice_Mid_2 - Wall 000_a - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {aa7ae702-3c5f-4dcd-8834-a851262a154b}, !- Surface Name
@@ -12422,7 +12422,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {1010e28c-3bda-401a-abd7-866bf0019d4a}, !- Handle
-  Sub Surface 15,                         !- Name
+  ClassRoom_Bot - Wall 000_a - Sub:a,     !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {49438c66-0fae-4b1f-8971-6c704cbb323e}, !- Surface Name
@@ -12439,7 +12439,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {95f075b0-42f4-4ae1-8f76-487a02a173f2}, !- Handle
-  Sub Surface 16,                         !- Name
+  OpenOffice_Bot_3 - Wall 000_a - Sub:a,  !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {760b961f-fda9-4e5c-b46e-e95c97659ac9}, !- Surface Name
@@ -12456,7 +12456,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {652993e4-f12e-4a8d-aee7-2522b5433cca}, !- Handle
-  Sub Surface 17,                         !- Name
+  EnclosedOffice_Mid_1 - Wall 000_a - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {aa741c95-947f-4828-a165-c636e6a497b8}, !- Surface Name
@@ -12473,7 +12473,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {eabac292-ddbc-4e41-8607-48d5e2c89167}, !- Handle
-  Sub Surface 18,                         !- Name
+  EnclosedOffice_Bot_2 - Wall 000_a - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {85cefc1a-7279-4ed5-8774-e414b076b756}, !- Surface Name
@@ -12490,7 +12490,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {33eb6ac2-8a86-4e50-879a-cc4f1dd0c45f}, !- Handle
-  Sub Surface 19,                         !- Name
+  EnclosedOffice_Mid_1 - Wall 270_a - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {1d081beb-e1b0-4f68-ae07-bf494d782507}, !- Surface Name
@@ -12507,7 +12507,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {80d3875f-453d-467c-9940-ee008af38cd0}, !- Handle
-  Sub Surface 24,                         !- Name
+  ConfRoom_Top_2 - Wall 090_a - Sub:a,    !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {3ad91f30-1874-45bf-826f-4de126ebc76a}, !- Surface Name
@@ -12524,7 +12524,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {0f5594c1-1f59-4710-a49e-f0f9670b5cef}, !- Handle
-  Sub Surface 25,                         !- Name
+  OpenOffice_Top_4 - Wall 180_a - Sub:a,  !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {201a37ea-f8ed-42fb-9b65-f07245801d17}, !- Surface Name
@@ -12541,7 +12541,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {be420674-5c69-4af5-8ced-cd3fd8fee490}, !- Handle
-  Sub Surface 26,                         !- Name
+  ConfRoom_Mid_1 - Wall 180_a - Sub:a,    !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {0a981bab-79b7-4a02-a06a-97a9181484e6}, !- Surface Name
@@ -12558,7 +12558,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {1991bfd6-b1c0-488b-bd85-c95e55908628}, !- Handle
-  Sub Surface 27,                         !- Name
+  OpenOffice_Top_3 - Wall 000_a - Sub:a,  !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {31aaa649-a714-467a-ad54-52a464a4091d}, !- Surface Name
@@ -12575,7 +12575,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {63ccc8ea-3ba8-414c-ae32-095b3fe6fe17}, !- Handle
-  Sub Surface 28,                         !- Name
+  OpenOffice_Mid_3 - Wall 000_a - Sub:a,  !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {83ea213b-fb53-4b2a-96d3-537b60825b58}, !- Surface Name
@@ -12592,7 +12592,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {88f35a59-3820-42a9-ba09-8379983e1c61}, !- Handle
-  Sub Surface 29,                         !- Name
+  ConfRoom_Mid_1 - Wall 270_a - Sub:a,    !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {f1a48f62-a034-4d14-91c4-9499fe4ab574}, !- Surface Name
@@ -12609,7 +12609,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {4652aaba-494d-4876-93eb-0eafc3ae8f0c}, !- Handle
-  Sub Surface 31,                         !- Name
+  OpenOffice_Mid_4 - Wall 180_a - Sub:a,  !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {d1927d2b-4630-48f8-8e2b-d3d427798232}, !- Surface Name
@@ -12626,7 +12626,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {99cdf5d5-aa91-4bd4-98cb-fc69abeb5716}, !- Handle
-  Sub Surface 34,                         !- Name
+  EnclosedOffice_Top_2 - Wall 000_a - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {b077d97e-9c8a-4261-9da8-c1a47d93f40a}, !- Surface Name
@@ -12643,7 +12643,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {5551f593-09f5-4ab1-a1c8-2088453238c0}, !- Handle
-  Sub Surface 36,                         !- Name
+  EnclosedOffice_Top_2 - Wall 090_a - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {92bd749b-a0f8-4c85-9dd8-2a3845c85a89}, !- Surface Name
@@ -12660,7 +12660,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {e789c599-617f-4144-afcb-2e8cabf2bf98}, !- Handle
-  Sub Surface 37,                         !- Name
+  ConfRoom_Mid_2 - Wall 180_a - Sub:a,    !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {7c5ce8a2-d811-4570-933e-3488543af5b1}, !- Surface Name
@@ -12677,7 +12677,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {ae9e4d99-6706-40d2-a669-220e6f06e22b}, !- Handle
-  Sub Surface 38,                         !- Name
+  ConfRoom_Top_2 - Wall 180_a - Sub:a,    !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {e4674b9e-70bf-41f9-828b-87c7a218e496}, !- Surface Name
@@ -12694,7 +12694,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {777ce972-097b-405b-9c91-d6eaebb29745}, !- Handle
-  Sub Surface 39,                         !- Name
+  EnclosedOffice_Top_1 - Wall 270_a - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {fdfd425e-9e85-4d74-bc81-281d983f8a70}, !- Surface Name
@@ -12711,7 +12711,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {0099c3ab-8de6-4454-a0c0-37d0988d6850}, !- Handle
-  Sub Surface 40,                         !- Name
+  ConfRoom_Top_1 - Wall 180_a - Sub:a,    !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {0da0da04-6579-4a9e-8569-c8b552e9e00b}, !- Surface Name
@@ -12728,7 +12728,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {3d1d4243-7722-43d4-97d8-e77aa2c88afa}, !- Handle
-  Sub Surface 41,                         !- Name
+  ConfRoom_Top_1 - Wall 270_a - Sub:a,    !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {804b67bd-5780-4d6b-9472-6268e44431ac}, !- Surface Name
@@ -12745,7 +12745,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {dfddfcb9-4066-4dad-b85c-386cada1431c}, !- Handle
-  Sub Surface 42,                         !- Name
+  EnclosedOffice_Top_1 - Wall 000_a - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {de02315f-5f2f-4d6f-bc9d-3c43a65f9775}, !- Surface Name
@@ -12762,7 +12762,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {840aa250-249c-4d77-a305-b6f274a3c103}, !- Handle
-  Sub Surface 45,                         !- Name
+  EnclosedOffice_Top_3 - Wall 000_a - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {94b17f05-9f1f-420d-94db-abda53a2e5e9}, !- Surface Name
@@ -12779,7 +12779,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {90dd8d52-9895-43f4-9db0-4d06ec965cc2}, !- Handle
-  Sub Surface 46,                         !- Name
+  ConfRoom_Mid_2 - Wall 090_a - Sub:a,    !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {bb2b7e0d-439e-42fd-8468-48a775da8188}, !- Surface Name
@@ -12796,7 +12796,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {6c1fe987-f6c9-4438-9fb6-d520d5293f4a}, !- Handle
-  Sub Surface 47,                         !- Name
+  EnclosedOffice_Mid_2 - Wall 090_a - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {aa8ea45f-e806-442c-82c4-6fbcd8c01f9c}, !- Surface Name
@@ -12888,7 +12888,7 @@ OS:Rendering:Color,
 
 OS:Building,
   {8ce3d32a-d3ae-476d-af4d-68f081d882ac}, !- Handle
-  Building 1,                             !- Name
+  ASHRAE9012013MediumOfficeDetailed,      !- Name
   ,                                       !- Building Sector Type
   ,                                       !- North Axis {deg}
   6.76791955811492e-017,                  !- Nominal Floor to Floor Height {m}
@@ -12897,6 +12897,7 @@ OS:Building,
   ,                                       !- Default Schedule Set Name
   3,                                      !- Standards Number of Stories
   0,                                      !- Standards Number of Above Ground Stories
+  ,                                       !- Standards Template
   ,                                       !- Standards Building Type
   ,                                       !- Standards Number of Living Units
   ,                                       !- Relocatable
@@ -12909,6 +12910,7 @@ OS:SpaceType,
   ,                                       !- Default Schedule Set Name
   {eb522dc0-a29a-484b-bcb5-8ff1eef34cb0}, !- Group Rendering Name
   ,                                       !- Design Specification Outdoor Air Object Name
+  ,                                       !- Standards Template
   Office,                                 !- Standards Building Type
   MediumOffice - OpenOffice;              !- Standards Space Type
 
@@ -12926,6 +12928,7 @@ OS:SpaceType,
   ,                                       !- Default Schedule Set Name
   {95b38b88-279a-4835-9d48-89da8042a72e}, !- Group Rendering Name
   ,                                       !- Design Specification Outdoor Air Object Name
+  ,                                       !- Standards Template
   Office,                                 !- Standards Building Type
   MediumOffice - ClosedOffice;            !- Standards Space Type
 
@@ -12943,6 +12946,7 @@ OS:SpaceType,
   ,                                       !- Default Schedule Set Name
   {687dbd99-171a-4640-8f08-41d2fb660847}, !- Group Rendering Name
   ,                                       !- Design Specification Outdoor Air Object Name
+  ,                                       !- Standards Template
   Office,                                 !- Standards Building Type
   MediumOffice - Classroom;               !- Standards Space Type
 
@@ -12960,6 +12964,7 @@ OS:SpaceType,
   ,                                       !- Default Schedule Set Name
   {af24da99-6231-473d-a4ee-98e18dec0b26}, !- Group Rendering Name
   ,                                       !- Design Specification Outdoor Air Object Name
+  ,                                       !- Standards Template
   Office,                                 !- Standards Building Type
   MediumOffice - Conference;              !- Standards Space Type
 
@@ -12977,6 +12982,7 @@ OS:SpaceType,
   ,                                       !- Default Schedule Set Name
   {b88bdaea-5220-4f5f-8918-1277d0cb2bef}, !- Group Rendering Name
   ,                                       !- Design Specification Outdoor Air Object Name
+  ,                                       !- Standards Template
   Office,                                 !- Standards Building Type
   MediumOffice - Storage;                 !- Standards Space Type
 
@@ -12994,6 +13000,7 @@ OS:SpaceType,
   ,                                       !- Default Schedule Set Name
   {b365ceb4-b39a-4c6e-be79-d8570755bc74}, !- Group Rendering Name
   ,                                       !- Design Specification Outdoor Air Object Name
+  ,                                       !- Standards Template
   Office,                                 !- Standards Building Type
   MediumOffice - Corridor;                !- Standards Space Type
 
@@ -13011,6 +13018,7 @@ OS:SpaceType,
   ,                                       !- Default Schedule Set Name
   {b3caefa0-edb1-4409-bb19-0da21d57131f}, !- Group Rendering Name
   ,                                       !- Design Specification Outdoor Air Object Name
+  ,                                       !- Standards Template
   Office,                                 !- Standards Building Type
   MediumOffice - Dining;                  !- Standards Space Type
 
@@ -13028,6 +13036,7 @@ OS:SpaceType,
   ,                                       !- Default Schedule Set Name
   {a733da76-dbef-4059-a66c-7a259eba3233}, !- Group Rendering Name
   ,                                       !- Design Specification Outdoor Air Object Name
+  ,                                       !- Standards Template
   Office,                                 !- Standards Building Type
   MediumOffice - Lobby;                   !- Standards Space Type
 
@@ -13045,6 +13054,7 @@ OS:SpaceType,
   ,                                       !- Default Schedule Set Name
   {22c28617-85f5-4120-8ce3-46c49fba1406}, !- Group Rendering Name
   ,                                       !- Design Specification Outdoor Air Object Name
+  ,                                       !- Standards Template
   Office,                                 !- Standards Building Type
   MediumOffice - Elec/MechRoom;           !- Standards Space Type
 
@@ -13062,6 +13072,7 @@ OS:SpaceType,
   ,                                       !- Default Schedule Set Name
   {7c21f5c0-74ce-48f5-ac78-18545b8bd117}, !- Group Rendering Name
   ,                                       !- Design Specification Outdoor Air Object Name
+  ,                                       !- Standards Template
   Office,                                 !- Standards Building Type
   MediumOffice - Stair;                   !- Standards Space Type
 
@@ -13079,6 +13090,7 @@ OS:SpaceType,
   ,                                       !- Default Schedule Set Name
   {0aa78b18-9198-4ff7-ba83-ca611bc87c18}, !- Group Rendering Name
   ,                                       !- Design Specification Outdoor Air Object Name
+  ,                                       !- Standards Template
   Office,                                 !- Standards Building Type
   MediumOffice - Restroom;                !- Standards Space Type
 
@@ -13139,15 +13151,21 @@ OS:ThermalZone,
   {fc6b35e2-9941-41d0-a7cb-9562aa803315}, !- Zone Air Inlet Port List
   {bd805c8b-810b-4a0f-a354-5280252eff84}, !- Zone Air Exhaust Port List
   {700ddf99-4354-4a48-ae70-51c86d407335}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {634e7d66-b85b-4b22-a326-33db96b9e544}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {94001235-df58-4728-9a24-9a20d43df931}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {634e7d66-b85b-4b22-a326-33db96b9e544}, !- Handle
+  Port List 4,                            !- Name
+  {41cd6239-97fc-4edf-9fb2-e6e6b420e09f}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {94e0b8e9-dfc1-43a2-9a5a-87c26fed68b2}, !- Handle
@@ -13221,15 +13239,21 @@ OS:ThermalZone,
   {23a524a0-39ed-492f-bdef-97175209ca53}, !- Zone Air Inlet Port List
   {afb8f695-9f3f-462f-a35d-4b61890c9ef1}, !- Zone Air Exhaust Port List
   {e8b8fc5f-e567-4daa-83bf-1178455fe92f}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {d7efc9bb-93b8-4f86-9cd5-3f840f535a79}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {4a85f779-2db6-4f45-9f61-50b3e7a5ce69}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {d7efc9bb-93b8-4f86-9cd5-3f840f535a79}, !- Handle
+  Port List 5,                            !- Name
+  {4db7eee2-73e2-4fff-9953-3af33d6ba40d}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {e6a938ff-a5f7-4d17-b946-1bfdbb70e94a}, !- Handle
@@ -13303,15 +13327,21 @@ OS:ThermalZone,
   {ec0c35d2-31d8-4ccb-8ea2-7b2ab1352a8b}, !- Zone Air Inlet Port List
   {1356f7f3-fe34-4ed0-b461-cce8a289e431}, !- Zone Air Exhaust Port List
   {e1869a44-8c64-4029-85cd-941e1de43846}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {bcec24fe-c291-4d56-b6b5-86596d307269}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {f6054f94-fe87-4594-bb42-c8505ebb712a}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {bcec24fe-c291-4d56-b6b5-86596d307269}, !- Handle
+  Port List 6,                            !- Name
+  {1bd749a4-6837-49ff-a664-93c3d1862eff}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {f2ce5df1-3d1a-4e48-85c6-1b07f527cce5}, !- Handle
@@ -13385,15 +13415,21 @@ OS:ThermalZone,
   {fc30e6dc-4dbd-49e1-b1b8-cd02a48e0d2d}, !- Zone Air Inlet Port List
   {9d4c8126-cc62-4b18-878e-61aebf557214}, !- Zone Air Exhaust Port List
   {0dba346e-8322-4dda-8ce9-0d7c912bb3bf}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {f126dcc3-7c42-4c61-9f06-b6036ef5c353}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {8965a7a9-f4ae-4bec-a3ca-8cfb7139f42e}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {f126dcc3-7c42-4c61-9f06-b6036ef5c353}, !- Handle
+  Port List 7,                            !- Name
+  {67de5769-0be9-4996-820e-fffc469a52b0}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {e988da9e-8143-4efb-bb4a-7b4bacc62af5}, !- Handle
@@ -13467,15 +13503,21 @@ OS:ThermalZone,
   {598912ee-2dcc-4473-b042-4d09223a07e1}, !- Zone Air Inlet Port List
   {b1694f45-7c31-4fd6-8c67-e1803adff05b}, !- Zone Air Exhaust Port List
   {4ce0d0af-d92e-4648-8e89-02ae3853c9c8}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {098790f2-0909-470a-99ed-835bf12bf187}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {11f94e12-2e5f-4bd8-bbfa-61159840d181}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {098790f2-0909-470a-99ed-835bf12bf187}, !- Handle
+  Port List 8,                            !- Name
+  {355e4c73-cb17-4378-ba21-8644519dfb5a}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {1c1b61bf-1415-4c3b-946a-0b610e62014d}, !- Handle
@@ -13549,15 +13591,21 @@ OS:ThermalZone,
   {e3b87378-19a6-4f61-97b8-76eda2a54d1c}, !- Zone Air Inlet Port List
   {cbd2f1b7-1be8-4b6b-bf90-b09c344a57db}, !- Zone Air Exhaust Port List
   {198b245b-5f7c-4a99-84fd-eb1e8f3ed21d}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {64de5d08-5190-4221-a15f-0c731891b71e}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {dd73097c-f4a7-4c11-887a-1e08102ada6f}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {64de5d08-5190-4221-a15f-0c731891b71e}, !- Handle
+  Port List 9,                            !- Name
+  {3456fdaf-1ee8-4a3e-9844-127f74ff3c5a}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {7c0be923-c9d7-4753-aee2-c5cf346f42af}, !- Handle
@@ -13631,15 +13679,21 @@ OS:ThermalZone,
   {825171ac-6e34-4f97-ab92-7e28e22b49be}, !- Zone Air Inlet Port List
   {92e832b9-79c2-4942-8254-68423297b159}, !- Zone Air Exhaust Port List
   {b1ff2c32-8888-442f-b0f6-618a3a9182b9}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {d8d7c7c0-55e1-4540-aab7-4a7f1098d71c}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {d8d9ae88-849d-42c4-8b96-e8cc7419029d}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {d8d7c7c0-55e1-4540-aab7-4a7f1098d71c}, !- Handle
+  Port List 10,                           !- Name
+  {40974fb9-e93b-44c4-a16d-088b59a37fa6}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {15d2c51b-944c-4b3f-9abf-8d61f00edd9f}, !- Handle
@@ -13713,15 +13767,21 @@ OS:ThermalZone,
   {bfcac9c2-2742-4de7-8e3c-767020e56c48}, !- Zone Air Inlet Port List
   {adab0ff0-d7f0-42a3-b390-1799f3d7ce69}, !- Zone Air Exhaust Port List
   {e8f24604-3b1f-49a9-8410-89bdd1b06506}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {3d947af2-f118-435b-ac59-b3c4c8085666}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {a55d82e4-6f5f-4cf6-b46f-b17ee21e397b}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {3d947af2-f118-435b-ac59-b3c4c8085666}, !- Handle
+  Port List 11,                           !- Name
+  {af46f94b-979f-4baf-a003-e6a733d39a41}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {2369daac-e5c6-49f2-8b26-ac1251ed5890}, !- Handle
@@ -13795,15 +13855,21 @@ OS:ThermalZone,
   {25cb85da-3397-47b4-9339-c3f2ff112bdd}, !- Zone Air Inlet Port List
   {0aec8d2e-6f75-46e7-ba4b-f5a3de5798d1}, !- Zone Air Exhaust Port List
   {9308f7f8-85e3-4036-9e8b-241ca30e4619}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {cd1f523d-a08e-49fb-b3e2-7c6642a69575}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {0b50f197-03d2-426a-a8b9-62af738466d1}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {cd1f523d-a08e-49fb-b3e2-7c6642a69575}, !- Handle
+  Port List 12,                           !- Name
+  {fed42c3c-cef1-4c79-9b92-13675d5c52ae}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {275530ff-820c-4ba2-9ad3-7c8de03d4c63}, !- Handle
@@ -13877,15 +13943,21 @@ OS:ThermalZone,
   {fa173f3b-ca94-45b1-b15f-0673908223bf}, !- Zone Air Inlet Port List
   {dcf50706-92c2-4afd-b800-45929abb899c}, !- Zone Air Exhaust Port List
   {6f6577ca-554b-4351-b995-6f6dbce257dc}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {f5e1135f-0508-4968-b54f-fdbf223390b2}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {716485c8-3805-4ada-a030-78732ece8303}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {f5e1135f-0508-4968-b54f-fdbf223390b2}, !- Handle
+  Port List 13,                           !- Name
+  {e45c6c6a-d922-4d61-a121-4f32dbc6de11}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {8b29b7a6-7e76-4e43-b394-0760418731e3}, !- Handle
@@ -13959,15 +14031,21 @@ OS:ThermalZone,
   {cb1b076a-349c-4b2e-b7e4-f321040e8884}, !- Zone Air Inlet Port List
   {6e6a9f0d-ae99-47b8-9add-a903e8bd267d}, !- Zone Air Exhaust Port List
   {3b465429-ed4e-4c7b-bd8f-85a409d228c0}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {a8b383b7-36ab-48d0-857d-b2db7a1625c7}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {a62b37b0-b3fd-4587-8a23-4a38426ebb5d}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {a8b383b7-36ab-48d0-857d-b2db7a1625c7}, !- Handle
+  Port List 14,                           !- Name
+  {50f269fe-e2e6-4649-9146-723f691a44fb}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {25cefcef-aa8b-461f-a688-325ad58ab553}, !- Handle
@@ -14041,15 +14119,21 @@ OS:ThermalZone,
   {23d94b94-0701-4646-9c57-4bcbe98fb923}, !- Zone Air Inlet Port List
   {ded72ebc-6141-4864-9d29-fba6406f3b69}, !- Zone Air Exhaust Port List
   {7d578e39-c571-486c-9fb2-224b431612d1}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {5bea330f-7228-47f3-9e41-79acd7cba726}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {d7b5365e-7b2d-4e9f-afa9-35a1c5d132f7}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {5bea330f-7228-47f3-9e41-79acd7cba726}, !- Handle
+  Port List 15,                           !- Name
+  {dd8f204f-43c7-488b-aced-b516b7634775}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {0f8d5a9f-eba1-41b8-a66b-aba16fe35520}, !- Handle
@@ -14123,15 +14207,21 @@ OS:ThermalZone,
   {88a38463-371f-4d71-ba05-981d20154d95}, !- Zone Air Inlet Port List
   {ace2cc82-995f-44b9-bd08-61c452c3be53}, !- Zone Air Exhaust Port List
   {2d167c22-bdc2-4e39-bf74-bae9b46ef912}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {eed90f52-9000-4c13-9f59-360fcecef45f}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {148f2e98-b820-42ee-863a-488cce67f0d8}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {eed90f52-9000-4c13-9f59-360fcecef45f}, !- Handle
+  Port List 16,                           !- Name
+  {aefed899-7bbf-40b3-83e8-48f3aa1ab1f4}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {77a79cf3-603d-41eb-99da-e157ccb709d9}, !- Handle
@@ -14205,15 +14295,21 @@ OS:ThermalZone,
   {074f120d-1763-4305-8e50-879558abe28f}, !- Zone Air Inlet Port List
   {8b577cc9-f353-4902-99a4-8339ab9c03ca}, !- Zone Air Exhaust Port List
   {2e767ef0-ec2c-4630-8d52-9ec9e0c77f53}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {0a94a881-d930-44c2-8cac-e97668c71e21}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {0a912974-a159-4100-93b0-4d6e4a29449b}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {0a94a881-d930-44c2-8cac-e97668c71e21}, !- Handle
+  Port List 17,                           !- Name
+  {b77be4f7-7476-403e-ba6b-617ed7b714c5}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {64c83172-2655-4e80-b5a7-be67af1992f1}, !- Handle
@@ -14287,15 +14383,21 @@ OS:ThermalZone,
   {40cf9f38-680c-4df8-85a7-bf545a06e5d3}, !- Zone Air Inlet Port List
   {87a37937-327c-4ecc-9cfc-b4565327849b}, !- Zone Air Exhaust Port List
   {cdc37dd5-7f0c-4728-b3a5-880a7cd84484}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {86c0202b-586b-4fb9-a385-6f269877327c}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {fcebfc12-1b0e-429c-8918-fad8785172f2}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {86c0202b-586b-4fb9-a385-6f269877327c}, !- Handle
+  Port List 18,                           !- Name
+  {7590f5b7-76ad-4e98-bbf5-6f2ef605fba6}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {ce2bebce-bd67-45b2-94d7-bd08c4261a33}, !- Handle
@@ -14369,15 +14471,21 @@ OS:ThermalZone,
   {ab322f03-01d0-46e1-8659-b11b6a11318b}, !- Zone Air Inlet Port List
   {603d90c0-21ea-4d43-a80a-4ead97ec6047}, !- Zone Air Exhaust Port List
   {cf3cb915-974f-46ae-afcc-a5379ec2e590}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {bb542631-e8d6-4588-a31b-b425444d242a}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {e228138e-1eee-4e28-be5a-bb586618f2af}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {bb542631-e8d6-4588-a31b-b425444d242a}, !- Handle
+  Port List 19,                           !- Name
+  {4d141c4e-7af4-412e-910f-e17d39945991}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {61dd920b-e59a-4537-9762-a7a76814d899}, !- Handle
@@ -14451,15 +14559,21 @@ OS:ThermalZone,
   {7f8e6a66-c985-46a0-a157-1fbe69ac976d}, !- Zone Air Inlet Port List
   {da1fe08a-3d5e-492a-abe2-259b158f8fa1}, !- Zone Air Exhaust Port List
   {40336700-1b70-45f7-b0a7-f5f4154dc175}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {f614c899-6383-4234-ab85-4b4e2f84c496}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {a1298917-acfd-46cc-8b90-6a4d1d880349}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {f614c899-6383-4234-ab85-4b4e2f84c496}, !- Handle
+  Port List 20,                           !- Name
+  {3a7886cf-2a83-410c-b706-a9101db3432f}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {712db7fe-a285-44ca-ae3a-97626dff97d4}, !- Handle
@@ -14533,15 +14647,21 @@ OS:ThermalZone,
   {f7090672-c4b6-4000-86c5-d009d4c4f639}, !- Zone Air Inlet Port List
   {5cd9172e-2e7e-498d-aa6b-74307d4e8eae}, !- Zone Air Exhaust Port List
   {ae96f91e-d7c1-4e84-bfe2-c0bd6b8e7ddd}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {0561dd16-cda8-491e-afcb-ac5742deb425}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {8e7d9336-bf00-4f15-9294-e1ef3fb31d7f}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {0561dd16-cda8-491e-afcb-ac5742deb425}, !- Handle
+  Port List 22,                           !- Name
+  {d7559f81-feff-4e7d-90a9-3719a14d60ee}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {480560cb-d004-495c-acd3-1ccff7d6bae7}, !- Handle
@@ -14615,15 +14735,21 @@ OS:ThermalZone,
   {c3a42985-13b5-42c5-bc4b-fc3952ef5bcc}, !- Zone Air Inlet Port List
   {21a2637e-70a3-4a3f-9384-45d7e69238b9}, !- Zone Air Exhaust Port List
   {c9c2264b-bc6b-4019-ae74-6bc2ccb9c470}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {ab488a4f-7264-400c-a9ab-565aec765315}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {7f026f8e-3cc7-4dbe-9d3b-3ff95f2c8ada}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {ab488a4f-7264-400c-a9ab-565aec765315}, !- Handle
+  Port List 23,                           !- Name
+  {8c0b6af5-fb91-4b2d-a4f7-84b0129c6bac}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {4cc68057-4538-45e3-8398-ec0b71df6ebc}, !- Handle
@@ -14697,15 +14823,21 @@ OS:ThermalZone,
   {40a723e7-fb26-4fdc-9f4a-7c100e759edc}, !- Zone Air Inlet Port List
   {f5c78181-1f8c-4956-a9e2-59e44d56a132}, !- Zone Air Exhaust Port List
   {2e0e1aa0-97cc-4bbe-b65c-413a2ecc0dc0}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {682ae5ab-149e-4b80-90d4-9aea35b052d7}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {142c39f0-aa80-42f1-bb93-b3af0a3ec796}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {682ae5ab-149e-4b80-90d4-9aea35b052d7}, !- Handle
+  Port List 24,                           !- Name
+  {189c8ddc-f078-4a70-b892-259857f77f05}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {18025da5-7669-4059-b00d-ff4d4a8d25e6}, !- Handle
@@ -14779,15 +14911,21 @@ OS:ThermalZone,
   {02fff954-9266-4f9a-8c14-7d7987c58cbc}, !- Zone Air Inlet Port List
   {69fcb1e1-4bf8-4b4d-adeb-4f94ea68f8a7}, !- Zone Air Exhaust Port List
   {e0899266-c86d-44ef-813b-1d00158a00d7}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {5eb4e7ae-abae-4bff-ab0e-0175aa8801fa}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {79c04414-72c0-4b0c-97c2-e285e08fdcac}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {5eb4e7ae-abae-4bff-ab0e-0175aa8801fa}, !- Handle
+  Port List 25,                           !- Name
+  {565b61f6-2e86-41f6-aae0-b9a531aa9bb0}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {5cee7763-ff43-49ce-bfec-758089ba198c}, !- Handle
@@ -14861,15 +14999,21 @@ OS:ThermalZone,
   {a87e74b3-1d4e-40c8-bd5a-487f68f2a391}, !- Zone Air Inlet Port List
   {64abf24c-3251-4205-8b1a-3e6fc1478207}, !- Zone Air Exhaust Port List
   {ef46c54e-c0e2-4380-bceb-89b8b7057b6c}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {6f0c8bfc-5800-4df6-b9b2-12baef4c64bd}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {988167de-41f8-47d8-9e0d-a04c067a4387}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {6f0c8bfc-5800-4df6-b9b2-12baef4c64bd}, !- Handle
+  Port List 26,                           !- Name
+  {2586f405-4f2a-4830-968b-a9e77efc1629}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {bde7b620-a869-480f-b8db-3741305a43cf}, !- Handle
@@ -14943,15 +15087,21 @@ OS:ThermalZone,
   {287b9214-c208-40f9-832a-7f6b21820161}, !- Zone Air Inlet Port List
   {c397f991-2d4b-443e-8a5a-f97e1c9013a7}, !- Zone Air Exhaust Port List
   {963d16ee-084c-4387-a1ee-288db5ce6482}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {5b3a8329-ce0c-495a-91dc-5023adf99ff4}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {53e5cc82-80a7-4050-8751-8f21a72f6257}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {5b3a8329-ce0c-495a-91dc-5023adf99ff4}, !- Handle
+  Port List 27,                           !- Name
+  {6ace123f-abf3-430c-a767-2511c188ec0c}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {b7e5e578-a259-4c5a-a7ae-cf08e7cbb25f}, !- Handle
@@ -15025,15 +15175,21 @@ OS:ThermalZone,
   {9e28fd78-852a-4a13-936d-8f917ea4e67b}, !- Zone Air Inlet Port List
   {8401fca8-1bc0-42e8-8cd9-0589ece85da5}, !- Zone Air Exhaust Port List
   {91076757-7f66-4aee-9023-0c06a536fa3c}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {4f9afe74-0cf8-494e-8752-b1a693ad57df}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {7aa52b00-5421-4e61-8df2-c40b2e474b76}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {4f9afe74-0cf8-494e-8752-b1a693ad57df}, !- Handle
+  Port List 28,                           !- Name
+  {9235bed7-49c4-4f8c-a0f5-249682f43044}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {635d8ff7-b7ba-41b3-bd5d-5f08d18db823}, !- Handle
@@ -15107,15 +15263,21 @@ OS:ThermalZone,
   {9475ff85-9161-4c2f-874e-f7227a4ba1b1}, !- Zone Air Inlet Port List
   {2f8f67b3-2525-4bdd-b011-0dabf605a4bc}, !- Zone Air Exhaust Port List
   {b111ffbe-e147-4538-a1a7-e20cbf7431ca}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {cff78235-8bdd-44a9-95cb-d7c1ca52f037}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {5a4e03f5-5aaf-4788-8fcf-53376e80fa80}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {cff78235-8bdd-44a9-95cb-d7c1ca52f037}, !- Handle
+  Port List 29,                           !- Name
+  {bd69f731-f897-40c0-9bbc-da49b08fa43c}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {4d88fc28-af8a-4470-9960-44081dd59421}, !- Handle
@@ -15189,15 +15351,21 @@ OS:ThermalZone,
   {b68f484b-5d83-495b-af66-5bad551ae316}, !- Zone Air Inlet Port List
   {487a32e5-6b81-4bb2-a962-0e5af4027c3b}, !- Zone Air Exhaust Port List
   {036ccad2-9d56-452d-a2ff-bd5740041470}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {ee89ade4-43d6-4a84-8f0f-1f39ab439135}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {168b2b86-fe37-4390-82c9-590568a5cb24}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {ee89ade4-43d6-4a84-8f0f-1f39ab439135}, !- Handle
+  Port List 30,                           !- Name
+  {8b6a66f3-1dc1-484b-82fc-1495af27d153}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {8b994bd7-79ec-4c53-8ce8-cf5fb69571b0}, !- Handle
@@ -15271,15 +15439,21 @@ OS:ThermalZone,
   {91253d8b-14ac-43c4-ad39-21b5338f5454}, !- Zone Air Inlet Port List
   {9821666c-e011-48f2-a978-9bb35f8306b3}, !- Zone Air Exhaust Port List
   {1897a55f-2b35-4eb7-aae0-1aa64e0521c5}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {f91bf42f-873e-4999-a746-fb3bb79df8ef}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {e141ea41-ac2c-40ec-8c21-12056b2d9ec9}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {f91bf42f-873e-4999-a746-fb3bb79df8ef}, !- Handle
+  Port List 31,                           !- Name
+  {58a6dd06-bc3c-43f1-9705-cfcdd57e5995}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {c0362ce7-7333-494a-85c4-cf3781212dc9}, !- Handle
@@ -15353,15 +15527,21 @@ OS:ThermalZone,
   {38eb4add-253f-4bdd-9636-64c7160590ea}, !- Zone Air Inlet Port List
   {560215c1-4d17-4351-b8a1-a761d8ae0c99}, !- Zone Air Exhaust Port List
   {0406f948-77b3-49f1-817a-efb2b1d151d8}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {f3320172-6250-4842-a3ae-3828c5b52ccf}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {453a620e-4faa-4be6-9d66-851b4095c6a5}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {f3320172-6250-4842-a3ae-3828c5b52ccf}, !- Handle
+  Port List 32,                           !- Name
+  {21213f5c-925d-448d-b9a4-22723892e069}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {e5bea7f7-4467-47e3-97a6-3ecdbcd28d9b}, !- Handle
@@ -15435,15 +15615,21 @@ OS:ThermalZone,
   {f79ba28f-8d7b-4612-ab4d-5c8f2aa16b19}, !- Zone Air Inlet Port List
   {4ea65329-6b27-4e3f-8bd9-4c74bbb8db41}, !- Zone Air Exhaust Port List
   {3a777d2a-7416-4556-a4b6-8ccc7005a5f1}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {ee115445-edea-471b-b1b7-5376e31a669d}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {6c870542-f249-4aa1-80ee-889c6076aafd}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {ee115445-edea-471b-b1b7-5376e31a669d}, !- Handle
+  Port List 33,                           !- Name
+  {e57a208a-d0a0-483c-834b-83f1b15670ba}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {6b934b6f-e566-4d00-84ac-50be8c12a468}, !- Handle
@@ -15517,15 +15703,21 @@ OS:ThermalZone,
   {94306778-1b16-4a8f-a6f6-3de9c790fca5}, !- Zone Air Inlet Port List
   {02bf69be-956e-429a-8f6d-6c1722d9052b}, !- Zone Air Exhaust Port List
   {62e5bf01-1204-430b-aa91-ef499d23931a}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {e3c60d61-2ca6-4fc8-8b0a-01f4c46abaf7}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {ae3565fa-90aa-407d-af84-4da598fc1571}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {e3c60d61-2ca6-4fc8-8b0a-01f4c46abaf7}, !- Handle
+  Port List 34,                           !- Name
+  {61acd950-16f4-4c9f-9bf5-f6ac94f01c7c}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {baa1aecf-fbdd-4637-9a8f-0d1f1df862ee}, !- Handle
@@ -15599,15 +15791,21 @@ OS:ThermalZone,
   {c5845238-d61b-47a4-8f59-12ab3db492ff}, !- Zone Air Inlet Port List
   {38875749-6dda-458a-ab2d-3886920b5594}, !- Zone Air Exhaust Port List
   {33a5fa01-fdf0-4157-bb55-6e12bbdfbf3f}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {18358dc7-a271-44cb-9b3f-d55bb1d9683f}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {d8005d63-7d7e-456b-900b-59b8907679f5}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {18358dc7-a271-44cb-9b3f-d55bb1d9683f}, !- Handle
+  Port List 35,                           !- Name
+  {f5662b78-3bfa-482a-a1b9-0364a539e96a}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {c964b9dd-f511-4605-bdb2-ff2acdcbca12}, !- Handle
@@ -15681,15 +15879,21 @@ OS:ThermalZone,
   {664abcc8-ae9f-4e48-9a4e-a5e2b0ace753}, !- Zone Air Inlet Port List
   {4a1d29a5-2825-4677-aeee-1f88892149b7}, !- Zone Air Exhaust Port List
   {fbf3a480-d4ed-49e9-8366-2f698a87fc41}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {45bf28fd-ed34-4422-a93d-e2d3c11a43b2}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {100b784b-cdc9-464f-884b-2d837aef6123}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {45bf28fd-ed34-4422-a93d-e2d3c11a43b2}, !- Handle
+  Port List 36,                           !- Name
+  {c1a15444-a578-4521-8793-433c820bcd9c}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {1cfcbf43-a2a9-4f70-80e0-38b835cf492a}, !- Handle
@@ -15763,15 +15967,21 @@ OS:ThermalZone,
   {45633a52-ab73-486f-b49d-f11a91f48e2e}, !- Zone Air Inlet Port List
   {e4090c83-48bd-410d-9052-abad6228a43e}, !- Zone Air Exhaust Port List
   {72df3f8a-7501-44ec-acb8-ba3f6dfd01f7}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {fc42e028-0e1f-4cc8-82a5-eec875f60a22}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {2713d5d1-429e-45ca-add1-ebd18b244bc0}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {fc42e028-0e1f-4cc8-82a5-eec875f60a22}, !- Handle
+  Port List 37,                           !- Name
+  {3f5d3178-72bf-4636-a11d-c5edb98cbc19}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {a50464b3-d231-493d-98d1-1b3c90c2f2ce}, !- Handle
@@ -15845,15 +16055,21 @@ OS:ThermalZone,
   {8fe167b3-20d0-4a3b-afa2-01dd46a94ddb}, !- Zone Air Inlet Port List
   {cc330fac-a135-4679-9301-3b99508d4c5c}, !- Zone Air Exhaust Port List
   {9d68ee72-7a04-4b52-9723-245a08edf6f2}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {1cae2c2c-a2a3-4e44-85ed-d210f305c488}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {d4a6b0ef-22f0-40c5-8ff8-9079a0f13877}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {1cae2c2c-a2a3-4e44-85ed-d210f305c488}, !- Handle
+  Port List 38,                           !- Name
+  {4e496989-a555-48b1-8271-e070772f4120}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {bd2fac62-d525-49f6-88a3-f94a2fc62f30}, !- Handle
@@ -15927,15 +16143,21 @@ OS:ThermalZone,
   {4a8fb1e1-99f7-4262-93df-589c6a679578}, !- Zone Air Inlet Port List
   {6b74a1b7-9948-43ef-8848-2e266a72c9c7}, !- Zone Air Exhaust Port List
   {710c4738-fa34-436d-9847-e5fa1cb29144}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {ff584f3f-4c27-4486-ab86-af2937da6909}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {ddfd8286-0d73-412c-b4f9-64bbaeb69608}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {ff584f3f-4c27-4486-ab86-af2937da6909}, !- Handle
+  Port List 39,                           !- Name
+  {3f26caba-10b2-48c4-a6e2-5f74653bbc44}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {664924ad-1ee3-4c19-9fc5-29ff17cd864c}, !- Handle
@@ -16009,15 +16231,21 @@ OS:ThermalZone,
   {2b2cf5bf-eff0-4d8f-a752-23e21cea8c0b}, !- Zone Air Inlet Port List
   {95abce79-d228-4b71-ac96-484943543b8b}, !- Zone Air Exhaust Port List
   {9ad9cdcd-2c0d-4f1e-9c3b-1e1d1e8ad837}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {0bc9c4e1-7a8b-44a7-bbc8-f02a06efec0b}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {5334ff38-c66a-4446-b949-3b79cfe7f45c}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {0bc9c4e1-7a8b-44a7-bbc8-f02a06efec0b}, !- Handle
+  Port List 40,                           !- Name
+  {05d36b9e-f449-426c-b8eb-b5032321d155}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {3313b6e5-0cb4-4c04-8a9f-136f82267002}, !- Handle
@@ -16091,15 +16319,21 @@ OS:ThermalZone,
   {8c426881-7117-4a87-9d82-899c17dd428a}, !- Zone Air Inlet Port List
   {737bcf18-48ab-4027-9c9c-c0f8b496947b}, !- Zone Air Exhaust Port List
   {d4de5226-4001-4d34-a787-2b62764ecfb5}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {bac21431-651f-4836-af96-6da55b5d8767}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {8a5e3fea-b0aa-4999-9818-253184b62efd}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {bac21431-651f-4836-af96-6da55b5d8767}, !- Handle
+  Port List 41,                           !- Name
+  {67ed0980-f2da-40fd-994a-63fb55b9c564}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {a8761a29-774d-4b1f-b36c-bcef8dc6dbc0}, !- Handle
@@ -16173,15 +16407,21 @@ OS:ThermalZone,
   {ef22834c-dfd2-46ae-aa20-4219ea835e41}, !- Zone Air Inlet Port List
   {b4a4f4a3-2892-4bd0-8ec9-1fc0043587a3}, !- Zone Air Exhaust Port List
   {c3a29c7d-1381-44b0-bd9f-f88fd485a590}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {0526b42b-a795-4e9f-9005-0eb2ee3fc83c}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {7640594f-7b24-44ea-b9ef-549a7f3eb798}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {0526b42b-a795-4e9f-9005-0eb2ee3fc83c}, !- Handle
+  Port List 42,                           !- Name
+  {02b55a4a-a5ec-4d4b-9841-96aad4cca002}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {469e7800-1733-4614-88e4-b4beae7bcee2}, !- Handle
@@ -16255,15 +16495,21 @@ OS:ThermalZone,
   {d6fe8fa1-50c2-4f18-870a-321c4c20e9ee}, !- Zone Air Inlet Port List
   {4a46bf2d-a5cc-4af8-944e-a7b2cd769a15}, !- Zone Air Exhaust Port List
   {1ad4a9f1-4b8f-48b6-8c20-db66060e9664}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {22a3d716-49c2-45cc-b835-ea1ce77d4bad}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {68c6b0f2-f740-4cb4-95e7-aecccae5e02b}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {22a3d716-49c2-45cc-b835-ea1ce77d4bad}, !- Handle
+  Port List 43,                           !- Name
+  {a9e78f84-bbf7-4eb0-b4f0-996f80cefed9}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {b84d82b9-0197-44c9-9457-55337b0791f3}, !- Handle
@@ -16337,15 +16583,21 @@ OS:ThermalZone,
   {ee1d3177-a6fd-4c7f-bf1b-b940a4b44fb6}, !- Zone Air Inlet Port List
   {129cdb73-bc3c-45fe-a5b4-174eb80591db}, !- Zone Air Exhaust Port List
   {0fc6402d-40ad-4a0c-b505-a606a9335318}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {3c06169a-abf2-492e-9aed-2305a767d429}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {dc6479e4-cf34-455f-9d25-440fbfd346a9}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {3c06169a-abf2-492e-9aed-2305a767d429}, !- Handle
+  Port List 44,                           !- Name
+  {cfe70983-ff7f-498a-a553-eae07d8e721f}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {1bc71a3d-27b4-4e5c-a788-e48dcc8c3c0c}, !- Handle
@@ -16419,15 +16671,21 @@ OS:ThermalZone,
   {2fa9eb55-2367-498b-8694-a251081d4c0e}, !- Zone Air Inlet Port List
   {ca58bf9c-6d36-4ef5-8e8d-7b54c873cf73}, !- Zone Air Exhaust Port List
   {49cb915e-d121-4779-a5d8-97ac09ddf57e}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {cdd9443e-30b0-4e4c-acc5-aacd88d6d5d3}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {a7ace894-299c-411f-bb55-480c483aea6d}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {cdd9443e-30b0-4e4c-acc5-aacd88d6d5d3}, !- Handle
+  Port List 45,                           !- Name
+  {80a3580d-b968-449c-a5cc-d3b35a0abc8f}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {fe82874d-bb92-49bf-85ab-35be445f6004}, !- Handle
@@ -16501,15 +16759,21 @@ OS:ThermalZone,
   {bbbad56f-b8bf-472a-8be0-08cb8b742b35}, !- Zone Air Inlet Port List
   {33491dfb-bc4d-4e33-9dfd-b83169e3910b}, !- Zone Air Exhaust Port List
   {f35b4c88-ace1-404d-bf56-bb0e386dd4a8}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {ce156efd-a797-48e8-950c-ca9a520f9748}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {361568d0-e211-4dfc-9741-9388d74e5dd1}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {ce156efd-a797-48e8-950c-ca9a520f9748}, !- Handle
+  Port List 46,                           !- Name
+  {774bfcef-ec77-49e6-8be7-6fdfdd560d07}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {e09841d6-174c-40b1-9714-3bc7a2de8553}, !- Handle
@@ -16583,15 +16847,21 @@ OS:ThermalZone,
   {d9d7e953-bf3a-4cae-8170-453c438aea64}, !- Zone Air Inlet Port List
   {62ee3c5b-3282-4755-898b-fad38b128c45}, !- Zone Air Exhaust Port List
   {8392d943-ddb8-4efa-af40-e7b3a1f9aca1}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {552e33c3-3b64-41c6-bf5b-64b7de25ff18}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {ae52967a-de3a-45ea-91b8-613fcaf84d75}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {552e33c3-3b64-41c6-bf5b-64b7de25ff18}, !- Handle
+  Port List 47,                           !- Name
+  {def599db-7c71-497c-8a7e-0f727c3b6089}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {4181c431-0281-453b-b959-9ad20bef4b52}, !- Handle
@@ -16665,15 +16935,21 @@ OS:ThermalZone,
   {b9430f32-65b0-42d5-81d1-044ba2724bf9}, !- Zone Air Inlet Port List
   {d9ebd35b-8a92-4033-ae23-f4b1b5bc6bfc}, !- Zone Air Exhaust Port List
   {74de61cd-f031-4982-b1f1-22523c4c4102}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {5da2e335-de0a-4f81-8615-e78ff468eaf4}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {a2ec5fa1-8361-4a62-9ad9-18236d9fa1f9}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {5da2e335-de0a-4f81-8615-e78ff468eaf4}, !- Handle
+  Port List 48,                           !- Name
+  {ecd7832e-2da2-481c-8cda-24c6441f4211}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {adc2504b-062c-4f94-b511-c24e30f8fd1b}, !- Handle
@@ -16747,15 +17023,21 @@ OS:ThermalZone,
   {38ff807f-8ef3-4d24-a9e8-7965f0ba57d7}, !- Zone Air Inlet Port List
   {d564a6fe-3c3e-4e0b-8fff-d21087b38030}, !- Zone Air Exhaust Port List
   {1ff909e4-98a7-41cc-8428-ec0f759e4ab4}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {ab0598ee-a4ef-45f3-9d36-1e5d4785ba35}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {199f4a25-5ce6-456e-8938-41d7d8429e5a}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {ab0598ee-a4ef-45f3-9d36-1e5d4785ba35}, !- Handle
+  Port List 49,                           !- Name
+  {5f9749b4-9adf-40cf-baf8-218be7eb55e4}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {f5c79561-8d9c-4845-882c-5861543ea7d2}, !- Handle
@@ -16829,15 +17111,21 @@ OS:ThermalZone,
   {b622786a-06ea-4c85-9223-252382154d7a}, !- Zone Air Inlet Port List
   {b3629488-10d0-46ce-9ed9-5edbbb4ee166}, !- Zone Air Exhaust Port List
   {a7ccdec8-6a12-4aab-86ec-86e26403478b}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {b7ea2477-947e-4b00-8a18-e6b5b35fc076}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {31e0b088-8254-4883-b617-979712a4f410}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {b7ea2477-947e-4b00-8a18-e6b5b35fc076}, !- Handle
+  Port List 50,                           !- Name
+  {34e2116a-bc2e-4145-914c-ee5402691877}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {1f26c40f-b296-4673-a0cb-ea236944f556}, !- Handle
@@ -16911,15 +17199,21 @@ OS:ThermalZone,
   {d53a0eb3-994c-4440-9b4b-aae3659a3045}, !- Zone Air Inlet Port List
   {cccbd29b-5bcc-4f1b-86b2-f4bcf20f6acd}, !- Zone Air Exhaust Port List
   {163cb348-9b8c-4276-b96a-9bf545e46b08}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {0aab2e3e-cace-4177-9cfa-d04db54075f1}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {56049e62-cc44-489d-90a7-a20a7c3fdb10}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {0aab2e3e-cace-4177-9cfa-d04db54075f1}, !- Handle
+  Port List 2,                            !- Name
+  {37181995-c697-4566-b686-e314123b3060}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {d685ea11-34d0-46f2-a5e8-9288135cbfd4}, !- Handle
@@ -16993,15 +17287,21 @@ OS:ThermalZone,
   {8504ff64-fd33-4cc8-8fb2-ab3b026fb51c}, !- Zone Air Inlet Port List
   {4a4dc708-939b-408f-a083-d654b3e544ed}, !- Zone Air Exhaust Port List
   {5788baf0-f062-4409-b748-0f0607c7acd9}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {48ee7fc3-0c75-41f2-bdea-ff8a2b6e4a4e}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {4235472c-3c21-4337-b4d8-c08a5384d45e}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {48ee7fc3-0c75-41f2-bdea-ff8a2b6e4a4e}, !- Handle
+  Port List 51,                           !- Name
+  {26a377b7-4408-48d2-bf23-ba3ca649317e}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {27a029ce-d19d-4a01-87bf-f54e28404a0b}, !- Handle
@@ -17075,15 +17375,21 @@ OS:ThermalZone,
   {a9d07d65-3bde-4c2a-b840-ee4f4665f5e3}, !- Zone Air Inlet Port List
   {ddb25a7d-7ec2-4309-a773-009a8a7b9dc9}, !- Zone Air Exhaust Port List
   {73316560-cfe1-4509-9ffa-4229546b9c50}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {1cc536f3-64d9-40e3-a088-262d2fb98db6}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {1814da03-c8da-45e8-a091-e52446458e32}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {1cc536f3-64d9-40e3-a088-262d2fb98db6}, !- Handle
+  Port List 52,                           !- Name
+  {8ead2b82-5479-452a-ae97-540bbed210f8}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {49233823-2b15-4519-b921-af3413b653fe}, !- Handle
@@ -17157,15 +17463,21 @@ OS:ThermalZone,
   {1cf9c9d8-3b69-4929-948b-c8ba433e8b4c}, !- Zone Air Inlet Port List
   {c4642e1d-62e4-4c7c-98fe-2b4cc8dfe461}, !- Zone Air Exhaust Port List
   {63678d07-689e-4c94-abdb-ea636706cd38}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {e47f0f74-7bc3-40f0-a497-5fd96fd77b49}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {cbfe32d8-9b0a-421c-89fd-9e130a6837fd}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {e47f0f74-7bc3-40f0-a497-5fd96fd77b49}, !- Handle
+  Port List 53,                           !- Name
+  {0d1bd9b9-16d1-4378-ba7a-4ac952440963}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {2ff024f1-5362-43f2-8f99-6454cb2d41b1}, !- Handle
@@ -17239,15 +17551,21 @@ OS:ThermalZone,
   {c6c5e674-95a6-4b45-b60e-293b467b9b7e}, !- Zone Air Inlet Port List
   {c0f287a2-9409-43a6-80ef-149cadd02ee8}, !- Zone Air Exhaust Port List
   {dab4be14-4ec8-4669-a869-34734d22432d}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {b4d16353-d1db-4252-a03e-041bd0b0cc21}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {dcf1b432-36dc-4ae3-95de-8cac1fdb0c98}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {b4d16353-d1db-4252-a03e-041bd0b0cc21}, !- Handle
+  Port List 54,                           !- Name
+  {1ce45898-8a87-4247-875d-8b2234ad4cd1}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {c2b653e1-454c-47d0-9742-d64c95820b70}, !- Handle
@@ -17321,15 +17639,21 @@ OS:ThermalZone,
   {93849544-1958-44c9-bd5b-5a7cf5bf7343}, !- Zone Air Inlet Port List
   {9199effa-5a2d-469b-987d-5ddf84937e09}, !- Zone Air Exhaust Port List
   {adc83bf3-3e41-4db3-bb61-2cdf18b0af74}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {cd06cf65-903c-4a2f-91ac-e33a34884f9f}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {7587aa9b-5f51-4de5-9d09-33aae9f0b0e9}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {cd06cf65-903c-4a2f-91ac-e33a34884f9f}, !- Handle
+  Port List 55,                           !- Name
+  {eb3fcf73-8d14-45e9-ad6e-a3a1445d6895}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {028d42ca-6de3-46f3-a79e-f7cd481db9cb}, !- Handle
@@ -17403,15 +17727,21 @@ OS:ThermalZone,
   {fa842318-325b-4632-b36c-dddcfeddabd2}, !- Zone Air Inlet Port List
   {b7ae91cc-0512-4755-b36e-59a564c71b68}, !- Zone Air Exhaust Port List
   {d1986678-9d5e-4236-96dd-292cdc92e44e}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {648ccd0e-4e53-42ec-a8f2-f521f7c5a4d1}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {2fad37cd-3fd3-4152-82a0-680aeb9211b6}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {648ccd0e-4e53-42ec-a8f2-f521f7c5a4d1}, !- Handle
+  Port List 56,                           !- Name
+  {5d11a456-633f-4fdf-91e9-14d4dabfa08b}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {e289bcf9-5659-42f6-9a02-20bbea3e33f8}, !- Handle
@@ -17485,15 +17815,21 @@ OS:ThermalZone,
   {4daeeef5-cece-48ca-93b8-df182435efc0}, !- Zone Air Inlet Port List
   {8e1b5fe6-a715-4203-b760-c4ca81735dcb}, !- Zone Air Exhaust Port List
   {ecd221de-d879-4b8d-b3a8-85d221cb5154}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {6d96e874-f079-446c-bf76-dda7af602c0f}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {9e9ea672-4384-4c2b-a56e-482fb244c405}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {6d96e874-f079-446c-bf76-dda7af602c0f}, !- Handle
+  Port List 57,                           !- Name
+  {c09d0857-b8ca-46fc-9eb8-5192fa1a16a7}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {244ff76a-8963-4367-99ba-3686510addbb}, !- Handle
@@ -17567,15 +17903,21 @@ OS:ThermalZone,
   {b6c519b9-70f2-45b1-bd00-209d47881f05}, !- Zone Air Inlet Port List
   {b75b698e-e5ac-406d-b299-000309c448d5}, !- Zone Air Exhaust Port List
   {70623d19-f1e0-47ea-a0f7-8a2cee67f8ca}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {d6711694-11da-4671-b917-545807293655}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {c40fc8a0-cf52-4708-80f5-578e370a7743}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {d6711694-11da-4671-b917-545807293655}, !- Handle
+  Port List 58,                           !- Name
+  {2ec9e0b6-744b-4acf-82ff-75ba8fd8d44f}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {00a28442-ee04-40c8-8258-c58f2552972e}, !- Handle
@@ -17649,15 +17991,21 @@ OS:ThermalZone,
   {a54ab23c-3bc8-486a-b3c9-eb3dea0e8534}, !- Zone Air Inlet Port List
   {b5a7ecba-9662-4f93-a2be-4e4a27cb6473}, !- Zone Air Exhaust Port List
   {d9ace7e8-9016-4f03-bc5e-6d36c2e7c938}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {67f463f8-d3ab-4a2d-9ded-a3f1a32df0d8}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {ef8c64dc-52db-441b-a054-18313706acdd}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {67f463f8-d3ab-4a2d-9ded-a3f1a32df0d8}, !- Handle
+  Port List 3,                            !- Name
+  {5d45a573-f58e-4d13-be4b-0a4f4540251e}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {331d8dfb-e7f6-4dc7-a3c6-d638c2b1edd3}, !- Handle
@@ -17731,15 +18079,21 @@ OS:ThermalZone,
   {93965702-c985-4989-9c1d-326162e2b65f}, !- Zone Air Inlet Port List
   {b8021d81-7886-4422-b262-4085da59d27d}, !- Zone Air Exhaust Port List
   {f978c1d3-63f4-4424-a38e-8c4b2fb72285}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {a29e5c41-f583-49ad-bc64-bc95088f6fa7}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {26fb457c-2bc3-44a5-8ecd-cb0ee74a695a}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {a29e5c41-f583-49ad-bc64-bc95088f6fa7}, !- Handle
+  Port List 1,                            !- Name
+  {bf624746-7178-45e3-b173-e4653888d0fd}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {5dc47a6d-e07a-423b-af0a-d4cd6a3e3911}, !- Handle
@@ -17813,15 +18167,21 @@ OS:ThermalZone,
   {d8b77775-5507-4594-9c26-97f2a1e001eb}, !- Zone Air Inlet Port List
   {41798bc4-ecaf-4d6a-9084-74cc544217cf}, !- Zone Air Exhaust Port List
   {4acc5f3f-10b5-436e-bca1-6b47c53f8149}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {0cbfab9c-fe7c-44dc-8aad-95f56c8f5df4}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {95669c0d-77f4-4fc7-9291-d78327abe946}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {0cbfab9c-fe7c-44dc-8aad-95f56c8f5df4}, !- Handle
+  Port List 21,                           !- Name
+  {645c4cf5-8c36-4b5c-8c01-fb7daf9dd828}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {bf8f936c-1a8b-42ac-8a1b-d667f2cd969d}, !- Handle
@@ -17895,15 +18255,21 @@ OS:ThermalZone,
   {222a5a44-bd1a-48cb-b200-84530656a210}, !- Zone Air Inlet Port List
   {4dc2eb77-2284-4f25-8519-167be7f92d79}, !- Zone Air Exhaust Port List
   {75a0705d-cc63-430c-8884-787039534a25}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {0e6b56fe-0461-4fc2-af15-9b2d2103e23e}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {5c65d270-6909-4d85-9a9b-11d7e6fb3a1c}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {0e6b56fe-0461-4fc2-af15-9b2d2103e23e}, !- Handle
+  Port List 59,                           !- Name
+  {c6b78f1d-6990-419f-accd-c9dcaa76d920}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {90b6d867-5ddc-4094-857d-31600840e083}, !- Handle
@@ -17977,15 +18343,21 @@ OS:ThermalZone,
   {13d1b7e2-f592-40b7-873e-90832ca917fc}, !- Zone Air Inlet Port List
   {9a663573-db14-4515-88f8-58c4bb5de962}, !- Zone Air Exhaust Port List
   {55e1dc14-604f-4bd1-8d81-f105b6bac183}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {2d2149a5-52b6-46c4-8b98-631c632eeb31}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {f51c7870-1f44-432c-bbed-43370bc9874f}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {2d2149a5-52b6-46c4-8b98-631c632eeb31}, !- Handle
+  Port List 60,                           !- Name
+  {e5aaa50b-0c4f-4b64-9f0f-68e37b10c8e6}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {98f21589-fe61-40d9-9658-0d12efcb2ee6}, !- Handle
@@ -18059,15 +18431,21 @@ OS:ThermalZone,
   {0976eec2-32fe-43fb-8373-378d7a340840}, !- Zone Air Inlet Port List
   {7572d0a2-327b-41d2-bf4c-1d2c3f6d36bd}, !- Zone Air Exhaust Port List
   {349b47d6-ed04-4350-b6f2-a3d9710e5902}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {2f61ec10-80f2-4024-ad8e-269ec1d3d61e}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {0abaee19-5db2-4dcf-9370-fd3366f059c5}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {2f61ec10-80f2-4024-ad8e-269ec1d3d61e}, !- Handle
+  Port List 61,                           !- Name
+  {020322ec-6c5c-48ec-b5df-b99f6ad2cca5}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {a4f45de5-853c-4548-9642-82df22a1aaf5}, !- Handle
@@ -18141,15 +18519,21 @@ OS:ThermalZone,
   {f1bb8829-034e-4783-aa6f-a3db5a10d081}, !- Zone Air Inlet Port List
   {07d09f1a-f595-4250-852e-37035637f24c}, !- Zone Air Exhaust Port List
   {a3f28fb9-56dc-45eb-950f-1b3ad8af8c9d}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {c3134bcf-bf24-45dc-9371-c4f2fc5fb1a8}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {4815d931-66a6-47d1-98cc-10748e445b8f}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {c3134bcf-bf24-45dc-9371-c4f2fc5fb1a8}, !- Handle
+  Port List 62,                           !- Name
+  {a752b066-febb-43d6-8ce7-a33016318c0b}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {88c18d68-1c3c-4444-9d86-41e292184a41}, !- Handle
@@ -18223,15 +18607,21 @@ OS:ThermalZone,
   {462310b1-98bd-412f-98f9-be714a3614e3}, !- Zone Air Inlet Port List
   {4a157835-eebf-4231-9169-6353f694348b}, !- Zone Air Exhaust Port List
   {99db11bf-9d64-4bff-a7fe-fb0a8ec46480}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {22d82ab1-2490-4b7a-92a0-14aa2889a468}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {b64df354-0b28-4c15-b676-66883a9490dc}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {22d82ab1-2490-4b7a-92a0-14aa2889a468}, !- Handle
+  Port List 63,                           !- Name
+  {54cfb823-762b-47e6-8778-e96443e8f870}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {6a2c300b-47aa-46c5-b1b2-07ea965a4d70}, !- Handle
@@ -18305,15 +18695,21 @@ OS:ThermalZone,
   {be2c0f99-96d4-422a-bc26-5544e5161237}, !- Zone Air Inlet Port List
   {311ef473-437c-490d-9459-eb18e10d0e3d}, !- Zone Air Exhaust Port List
   {b5bbef04-9469-43e3-ba66-a6e05ff68cb6}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {09b101f6-9695-4004-935b-14be18a87b21}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {2165155b-6979-455b-9186-f9383a242bf3}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {09b101f6-9695-4004-935b-14be18a87b21}, !- Handle
+  Port List 64,                           !- Name
+  {a1add966-6ea6-4014-95f8-f7eea197b91c}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {9c658678-07b3-40d8-b343-f8d9a678c953}, !- Handle
@@ -18387,15 +18783,21 @@ OS:ThermalZone,
   {e2913218-d349-46de-9c70-b7941eba8a71}, !- Zone Air Inlet Port List
   {4ca5049f-04db-4e67-b566-aeffec184c79}, !- Zone Air Exhaust Port List
   {0936b928-825e-457a-80da-5928d9d5256b}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {ca78ecd6-de11-43b6-a187-cb41120af2b5}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {83f479da-7a15-47c1-9300-422bcc556f51}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {ca78ecd6-de11-43b6-a187-cb41120af2b5}, !- Handle
+  Port List 65,                           !- Name
+  {8994d32d-4b2e-4b58-a451-e239a7a6cd26}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {83eec549-a431-442f-bdb3-930b27be2866}, !- Handle
@@ -18469,15 +18871,21 @@ OS:ThermalZone,
   {cd39a2d5-21e8-43f2-92c3-d965dfa5780f}, !- Zone Air Inlet Port List
   {ae6d6078-eb66-4461-8b96-059f6a27540b}, !- Zone Air Exhaust Port List
   {25628fae-8470-4774-93dd-e2623b7bf3e0}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {65f16fd9-6f85-46b0-b967-1954ff609b2d}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {f7029df2-59f0-41e2-86cc-e6cdf7b0a551}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {65f16fd9-6f85-46b0-b967-1954ff609b2d}, !- Handle
+  Port List 66,                           !- Name
+  {96055c48-37e2-41ed-98fd-e2a74c79c217}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {55b350ab-093d-46cc-bba6-5ca51abee0f9}, !- Handle
@@ -18551,15 +18959,21 @@ OS:ThermalZone,
   {a51e8f0c-8cf6-4c50-91c6-dd958e17d0b5}, !- Zone Air Inlet Port List
   {dd4247b8-5bdf-4c7d-b848-f0c6d37d675f}, !- Zone Air Exhaust Port List
   {b4114c68-3424-4170-8d51-9026fb5e7abc}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {d2b92ec8-0511-4e4e-8c72-fc7b625c7e5a}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {c6dcf088-372a-42d2-a3b8-1325f1523009}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {d2b92ec8-0511-4e4e-8c72-fc7b625c7e5a}, !- Handle
+  Port List 67,                           !- Name
+  {0d120da8-0d40-4a9f-92e4-6351ebfc47c1}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {a0790a42-c7b9-4d4f-b4b4-dfef2b0055d5}, !- Handle
@@ -18633,15 +19047,21 @@ OS:ThermalZone,
   {8fe5dbc3-cf29-4dc8-9a17-d0d1c96260da}, !- Zone Air Inlet Port List
   {6272659a-01a8-4cb7-87a0-7f80d855c481}, !- Zone Air Exhaust Port List
   {bc23f2f5-5284-41e8-ab8e-5d6b9222bfe1}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {d4226ba1-8168-4a1b-83f5-a64fe0851475}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {2874248f-7774-44ae-973f-b6652de9f9e7}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {d4226ba1-8168-4a1b-83f5-a64fe0851475}, !- Handle
+  Port List 68,                           !- Name
+  {009ccf37-480b-4fd7-94ba-1bef9b6d6975}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {393814bd-f360-4d44-8707-77b1c25488d7}, !- Handle
@@ -18701,4 +19121,480 @@ OS:ZoneHVAC:EquipmentList,
   {42645048-c133-4eb0-b4e1-c087f9d3480c}, !- Handle
   Zone HVAC Equipment List 9,             !- Name
   {009ccf37-480b-4fd7-94ba-1bef9b6d6975}; !- Thermal Zone
+
+OS:Rendering:Color,
+  {ddfd8286-0d73-412c-b4f9-64bbaeb69608}, !- Handle
+  Rendering Color 18,                     !- Name
+  205,                                    !- Rendering Red Value
+  133,                                    !- Rendering Green Value
+  63;                                     !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {2874248f-7774-44ae-973f-b6652de9f9e7}, !- Handle
+  Rendering Color 19,                     !- Name
+  72,                                     !- Rendering Red Value
+  61,                                     !- Rendering Green Value
+  139;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {c6dcf088-372a-42d2-a3b8-1325f1523009}, !- Handle
+  Rendering Color 20,                     !- Name
+  255,                                    !- Rendering Red Value
+  99,                                     !- Rendering Green Value
+  71;                                     !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {f7029df2-59f0-41e2-86cc-e6cdf7b0a551}, !- Handle
+  Rendering Color 21,                     !- Name
+  143,                                    !- Rendering Red Value
+  188,                                    !- Rendering Green Value
+  143;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {83f479da-7a15-47c1-9300-422bcc556f51}, !- Handle
+  Rendering Color 22,                     !- Name
+  105,                                    !- Rendering Red Value
+  105,                                    !- Rendering Green Value
+  105;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {2165155b-6979-455b-9186-f9383a242bf3}, !- Handle
+  Rendering Color 23,                     !- Name
+  255,                                    !- Rendering Red Value
+  228,                                    !- Rendering Green Value
+  181;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {b64df354-0b28-4c15-b676-66883a9490dc}, !- Handle
+  Rendering Color 24,                     !- Name
+  233,                                    !- Rendering Red Value
+  150,                                    !- Rendering Green Value
+  122;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {4815d931-66a6-47d1-98cc-10748e445b8f}, !- Handle
+  Rendering Color 25,                     !- Name
+  250,                                    !- Rendering Red Value
+  240,                                    !- Rendering Green Value
+  230;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {0abaee19-5db2-4dcf-9370-fd3366f059c5}, !- Handle
+  Rendering Color 26,                     !- Name
+  0,                                      !- Rendering Red Value
+  0,                                      !- Rendering Green Value
+  255;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {f51c7870-1f44-432c-bbed-43370bc9874f}, !- Handle
+  Rendering Color 27,                     !- Name
+  240,                                    !- Rendering Red Value
+  255,                                    !- Rendering Green Value
+  255;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {5c65d270-6909-4d85-9a9b-11d7e6fb3a1c}, !- Handle
+  Rendering Color 28,                     !- Name
+  60,                                     !- Rendering Red Value
+  179,                                    !- Rendering Green Value
+  113;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {95669c0d-77f4-4fc7-9291-d78327abe946}, !- Handle
+  Rendering Color 29,                     !- Name
+  255,                                    !- Rendering Red Value
+  250,                                    !- Rendering Green Value
+  240;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {26fb457c-2bc3-44a5-8ecd-cb0ee74a695a}, !- Handle
+  Rendering Color 30,                     !- Name
+  240,                                    !- Rendering Red Value
+  255,                                    !- Rendering Green Value
+  255;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {ef8c64dc-52db-441b-a054-18313706acdd}, !- Handle
+  Rendering Color 31,                     !- Name
+  255,                                    !- Rendering Red Value
+  245,                                    !- Rendering Green Value
+  238;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {94001235-df58-4728-9a24-9a20d43df931}, !- Handle
+  Rendering Color 32,                     !- Name
+  138,                                    !- Rendering Red Value
+  43,                                     !- Rendering Green Value
+  226;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {4a85f779-2db6-4f45-9f61-50b3e7a5ce69}, !- Handle
+  Rendering Color 33,                     !- Name
+  245,                                    !- Rendering Red Value
+  255,                                    !- Rendering Green Value
+  250;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {f6054f94-fe87-4594-bb42-c8505ebb712a}, !- Handle
+  Rendering Color 34,                     !- Name
+  0,                                      !- Rendering Red Value
+  128,                                    !- Rendering Green Value
+  0;                                      !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {8965a7a9-f4ae-4bec-a3ca-8cfb7139f42e}, !- Handle
+  Rendering Color 35,                     !- Name
+  0,                                      !- Rendering Red Value
+  191,                                    !- Rendering Green Value
+  255;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {11f94e12-2e5f-4bd8-bbfa-61159840d181}, !- Handle
+  Rendering Color 36,                     !- Name
+  127,                                    !- Rendering Red Value
+  255,                                    !- Rendering Green Value
+  212;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {dd73097c-f4a7-4c11-887a-1e08102ada6f}, !- Handle
+  Rendering Color 37,                     !- Name
+  205,                                    !- Rendering Red Value
+  133,                                    !- Rendering Green Value
+  63;                                     !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {d8d9ae88-849d-42c4-8b96-e8cc7419029d}, !- Handle
+  Rendering Color 38,                     !- Name
+  123,                                    !- Rendering Red Value
+  104,                                    !- Rendering Green Value
+  238;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {a55d82e4-6f5f-4cf6-b46f-b17ee21e397b}, !- Handle
+  Rendering Color 39,                     !- Name
+  255,                                    !- Rendering Red Value
+  0,                                      !- Rendering Green Value
+  0;                                      !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {0b50f197-03d2-426a-a8b9-62af738466d1}, !- Handle
+  Rendering Color 40,                     !- Name
+  72,                                     !- Rendering Red Value
+  209,                                    !- Rendering Green Value
+  204;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {716485c8-3805-4ada-a030-78732ece8303}, !- Handle
+  Rendering Color 41,                     !- Name
+  255,                                    !- Rendering Red Value
+  250,                                    !- Rendering Green Value
+  205;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {a62b37b0-b3fd-4587-8a23-4a38426ebb5d}, !- Handle
+  Rendering Color 42,                     !- Name
+  0,                                      !- Rendering Red Value
+  206,                                    !- Rendering Green Value
+  209;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {d7b5365e-7b2d-4e9f-afa9-35a1c5d132f7}, !- Handle
+  Rendering Color 43,                     !- Name
+  0,                                      !- Rendering Red Value
+  0,                                      !- Rendering Green Value
+  205;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {148f2e98-b820-42ee-863a-488cce67f0d8}, !- Handle
+  Rendering Color 44,                     !- Name
+  255,                                    !- Rendering Red Value
+  140,                                    !- Rendering Green Value
+  0;                                      !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {0a912974-a159-4100-93b0-4d6e4a29449b}, !- Handle
+  Rendering Color 45,                     !- Name
+  123,                                    !- Rendering Red Value
+  104,                                    !- Rendering Green Value
+  238;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {fcebfc12-1b0e-429c-8918-fad8785172f2}, !- Handle
+  Rendering Color 46,                     !- Name
+  64,                                     !- Rendering Red Value
+  224,                                    !- Rendering Green Value
+  208;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {e228138e-1eee-4e28-be5a-bb586618f2af}, !- Handle
+  Rendering Color 47,                     !- Name
+  144,                                    !- Rendering Red Value
+  238,                                    !- Rendering Green Value
+  144;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {a1298917-acfd-46cc-8b90-6a4d1d880349}, !- Handle
+  Rendering Color 48,                     !- Name
+  139,                                    !- Rendering Red Value
+  0,                                      !- Rendering Green Value
+  0;                                      !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {8e7d9336-bf00-4f15-9294-e1ef3fb31d7f}, !- Handle
+  Rendering Color 49,                     !- Name
+  139,                                    !- Rendering Red Value
+  0,                                      !- Rendering Green Value
+  0;                                      !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {7f026f8e-3cc7-4dbe-9d3b-3ff95f2c8ada}, !- Handle
+  Rendering Color 50,                     !- Name
+  255,                                    !- Rendering Red Value
+  222,                                    !- Rendering Green Value
+  173;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {142c39f0-aa80-42f1-bb93-b3af0a3ec796}, !- Handle
+  Rendering Color 51,                     !- Name
+  245,                                    !- Rendering Red Value
+  222,                                    !- Rendering Green Value
+  179;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {79c04414-72c0-4b0c-97c2-e285e08fdcac}, !- Handle
+  Rendering Color 52,                     !- Name
+  255,                                    !- Rendering Red Value
+  245,                                    !- Rendering Green Value
+  238;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {988167de-41f8-47d8-9e0d-a04c067a4387}, !- Handle
+  Rendering Color 53,                     !- Name
+  128,                                    !- Rendering Red Value
+  0,                                      !- Rendering Green Value
+  128;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {53e5cc82-80a7-4050-8751-8f21a72f6257}, !- Handle
+  Rendering Color 54,                     !- Name
+  250,                                    !- Rendering Red Value
+  240,                                    !- Rendering Green Value
+  230;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {7aa52b00-5421-4e61-8df2-c40b2e474b76}, !- Handle
+  Rendering Color 55,                     !- Name
+  255,                                    !- Rendering Red Value
+  215,                                    !- Rendering Green Value
+  0;                                      !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {5a4e03f5-5aaf-4788-8fcf-53376e80fa80}, !- Handle
+  Rendering Color 56,                     !- Name
+  112,                                    !- Rendering Red Value
+  128,                                    !- Rendering Green Value
+  144;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {168b2b86-fe37-4390-82c9-590568a5cb24}, !- Handle
+  Rendering Color 57,                     !- Name
+  175,                                    !- Rendering Red Value
+  238,                                    !- Rendering Green Value
+  238;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {e141ea41-ac2c-40ec-8c21-12056b2d9ec9}, !- Handle
+  Rendering Color 58,                     !- Name
+  175,                                    !- Rendering Red Value
+  238,                                    !- Rendering Green Value
+  238;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {453a620e-4faa-4be6-9d66-851b4095c6a5}, !- Handle
+  Rendering Color 59,                     !- Name
+  218,                                    !- Rendering Red Value
+  112,                                    !- Rendering Green Value
+  214;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {6c870542-f249-4aa1-80ee-889c6076aafd}, !- Handle
+  Rendering Color 60,                     !- Name
+  173,                                    !- Rendering Red Value
+  216,                                    !- Rendering Green Value
+  230;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {ae3565fa-90aa-407d-af84-4da598fc1571}, !- Handle
+  Rendering Color 61,                     !- Name
+  244,                                    !- Rendering Red Value
+  164,                                    !- Rendering Green Value
+  96;                                     !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {d8005d63-7d7e-456b-900b-59b8907679f5}, !- Handle
+  Rendering Color 62,                     !- Name
+  192,                                    !- Rendering Red Value
+  192,                                    !- Rendering Green Value
+  192;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {100b784b-cdc9-464f-884b-2d837aef6123}, !- Handle
+  Rendering Color 63,                     !- Name
+  0,                                      !- Rendering Red Value
+  128,                                    !- Rendering Green Value
+  0;                                      !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {2713d5d1-429e-45ca-add1-ebd18b244bc0}, !- Handle
+  Rendering Color 64,                     !- Name
+  255,                                    !- Rendering Red Value
+  222,                                    !- Rendering Green Value
+  173;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {d4a6b0ef-22f0-40c5-8ff8-9079a0f13877}, !- Handle
+  Rendering Color 65,                     !- Name
+  0,                                      !- Rendering Red Value
+  0,                                      !- Rendering Green Value
+  139;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {c40fc8a0-cf52-4708-80f5-578e370a7743}, !- Handle
+  Rendering Color 66,                     !- Name
+  0,                                      !- Rendering Red Value
+  255,                                    !- Rendering Green Value
+  255;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {5334ff38-c66a-4446-b949-3b79cfe7f45c}, !- Handle
+  Rendering Color 67,                     !- Name
+  210,                                    !- Rendering Red Value
+  105,                                    !- Rendering Green Value
+  30;                                     !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {8a5e3fea-b0aa-4999-9818-253184b62efd}, !- Handle
+  Rendering Color 68,                     !- Name
+  189,                                    !- Rendering Red Value
+  183,                                    !- Rendering Green Value
+  107;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {7640594f-7b24-44ea-b9ef-549a7f3eb798}, !- Handle
+  Rendering Color 69,                     !- Name
+  255,                                    !- Rendering Red Value
+  140,                                    !- Rendering Green Value
+  0;                                      !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {68c6b0f2-f740-4cb4-95e7-aecccae5e02b}, !- Handle
+  Rendering Color 70,                     !- Name
+  119,                                    !- Rendering Red Value
+  136,                                    !- Rendering Green Value
+  153;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {dc6479e4-cf34-455f-9d25-440fbfd346a9}, !- Handle
+  Rendering Color 71,                     !- Name
+  255,                                    !- Rendering Red Value
+  69,                                     !- Rendering Green Value
+  0;                                      !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {a7ace894-299c-411f-bb55-480c483aea6d}, !- Handle
+  Rendering Color 72,                     !- Name
+  64,                                     !- Rendering Red Value
+  224,                                    !- Rendering Green Value
+  208;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {361568d0-e211-4dfc-9741-9388d74e5dd1}, !- Handle
+  Rendering Color 73,                     !- Name
+  255,                                    !- Rendering Red Value
+  127,                                    !- Rendering Green Value
+  80;                                     !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {ae52967a-de3a-45ea-91b8-613fcaf84d75}, !- Handle
+  Rendering Color 74,                     !- Name
+  248,                                    !- Rendering Red Value
+  248,                                    !- Rendering Green Value
+  255;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {a2ec5fa1-8361-4a62-9ad9-18236d9fa1f9}, !- Handle
+  Rendering Color 75,                     !- Name
+  244,                                    !- Rendering Red Value
+  164,                                    !- Rendering Green Value
+  96;                                     !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {199f4a25-5ce6-456e-8938-41d7d8429e5a}, !- Handle
+  Rendering Color 76,                     !- Name
+  255,                                    !- Rendering Red Value
+  255,                                    !- Rendering Green Value
+  0;                                      !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {31e0b088-8254-4883-b617-979712a4f410}, !- Handle
+  Rendering Color 77,                     !- Name
+  255,                                    !- Rendering Red Value
+  228,                                    !- Rendering Green Value
+  225;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {56049e62-cc44-489d-90a7-a20a7c3fdb10}, !- Handle
+  Rendering Color 78,                     !- Name
+  144,                                    !- Rendering Red Value
+  238,                                    !- Rendering Green Value
+  144;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {9e9ea672-4384-4c2b-a56e-482fb244c405}, !- Handle
+  Rendering Color 79,                     !- Name
+  255,                                    !- Rendering Red Value
+  165,                                    !- Rendering Green Value
+  0;                                      !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {1814da03-c8da-45e8-a091-e52446458e32}, !- Handle
+  Rendering Color 80,                     !- Name
+  112,                                    !- Rendering Red Value
+  128,                                    !- Rendering Green Value
+  144;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {cbfe32d8-9b0a-421c-89fd-9e130a6837fd}, !- Handle
+  Rendering Color 81,                     !- Name
+  221,                                    !- Rendering Red Value
+  160,                                    !- Rendering Green Value
+  221;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {dcf1b432-36dc-4ae3-95de-8cac1fdb0c98}, !- Handle
+  Rendering Color 82,                     !- Name
+  75,                                     !- Rendering Red Value
+  0,                                      !- Rendering Green Value
+  130;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {7587aa9b-5f51-4de5-9d09-33aae9f0b0e9}, !- Handle
+  Rendering Color 83,                     !- Name
+  253,                                    !- Rendering Red Value
+  245,                                    !- Rendering Green Value
+  230;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {2fad37cd-3fd3-4152-82a0-680aeb9211b6}, !- Handle
+  Rendering Color 84,                     !- Name
+  240,                                    !- Rendering Red Value
+  230,                                    !- Rendering Green Value
+  140;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {4235472c-3c21-4337-b4d8-c08a5384d45e}, !- Handle
+  Rendering Color 85,                     !- Name
+  219,                                    !- Rendering Red Value
+  112,                                    !- Rendering Green Value
+  147;                                    !- Rendering Blue Value
 

--- a/data/geometry/ASHRAELargeOfficeDetailed.osm
+++ b/data/geometry/ASHRAELargeOfficeDetailed.osm
@@ -3848,7 +3848,7 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {23bb7aaa-6a7c-4d7a-826f-f4ffe1c733a5}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
@@ -6879,7 +6879,7 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {23bb7aaa-6a7c-4d7a-826f-f4ffe1c733a5}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
@@ -6896,7 +6896,7 @@ OS:Surface,
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {23bb7aaa-6a7c-4d7a-826f-f4ffe1c733a5}, !- Space Name
-  Ground,                                 !- Outside Boundary Condition
+  Adiabatic,                              !- Outside Boundary Condition
   ,                                       !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure

--- a/data/geometry/ASHRAELargeOfficeDetailed.osm
+++ b/data/geometry/ASHRAELargeOfficeDetailed.osm
@@ -1,7 +1,7 @@
 
 OS:Version,
-  {9e735feb-770a-44eb-9589-3a1ec5d86631}, !- Handle
-  2.6.0;                                  !- Version Identifier
+  {12c898a0-f630-4fa1-a075-bdc1b2f5be09}, !- Handle
+  2.7.1;                                  !- Version Identifier
 
 OS:Site,
   {84df88f5-7a35-4631-b533-5d8e10b21d42}, !- Handle
@@ -207,6 +207,7 @@ OS:Building,
   ,                                       !- Default Schedule Set Name
   13,                                     !- Standards Number of Stories
   12,                                     !- Standards Number of Above Ground Stories
+  ,                                       !- Standards Template
   ,                                       !- Standards Building Type
   ,                                       !- Standards Number of Living Units
   ,                                       !- Relocatable
@@ -300,7 +301,7 @@ OS:Space,
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
   0,                                      !- Y Origin {m}
-  -3.17641024594195e-014,                 !- Z Origin {m}
+  0,                                      !- Z Origin {m}
   {c136f41b-5899-4461-9ab1-ce81a1bb07cd}, !- Building Story Name
   {b7e1732c-8f7b-4d17-b493-30105978df29}, !- Thermal Zone Name
   ,                                       !- Part of Total Floor Area
@@ -308,7 +309,7 @@ OS:Space,
 
 OS:Surface,
   {802e8ff6-a345-47ad-9880-24246e50b9d0}, !- Handle
-  Surface 7,                              !- Name
+  OpenOffice_Basement_ZN_1 - Floor_a,     !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {028af023-65bd-494f-805d-65623355f305}, !- Space Name
@@ -325,7 +326,7 @@ OS:Surface,
 
 OS:Surface,
   {53a1330a-3976-4001-9634-0bb0805673a4}, !- Handle
-  Surface 8,                              !- Name
+  OpenOffice_Basement_ZN_1 - RoofCeiling_a, !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {028af023-65bd-494f-805d-65623355f305}, !- Space Name
@@ -335,14 +336,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.0416275, 0, 2.31011654250324e-014,   !- X,Y,Z Vertex 1 {m}
-  46.0416275, 12.1618375, 2.31011654250324e-014, !- X,Y,Z Vertex 2 {m}
-  41.7576, 12.1618375, -5.12948915010911e-030, !- X,Y,Z Vertex 3 {m}
-  41.7576, -9.9636129237382e-017, -5.12948915010911e-030; !- X,Y,Z Vertex 4 {m}
+  46.0416275, 0, 0,                       !- X,Y,Z Vertex 1 {m}
+  46.0416275, 12.1618375, 0,              !- X,Y,Z Vertex 2 {m}
+  41.7576, 12.1618375, 0,                 !- X,Y,Z Vertex 3 {m}
+  41.7576, 0, 0;                          !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {11db6f98-7620-4c19-b2f9-04176446a5f0}, !- Handle
-  Surface 9,                              !- Name
+  OpenOffice_Basement_ZN_1 - Wall 180_a,  !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {028af023-65bd-494f-805d-65623355f305}, !- Space Name
@@ -352,14 +353,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   0,                                      !- View Factor to Ground
   ,                                       !- Number of Vertices
-  16.0797875, 0, 2.31011654250324e-014,   !- X,Y,Z Vertex 1 {m}
+  16.0797875, 0, 0,                       !- X,Y,Z Vertex 1 {m}
   16.0797875, 0, -2.4384,                 !- X,Y,Z Vertex 2 {m}
   46.0416275, 0, -2.4384,                 !- X,Y,Z Vertex 3 {m}
-  46.0416275, 0, 2.31011654250324e-014;   !- X,Y,Z Vertex 4 {m}
+  46.0416275, 0, 0;                       !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {53807301-7187-4754-9cbd-5868b3641d01}, !- Handle
-  Surface 10,                             !- Name
+  OpenOffice_Basement_ZN_1 - Wall 270_a,  !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {028af023-65bd-494f-805d-65623355f305}, !- Space Name
@@ -369,14 +370,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  16.0797875, 12.1618375, 2.31011654250324e-014, !- X,Y,Z Vertex 1 {m}
+  16.0797875, 12.1618375, 0,              !- X,Y,Z Vertex 1 {m}
   16.0797875, 12.1618375, -2.4384,        !- X,Y,Z Vertex 2 {m}
   16.0797875, 0, -2.4384,                 !- X,Y,Z Vertex 3 {m}
-  16.0797875, 0, 2.31011654250324e-014;   !- X,Y,Z Vertex 4 {m}
+  16.0797875, 0, 0;                       !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {92346f21-933e-4dc4-9133-d65a286c47be}, !- Handle
-  Surface 11,                             !- Name
+  OpenOffice_Basement_ZN_1 - Wall 000_a,  !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {028af023-65bd-494f-805d-65623355f305}, !- Space Name
@@ -386,14 +387,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  35.3568, 12.1618375, 2.31011654250324e-014, !- X,Y,Z Vertex 1 {m}
+  35.3568, 12.1618375, 0,                 !- X,Y,Z Vertex 1 {m}
   35.3568, 12.1618375, -2.4384,           !- X,Y,Z Vertex 2 {m}
   16.0797875, 12.1618375, -2.4384,        !- X,Y,Z Vertex 3 {m}
-  16.0797875, 12.1618375, 2.31011654250324e-014; !- X,Y,Z Vertex 4 {m}
+  16.0797875, 12.1618375, 0;              !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {638171c0-d9de-4262-ae60-5c8a36a29186}, !- Handle
-  Surface 12,                             !- Name
+  OpenOffice_Basement_ZN_1 - Wall 090_a,  !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {028af023-65bd-494f-805d-65623355f305}, !- Space Name
@@ -403,10 +404,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.0416275, 0, 2.31011654250324e-014,   !- X,Y,Z Vertex 1 {m}
+  46.0416275, 0, 0,                       !- X,Y,Z Vertex 1 {m}
   46.0416275, 0, -2.4384,                 !- X,Y,Z Vertex 2 {m}
   46.0416275, 12.1618375, -2.4384,        !- X,Y,Z Vertex 3 {m}
-  46.0416275, 12.1618375, 2.31011654250324e-014; !- X,Y,Z Vertex 4 {m}
+  46.0416275, 12.1618375, 0;              !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {221e8adf-462f-4102-abb1-0bbedcc1010c}, !- Handle
@@ -417,7 +418,7 @@ OS:Space,
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
   0,                                      !- Y Origin {m}
-  -3.17641024594195e-014,                 !- Z Origin {m}
+  0,                                      !- Z Origin {m}
   {c136f41b-5899-4461-9ab1-ce81a1bb07cd}, !- Building Story Name
   {2f0fb3d4-ceca-4279-afc1-c6190ec86ec6}, !- Thermal Zone Name
   ,                                       !- Part of Total Floor Area
@@ -426,7 +427,7 @@ OS:Space,
 
 OS:Surface,
   {258635a7-168d-4200-94db-dc4618b08d2f}, !- Handle
-  Surface 13,                             !- Name
+  Corridor_Basement_ZN_1 - Floor_a,       !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {221e8adf-462f-4102-abb1-0bbedcc1010c}, !- Space Name
@@ -445,7 +446,7 @@ OS:Surface,
 
 OS:Surface,
   {eab8fd23-f85f-4a65-96f1-d200c9d74915}, !- Handle
-  Surface 14,                             !- Name
+  Corridor_Basement_ZN_1 - Wall 000_a,    !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {221e8adf-462f-4102-abb1-0bbedcc1010c}, !- Space Name
@@ -455,14 +456,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  17.6037875, 36.5458375, 2.31011654250324e-014, !- X,Y,Z Vertex 1 {m}
+  17.6037875, 36.5458375, 0,              !- X,Y,Z Vertex 1 {m}
   17.6037875, 36.5458375, -2.4384,        !- X,Y,Z Vertex 2 {m}
   16.0797875, 36.5458375, -2.4384,        !- X,Y,Z Vertex 3 {m}
-  16.0797875, 36.5458375, 2.08245130510991e-014; !- X,Y,Z Vertex 4 {m}
+  16.0797875, 36.5458375, 0;              !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {235e931c-dcef-4394-960d-aee6914558e3}, !- Handle
-  Surface 15,                             !- Name
+  Corridor_Basement_ZN_1 - Wall 270_a,    !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {221e8adf-462f-4102-abb1-0bbedcc1010c}, !- Space Name
@@ -472,14 +473,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  16.0797875, 36.5458375, 2.08245130510991e-014, !- X,Y,Z Vertex 1 {m}
+  16.0797875, 36.5458375, 0,              !- X,Y,Z Vertex 1 {m}
   16.0797875, 36.5458375, -2.4384,        !- X,Y,Z Vertex 2 {m}
   16.0797875, 12.1618375, -2.4384,        !- X,Y,Z Vertex 3 {m}
-  16.0797875, 12.1618375, 9.58513002759797e-015; !- X,Y,Z Vertex 4 {m}
+  16.0797875, 12.1618375, 0;              !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {f5f11691-525d-4fad-8719-b34e2d02e833}, !- Handle
-  Surface 16,                             !- Name
+  Corridor_Basement_ZN_1 - RoofCeiling_a, !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {221e8adf-462f-4102-abb1-0bbedcc1010c}, !- Space Name
@@ -489,14 +490,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  17.6037875, 13.6858375, 2.23280116459253e-014, !- X,Y,Z Vertex 1 {m}
-  17.6037875, 35.0218375, 2.48408728770166e-014, !- X,Y,Z Vertex 2 {m}
-  16.58112, 35.0218375, 1.68092972453691e-014, !- X,Y,Z Vertex 3 {m}
-  16.58112, 13.6858375, 1.42964360142778e-014; !- X,Y,Z Vertex 4 {m}
+  17.6037875, 13.6858375, 0,              !- X,Y,Z Vertex 1 {m}
+  17.6037875, 35.0218375, 0,              !- X,Y,Z Vertex 2 {m}
+  16.58112, 35.0218375, 0,                !- X,Y,Z Vertex 3 {m}
+  16.58112, 13.6858375, 0;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {f6ff09bb-1132-4612-a93a-7cf71bfb0796}, !- Handle
-  Surface 17,                             !- Name
+  Corridor_Basement_ZN_1 - Wall 180_a,    !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {221e8adf-462f-4102-abb1-0bbedcc1010c}, !- Space Name
@@ -506,14 +507,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  16.0797875, 12.1618375, 9.58513002759797e-015, !- X,Y,Z Vertex 1 {m}
+  16.0797875, 12.1618375, 0,              !- X,Y,Z Vertex 1 {m}
   16.0797875, 12.1618375, -2.4384,        !- X,Y,Z Vertex 2 {m}
   35.3568, 12.1618375, -2.4384,           !- X,Y,Z Vertex 3 {m}
-  35.3568, 12.1618375, 2.29680037883233e-014; !- X,Y,Z Vertex 4 {m}
+  35.3568, 12.1618375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {cb7a6704-3ef6-431b-ba9e-fe18d0032187}, !- Handle
-  Surface 18,                             !- Name
+  Corridor_Basement_ZN_1 - Wall 090_b,    !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {221e8adf-462f-4102-abb1-0bbedcc1010c}, !- Space Name
@@ -523,14 +524,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  35.3568, 12.1618375, 2.29680037883233e-014, !- X,Y,Z Vertex 1 {m}
+  35.3568, 12.1618375, 0,                 !- X,Y,Z Vertex 1 {m}
   35.3568, 12.1618375, -2.4384,           !- X,Y,Z Vertex 2 {m}
   35.3568, 13.6858375, -2.4384,           !- X,Y,Z Vertex 3 {m}
-  35.3568, 13.6858375, 2.36704652272921e-014; !- X,Y,Z Vertex 4 {m}
+  35.3568, 13.6858375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {4cd299cc-3cac-46f7-9f01-0ed88aee9870}, !- Handle
-  Surface 19,                             !- Name
+  Corridor_Basement_ZN_1 - Wall 000_b,    !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {221e8adf-462f-4102-abb1-0bbedcc1010c}, !- Space Name
@@ -540,14 +541,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  17.6037875, 13.6858375, 2.59888111031614e-014, !- X,Y,Z Vertex 1 {m}
-  35.3568, 13.6858375, 2.36704652272921e-014, !- X,Y,Z Vertex 2 {m}
-  35.3568, 13.6858375, -2.4384,           !- X,Y,Z Vertex 3 {m}
-  17.6037875, 13.6858375, -2.4384;        !- X,Y,Z Vertex 4 {m}
+  35.3568, 13.6858375, 0,                 !- X,Y,Z Vertex 1 {m}
+  35.3568, 13.6858375, -2.4384,           !- X,Y,Z Vertex 2 {m}
+  17.6037875, 13.6858375, -2.4384,        !- X,Y,Z Vertex 3 {m}
+  17.6037875, 13.6858375, 0;              !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {afffcbd1-000d-4894-abf4-e2d7f338b400}, !- Handle
-  Surface 20,                             !- Name
+  Corridor_Basement_ZN_1 - Wall 090_a,    !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {221e8adf-462f-4102-abb1-0bbedcc1010c}, !- Space Name
@@ -557,10 +558,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  17.6037875, 13.6858375, 2.59888111031614e-014, !- X,Y,Z Vertex 1 {m}
+  17.6037875, 13.6858375, 0,              !- X,Y,Z Vertex 1 {m}
   17.6037875, 13.6858375, -2.4384,        !- X,Y,Z Vertex 2 {m}
   17.6037875, 18.8674375, -2.4384,        !- X,Y,Z Vertex 3 {m}
-  17.6037875, 18.8674375, 2.31011654250324e-014; !- X,Y,Z Vertex 4 {m}
+  17.6037875, 18.8674375, 0;              !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {6e08b2d6-7428-43a2-bb23-1dba7f241ea7}, !- Handle
@@ -571,7 +572,7 @@ OS:Space,
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
   0,                                      !- Y Origin {m}
-  -8.66293703438714e-015,                 !- Z Origin {m}
+  0,                                      !- Z Origin {m}
   {c136f41b-5899-4461-9ab1-ce81a1bb07cd}, !- Building Story Name
   {4f1eb317-106d-40ec-a2ea-11206537f0a1}, !- Thermal Zone Name
   ,                                       !- Part of Total Floor Area
@@ -580,7 +581,7 @@ OS:Space,
 
 OS:Surface,
   {f65dce93-5626-4b28-91cc-afaf637ca691}, !- Handle
-  Surface 21,                             !- Name
+  EnclosedOffice_Basement_ZN_1 - Floor_a, !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {6e08b2d6-7428-43a2-bb23-1dba7f241ea7}, !- Space Name
@@ -590,14 +591,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  35.3568, 18.8674375, -2.43840000000002, !- X,Y,Z Vertex 1 {m}
-  35.3568, 13.6858375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  17.6037875, 13.6858375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  17.6037875, 18.8674375, -2.43840000000002; !- X,Y,Z Vertex 4 {m}
+  35.3568, 18.8674375, -2.4384,           !- X,Y,Z Vertex 1 {m}
+  35.3568, 13.6858375, -2.4384,           !- X,Y,Z Vertex 2 {m}
+  17.6037875, 13.6858375, -2.4384,        !- X,Y,Z Vertex 3 {m}
+  17.6037875, 18.8674375, -2.4384;        !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {a0645a15-5aff-433f-b9ca-ea3c05a0e718}, !- Handle
-  Surface 22,                             !- Name
+  EnclosedOffice_Basement_ZN_1 - Wall 180_a, !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {6e08b2d6-7428-43a2-bb23-1dba7f241ea7}, !- Space Name
@@ -607,14 +608,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  17.6037875, 13.6858375, -1.05128350469386e-014, !- X,Y,Z Vertex 1 {m}
-  17.6037875, 13.6858375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  35.3568, 13.6858375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  35.3568, 13.6858375, -1.08286712929839e-014; !- X,Y,Z Vertex 4 {m}
+  17.6037875, 13.6858375, 0,              !- X,Y,Z Vertex 1 {m}
+  17.6037875, 13.6858375, -2.4384,        !- X,Y,Z Vertex 2 {m}
+  35.3568, 13.6858375, -2.4384,           !- X,Y,Z Vertex 3 {m}
+  35.3568, 13.6858375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {802df1ad-7926-4ac7-a4d3-9e008db1c3aa}, !- Handle
-  Surface 23,                             !- Name
+  EnclosedOffice_Basement_ZN_1 - Wall 090_a, !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {6e08b2d6-7428-43a2-bb23-1dba7f241ea7}, !- Space Name
@@ -624,14 +625,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  35.3568, 13.6858375, -1.08286712929839e-014, !- X,Y,Z Vertex 1 {m}
-  35.3568, 13.6858375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  35.3568, 18.8674375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  35.3568, 18.8674375, -1.22724941320485e-014; !- X,Y,Z Vertex 4 {m}
+  35.3568, 13.6858375, 0,                 !- X,Y,Z Vertex 1 {m}
+  35.3568, 13.6858375, -2.4384,           !- X,Y,Z Vertex 2 {m}
+  35.3568, 18.8674375, -2.4384,           !- X,Y,Z Vertex 3 {m}
+  35.3568, 18.8674375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {cc34931f-eb4e-46af-a5e6-fb4fa7717d8b}, !- Handle
-  Surface 24,                             !- Name
+  EnclosedOffice_Basement_ZN_1 - Wall 000_b, !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {6e08b2d6-7428-43a2-bb23-1dba7f241ea7}, !- Space Name
@@ -641,14 +642,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  25.4508, 18.8674375, -1.15505827125162e-014, !- X,Y,Z Vertex 1 {m}
-  35.3568, 18.8674375, -1.22724941320485e-014, !- X,Y,Z Vertex 2 {m}
-  35.3568, 18.8674375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  25.4508, 18.8674375, -2.43840000000002; !- X,Y,Z Vertex 4 {m}
+  35.3568, 18.8674375, 0,                 !- X,Y,Z Vertex 1 {m}
+  35.3568, 18.8674375, -2.4384,           !- X,Y,Z Vertex 2 {m}
+  25.4508, 18.8674375, -2.4384,           !- X,Y,Z Vertex 3 {m}
+  25.4508, 18.8674375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {38cb8931-7a38-4a41-a800-455c92736870}, !- Handle
-  Surface 25,                             !- Name
+  EnclosedOffice_Basement_ZN_1 - Wall 270_a, !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {6e08b2d6-7428-43a2-bb23-1dba7f241ea7}, !- Space Name
@@ -658,14 +659,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  17.6037875, 13.6858375, -1.05128350469386e-014, !- X,Y,Z Vertex 1 {m}
-  17.6037875, 18.8674375, -1.15505827125162e-014, !- X,Y,Z Vertex 2 {m}
-  17.6037875, 18.8674375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  17.6037875, 13.6858375, -2.43840000000002; !- X,Y,Z Vertex 4 {m}
+  17.6037875, 18.8674375, 0,              !- X,Y,Z Vertex 1 {m}
+  17.6037875, 18.8674375, -2.4384,        !- X,Y,Z Vertex 2 {m}
+  17.6037875, 13.6858375, -2.4384,        !- X,Y,Z Vertex 3 {m}
+  17.6037875, 13.6858375, 0;              !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {fd02bb81-9768-4e9e-9947-32eb0de04be9}, !- Handle
-  Surface 26,                             !- Name
+  EnclosedOffice_Basement_ZN_1 - RoofCeiling_b, !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {6e08b2d6-7428-43a2-bb23-1dba7f241ea7}, !- Space Name
@@ -675,10 +676,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  18.288, 13.6858375, -2.24807727988718e-014, !- X,Y,Z Vertex 1 {m}
-  18.288, 18.8674375, -2.37215580511929e-014, !- X,Y,Z Vertex 2 {m}
-  17.6037875, 18.8674375, -1.16521015058879e-014, !- X,Y,Z Vertex 3 {m}
-  17.6037875, 13.6858375, -1.04113162535669e-014; !- X,Y,Z Vertex 4 {m}
+  18.288, 13.6858375, 0,                  !- X,Y,Z Vertex 1 {m}
+  18.288, 18.8674375, 0,                  !- X,Y,Z Vertex 2 {m}
+  17.6037875, 18.8674375, 0,              !- X,Y,Z Vertex 3 {m}
+  17.6037875, 13.6858375, 0;              !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {f3f01a65-ee28-4594-ace9-a07c8a1f8e53}, !- Handle
@@ -689,7 +690,7 @@ OS:Space,
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
   0,                                      !- Y Origin {m}
-  -8.66293703438714e-015,                 !- Z Origin {m}
+  0,                                      !- Z Origin {m}
   {c136f41b-5899-4461-9ab1-ce81a1bb07cd}, !- Building Story Name
   {ee4cc09b-6e36-4e4f-87e2-0d0c12691c4c}, !- Thermal Zone Name
   ,                                       !- Part of Total Floor Area
@@ -698,7 +699,7 @@ OS:Space,
 
 OS:Surface,
   {fbb3f928-7424-464b-8c90-6bf54af59812}, !- Handle
-  Surface 27,                             !- Name
+  Locker_Basement_ZN - Floor_a,           !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {f3f01a65-ee28-4594-ace9-a07c8a1f8e53}, !- Space Name
@@ -708,14 +709,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  22.7076, 29.8402375, -2.43840000000002, !- X,Y,Z Vertex 1 {m}
-  22.7076, 18.8674375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  17.6037875, 18.8674375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  17.6037875, 29.8402375, -2.43840000000002; !- X,Y,Z Vertex 4 {m}
+  22.7076, 29.8402375, -2.4384,           !- X,Y,Z Vertex 1 {m}
+  22.7076, 18.8674375, -2.4384,           !- X,Y,Z Vertex 2 {m}
+  17.6037875, 18.8674375, -2.4384,        !- X,Y,Z Vertex 3 {m}
+  17.6037875, 29.8402375, -2.4384;        !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {4eefc488-4b3b-4aa8-a80c-f86fd6806d8e}, !- Handle
-  Surface 28,                             !- Name
+  Locker_Basement_ZN - Wall 090_a,        !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f3f01a65-ee28-4594-ace9-a07c8a1f8e53}, !- Space Name
@@ -725,14 +726,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  22.7076, 18.8674375, -7.21911419532328e-016, !- X,Y,Z Vertex 1 {m}
-  22.7076, 18.8674375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  22.7076, 29.8402375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  22.7076, 29.8402375, 7.21911419532196e-016; !- X,Y,Z Vertex 4 {m}
+  22.7076, 18.8674375, 0,                 !- X,Y,Z Vertex 1 {m}
+  22.7076, 18.8674375, -2.4384,           !- X,Y,Z Vertex 2 {m}
+  22.7076, 29.8402375, -2.4384,           !- X,Y,Z Vertex 3 {m}
+  22.7076, 29.8402375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {038e8b33-9733-4336-b45e-c529769a976d}, !- Handle
-  Surface 29,                             !- Name
+  Locker_Basement_ZN - Wall 000_a,        !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f3f01a65-ee28-4594-ace9-a07c8a1f8e53}, !- Space Name
@@ -742,14 +743,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  22.7076, 29.8402375, 7.21911419532196e-016, !- X,Y,Z Vertex 1 {m}
-  22.7076, 29.8402375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  17.6037875, 29.8402375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  17.6037875, 29.8402375, 7.21911419532236e-016; !- X,Y,Z Vertex 4 {m}
+  22.7076, 29.8402375, 0,                 !- X,Y,Z Vertex 1 {m}
+  22.7076, 29.8402375, -2.4384,           !- X,Y,Z Vertex 2 {m}
+  17.6037875, 29.8402375, -2.4384,        !- X,Y,Z Vertex 3 {m}
+  17.6037875, 29.8402375, 0;              !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {c31cd61c-ba33-4805-9e56-e8f01bc3f306}, !- Handle
-  Surface 30,                             !- Name
+  Locker_Basement_ZN - Wall 270_a,        !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f3f01a65-ee28-4594-ace9-a07c8a1f8e53}, !- Space Name
@@ -759,14 +760,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  17.6037875, 29.8402375, 7.21911419532236e-016, !- X,Y,Z Vertex 1 {m}
-  17.6037875, 29.8402375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  17.6037875, 18.8674375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  17.6037875, 18.8674375, -7.21911419532287e-016; !- X,Y,Z Vertex 4 {m}
+  17.6037875, 29.8402375, 0,              !- X,Y,Z Vertex 1 {m}
+  17.6037875, 29.8402375, -2.4384,        !- X,Y,Z Vertex 2 {m}
+  17.6037875, 18.8674375, -2.4384,        !- X,Y,Z Vertex 3 {m}
+  17.6037875, 18.8674375, 0;              !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {79afe816-f898-4733-8bdd-d659b7bf4b3b}, !- Handle
-  Surface 31,                             !- Name
+  Locker_Basement_ZN - Wall 180_a,        !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f3f01a65-ee28-4594-ace9-a07c8a1f8e53}, !- Space Name
@@ -776,14 +777,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  17.6037875, 18.8674375, -7.21911419532287e-016, !- X,Y,Z Vertex 1 {m}
-  17.6037875, 18.8674375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  22.7076, 18.8674375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  22.7076, 18.8674375, -7.21911419532328e-016; !- X,Y,Z Vertex 4 {m}
+  17.6037875, 18.8674375, 0,              !- X,Y,Z Vertex 1 {m}
+  17.6037875, 18.8674375, -2.4384,        !- X,Y,Z Vertex 2 {m}
+  22.7076, 18.8674375, -2.4384,           !- X,Y,Z Vertex 3 {m}
+  22.7076, 18.8674375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {4c43c456-ad7a-41c7-a108-f525f2e71403}, !- Handle
-  Surface 32,                             !- Name
+  Locker_Basement_ZN - RoofCeiling_a,     !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {f3f01a65-ee28-4594-ace9-a07c8a1f8e53}, !- Space Name
@@ -793,10 +794,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  22.7076, 18.8674375, -7.21911419532328e-016, !- X,Y,Z Vertex 1 {m}
-  22.7076, 29.8402375, 7.21911419532196e-016, !- X,Y,Z Vertex 2 {m}
-  18.288, 29.8402375, -2.23792540055001e-014, !- X,Y,Z Vertex 3 {m}
-  18.288, 18.8674375, -2.38230768445646e-014; !- X,Y,Z Vertex 4 {m}
+  22.7076, 18.8674375, 0,                 !- X,Y,Z Vertex 1 {m}
+  22.7076, 29.8402375, 0,                 !- X,Y,Z Vertex 2 {m}
+  18.288, 29.8402375, 0,                  !- X,Y,Z Vertex 3 {m}
+  18.288, 18.8674375, 0;                  !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {7cdb8a9e-d879-43e9-9157-d878397b9413}, !- Handle
@@ -807,7 +808,7 @@ OS:Space,
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
   0,                                      !- Y Origin {m}
-  -8.66293703438714e-015,                 !- Z Origin {m}
+  0,                                      !- Z Origin {m}
   {c136f41b-5899-4461-9ab1-ce81a1bb07cd}, !- Building Story Name
   {fec48942-2cf5-46e1-ae13-1569781a05d8}, !- Thermal Zone Name
   ,                                       !- Part of Total Floor Area
@@ -816,7 +817,7 @@ OS:Space,
 
 OS:Surface,
   {0b5b2d9c-e67c-46dc-87ca-dca8511a7535}, !- Handle
-  Surface 33,                             !- Name
+  ConfRoom_Basement_ZN - Floor_a,         !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {7cdb8a9e-d879-43e9-9157-d878397b9413}, !- Space Name
@@ -826,14 +827,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  25.4508, 36.5458375, -2.43840000000002, !- X,Y,Z Vertex 1 {m}
-  25.4508, 29.8402375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  17.6037875, 29.8402375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  17.6037875, 36.5458375, -2.43840000000002; !- X,Y,Z Vertex 4 {m}
+  25.4508, 36.5458375, -2.4384,           !- X,Y,Z Vertex 1 {m}
+  25.4508, 29.8402375, -2.4384,           !- X,Y,Z Vertex 2 {m}
+  17.6037875, 29.8402375, -2.4384,        !- X,Y,Z Vertex 3 {m}
+  17.6037875, 36.5458375, -2.4384;        !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {88a81738-6ae7-4fc2-b72e-378a0babac4c}, !- Handle
-  Surface 34,                             !- Name
+  ConfRoom_Basement_ZN - Wall 000_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {7cdb8a9e-d879-43e9-9157-d878397b9413}, !- Space Name
@@ -843,31 +844,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  25.4508, 36.5458375, 2.14733210084457e-014, !- X,Y,Z Vertex 1 {m}
-  25.4508, 36.5458375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  17.6037875, 36.5458375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  17.6037875, 36.5458375, 1.85587697228379e-015; !- X,Y,Z Vertex 4 {m}
-
-OS:Surface,
-  {1f8ce1b3-e3a8-41dc-afe6-814580993bab}, !- Handle
-  Surface 35,                             !- Name
-  RoofCeiling,                            !- Surface Type
-  ,                                       !- Construction Name
-  {7cdb8a9e-d879-43e9-9157-d878397b9413}, !- Space Name
-  Surface,                                !- Outside Boundary Condition
-  {75470229-c6fb-4f6a-8ece-45e3c32d2385}, !- Outside Boundary Condition Object
-  NoSun,                                  !- Sun Exposure
-  NoWind,                                 !- Wind Exposure
-  ,                                       !- View Factor to Ground
-  ,                                       !- Number of Vertices
-  25.4508, 35.0218375, 7.36437577580143e-015, !- X,Y,Z Vertex 1 {m}
-  25.4508, 35.0708215764634, 3.81708408457397e-015, !- X,Y,Z Vertex 2 {m}
-  18.288, 35.0708215764634, -2.24622501795439e-014, !- X,Y,Z Vertex 3 {m}
-  18.288, 35.0218375, -1.89149584883163e-014; !- X,Y,Z Vertex 4 {m}
+  25.4508, 36.5458375, 0,                 !- X,Y,Z Vertex 1 {m}
+  25.4508, 36.5458375, -2.4384,           !- X,Y,Z Vertex 2 {m}
+  17.6037875, 36.5458375, -2.4384,        !- X,Y,Z Vertex 3 {m}
+  17.6037875, 36.5458375, 0;              !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {dadd9e2f-bed4-45ad-8f50-89c545d9e04d}, !- Handle
-  Surface 36,                             !- Name
+  ConfRoom_Basement_ZN - Wall 090_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {7cdb8a9e-d879-43e9-9157-d878397b9413}, !- Space Name
@@ -877,14 +861,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  25.4508, 29.8402375, 1.15505827125162e-014, !- X,Y,Z Vertex 1 {m}
-  25.4508, 29.8402375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  25.4508, 36.5458375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  25.4508, 36.5458375, 2.14733210084457e-014; !- X,Y,Z Vertex 4 {m}
+  25.4508, 29.8402375, 0,                 !- X,Y,Z Vertex 1 {m}
+  25.4508, 29.8402375, -2.4384,           !- X,Y,Z Vertex 2 {m}
+  25.4508, 36.5458375, -2.4384,           !- X,Y,Z Vertex 3 {m}
+  25.4508, 36.5458375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {b928fcf8-b7d5-4ff7-a226-93673c96e31d}, !- Handle
-  Surface 37,                             !- Name
+  ConfRoom_Basement_ZN - Wall 270_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {7cdb8a9e-d879-43e9-9157-d878397b9413}, !- Space Name
@@ -894,14 +878,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  17.6037875, 36.5458375, 1.85587697228379e-015, !- X,Y,Z Vertex 1 {m}
-  17.6037875, 36.5458375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  17.6037875, 29.8402375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  17.6037875, 29.8402375, 1.15505827125162e-014; !- X,Y,Z Vertex 4 {m}
+  17.6037875, 36.5458375, 0,              !- X,Y,Z Vertex 1 {m}
+  17.6037875, 36.5458375, -2.4384,        !- X,Y,Z Vertex 2 {m}
+  17.6037875, 29.8402375, -2.4384,        !- X,Y,Z Vertex 3 {m}
+  17.6037875, 29.8402375, 0;              !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {d9dbc284-72b8-4b8b-8aa0-c29669506f1b}, !- Handle
-  Surface 38,                             !- Name
+  ConfRoom_Basement_ZN - Wall 180_b,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {7cdb8a9e-d879-43e9-9157-d878397b9413}, !- Space Name
@@ -911,10 +895,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  22.7076, 29.8402375, 1.15505827125162e-014, !- X,Y,Z Vertex 1 {m}
-  22.7076, 29.8402375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  25.4508, 29.8402375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  25.4508, 29.8402375, 1.15505827125162e-014; !- X,Y,Z Vertex 4 {m}
+  22.7076, 29.8402375, 0,                 !- X,Y,Z Vertex 1 {m}
+  22.7076, 29.8402375, -2.4384,           !- X,Y,Z Vertex 2 {m}
+  25.4508, 29.8402375, -2.4384,           !- X,Y,Z Vertex 3 {m}
+  25.4508, 29.8402375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {beb9ddd0-3c85-46de-b2b6-f852dfd94f00}, !- Handle
@@ -925,7 +909,7 @@ OS:Space,
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
   0,                                      !- Y Origin {m}
-  -2.88764567812905e-015,                 !- Z Origin {m}
+  0,                                      !- Z Origin {m}
   {c136f41b-5899-4461-9ab1-ce81a1bb07cd}, !- Building Story Name
   {c7c5710b-5396-45b9-aef3-b4851ec51476}, !- Thermal Zone Name
   ,                                       !- Part of Total Floor Area
@@ -933,7 +917,7 @@ OS:Space,
 
 OS:Surface,
   {a70dba8b-257a-42ae-b877-bd48a8c05f4d}, !- Handle
-  Surface 39,                             !- Name
+  Stair_Basement_ZN_1 - Floor_a,          !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {beb9ddd0-3c85-46de-b2b6-f852dfd94f00}, !- Space Name
@@ -943,14 +927,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  25.4508, 29.8402375, -2.43840000000002, !- X,Y,Z Vertex 1 {m}
-  25.4508, 18.8674375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  22.7076, 18.8674375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  22.7076, 29.8402375, -2.43840000000002; !- X,Y,Z Vertex 4 {m}
+  25.4508, 29.8402375, -2.4384,           !- X,Y,Z Vertex 1 {m}
+  25.4508, 18.8674375, -2.4384,           !- X,Y,Z Vertex 2 {m}
+  22.7076, 18.8674375, -2.4384,           !- X,Y,Z Vertex 3 {m}
+  22.7076, 29.8402375, -2.4384;           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {75f7f714-a157-4fa7-99ed-4075dee33c88}, !- Handle
-  Surface 40,                             !- Name
+  Stair_Basement_ZN_1 - Wall 180_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {beb9ddd0-3c85-46de-b2b6-f852dfd94f00}, !- Space Name
@@ -960,14 +944,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  22.7076, 18.8674375, -2.56474457505455e-029, !- X,Y,Z Vertex 1 {m}
-  22.7076, 18.8674375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  25.4508, 18.8674375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  25.4508, 18.8674375, -2.56474457505455e-029; !- X,Y,Z Vertex 4 {m}
+  22.7076, 18.8674375, 0,                 !- X,Y,Z Vertex 1 {m}
+  22.7076, 18.8674375, -2.4384,           !- X,Y,Z Vertex 2 {m}
+  25.4508, 18.8674375, -2.4384,           !- X,Y,Z Vertex 3 {m}
+  25.4508, 18.8674375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {054ba7a9-c339-4122-9dde-dbe9fc8164ae}, !- Handle
-  Surface 41,                             !- Name
+  Stair_Basement_ZN_1 - Wall 090_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {beb9ddd0-3c85-46de-b2b6-f852dfd94f00}, !- Space Name
@@ -977,14 +961,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  25.4508, 27.7066375, -2.56474457505455e-029, !- X,Y,Z Vertex 1 {m}
-  25.4508, 27.7066375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  25.4508, 29.8402375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  25.4508, 29.8402375, -2.56474457505455e-029; !- X,Y,Z Vertex 4 {m}
+  25.4508, 27.7066375, 0,                 !- X,Y,Z Vertex 1 {m}
+  25.4508, 27.7066375, -2.4384,           !- X,Y,Z Vertex 2 {m}
+  25.4508, 29.8402375, -2.4384,           !- X,Y,Z Vertex 3 {m}
+  25.4508, 29.8402375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {cfe38eca-5aec-475f-b9bf-7c4986321041}, !- Handle
-  Surface 42,                             !- Name
+  Stair_Basement_ZN_1 - Wall 000_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {beb9ddd0-3c85-46de-b2b6-f852dfd94f00}, !- Space Name
@@ -994,14 +978,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  25.4508, 29.8402375, -2.56474457505455e-029, !- X,Y,Z Vertex 1 {m}
-  25.4508, 29.8402375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  22.7076, 29.8402375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  22.7076, 29.8402375, -2.56474457505455e-029; !- X,Y,Z Vertex 4 {m}
+  25.4508, 29.8402375, 0,                 !- X,Y,Z Vertex 1 {m}
+  25.4508, 29.8402375, -2.4384,           !- X,Y,Z Vertex 2 {m}
+  22.7076, 29.8402375, -2.4384,           !- X,Y,Z Vertex 3 {m}
+  22.7076, 29.8402375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {34da6677-1310-4052-b473-3e7746cf67b8}, !- Handle
-  Surface 43,                             !- Name
+  Stair_Basement_ZN_1 - Wall 270_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {beb9ddd0-3c85-46de-b2b6-f852dfd94f00}, !- Space Name
@@ -1011,14 +995,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  22.7076, 29.8402375, -2.56474457505455e-029, !- X,Y,Z Vertex 1 {m}
-  22.7076, 29.8402375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  22.7076, 18.8674375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  22.7076, 18.8674375, -2.56474457505455e-029; !- X,Y,Z Vertex 4 {m}
+  22.7076, 29.8402375, 0,                 !- X,Y,Z Vertex 1 {m}
+  22.7076, 29.8402375, -2.4384,           !- X,Y,Z Vertex 2 {m}
+  22.7076, 18.8674375, -2.4384,           !- X,Y,Z Vertex 3 {m}
+  22.7076, 18.8674375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {46a1e3f9-c5e1-495a-81ac-4e87417c7d5f}, !- Handle
-  Surface 44,                             !- Name
+  Stair_Basement_ZN_1 - RoofCeiling_a,    !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {beb9ddd0-3c85-46de-b2b6-f852dfd94f00}, !- Space Name
@@ -1028,10 +1012,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  25.4508, 18.8674375, -2.56474457505455e-029, !- X,Y,Z Vertex 1 {m}
-  25.4508, 29.8402375, -2.56474457505455e-029, !- X,Y,Z Vertex 2 {m}
-  22.7076, 29.8402375, -2.56474457505455e-029, !- X,Y,Z Vertex 3 {m}
-  22.7076, 18.8674375, -2.56474457505455e-029; !- X,Y,Z Vertex 4 {m}
+  25.4508, 18.8674375, 0,                 !- X,Y,Z Vertex 1 {m}
+  25.4508, 29.8402375, 0,                 !- X,Y,Z Vertex 2 {m}
+  22.7076, 29.8402375, 0,                 !- X,Y,Z Vertex 3 {m}
+  22.7076, 18.8674375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {b14c3df4-6d5f-4e37-a007-3f230581586d}, !- Handle
@@ -1042,7 +1026,7 @@ OS:Space,
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
   0,                                      !- Y Origin {m}
-  -8.66293703438714e-015,                 !- Z Origin {m}
+  0,                                      !- Z Origin {m}
   {c136f41b-5899-4461-9ab1-ce81a1bb07cd}, !- Building Story Name
   {0575665a-e229-4d0e-af4a-df83f635d52b}, !- Thermal Zone Name
   ,                                       !- Part of Total Floor Area
@@ -1050,7 +1034,7 @@ OS:Space,
 
 OS:Surface,
   {9c7b7c5b-d6e1-4d31-b4d3-03758e40ebfe}, !- Handle
-  Surface 45,                             !- Name
+  Restroom_Basement_ZN - Floor_a,         !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {b14c3df4-6d5f-4e37-a007-3f230581586d}, !- Space Name
@@ -1060,14 +1044,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  35.3568, 27.7066375, -2.43840000000002, !- X,Y,Z Vertex 1 {m}
-  35.3568, 18.8674375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  25.4508, 18.8674375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  25.4508, 27.7066375, -2.43840000000002; !- X,Y,Z Vertex 4 {m}
+  35.3568, 27.7066375, -2.4384,           !- X,Y,Z Vertex 1 {m}
+  35.3568, 18.8674375, -2.4384,           !- X,Y,Z Vertex 2 {m}
+  25.4508, 18.8674375, -2.4384,           !- X,Y,Z Vertex 3 {m}
+  25.4508, 27.7066375, -2.4384;           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {74d190e9-84f3-42ac-b79f-5b0c1144f72c}, !- Handle
-  Surface 46,                             !- Name
+  Restroom_Basement_ZN - Wall 270_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {b14c3df4-6d5f-4e37-a007-3f230581586d}, !- Space Name
@@ -1077,14 +1061,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  25.4508, 27.7066375, -2.56474457505455e-029, !- X,Y,Z Vertex 1 {m}
-  25.4508, 27.7066375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  25.4508, 18.8674375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  25.4508, 18.8674375, -2.56474457505455e-029; !- X,Y,Z Vertex 4 {m}
+  25.4508, 27.7066375, 0,                 !- X,Y,Z Vertex 1 {m}
+  25.4508, 27.7066375, -2.4384,           !- X,Y,Z Vertex 2 {m}
+  25.4508, 18.8674375, -2.4384,           !- X,Y,Z Vertex 3 {m}
+  25.4508, 18.8674375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {76e0a1ee-86ed-4fe4-9ad1-03027558bac3}, !- Handle
-  Surface 47,                             !- Name
+  Restroom_Basement_ZN - Wall 000_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {b14c3df4-6d5f-4e37-a007-3f230581586d}, !- Space Name
@@ -1094,14 +1078,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  30.4038, 27.7066375, 1.15505827125162e-014, !- X,Y,Z Vertex 1 {m}
-  30.4038, 27.7066375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  25.4508, 27.7066375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  25.4508, 27.7066375, -2.56474457505455e-029; !- X,Y,Z Vertex 4 {m}
+  30.4038, 27.7066375, 0,                 !- X,Y,Z Vertex 1 {m}
+  30.4038, 27.7066375, -2.4384,           !- X,Y,Z Vertex 2 {m}
+  25.4508, 27.7066375, -2.4384,           !- X,Y,Z Vertex 3 {m}
+  25.4508, 27.7066375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {ef0b51ce-fc86-4b4b-a763-a592b488e374}, !- Handle
-  Surface 48,                             !- Name
+  Restroom_Basement_ZN - Wall 180_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {b14c3df4-6d5f-4e37-a007-3f230581586d}, !- Space Name
@@ -1111,14 +1095,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  25.4508, 18.8674375, -2.56474457505455e-029, !- X,Y,Z Vertex 1 {m}
-  25.4508, 18.8674375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  35.3568, 18.8674375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  35.3568, 18.8674375, -2.56474457505455e-029; !- X,Y,Z Vertex 4 {m}
+  25.4508, 18.8674375, 0,                 !- X,Y,Z Vertex 1 {m}
+  25.4508, 18.8674375, -2.4384,           !- X,Y,Z Vertex 2 {m}
+  35.3568, 18.8674375, -2.4384,           !- X,Y,Z Vertex 3 {m}
+  35.3568, 18.8674375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {462c9b8b-25b2-4a1a-9548-35cba17b6b7d}, !- Handle
-  Surface 49,                             !- Name
+  Restroom_Basement_ZN - RoofCeiling_a,   !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {b14c3df4-6d5f-4e37-a007-3f230581586d}, !- Space Name
@@ -1128,14 +1112,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  35.3568, 18.8674375, -2.56474457505455e-029, !- X,Y,Z Vertex 1 {m}
-  35.3568, 27.7066375, -2.56474457505455e-029, !- X,Y,Z Vertex 2 {m}
-  25.4508, 27.7066375, -2.56474457505455e-029, !- X,Y,Z Vertex 3 {m}
-  25.4508, 18.8674375, -2.56474457505455e-029; !- X,Y,Z Vertex 4 {m}
+  35.3568, 18.8674375, 0,                 !- X,Y,Z Vertex 1 {m}
+  35.3568, 27.7066375, 0,                 !- X,Y,Z Vertex 2 {m}
+  25.4508, 27.7066375, 0,                 !- X,Y,Z Vertex 3 {m}
+  25.4508, 18.8674375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {ec0b4244-2a29-4efa-8223-ad2196b3403c}, !- Handle
-  Surface 50,                             !- Name
+  Restroom_Basement_ZN - Wall 090_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {b14c3df4-6d5f-4e37-a007-3f230581586d}, !- Space Name
@@ -1145,10 +1129,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  35.3568, 18.8674375, -2.56474457505455e-029, !- X,Y,Z Vertex 1 {m}
-  35.3568, 18.8674375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  35.3568, 27.7066375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  35.3568, 27.7066375, -2.56474457505455e-029; !- X,Y,Z Vertex 4 {m}
+  35.3568, 18.8674375, 0,                 !- X,Y,Z Vertex 1 {m}
+  35.3568, 18.8674375, -2.4384,           !- X,Y,Z Vertex 2 {m}
+  35.3568, 27.7066375, -2.4384,           !- X,Y,Z Vertex 3 {m}
+  35.3568, 27.7066375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {0389314a-0c21-4461-800d-cffcf0fed6e9}, !- Handle
@@ -1159,7 +1143,7 @@ OS:Space,
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
   0,                                      !- Y Origin {m}
-  -3.17641024594195e-014,                 !- Z Origin {m}
+  0,                                      !- Z Origin {m}
   {c136f41b-5899-4461-9ab1-ce81a1bb07cd}, !- Building Story Name
   {bb950b64-26be-42cf-820c-f100acf37277}, !- Thermal Zone Name
   ,                                       !- Part of Total Floor Area
@@ -1168,7 +1152,7 @@ OS:Space,
 
 OS:Surface,
   {810a139e-6f9a-4349-b78e-fae28a318691}, !- Handle
-  Surface 51,                             !- Name
+  FoodPrep_Basement_ZN - Floor_a,         !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0389314a-0c21-4461-800d-cffcf0fed6e9}, !- Space Name
@@ -1185,7 +1169,7 @@ OS:Surface,
 
 OS:Surface,
   {1b5196cb-13ae-43a1-9b06-e85af2568429}, !- Handle
-  Surface 52,                             !- Name
+  FoodPrep_Basement_ZN - Wall 000_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {0389314a-0c21-4461-800d-cffcf0fed6e9}, !- Space Name
@@ -1195,14 +1179,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  30.4038, 36.5458375, 3.46517481375486e-014, !- X,Y,Z Vertex 1 {m}
+  30.4038, 36.5458375, 0,                 !- X,Y,Z Vertex 1 {m}
   30.4038, 36.5458375, -2.4384,           !- X,Y,Z Vertex 2 {m}
   25.4508, 36.5458375, -2.4384,           !- X,Y,Z Vertex 3 {m}
-  25.4508, 36.5458375, 3.46517481375486e-014; !- X,Y,Z Vertex 4 {m}
+  25.4508, 36.5458375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {450231e4-ee80-410f-a5fc-c1179e0a0dd3}, !- Handle
-  Surface 53,                             !- Name
+  FoodPrep_Basement_ZN - Wall 270_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {0389314a-0c21-4461-800d-cffcf0fed6e9}, !- Space Name
@@ -1212,14 +1196,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  25.4508, 27.7066375, 2.8966695708732e-014, !- X,Y,Z Vertex 1 {m}
-  25.4508, 29.8402375, 5.77529135625807e-015, !- X,Y,Z Vertex 2 {m}
-  25.4508, 29.8402375, -2.4384,           !- X,Y,Z Vertex 3 {m}
-  25.4508, 27.7066375, -2.4384;           !- X,Y,Z Vertex 4 {m}
+  25.4508, 29.8402375, 0,                 !- X,Y,Z Vertex 1 {m}
+  25.4508, 29.8402375, -2.4384,           !- X,Y,Z Vertex 2 {m}
+  25.4508, 27.7066375, -2.4384,           !- X,Y,Z Vertex 3 {m}
+  25.4508, 27.7066375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {f8a053dc-0e7d-428e-9281-b37d34846cce}, !- Handle
-  Surface 54,                             !- Name
+  FoodPrep_Basement_ZN - Wall 180_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {0389314a-0c21-4461-800d-cffcf0fed6e9}, !- Space Name
@@ -1229,14 +1213,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  25.4508, 27.7066375, 2.8966695708732e-014, !- X,Y,Z Vertex 1 {m}
+  25.4508, 27.7066375, 0,                 !- X,Y,Z Vertex 1 {m}
   25.4508, 27.7066375, -2.4384,           !- X,Y,Z Vertex 2 {m}
   30.4038, 27.7066375, -2.4384,           !- X,Y,Z Vertex 3 {m}
-  30.4038, 27.7066375, 4.03368005663651e-014; !- X,Y,Z Vertex 4 {m}
+  30.4038, 27.7066375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {e9557fdf-d286-4305-a626-58ed7a7b215a}, !- Handle
-  Surface 55,                             !- Name
+  FoodPrep_Basement_ZN - Wall 090_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {0389314a-0c21-4461-800d-cffcf0fed6e9}, !- Space Name
@@ -1246,14 +1230,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  30.4038, 27.7066375, 4.03368005663651e-014, !- X,Y,Z Vertex 1 {m}
+  30.4038, 27.7066375, 0,                 !- X,Y,Z Vertex 1 {m}
   30.4038, 27.7066375, -2.4384,           !- X,Y,Z Vertex 2 {m}
   30.4038, 36.5458375, -2.4384,           !- X,Y,Z Vertex 3 {m}
-  30.4038, 36.5458375, 3.46517481375486e-014; !- X,Y,Z Vertex 4 {m}
+  30.4038, 36.5458375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {d3924a1b-056a-4a86-95a9-2e8168de6722}, !- Handle
-  Surface 56,                             !- Name
+  FoodPrep_Basement_ZN - RoofCeiling_a,   !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {0389314a-0c21-4461-800d-cffcf0fed6e9}, !- Space Name
@@ -1263,10 +1247,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  30.4038, 29.8402375, 1.48668632959924e-014, !- X,Y,Z Vertex 1 {m}
-  30.4038, 35.0218375, 3.79229092573041e-014, !- X,Y,Z Vertex 2 {m}
-  25.4508, 35.0218375, 3.1380587017793e-014, !- X,Y,Z Vertex 3 {m}
-  25.4508, 29.8402375, 8.32454105648133e-015; !- X,Y,Z Vertex 4 {m}
+  30.4038, 29.8402375, 0,                 !- X,Y,Z Vertex 1 {m}
+  30.4038, 35.0218375, 0,                 !- X,Y,Z Vertex 2 {m}
+  25.4508, 35.0218375, 0,                 !- X,Y,Z Vertex 3 {m}
+  25.4508, 29.8402375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {5222a123-fcee-4465-a1d8-1fe3a55ed431}, !- Handle
@@ -1277,15 +1261,16 @@ OS:Space,
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
   0,                                      !- Y Origin {m}
-  -3.17641024594195e-014,                 !- Z Origin {m}
+  0,                                      !- Z Origin {m}
   {c136f41b-5899-4461-9ab1-ce81a1bb07cd}, !- Building Story Name
   {fcf9f4c0-15f2-4969-b91f-da010923ed44}, !- Thermal Zone Name
   ,                                       !- Part of Total Floor Area
-  ;                                       !- Design Specification Outdoor Air Object Name
+  ,                                       !- Design Specification Outdoor Air Object Name
+  ;                                       !- Building Unit Name
 
 OS:Surface,
   {c4502b5b-9db9-42b9-9d0e-0c3d1be80aca}, !- Handle
-  Surface 57,                             !- Name
+  Dining_Basement_ZN - Floor_a,           !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {5222a123-fcee-4465-a1d8-1fe3a55ed431}, !- Space Name
@@ -1302,7 +1287,7 @@ OS:Surface,
 
 OS:Surface,
   {c4a7380b-8416-4cbd-8af5-fa50ce73bc28}, !- Handle
-  Surface 58,                             !- Name
+  Dining_Basement_ZN - Wall 180_a,        !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {5222a123-fcee-4465-a1d8-1fe3a55ed431}, !- Space Name
@@ -1312,14 +1297,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  30.4038, 27.7066375, 2.59888111031615e-014, !- X,Y,Z Vertex 1 {m}
+  30.4038, 27.7066375, 0,                 !- X,Y,Z Vertex 1 {m}
   30.4038, 27.7066375, -2.4384,           !- X,Y,Z Vertex 2 {m}
   35.3568, 27.7066375, -2.4384,           !- X,Y,Z Vertex 3 {m}
-  35.3568, 27.7066375, 2.02135197469033e-014; !- X,Y,Z Vertex 4 {m}
+  35.3568, 27.7066375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {171f4f24-d0a3-466f-b82f-be2f239e3160}, !- Handle
-  Surface 59,                             !- Name
+  Dining_Basement_ZN - Wall 090_a,        !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {5222a123-fcee-4465-a1d8-1fe3a55ed431}, !- Space Name
@@ -1329,14 +1314,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  35.3568, 27.7066375, 2.02135197469033e-014, !- X,Y,Z Vertex 1 {m}
+  35.3568, 27.7066375, 0,                 !- X,Y,Z Vertex 1 {m}
   35.3568, 27.7066375, -2.4384,           !- X,Y,Z Vertex 2 {m}
   35.3568, 36.5458375, -2.4384,           !- X,Y,Z Vertex 3 {m}
-  35.3568, 36.5458375, 1.87696969078388e-014; !- X,Y,Z Vertex 4 {m}
+  35.3568, 36.5458375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {11a91646-7232-4773-8e8f-7c3cc5f70c43}, !- Handle
-  Surface 60,                             !- Name
+  Dining_Basement_ZN - Wall 000_a,        !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {5222a123-fcee-4465-a1d8-1fe3a55ed431}, !- Space Name
@@ -1346,14 +1331,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  35.3568, 36.5458375, 1.87696969078388e-014, !- X,Y,Z Vertex 1 {m}
+  35.3568, 36.5458375, 0,                 !- X,Y,Z Vertex 1 {m}
   35.3568, 36.5458375, -2.4384,           !- X,Y,Z Vertex 2 {m}
   30.4038, 36.5458375, -2.4384,           !- X,Y,Z Vertex 3 {m}
-  30.4038, 36.5458375, 2.7432633942226e-014; !- X,Y,Z Vertex 4 {m}
+  30.4038, 36.5458375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {69c5f012-fe0c-470a-8f88-24f26fad6802}, !- Handle
-  Surface 61,                             !- Name
+  Dining_Basement_ZN - Wall 270_a,        !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {5222a123-fcee-4465-a1d8-1fe3a55ed431}, !- Space Name
@@ -1363,14 +1348,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  30.4038, 36.5458375, 2.7432633942226e-014, !- X,Y,Z Vertex 1 {m}
+  30.4038, 36.5458375, 0,                 !- X,Y,Z Vertex 1 {m}
   30.4038, 36.5458375, -2.4384,           !- X,Y,Z Vertex 2 {m}
   30.4038, 27.7066375, -2.4384,           !- X,Y,Z Vertex 3 {m}
-  30.4038, 27.7066375, 2.59888111031615e-014; !- X,Y,Z Vertex 4 {m}
+  30.4038, 27.7066375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {ff83ab8a-b085-4d35-8a8c-8c55ff4aacd8}, !- Handle
-  Surface 62,                             !- Name
+  Dining_Basement_ZN - RoofCeiling_a,     !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {5222a123-fcee-4465-a1d8-1fe3a55ed431}, !- Space Name
@@ -1380,10 +1365,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  35.3568, 35.0708215764634, 1.29944055515807e-014, !- X,Y,Z Vertex 1 {m}
-  35.3568, 36.5458375, 1.87696969078388e-014, !- X,Y,Z Vertex 2 {m}
-  30.4038, 36.5458375, 2.7432633942226e-014, !- X,Y,Z Vertex 3 {m}
-  30.4038, 35.0708215764634, 2.16573425859678e-014; !- X,Y,Z Vertex 4 {m}
+  35.3568, 35.0218375, 0,                 !- X,Y,Z Vertex 1 {m}
+  35.3568, 36.5458375, 0,                 !- X,Y,Z Vertex 2 {m}
+  30.4038, 36.5458375, 0,                 !- X,Y,Z Vertex 3 {m}
+  30.4038, 35.0218375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {2a9fe3f6-0245-47e1-83d4-2e202cf00843}, !- Handle
@@ -1394,7 +1379,7 @@ OS:Space,
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
   0,                                      !- Y Origin {m}
-  -8.66293703438714e-015,                 !- Z Origin {m}
+  0,                                      !- Z Origin {m}
   {c136f41b-5899-4461-9ab1-ce81a1bb07cd}, !- Building Story Name
   {f9243986-e4ac-45e4-b930-282147fe7d69}, !- Thermal Zone Name
   ,                                       !- Part of Total Floor Area
@@ -1403,7 +1388,7 @@ OS:Space,
 
 OS:Surface,
   {44017164-8327-4ab0-9c46-f20b4f38ff9d}, !- Handle
-  Surface 63,                             !- Name
+  Lobby_Basement_ZN - Floor_a,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {2a9fe3f6-0245-47e1-83d4-2e202cf00843}, !- Space Name
@@ -1413,14 +1398,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  37.7952, 36.5458375, -2.43840000000002, !- X,Y,Z Vertex 1 {m}
-  37.7952, 12.1618375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  35.3568, 12.1618375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  35.3568, 36.5458375, -2.43840000000002; !- X,Y,Z Vertex 4 {m}
+  37.7952, 36.5458375, -2.4384,           !- X,Y,Z Vertex 1 {m}
+  37.7952, 12.1618375, -2.4384,           !- X,Y,Z Vertex 2 {m}
+  35.3568, 12.1618375, -2.4384,           !- X,Y,Z Vertex 3 {m}
+  35.3568, 36.5458375, -2.4384;           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {63baeb93-84c8-4674-968f-a7b84b5a68ad}, !- Handle
-  Surface 64,                             !- Name
+  Lobby_Basement_ZN - Wall 090_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {2a9fe3f6-0245-47e1-83d4-2e202cf00843}, !- Space Name
@@ -1430,14 +1415,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  37.7952, 35.0218375, 5.77529135625807e-015, !- X,Y,Z Vertex 1 {m}
-  37.7952, 35.0218375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  37.7952, 36.5458375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  37.7952, 36.5458375, -2.56474457505455e-029; !- X,Y,Z Vertex 4 {m}
+  37.7952, 35.0218375, 0,                 !- X,Y,Z Vertex 1 {m}
+  37.7952, 35.0218375, -2.4384,           !- X,Y,Z Vertex 2 {m}
+  37.7952, 36.5458375, -2.4384,           !- X,Y,Z Vertex 3 {m}
+  37.7952, 36.5458375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {941b38f4-ce12-415a-97b2-327c34c3d7b7}, !- Handle
-  Surface 65,                             !- Name
+  Lobby_Basement_ZN - Wall 000_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {2a9fe3f6-0245-47e1-83d4-2e202cf00843}, !- Space Name
@@ -1447,14 +1432,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  37.7952, 36.5458375, -2.56474457505455e-029, !- X,Y,Z Vertex 1 {m}
-  37.7952, 36.5458375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  35.3568, 36.5458375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  35.3568, 36.5458375, -2.56474457505455e-029; !- X,Y,Z Vertex 4 {m}
+  37.7952, 36.5458375, 0,                 !- X,Y,Z Vertex 1 {m}
+  37.7952, 36.5458375, -2.4384,           !- X,Y,Z Vertex 2 {m}
+  35.3568, 36.5458375, -2.4384,           !- X,Y,Z Vertex 3 {m}
+  35.3568, 36.5458375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {4b39745b-3b8d-45cf-b54b-d66ec1f0b8c6}, !- Handle
-  Surface 66,                             !- Name
+  Lobby_Basement_ZN - Wall 270_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {2a9fe3f6-0245-47e1-83d4-2e202cf00843}, !- Space Name
@@ -1464,14 +1449,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  35.3568, 27.7066375, -2.56474457505455e-029, !- X,Y,Z Vertex 1 {m}
-  35.3568, 27.7066375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  35.3568, 18.8674375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  35.3568, 18.8674375, -1.15505827125162e-014; !- X,Y,Z Vertex 4 {m}
+  35.3568, 27.7066375, 0,                 !- X,Y,Z Vertex 1 {m}
+  35.3568, 27.7066375, -2.4384,           !- X,Y,Z Vertex 2 {m}
+  35.3568, 18.8674375, -2.4384,           !- X,Y,Z Vertex 3 {m}
+  35.3568, 18.8674375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {f60ee5bf-6251-4020-8b01-0b0ebce4224b}, !- Handle
-  Surface 67,                             !- Name
+  Lobby_Basement_ZN - Wall 180_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {2a9fe3f6-0245-47e1-83d4-2e202cf00843}, !- Space Name
@@ -1481,14 +1466,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  35.3568, 12.1618375, -2.56474457505455e-029, !- X,Y,Z Vertex 1 {m}
-  35.3568, 12.1618375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  37.7952, 12.1618375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  37.7952, 12.1618375, -2.56474457505455e-029; !- X,Y,Z Vertex 4 {m}
+  35.3568, 12.1618375, 0,                 !- X,Y,Z Vertex 1 {m}
+  35.3568, 12.1618375, -2.4384,           !- X,Y,Z Vertex 2 {m}
+  37.7952, 12.1618375, -2.4384,           !- X,Y,Z Vertex 3 {m}
+  37.7952, 12.1618375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {83b26763-f0c1-4b8e-9b28-8ccdb4b9c310}, !- Handle
-  Surface 68,                             !- Name
+  Lobby_Basement_ZN - RoofCeiling_a,      !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {2a9fe3f6-0245-47e1-83d4-2e202cf00843}, !- Space Name
@@ -1498,10 +1483,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  37.7952, 12.1618375, -2.56474457505455e-029, !- X,Y,Z Vertex 1 {m}
-  37.7952, 36.5458375, -2.56474457505455e-029, !- X,Y,Z Vertex 2 {m}
-  35.3568, 36.5458375, -2.56474457505455e-029, !- X,Y,Z Vertex 3 {m}
-  35.3568, 12.1618375, -2.56474457505455e-029; !- X,Y,Z Vertex 4 {m}
+  37.7952, 12.1618375, 0,                 !- X,Y,Z Vertex 1 {m}
+  37.7952, 36.5458375, 0,                 !- X,Y,Z Vertex 2 {m}
+  35.3568, 36.5458375, 0,                 !- X,Y,Z Vertex 3 {m}
+  35.3568, 12.1618375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {99c786c6-085f-4396-970f-e677ee574088}, !- Handle
@@ -1512,7 +1497,7 @@ OS:Space,
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
   0,                                      !- Y Origin {m}
-  -8.66293703438714e-015,                 !- Z Origin {m}
+  0,                                      !- Z Origin {m}
   {c136f41b-5899-4461-9ab1-ce81a1bb07cd}, !- Building Story Name
   {4b4a36c9-7e4d-4aba-b6c4-e1ddb1b871bf}, !- Thermal Zone Name
   ,                                       !- Part of Total Floor Area
@@ -1521,7 +1506,7 @@ OS:Space,
 
 OS:Surface,
   {171cfb2e-39e6-4c86-90ad-29e475cc0aeb}, !- Handle
-  Surface 69,                             !- Name
+  Corridor_Basement_ZN_3 - Floor_a,       !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {99c786c6-085f-4396-970f-e677ee574088}, !- Space Name
@@ -1531,14 +1516,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.0416275, 13.6858375, -2.43840000000002, !- X,Y,Z Vertex 1 {m}
-  46.0416275, 12.1618375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  37.7952, 12.1618375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  37.7952, 13.6858375, -2.43840000000002; !- X,Y,Z Vertex 4 {m}
+  46.0416275, 13.6858375, -2.4384,        !- X,Y,Z Vertex 1 {m}
+  46.0416275, 12.1618375, -2.4384,        !- X,Y,Z Vertex 2 {m}
+  37.7952, 12.1618375, -2.4384,           !- X,Y,Z Vertex 3 {m}
+  37.7952, 13.6858375, -2.4384;           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {e25d56a3-ebe2-408b-bff2-492acc515b7e}, !- Handle
-  Surface 70,                             !- Name
+  Corridor_Basement_ZN_3 - Wall 270_a,    !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {99c786c6-085f-4396-970f-e677ee574088}, !- Space Name
@@ -1548,14 +1533,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  37.7952, 13.6858375, -2.56474457505455e-029, !- X,Y,Z Vertex 1 {m}
-  37.7952, 13.6858375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  37.7952, 12.1618375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  37.7952, 12.1618375, -2.56474457505455e-029; !- X,Y,Z Vertex 4 {m}
+  37.7952, 13.6858375, 0,                 !- X,Y,Z Vertex 1 {m}
+  37.7952, 13.6858375, -2.4384,           !- X,Y,Z Vertex 2 {m}
+  37.7952, 12.1618375, -2.4384,           !- X,Y,Z Vertex 3 {m}
+  37.7952, 12.1618375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {cbd27e92-24e2-4654-9e05-b4f2f21cca90}, !- Handle
-  Surface 71,                             !- Name
+  Corridor_Basement_ZN_3 - RoofCeiling_a, !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {99c786c6-085f-4396-970f-e677ee574088}, !- Space Name
@@ -1565,14 +1550,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.0416275, 12.1618375, -2.56474457505455e-029, !- X,Y,Z Vertex 1 {m}
-  46.0416275, 13.6858375, -2.56474457505455e-029, !- X,Y,Z Vertex 2 {m}
-  37.7952, 13.6858375, -2.56474457505455e-029, !- X,Y,Z Vertex 3 {m}
-  37.7952, 12.1618375, -2.56474457505455e-029; !- X,Y,Z Vertex 4 {m}
+  46.0416275, 12.1618375, 0,              !- X,Y,Z Vertex 1 {m}
+  46.0416275, 13.6858375, 0,              !- X,Y,Z Vertex 2 {m}
+  37.7952, 13.6858375, 0,                 !- X,Y,Z Vertex 3 {m}
+  37.7952, 12.1618375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {beb2e2c9-3d3c-4a63-bf6e-f9e72f0cd2fb}, !- Handle
-  Surface 72,                             !- Name
+  Corridor_Basement_ZN_3 - Wall 090_a,    !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {99c786c6-085f-4396-970f-e677ee574088}, !- Space Name
@@ -1582,14 +1567,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.0416275, 12.1618375, -2.56474457505455e-029, !- X,Y,Z Vertex 1 {m}
-  46.0416275, 12.1618375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  46.0416275, 13.6858375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  46.0416275, 13.6858375, -2.56474457505455e-029; !- X,Y,Z Vertex 4 {m}
+  46.0416275, 12.1618375, 0,              !- X,Y,Z Vertex 1 {m}
+  46.0416275, 12.1618375, -2.4384,        !- X,Y,Z Vertex 2 {m}
+  46.0416275, 13.6858375, -2.4384,        !- X,Y,Z Vertex 3 {m}
+  46.0416275, 13.6858375, 0;              !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {7fbcf5ed-2d75-479c-bdbc-8d88c4125f08}, !- Handle
-  Surface 73,                             !- Name
+  Corridor_Basement_ZN_3 - Wall 180_a,    !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {99c786c6-085f-4396-970f-e677ee574088}, !- Space Name
@@ -1599,14 +1584,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  37.7952, 12.1618375, -2.56474457505455e-029, !- X,Y,Z Vertex 1 {m}
-  37.7952, 12.1618375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  46.0416275, 12.1618375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  46.0416275, 12.1618375, -2.56474457505455e-029; !- X,Y,Z Vertex 4 {m}
+  37.7952, 12.1618375, 0,                 !- X,Y,Z Vertex 1 {m}
+  37.7952, 12.1618375, -2.4384,           !- X,Y,Z Vertex 2 {m}
+  46.0416275, 12.1618375, -2.4384,        !- X,Y,Z Vertex 3 {m}
+  46.0416275, 12.1618375, 0;              !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {e6d71ae9-82a6-444c-a788-5bcb4f66b560}, !- Handle
-  Surface 74,                             !- Name
+  Corridor_Basement_ZN_3 - Wall 000_a,    !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {99c786c6-085f-4396-970f-e677ee574088}, !- Space Name
@@ -1616,10 +1601,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.0416275, 13.6858375, -2.56474457505455e-029, !- X,Y,Z Vertex 1 {m}
-  46.0416275, 13.6858375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  37.7952, 13.6858375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  37.7952, 13.6858375, -2.56474457505455e-029; !- X,Y,Z Vertex 4 {m}
+  46.0416275, 13.6858375, 0,              !- X,Y,Z Vertex 1 {m}
+  46.0416275, 13.6858375, -2.4384,        !- X,Y,Z Vertex 2 {m}
+  37.7952, 13.6858375, -2.4384,           !- X,Y,Z Vertex 3 {m}
+  37.7952, 13.6858375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {d98a7b10-1d11-48bd-a2e5-f333793a7830}, !- Handle
@@ -1630,7 +1615,7 @@ OS:Space,
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
   0,                                      !- Y Origin {m}
-  -3.17641024594195e-014,                 !- Z Origin {m}
+  0,                                      !- Z Origin {m}
   {c136f41b-5899-4461-9ab1-ce81a1bb07cd}, !- Building Story Name
   {c77c16ea-0b1a-45f9-a0c2-5ac6ea24dcd6}, !- Thermal Zone Name
   ,                                       !- Part of Total Floor Area
@@ -1638,7 +1623,7 @@ OS:Space,
 
 OS:Surface,
   {dfa646e8-30b2-42e4-b909-82ee230d5d06}, !- Handle
-  Surface 75,                             !- Name
+  EnclosedOffice_Basement_ZN_2 - Floor_a, !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {d98a7b10-1d11-48bd-a2e5-f333793a7830}, !- Space Name
@@ -1655,7 +1640,7 @@ OS:Surface,
 
 OS:Surface,
   {f44a73e7-22ee-428b-99ff-7d07a6ea5596}, !- Handle
-  Surface 76,                             !- Name
+  EnclosedOffice_Basement_ZN_2 - Wall 270_a, !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d98a7b10-1d11-48bd-a2e5-f333793a7830}, !- Space Name
@@ -1665,14 +1650,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  37.7952, 18.8674375, 2.31011654250324e-014, !- X,Y,Z Vertex 1 {m}
+  37.7952, 18.8674375, 0,                 !- X,Y,Z Vertex 1 {m}
   37.7952, 18.8674375, -2.4384,           !- X,Y,Z Vertex 2 {m}
   37.7952, 13.6858375, -2.4384,           !- X,Y,Z Vertex 3 {m}
-  37.7952, 13.6858375, 2.31011654250324e-014; !- X,Y,Z Vertex 4 {m}
+  37.7952, 13.6858375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {baaf0251-435f-40e7-b3ae-8d88290618bf}, !- Handle
-  Surface 77,                             !- Name
+  EnclosedOffice_Basement_ZN_2 - Wall 000_a, !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d98a7b10-1d11-48bd-a2e5-f333793a7830}, !- Space Name
@@ -1682,14 +1667,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  52.7304, 18.8674375, 2.31011654250324e-014, !- X,Y,Z Vertex 1 {m}
+  52.7304, 18.8674375, 0,                 !- X,Y,Z Vertex 1 {m}
   52.7304, 18.8674375, -2.4384,           !- X,Y,Z Vertex 2 {m}
   49.0728, 18.8674375, -2.4384,           !- X,Y,Z Vertex 3 {m}
   49.0728, 18.8674375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {f0baa3c2-8267-420a-b18b-2046f2e1e1d8}, !- Handle
-  Surface 78,                             !- Name
+  EnclosedOffice_Basement_ZN_2 - Wall 090_a, !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d98a7b10-1d11-48bd-a2e5-f333793a7830}, !- Space Name
@@ -1699,14 +1684,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  52.7304, 13.6858375, 2.31011654250324e-014, !- X,Y,Z Vertex 1 {m}
+  52.7304, 13.6858375, 0,                 !- X,Y,Z Vertex 1 {m}
   52.7304, 13.6858375, -2.4384,           !- X,Y,Z Vertex 2 {m}
   52.7304, 18.8674375, -2.4384,           !- X,Y,Z Vertex 3 {m}
-  52.7304, 18.8674375, 2.31011654250324e-014; !- X,Y,Z Vertex 4 {m}
+  52.7304, 18.8674375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {7e187f8d-62ca-45b6-ace4-a9edbbb55282}, !- Handle
-  Surface 79,                             !- Name
+  EnclosedOffice_Basement_ZN_2 - Wall 180_a, !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d98a7b10-1d11-48bd-a2e5-f333793a7830}, !- Space Name
@@ -1716,14 +1701,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.0416275, 13.6858375, 2.31011654250324e-014, !- X,Y,Z Vertex 1 {m}
+  46.0416275, 13.6858375, 0,              !- X,Y,Z Vertex 1 {m}
   46.0416275, 13.6858375, -2.4384,        !- X,Y,Z Vertex 2 {m}
   52.7304, 13.6858375, -2.4384,           !- X,Y,Z Vertex 3 {m}
-  52.7304, 13.6858375, 2.31011654250324e-014; !- X,Y,Z Vertex 4 {m}
+  52.7304, 13.6858375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {c4aa7210-a2ed-4885-856c-554eb8c02439}, !- Handle
-  Surface 80,                             !- Name
+  EnclosedOffice_Basement_ZN_2 - RoofCeiling_a, !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {d98a7b10-1d11-48bd-a2e5-f333793a7830}, !- Space Name
@@ -1733,10 +1718,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  52.7304, 13.6858375, 2.31011654250324e-014, !- X,Y,Z Vertex 1 {m}
-  52.7304, 18.8674375, 2.31011654250324e-014, !- X,Y,Z Vertex 2 {m}
-  37.7952, 18.8674375, 2.31011654250324e-014, !- X,Y,Z Vertex 3 {m}
-  37.7952, 13.6858375, 2.31011654250324e-014; !- X,Y,Z Vertex 4 {m}
+  52.7304, 13.6858375, 0,                 !- X,Y,Z Vertex 1 {m}
+  52.7304, 18.8674375, 0,                 !- X,Y,Z Vertex 2 {m}
+  37.7952, 18.8674375, 0,                 !- X,Y,Z Vertex 3 {m}
+  37.7952, 13.6858375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {3fff5dc0-4827-4f6b-b4bc-87a3a79e5610}, !- Handle
@@ -1747,7 +1732,7 @@ OS:Space,
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
   0,                                      !- Y Origin {m}
-  -8.66293703438714e-015,                 !- Z Origin {m}
+  0,                                      !- Z Origin {m}
   {c136f41b-5899-4461-9ab1-ce81a1bb07cd}, !- Building Story Name
   {ad9a0ecb-ccbe-4d88-a813-fd0452d413d0}, !- Thermal Zone Name
   ,                                       !- Part of Total Floor Area
@@ -1755,7 +1740,7 @@ OS:Space,
 
 OS:Surface,
   {995af0e4-4caa-4a33-854c-ee53cc9ea33f}, !- Handle
-  Surface 81,                             !- Name
+  Mechanical_Basement_ZN_2 - Floor_a,     !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {3fff5dc0-4827-4f6b-b4bc-87a3a79e5610}, !- Space Name
@@ -1765,14 +1750,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.3296, 24.3538375, -2.43840000000002, !- X,Y,Z Vertex 1 {m}
-  46.3296, 18.8674375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  37.7952, 18.8674375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  37.7952, 24.3538375, -2.43840000000002; !- X,Y,Z Vertex 4 {m}
+  46.3296, 24.3538375, -2.4384,           !- X,Y,Z Vertex 1 {m}
+  46.3296, 18.8674375, -2.4384,           !- X,Y,Z Vertex 2 {m}
+  37.7952, 18.8674375, -2.4384,           !- X,Y,Z Vertex 3 {m}
+  37.7952, 24.3538375, -2.4384;           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {3d5f87a3-dd5b-4c26-aec1-4fc75c1d24f0}, !- Handle
-  Surface 82,                             !- Name
+  Mechanical_Basement_ZN_2 - Wall 180_a,  !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3fff5dc0-4827-4f6b-b4bc-87a3a79e5610}, !- Space Name
@@ -1782,14 +1767,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  37.7952, 18.8674375, -2.56474457505455e-029, !- X,Y,Z Vertex 1 {m}
-  37.7952, 18.8674375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  46.3296, 18.8674375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  46.3296, 18.8674375, -2.56474457505455e-029; !- X,Y,Z Vertex 4 {m}
+  37.7952, 18.8674375, 0,                 !- X,Y,Z Vertex 1 {m}
+  37.7952, 18.8674375, -2.4384,           !- X,Y,Z Vertex 2 {m}
+  46.3296, 18.8674375, -2.4384,           !- X,Y,Z Vertex 3 {m}
+  46.3296, 18.8674375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {4a7fe282-f344-4d20-be48-a56771fe745d}, !- Handle
-  Surface 83,                             !- Name
+  Mechanical_Basement_ZN_2 - Wall 000_a,  !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3fff5dc0-4827-4f6b-b4bc-87a3a79e5610}, !- Space Name
@@ -1799,14 +1784,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.3296, 24.3538375, -2.56474457505455e-029, !- X,Y,Z Vertex 1 {m}
-  46.3296, 24.3538375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  37.7952, 24.3538375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  37.7952, 24.3538375, -2.56474457505455e-029; !- X,Y,Z Vertex 4 {m}
+  46.3296, 24.3538375, 0,                 !- X,Y,Z Vertex 1 {m}
+  46.3296, 24.3538375, -2.4384,           !- X,Y,Z Vertex 2 {m}
+  37.7952, 24.3538375, -2.4384,           !- X,Y,Z Vertex 3 {m}
+  37.7952, 24.3538375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {69ac4afc-3ea9-4bb9-8ac1-4cc3aec8daea}, !- Handle
-  Surface 84,                             !- Name
+  Mechanical_Basement_ZN_2 - RoofCeiling_a, !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {3fff5dc0-4827-4f6b-b4bc-87a3a79e5610}, !- Space Name
@@ -1816,14 +1801,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.3296, 18.8674375, -2.56474457505455e-029, !- X,Y,Z Vertex 1 {m}
-  46.3296, 24.3538375, -2.56474457505455e-029, !- X,Y,Z Vertex 2 {m}
-  37.7952, 24.3538375, -2.56474457505455e-029, !- X,Y,Z Vertex 3 {m}
-  37.7952, 18.8674375, -2.56474457505455e-029; !- X,Y,Z Vertex 4 {m}
+  46.3296, 18.8674375, 0,                 !- X,Y,Z Vertex 1 {m}
+  46.3296, 24.3538375, 0,                 !- X,Y,Z Vertex 2 {m}
+  37.7952, 24.3538375, 0,                 !- X,Y,Z Vertex 3 {m}
+  37.7952, 18.8674375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {8e5b0075-eb70-41ef-a6ad-53b8eb90be06}, !- Handle
-  Surface 85,                             !- Name
+  Mechanical_Basement_ZN_2 - Wall 270_a,  !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3fff5dc0-4827-4f6b-b4bc-87a3a79e5610}, !- Space Name
@@ -1833,14 +1818,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  37.7952, 24.3538375, -2.56474457505455e-029, !- X,Y,Z Vertex 1 {m}
-  37.7952, 24.3538375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  37.7952, 18.8674375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  37.7952, 18.8674375, -2.56474457505455e-029; !- X,Y,Z Vertex 4 {m}
+  37.7952, 24.3538375, 0,                 !- X,Y,Z Vertex 1 {m}
+  37.7952, 24.3538375, -2.4384,           !- X,Y,Z Vertex 2 {m}
+  37.7952, 18.8674375, -2.4384,           !- X,Y,Z Vertex 3 {m}
+  37.7952, 18.8674375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {eabab909-53fa-4017-b256-90c3adb27c97}, !- Handle
-  Surface 86,                             !- Name
+  Mechanical_Basement_ZN_2 - Wall 090_a,  !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3fff5dc0-4827-4f6b-b4bc-87a3a79e5610}, !- Space Name
@@ -1850,10 +1835,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.3296, 18.8674375, -2.56474457505455e-029, !- X,Y,Z Vertex 1 {m}
-  46.3296, 18.8674375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  46.3296, 24.3538375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  46.3296, 24.3538375, -2.56474457505455e-029; !- X,Y,Z Vertex 4 {m}
+  46.3296, 18.8674375, 0,                 !- X,Y,Z Vertex 1 {m}
+  46.3296, 18.8674375, -2.4384,           !- X,Y,Z Vertex 2 {m}
+  46.3296, 24.3538375, -2.4384,           !- X,Y,Z Vertex 3 {m}
+  46.3296, 24.3538375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {6a4fd8de-ac31-4c2d-8e19-bc00287778e6}, !- Handle
@@ -1864,7 +1849,7 @@ OS:Space,
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
   0,                                      !- Y Origin {m}
-  -8.66293703438714e-015,                 !- Z Origin {m}
+  0,                                      !- Z Origin {m}
   {c136f41b-5899-4461-9ab1-ce81a1bb07cd}, !- Building Story Name
   {2c7f8dae-7af0-4295-9fa3-da3a2d421cdf}, !- Thermal Zone Name
   ,                                       !- Part of Total Floor Area
@@ -1873,7 +1858,7 @@ OS:Space,
 
 OS:Surface,
   {b031678d-2512-4cbe-8863-2c5ecf507dfe}, !- Handle
-  Surface 87,                             !- Name
+  Classroom_Basement_ZN - Floor_a,        !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {6a4fd8de-ac31-4c2d-8e19-bc00287778e6}, !- Space Name
@@ -1883,14 +1868,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  54.864, 18.8674375, -2.43840000000002,  !- X,Y,Z Vertex 1 {m}
-  54.864, 13.6858375, -2.43840000000002,  !- X,Y,Z Vertex 2 {m}
-  52.7304, 13.6858375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  52.7304, 18.8674375, -2.43840000000002; !- X,Y,Z Vertex 4 {m}
+  54.864, 18.8674375, -2.4384,            !- X,Y,Z Vertex 1 {m}
+  54.864, 13.6858375, -2.4384,            !- X,Y,Z Vertex 2 {m}
+  52.7304, 13.6858375, -2.4384,           !- X,Y,Z Vertex 3 {m}
+  52.7304, 18.8674375, -2.4384;           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {8874b99a-602a-4c1f-8e36-e8d84daaefc6}, !- Handle
-  Surface 88,                             !- Name
+  Classroom_Basement_ZN - Wall 090_a,     !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {6a4fd8de-ac31-4c2d-8e19-bc00287778e6}, !- Space Name
@@ -1900,14 +1885,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  54.864, 13.6858375, -2.56474457505455e-029, !- X,Y,Z Vertex 1 {m}
-  54.864, 13.6858375, -2.43840000000002,  !- X,Y,Z Vertex 2 {m}
-  54.864, 18.8674375, -2.43840000000002,  !- X,Y,Z Vertex 3 {m}
-  54.864, 18.8674375, -2.56474457505455e-029; !- X,Y,Z Vertex 4 {m}
+  54.864, 13.6858375, 0,                  !- X,Y,Z Vertex 1 {m}
+  54.864, 13.6858375, -2.4384,            !- X,Y,Z Vertex 2 {m}
+  54.864, 18.8674375, -2.4384,            !- X,Y,Z Vertex 3 {m}
+  54.864, 18.8674375, 0;                  !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {f9e7ce85-b5eb-4073-89f7-61c8e86c4d49}, !- Handle
-  Surface 89,                             !- Name
+  Classroom_Basement_ZN - Wall 180_a,     !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {6a4fd8de-ac31-4c2d-8e19-bc00287778e6}, !- Space Name
@@ -1917,14 +1902,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  52.7304, 13.6858375, -2.56474457505455e-029, !- X,Y,Z Vertex 1 {m}
-  52.7304, 13.6858375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  54.864, 13.6858375, -2.43840000000002,  !- X,Y,Z Vertex 3 {m}
-  54.864, 13.6858375, -2.56474457505455e-029; !- X,Y,Z Vertex 4 {m}
+  52.7304, 13.6858375, 0,                 !- X,Y,Z Vertex 1 {m}
+  52.7304, 13.6858375, -2.4384,           !- X,Y,Z Vertex 2 {m}
+  54.864, 13.6858375, -2.4384,            !- X,Y,Z Vertex 3 {m}
+  54.864, 13.6858375, 0;                  !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {55797ba5-5b15-41be-8f8d-77f61f7c6dcf}, !- Handle
-  Surface 90,                             !- Name
+  Classroom_Basement_ZN - Wall 000_a,     !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {6a4fd8de-ac31-4c2d-8e19-bc00287778e6}, !- Space Name
@@ -1934,14 +1919,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  54.864, 18.8674375, -2.56474457505455e-029, !- X,Y,Z Vertex 1 {m}
-  54.864, 18.8674375, -2.43840000000002,  !- X,Y,Z Vertex 2 {m}
-  52.7304, 18.8674375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  52.7304, 18.8674375, -2.56474457505455e-029; !- X,Y,Z Vertex 4 {m}
+  54.864, 18.8674375, 0,                  !- X,Y,Z Vertex 1 {m}
+  54.864, 18.8674375, -2.4384,            !- X,Y,Z Vertex 2 {m}
+  52.7304, 18.8674375, -2.4384,           !- X,Y,Z Vertex 3 {m}
+  52.7304, 18.8674375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {7142902d-15a1-4650-9621-c9412cb40750}, !- Handle
-  Surface 91,                             !- Name
+  Classroom_Basement_ZN - RoofCeiling_a,  !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {6a4fd8de-ac31-4c2d-8e19-bc00287778e6}, !- Space Name
@@ -1951,14 +1936,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  54.864, 13.6858375, -2.56474457505455e-029, !- X,Y,Z Vertex 1 {m}
-  54.864, 18.8674375, -2.56474457505455e-029, !- X,Y,Z Vertex 2 {m}
-  52.7304, 18.8674375, -2.56474457505455e-029, !- X,Y,Z Vertex 3 {m}
-  52.7304, 13.6858375, -2.56474457505455e-029; !- X,Y,Z Vertex 4 {m}
+  54.864, 13.6858375, 0,                  !- X,Y,Z Vertex 1 {m}
+  54.864, 18.8674375, 0,                  !- X,Y,Z Vertex 2 {m}
+  52.7304, 18.8674375, 0,                 !- X,Y,Z Vertex 3 {m}
+  52.7304, 13.6858375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {366caf49-b7d5-45a4-98be-58cd2bd24d3a}, !- Handle
-  Surface 92,                             !- Name
+  Classroom_Basement_ZN - Wall 270_a,     !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {6a4fd8de-ac31-4c2d-8e19-bc00287778e6}, !- Space Name
@@ -1968,10 +1953,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  52.7304, 18.8674375, -2.56474457505455e-029, !- X,Y,Z Vertex 1 {m}
-  52.7304, 18.8674375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  52.7304, 13.6858375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  52.7304, 13.6858375, -2.56474457505455e-029; !- X,Y,Z Vertex 4 {m}
+  52.7304, 18.8674375, 0,                 !- X,Y,Z Vertex 1 {m}
+  52.7304, 18.8674375, -2.4384,           !- X,Y,Z Vertex 2 {m}
+  52.7304, 13.6858375, -2.4384,           !- X,Y,Z Vertex 3 {m}
+  52.7304, 13.6858375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {8f6dceaa-19e5-4672-b32e-31cdc78109d8}, !- Handle
@@ -1982,7 +1967,7 @@ OS:Space,
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
   0,                                      !- Y Origin {m}
-  -8.66293703438714e-015,                 !- Z Origin {m}
+  0,                                      !- Z Origin {m}
   {c136f41b-5899-4461-9ab1-ce81a1bb07cd}, !- Building Story Name
   {d1dadafa-f1ef-4c6e-bbd7-6bbe092ddda3}, !- Thermal Zone Name
   ,                                       !- Part of Total Floor Area
@@ -1991,7 +1976,7 @@ OS:Space,
 
 OS:Surface,
   {3ec5cfff-9869-4633-9d15-aaa7a50117e8}, !- Handle
-  Surface 93,                             !- Name
+  Workshop_Basement_ZN - Floor_a,         !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {8f6dceaa-19e5-4672-b32e-31cdc78109d8}, !- Space Name
@@ -2001,14 +1986,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.3296, 29.8402375, -2.43840000000002, !- X,Y,Z Vertex 1 {m}
-  46.3296, 24.3538375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  37.7952, 24.3538375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  37.7952, 29.8402375, -2.43840000000002; !- X,Y,Z Vertex 4 {m}
+  46.3296, 29.8402375, -2.4384,           !- X,Y,Z Vertex 1 {m}
+  46.3296, 24.3538375, -2.4384,           !- X,Y,Z Vertex 2 {m}
+  37.7952, 24.3538375, -2.4384,           !- X,Y,Z Vertex 3 {m}
+  37.7952, 29.8402375, -2.4384;           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {afaba54b-cf84-491b-9b40-802cdd9f761b}, !- Handle
-  Surface 94,                             !- Name
+  Workshop_Basement_ZN - Wall 180_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {8f6dceaa-19e5-4672-b32e-31cdc78109d8}, !- Space Name
@@ -2018,14 +2003,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  37.7952, 24.3538375, 1.15505827125162e-014, !- X,Y,Z Vertex 1 {m}
-  37.7952, 24.3538375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  46.3296, 24.3538375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  46.3296, 24.3538375, 1.15505827125162e-014; !- X,Y,Z Vertex 4 {m}
+  37.7952, 24.3538375, 0,                 !- X,Y,Z Vertex 1 {m}
+  37.7952, 24.3538375, -2.4384,           !- X,Y,Z Vertex 2 {m}
+  46.3296, 24.3538375, -2.4384,           !- X,Y,Z Vertex 3 {m}
+  46.3296, 24.3538375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {089713b4-ae0a-4f79-90b7-a8d0a97ff9d0}, !- Handle
-  Surface 95,                             !- Name
+  Workshop_Basement_ZN - Wall 270_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {8f6dceaa-19e5-4672-b32e-31cdc78109d8}, !- Space Name
@@ -2035,14 +2020,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  37.7952, 29.8402375, 1.15505827125162e-014, !- X,Y,Z Vertex 1 {m}
-  37.7952, 29.8402375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  37.7952, 24.3538375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  37.7952, 24.3538375, 1.15505827125162e-014; !- X,Y,Z Vertex 4 {m}
+  37.7952, 29.8402375, 0,                 !- X,Y,Z Vertex 1 {m}
+  37.7952, 29.8402375, -2.4384,           !- X,Y,Z Vertex 2 {m}
+  37.7952, 24.3538375, -2.4384,           !- X,Y,Z Vertex 3 {m}
+  37.7952, 24.3538375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {b85fadd1-d47f-40dd-9a17-e42cba9b3f91}, !- Handle
-  Surface 96,                             !- Name
+  Workshop_Basement_ZN - Wall 000_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {8f6dceaa-19e5-4672-b32e-31cdc78109d8}, !- Space Name
@@ -2052,14 +2037,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.3296, 29.8402375, 1.15505827125162e-014, !- X,Y,Z Vertex 1 {m}
-  46.3296, 29.8402375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  37.7952, 29.8402375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  37.7952, 29.8402375, 1.15505827125162e-014; !- X,Y,Z Vertex 4 {m}
+  46.3296, 29.8402375, 0,                 !- X,Y,Z Vertex 1 {m}
+  46.3296, 29.8402375, -2.4384,           !- X,Y,Z Vertex 2 {m}
+  37.7952, 29.8402375, -2.4384,           !- X,Y,Z Vertex 3 {m}
+  37.7952, 29.8402375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {12126b09-b6fb-4d68-9fef-99ee809b2b93}, !- Handle
-  Surface 97,                             !- Name
+  Workshop_Basement_ZN - RoofCeiling_a,   !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {8f6dceaa-19e5-4672-b32e-31cdc78109d8}, !- Space Name
@@ -2069,14 +2054,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.3296, 24.3538375, 1.15505827125162e-014, !- X,Y,Z Vertex 1 {m}
-  46.3296, 29.8402375, 1.15505827125162e-014, !- X,Y,Z Vertex 2 {m}
-  37.7952, 29.8402375, 1.15505827125162e-014, !- X,Y,Z Vertex 3 {m}
-  37.7952, 24.3538375, 1.15505827125162e-014; !- X,Y,Z Vertex 4 {m}
+  46.3296, 24.3538375, 0,                 !- X,Y,Z Vertex 1 {m}
+  46.3296, 29.8402375, 0,                 !- X,Y,Z Vertex 2 {m}
+  37.7952, 29.8402375, 0,                 !- X,Y,Z Vertex 3 {m}
+  37.7952, 24.3538375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {7cb3caff-e76d-4586-9ca2-19f7fb45b6bc}, !- Handle
-  Surface 98,                             !- Name
+  Workshop_Basement_ZN - Wall 090_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {8f6dceaa-19e5-4672-b32e-31cdc78109d8}, !- Space Name
@@ -2086,10 +2071,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.3296, 24.3538375, 1.15505827125162e-014, !- X,Y,Z Vertex 1 {m}
-  46.3296, 24.3538375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  46.3296, 29.8402375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  46.3296, 29.8402375, 1.15505827125162e-014; !- X,Y,Z Vertex 4 {m}
+  46.3296, 24.3538375, 0,                 !- X,Y,Z Vertex 1 {m}
+  46.3296, 24.3538375, -2.4384,           !- X,Y,Z Vertex 2 {m}
+  46.3296, 29.8402375, -2.4384,           !- X,Y,Z Vertex 3 {m}
+  46.3296, 29.8402375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {f31d9b3a-b907-4dea-8a8a-2b5de88b7c35}, !- Handle
@@ -2100,7 +2085,7 @@ OS:Space,
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
   0,                                      !- Y Origin {m}
-  -3.17641024594195e-014,                 !- Z Origin {m}
+  0,                                      !- Z Origin {m}
   {c136f41b-5899-4461-9ab1-ce81a1bb07cd}, !- Building Story Name
   {24692ccd-5552-4cbf-b595-a4c81c10d226}, !- Thermal Zone Name
   ,                                       !- Part of Total Floor Area
@@ -2108,7 +2093,7 @@ OS:Space,
 
 OS:Surface,
   {f6d5dbe2-eb29-4960-92a1-dd07408f6e55}, !- Handle
-  Surface 99,                             !- Name
+  Stair_Basement_ZN_2 - Floor_a,          !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {f31d9b3a-b907-4dea-8a8a-2b5de88b7c35}, !- Space Name
@@ -2125,7 +2110,7 @@ OS:Surface,
 
 OS:Surface,
   {a728245b-9665-4696-a0f9-0deab5a34e4e}, !- Handle
-  Surface 100,                            !- Name
+  Stair_Basement_ZN_2 - Wall 180_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f31d9b3a-b907-4dea-8a8a-2b5de88b7c35}, !- Space Name
@@ -2135,14 +2120,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.3296, 18.8674375, 2.31011654250324e-014, !- X,Y,Z Vertex 1 {m}
+  46.3296, 18.8674375, 0,                 !- X,Y,Z Vertex 1 {m}
   46.3296, 18.8674375, -2.4384,           !- X,Y,Z Vertex 2 {m}
   49.0728, 18.8674375, -2.4384,           !- X,Y,Z Vertex 3 {m}
-  49.0728, 18.8674375, 2.31011654250324e-014; !- X,Y,Z Vertex 4 {m}
+  49.0728, 18.8674375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {15e4ee28-1264-48f5-ae8b-b09f63a4e74a}, !- Handle
-  Surface 101,                            !- Name
+  Stair_Basement_ZN_2 - Wall 090_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f31d9b3a-b907-4dea-8a8a-2b5de88b7c35}, !- Space Name
@@ -2152,14 +2137,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  49.0728, 18.8674375, 2.31011654250324e-014, !- X,Y,Z Vertex 1 {m}
+  49.0728, 18.8674375, 0,                 !- X,Y,Z Vertex 1 {m}
   49.0728, 18.8674375, -2.4384,           !- X,Y,Z Vertex 2 {m}
   49.0728, 29.8402375, -2.4384,           !- X,Y,Z Vertex 3 {m}
-  49.0728, 29.8402375, 2.31011654250324e-014; !- X,Y,Z Vertex 4 {m}
+  49.0728, 29.8402375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {6c523ece-ebfe-4afe-8104-c5d5e520e65d}, !- Handle
-  Surface 102,                            !- Name
+  Stair_Basement_ZN_2 - Wall 270_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f31d9b3a-b907-4dea-8a8a-2b5de88b7c35}, !- Space Name
@@ -2169,14 +2154,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.3296, 24.3538375, 2.31011654250324e-014, !- X,Y,Z Vertex 1 {m}
+  46.3296, 24.3538375, 0,                 !- X,Y,Z Vertex 1 {m}
   46.3296, 24.3538375, -2.4384,           !- X,Y,Z Vertex 2 {m}
   46.3296, 18.8674375, -2.4384,           !- X,Y,Z Vertex 3 {m}
-  46.3296, 18.8674375, 2.31011654250324e-014; !- X,Y,Z Vertex 4 {m}
+  46.3296, 18.8674375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {d178ab26-0038-4a13-b9ea-0ae695df7850}, !- Handle
-  Surface 103,                            !- Name
+  Stair_Basement_ZN_2 - RoofCeiling_a,    !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {f31d9b3a-b907-4dea-8a8a-2b5de88b7c35}, !- Space Name
@@ -2186,14 +2171,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  49.0728, 18.8674375, 2.31011654250324e-014, !- X,Y,Z Vertex 1 {m}
-  49.0728, 29.8402375, 2.31011654250324e-014, !- X,Y,Z Vertex 2 {m}
-  46.3296, 29.8402375, 2.31011654250324e-014, !- X,Y,Z Vertex 3 {m}
-  46.3296, 18.8674375, 2.31011654250324e-014; !- X,Y,Z Vertex 4 {m}
+  49.0728, 18.8674375, 0,                 !- X,Y,Z Vertex 1 {m}
+  49.0728, 29.8402375, 0,                 !- X,Y,Z Vertex 2 {m}
+  46.3296, 29.8402375, 0,                 !- X,Y,Z Vertex 3 {m}
+  46.3296, 18.8674375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {cbca32ba-5b99-411b-80c5-12b13587b9aa}, !- Handle
-  Surface 104,                            !- Name
+  Stair_Basement_ZN_2 - Wall 000_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f31d9b3a-b907-4dea-8a8a-2b5de88b7c35}, !- Space Name
@@ -2203,10 +2188,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  49.0728, 29.8402375, 2.31011654250324e-014, !- X,Y,Z Vertex 1 {m}
+  49.0728, 29.8402375, 0,                 !- X,Y,Z Vertex 1 {m}
   49.0728, 29.8402375, -2.4384,           !- X,Y,Z Vertex 2 {m}
   46.3296, 29.8402375, -2.4384,           !- X,Y,Z Vertex 3 {m}
-  46.3296, 29.8402375, 2.31011654250324e-014; !- X,Y,Z Vertex 4 {m}
+  46.3296, 29.8402375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {703003c0-a8be-48e2-93b7-57710ac64710}, !- Handle
@@ -2217,7 +2202,7 @@ OS:Space,
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
   0,                                      !- Y Origin {m}
-  -3.17641024594195e-014,                 !- Z Origin {m}
+  0,                                      !- Z Origin {m}
   {c136f41b-5899-4461-9ab1-ce81a1bb07cd}, !- Building Story Name
   {24c6e98b-7d69-4992-a40c-cea5531906ef}, !- Thermal Zone Name
   ,                                       !- Part of Total Floor Area
@@ -2226,7 +2211,7 @@ OS:Space,
 
 OS:Surface,
   {edd83fb4-a4b2-47b9-8a4f-aa53f3c52b38}, !- Handle
-  Surface 105,                            !- Name
+  ActiveStorage_Basement_ZN - Floor_a,    !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {703003c0-a8be-48e2-93b7-57710ac64710}, !- Space Name
@@ -2243,7 +2228,7 @@ OS:Surface,
 
 OS:Surface,
   {76d90bb1-6291-4e68-a866-8edeea1901f8}, !- Handle
-  Surface 106,                            !- Name
+  ActiveStorage_Basement_ZN - Wall 180_a, !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {703003c0-a8be-48e2-93b7-57710ac64710}, !- Space Name
@@ -2253,14 +2238,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  52.7304, 18.8674375, 2.31011654250324e-014, !- X,Y,Z Vertex 1 {m}
+  52.7304, 18.8674375, 0,                 !- X,Y,Z Vertex 1 {m}
   52.7304, 18.8674375, -2.4384,           !- X,Y,Z Vertex 2 {m}
   54.864, 18.8674375, -2.4384,            !- X,Y,Z Vertex 3 {m}
-  54.864, 18.8674375, 2.31011654250324e-014; !- X,Y,Z Vertex 4 {m}
+  54.864, 18.8674375, 0;                  !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {b6dfdf1b-ba14-433a-bcbf-042c9aec00ad}, !- Handle
-  Surface 107,                            !- Name
+  ActiveStorage_Basement_ZN - Wall 000_a, !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {703003c0-a8be-48e2-93b7-57710ac64710}, !- Space Name
@@ -2270,14 +2255,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  54.864, 29.8402375, 2.31011654250324e-014, !- X,Y,Z Vertex 1 {m}
+  54.864, 29.8402375, 0,                  !- X,Y,Z Vertex 1 {m}
   54.864, 29.8402375, -2.4384,            !- X,Y,Z Vertex 2 {m}
   49.0728, 29.8402375, -2.4384,           !- X,Y,Z Vertex 3 {m}
-  49.0728, 29.8402375, 2.31011654250324e-014; !- X,Y,Z Vertex 4 {m}
+  49.0728, 29.8402375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {631708de-67fe-4485-a24a-dce85f406652}, !- Handle
-  Surface 108,                            !- Name
+  ActiveStorage_Basement_ZN - Wall 090_a, !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {703003c0-a8be-48e2-93b7-57710ac64710}, !- Space Name
@@ -2287,14 +2272,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  54.864, 18.8674375, 2.31011654250324e-014, !- X,Y,Z Vertex 1 {m}
+  54.864, 18.8674375, 0,                  !- X,Y,Z Vertex 1 {m}
   54.864, 18.8674375, -2.4384,            !- X,Y,Z Vertex 2 {m}
   54.864, 29.8402375, -2.4384,            !- X,Y,Z Vertex 3 {m}
-  54.864, 29.8402375, 2.31011654250324e-014; !- X,Y,Z Vertex 4 {m}
+  54.864, 29.8402375, 0;                  !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {6781cc9a-dae8-42ff-80c4-4a324c790a34}, !- Handle
-  Surface 109,                            !- Name
+  ActiveStorage_Basement_ZN - Wall 270_a, !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {703003c0-a8be-48e2-93b7-57710ac64710}, !- Space Name
@@ -2304,14 +2289,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  49.0728, 29.8402375, 2.31011654250324e-014, !- X,Y,Z Vertex 1 {m}
+  49.0728, 29.8402375, 0,                 !- X,Y,Z Vertex 1 {m}
   49.0728, 29.8402375, -2.4384,           !- X,Y,Z Vertex 2 {m}
   49.0728, 18.8674375, -2.4384,           !- X,Y,Z Vertex 3 {m}
-  49.0728, 18.8674375, 2.31011654250324e-014; !- X,Y,Z Vertex 4 {m}
+  49.0728, 18.8674375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {04df5109-04e1-4db7-9d8b-fad56dafc54b}, !- Handle
-  Surface 110,                            !- Name
+  ActiveStorage_Basement_ZN - RoofCeiling_a, !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {703003c0-a8be-48e2-93b7-57710ac64710}, !- Space Name
@@ -2321,10 +2306,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  54.864, 18.8674375, 2.31011654250324e-014, !- X,Y,Z Vertex 1 {m}
-  54.864, 29.8402375, 2.31011654250324e-014, !- X,Y,Z Vertex 2 {m}
-  49.0728, 29.8402375, 2.31011654250324e-014, !- X,Y,Z Vertex 3 {m}
-  49.0728, 18.8674375, 2.31011654250324e-014; !- X,Y,Z Vertex 4 {m}
+  54.864, 18.8674375, 0,                  !- X,Y,Z Vertex 1 {m}
+  54.864, 29.8402375, 0,                  !- X,Y,Z Vertex 2 {m}
+  49.0728, 29.8402375, 0,                 !- X,Y,Z Vertex 3 {m}
+  49.0728, 18.8674375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {69c83deb-630e-462f-b9e7-bda39f8a372d}, !- Handle
@@ -2335,7 +2320,7 @@ OS:Space,
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
   0,                                      !- Y Origin {m}
-  -3.17641024594195e-014,                 !- Z Origin {m}
+  0,                                      !- Z Origin {m}
   {c136f41b-5899-4461-9ab1-ce81a1bb07cd}, !- Building Story Name
   {edaaa869-f170-4cd8-9ec6-82a26cc1076e}, !- Thermal Zone Name
   ,                                       !- Part of Total Floor Area
@@ -2343,7 +2328,7 @@ OS:Space,
 
 OS:Surface,
   {dce51589-f264-4d02-8999-57e8f6b41c21}, !- Handle
-  Surface 111,                            !- Name
+  EnclosedOffice_Basement_ZN_3 - Floor_a, !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {69c83deb-630e-462f-b9e7-bda39f8a372d}, !- Space Name
@@ -2360,7 +2345,7 @@ OS:Surface,
 
 OS:Surface,
   {6b5560fc-bbeb-4907-b95f-207e4ffea18b}, !- Handle
-  Surface 112,                            !- Name
+  EnclosedOffice_Basement_ZN_3 - Wall 180_b, !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {69c83deb-630e-462f-b9e7-bda39f8a372d}, !- Space Name
@@ -2370,14 +2355,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  49.0728, 29.8402375, 2.31011654250324e-014, !- X,Y,Z Vertex 1 {m}
-  46.3296, 29.8402375, 0,                 !- X,Y,Z Vertex 2 {m}
-  46.3296, 29.8402375, -2.4384,           !- X,Y,Z Vertex 3 {m}
-  49.0728, 29.8402375, -2.4384;           !- X,Y,Z Vertex 4 {m}
+  46.3296, 29.8402375, 0,                 !- X,Y,Z Vertex 1 {m}
+  46.3296, 29.8402375, -2.4384,           !- X,Y,Z Vertex 2 {m}
+  49.0728, 29.8402375, -2.4384,           !- X,Y,Z Vertex 3 {m}
+  49.0728, 29.8402375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {5dee739f-0465-43af-8f8f-cbdf0c6d8639}, !- Handle
-  Surface 113,                            !- Name
+  EnclosedOffice_Basement_ZN_3 - Wall 090_a, !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {69c83deb-630e-462f-b9e7-bda39f8a372d}, !- Space Name
@@ -2387,14 +2372,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  54.864, 29.8402375, 2.31011654250324e-014, !- X,Y,Z Vertex 1 {m}
+  54.864, 29.8402375, 0,                  !- X,Y,Z Vertex 1 {m}
   54.864, 29.8402375, -2.4384,            !- X,Y,Z Vertex 2 {m}
   54.864, 35.0218375, -2.4384,            !- X,Y,Z Vertex 3 {m}
-  54.864, 35.0218375, 2.31011654250324e-014; !- X,Y,Z Vertex 4 {m}
+  54.864, 35.0218375, 0;                  !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {1b4bdc89-805b-4ded-aed9-aa616db6367f}, !- Handle
-  Surface 114,                            !- Name
+  EnclosedOffice_Basement_ZN_3 - Wall 270_a, !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {69c83deb-630e-462f-b9e7-bda39f8a372d}, !- Space Name
@@ -2404,14 +2389,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  37.7952, 35.0218375, 2.31011654250324e-014, !- X,Y,Z Vertex 1 {m}
+  37.7952, 35.0218375, 0,                 !- X,Y,Z Vertex 1 {m}
   37.7952, 35.0218375, -2.4384,           !- X,Y,Z Vertex 2 {m}
   37.7952, 29.8402375, -2.4384,           !- X,Y,Z Vertex 3 {m}
-  37.7952, 29.8402375, 2.31011654250324e-014; !- X,Y,Z Vertex 4 {m}
+  37.7952, 29.8402375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {14d5b373-d9d0-47b2-bf20-2adace8982ac}, !- Handle
-  Surface 115,                            !- Name
+  EnclosedOffice_Basement_ZN_3 - RoofCeiling_a, !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {69c83deb-630e-462f-b9e7-bda39f8a372d}, !- Space Name
@@ -2421,14 +2406,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.3296, 29.8402375, 2.05179566004364e-029, !- X,Y,Z Vertex 1 {m}
-  46.3296, 35.0218375, 2.05179566004364e-029, !- X,Y,Z Vertex 2 {m}
-  37.7952, 35.0218375, 2.31011654250324e-014, !- X,Y,Z Vertex 3 {m}
-  37.7952, 29.8402375, 2.31011654250324e-014; !- X,Y,Z Vertex 4 {m}
+  46.3296, 29.8402375, 0,                 !- X,Y,Z Vertex 1 {m}
+  46.3296, 35.0218375, 0,                 !- X,Y,Z Vertex 2 {m}
+  37.7952, 35.0218375, 0,                 !- X,Y,Z Vertex 3 {m}
+  37.7952, 29.8402375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {62940360-9c8a-456f-b6f0-877b798a9ddc}, !- Handle
-  Surface 116,                            !- Name
+  EnclosedOffice_Basement_ZN_3 - Wall 000_a, !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {69c83deb-630e-462f-b9e7-bda39f8a372d}, !- Space Name
@@ -2438,10 +2423,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  54.864, 35.0218375, 2.31011654250324e-014, !- X,Y,Z Vertex 1 {m}
+  54.864, 35.0218375, 0,                  !- X,Y,Z Vertex 1 {m}
   54.864, 35.0218375, -2.4384,            !- X,Y,Z Vertex 2 {m}
   37.7952, 35.0218375, -2.4384,           !- X,Y,Z Vertex 3 {m}
-  37.7952, 35.0218375, 2.31011654250324e-014; !- X,Y,Z Vertex 4 {m}
+  37.7952, 35.0218375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {d1bcd4f1-7920-4f82-a04e-3b6c9d4fab99}, !- Handle
@@ -2452,7 +2437,7 @@ OS:Space,
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
   0,                                      !- Y Origin {m}
-  -2.88764567812905e-015,                 !- Z Origin {m}
+  0,                                      !- Z Origin {m}
   {c136f41b-5899-4461-9ab1-ce81a1bb07cd}, !- Building Story Name
   {3ce80d2e-76d0-4859-8926-b77adf25a483}, !- Thermal Zone Name
   ,                                       !- Part of Total Floor Area
@@ -2461,7 +2446,7 @@ OS:Space,
 
 OS:Surface,
   {3899d5b0-87f2-4c57-b686-10eb23c587b3}, !- Handle
-  Surface 117,                            !- Name
+  Corridor_Basement_ZN_2 - Floor_a,       !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {d1bcd4f1-7920-4f82-a04e-3b6c9d4fab99}, !- Space Name
@@ -2471,14 +2456,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  54.864, 36.5458375, -2.43840000000002,  !- X,Y,Z Vertex 1 {m}
-  54.864, 35.0218375, -2.43840000000002,  !- X,Y,Z Vertex 2 {m}
-  37.7952, 35.0218375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  37.7952, 36.5458375, -2.43840000000002; !- X,Y,Z Vertex 4 {m}
+  54.864, 36.5458375, -2.4384,            !- X,Y,Z Vertex 1 {m}
+  54.864, 35.0218375, -2.4384,            !- X,Y,Z Vertex 2 {m}
+  37.7952, 35.0218375, -2.4384,           !- X,Y,Z Vertex 3 {m}
+  37.7952, 36.5458375, -2.4384;           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {fa8a6e2a-8464-4841-aa33-012e815746be}, !- Handle
-  Surface 118,                            !- Name
+  Corridor_Basement_ZN_2 - Wall 090_a,    !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d1bcd4f1-7920-4f82-a04e-3b6c9d4fab99}, !- Space Name
@@ -2488,14 +2473,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  54.864, 35.0218375, 5.77529135625807e-015, !- X,Y,Z Vertex 1 {m}
-  54.864, 35.0218375, -2.43840000000002,  !- X,Y,Z Vertex 2 {m}
-  54.864, 36.5458375, -2.43840000000002,  !- X,Y,Z Vertex 3 {m}
-  54.864, 36.5458375, 5.77529135625807e-015; !- X,Y,Z Vertex 4 {m}
+  54.864, 35.0218375, 0,                  !- X,Y,Z Vertex 1 {m}
+  54.864, 35.0218375, -2.4384,            !- X,Y,Z Vertex 2 {m}
+  54.864, 36.5458375, -2.4384,            !- X,Y,Z Vertex 3 {m}
+  54.864, 36.5458375, 0;                  !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {9d4bc09d-5eb1-431e-a0a0-9f9c111cb4b2}, !- Handle
-  Surface 119,                            !- Name
+  Corridor_Basement_ZN_2 - RoofCeiling_a, !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {d1bcd4f1-7920-4f82-a04e-3b6c9d4fab99}, !- Space Name
@@ -2505,14 +2490,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  54.864, 35.0218375, 5.77529135625805e-015, !- X,Y,Z Vertex 1 {m}
-  54.864, 36.5458375, 5.77529135625805e-015, !- X,Y,Z Vertex 2 {m}
-  46.3296, 36.5458375, -2.31011654250324e-014, !- X,Y,Z Vertex 3 {m}
-  46.3296, 35.0218375, -2.31011654250324e-014; !- X,Y,Z Vertex 4 {m}
+  54.864, 35.0218375, 0,                  !- X,Y,Z Vertex 1 {m}
+  54.864, 36.5458375, 0,                  !- X,Y,Z Vertex 2 {m}
+  46.3296, 36.5458375, 0,                 !- X,Y,Z Vertex 3 {m}
+  46.3296, 35.0218375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {e10a6092-a129-438b-ab56-652e3c4d9919}, !- Handle
-  Surface 120,                            !- Name
+  Corridor_Basement_ZN_2 - Wall 180_a,    !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d1bcd4f1-7920-4f82-a04e-3b6c9d4fab99}, !- Space Name
@@ -2522,14 +2507,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  37.7952, 35.0218375, 5.77529135625807e-015, !- X,Y,Z Vertex 1 {m}
-  37.7952, 35.0218375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  54.864, 35.0218375, -2.43840000000002,  !- X,Y,Z Vertex 3 {m}
-  54.864, 35.0218375, 5.77529135625807e-015; !- X,Y,Z Vertex 4 {m}
+  37.7952, 35.0218375, 0,                 !- X,Y,Z Vertex 1 {m}
+  37.7952, 35.0218375, -2.4384,           !- X,Y,Z Vertex 2 {m}
+  54.864, 35.0218375, -2.4384,            !- X,Y,Z Vertex 3 {m}
+  54.864, 35.0218375, 0;                  !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {55920cd4-8582-4db3-8039-be618794357b}, !- Handle
-  Surface 121,                            !- Name
+  Corridor_Basement_ZN_2 - Wall 000_a,    !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d1bcd4f1-7920-4f82-a04e-3b6c9d4fab99}, !- Space Name
@@ -2539,14 +2524,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  54.864, 36.5458375, 5.77529135625807e-015, !- X,Y,Z Vertex 1 {m}
-  54.864, 36.5458375, -2.43840000000002,  !- X,Y,Z Vertex 2 {m}
-  37.7952, 36.5458375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  37.7952, 36.5458375, 5.77529135625807e-015; !- X,Y,Z Vertex 4 {m}
+  54.864, 36.5458375, 0,                  !- X,Y,Z Vertex 1 {m}
+  54.864, 36.5458375, -2.4384,            !- X,Y,Z Vertex 2 {m}
+  37.7952, 36.5458375, -2.4384,           !- X,Y,Z Vertex 3 {m}
+  37.7952, 36.5458375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {f2b1f458-fb82-425b-839c-32791e9fabc4}, !- Handle
-  Surface 122,                            !- Name
+  Corridor_Basement_ZN_2 - Wall 270_a,    !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d1bcd4f1-7920-4f82-a04e-3b6c9d4fab99}, !- Space Name
@@ -2556,10 +2541,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  37.7952, 36.5458375, 5.77529135625807e-015, !- X,Y,Z Vertex 1 {m}
-  37.7952, 36.5458375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  37.7952, 35.0218375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  37.7952, 35.0218375, 5.77529135625807e-015; !- X,Y,Z Vertex 4 {m}
+  37.7952, 36.5458375, 0,                 !- X,Y,Z Vertex 1 {m}
+  37.7952, 36.5458375, -2.4384,           !- X,Y,Z Vertex 2 {m}
+  37.7952, 35.0218375, -2.4384,           !- X,Y,Z Vertex 3 {m}
+  37.7952, 35.0218375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {316fddf4-8cea-4c27-b604-515fad8156a5}, !- Handle
@@ -2570,7 +2555,7 @@ OS:Space,
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
   0,                                      !- Y Origin {m}
-  -1.15505827125162e-014,                 !- Z Origin {m}
+  0,                                      !- Z Origin {m}
   {c136f41b-5899-4461-9ab1-ce81a1bb07cd}, !- Building Story Name
   {5a6f1951-f616-4b87-8a81-4ec5d485061b}, !- Thermal Zone Name
   ,                                       !- Part of Total Floor Area
@@ -2579,7 +2564,7 @@ OS:Space,
 
 OS:Surface,
   {4de46be6-ec5c-46e6-9dfa-b7532431d107}, !- Handle
-  Surface 131,                            !- Name
+  OpenOffice_Basement_ZN_2 - Floor_a,     !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {316fddf4-8cea-4c27-b604-515fad8156a5}, !- Space Name
@@ -2589,14 +2574,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  73.10755, 48.7378375, -2.43840000000002, !- X,Y,Z Vertex 1 {m}
-  73.10755, 36.5458375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  16.0797875, 36.5458375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  16.0797875, 48.7378375, -2.43840000000002; !- X,Y,Z Vertex 4 {m}
+  73.10755, 48.7378375, -2.4384,          !- X,Y,Z Vertex 1 {m}
+  73.10755, 36.5458375, -2.4384,          !- X,Y,Z Vertex 2 {m}
+  16.0797875, 36.5458375, -2.4384,        !- X,Y,Z Vertex 3 {m}
+  16.0797875, 48.7378375, -2.4384;        !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {32b4b753-9147-40d4-a783-0b584ff271d2}, !- Handle
-  Surface 132,                            !- Name
+  OpenOffice_Basement_ZN_2 - Wall 270_a,  !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {316fddf4-8cea-4c27-b604-515fad8156a5}, !- Space Name
@@ -2606,14 +2591,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  16.0797875, 48.7378375, 1.15505827125162e-014, !- X,Y,Z Vertex 1 {m}
-  16.0797875, 48.7378375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  16.0797875, 36.5458375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  16.0797875, 36.5458375, 1.15505827125162e-014; !- X,Y,Z Vertex 4 {m}
+  16.0797875, 48.7378375, 0,              !- X,Y,Z Vertex 1 {m}
+  16.0797875, 48.7378375, -2.4384,        !- X,Y,Z Vertex 2 {m}
+  16.0797875, 36.5458375, -2.4384,        !- X,Y,Z Vertex 3 {m}
+  16.0797875, 36.5458375, 0;              !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {fa126b4f-595c-4c57-b017-7ec5abf32dfd}, !- Handle
-  Surface 133,                            !- Name
+  OpenOffice_Basement_ZN_2 - Wall 000_a,  !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {316fddf4-8cea-4c27-b604-515fad8156a5}, !- Space Name
@@ -2623,14 +2608,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   0,                                      !- View Factor to Ground
   ,                                       !- Number of Vertices
-  73.10755, 48.7378375, 1.15505827125162e-014, !- X,Y,Z Vertex 1 {m}
-  73.10755, 48.7378375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  16.0797875, 48.7378375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  16.0797875, 48.7378375, 1.15505827125162e-014; !- X,Y,Z Vertex 4 {m}
+  73.10755, 48.7378375, 0,                !- X,Y,Z Vertex 1 {m}
+  73.10755, 48.7378375, -2.4384,          !- X,Y,Z Vertex 2 {m}
+  16.0797875, 48.7378375, -2.4384,        !- X,Y,Z Vertex 3 {m}
+  16.0797875, 48.7378375, 0;              !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {304ed5ee-7c98-457b-8835-f66fa1237125}, !- Handle
-  Surface 134,                            !- Name
+  OpenOffice_Basement_ZN_2 - Wall 180_c,  !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {316fddf4-8cea-4c27-b604-515fad8156a5}, !- Space Name
@@ -2640,14 +2625,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  25.4508, 36.5458375, 1.15505827125162e-014, !- X,Y,Z Vertex 1 {m}
-  25.4508, 36.5458375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  30.4038, 36.5458375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  30.4038, 36.5458375, 1.15505827125162e-014; !- X,Y,Z Vertex 4 {m}
+  25.4508, 36.5458375, 0,                 !- X,Y,Z Vertex 1 {m}
+  25.4508, 36.5458375, -2.4384,           !- X,Y,Z Vertex 2 {m}
+  30.4038, 36.5458375, -2.4384,           !- X,Y,Z Vertex 3 {m}
+  30.4038, 36.5458375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {4ab7b51f-41b9-4973-93d6-41b213bcebe2}, !- Handle
-  Surface 135,                            !- Name
+  OpenOffice_Basement_ZN_2 - Wall 090_a,  !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {316fddf4-8cea-4c27-b604-515fad8156a5}, !- Space Name
@@ -2657,14 +2642,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   0,                                      !- View Factor to Ground
   ,                                       !- Number of Vertices
-  73.10755, 36.5458375, 1.15505827125162e-014, !- X,Y,Z Vertex 1 {m}
-  73.10755, 36.5458375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  73.10755, 48.7378375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  73.10755, 48.7378375, 1.15505827125162e-014; !- X,Y,Z Vertex 4 {m}
+  73.10755, 36.5458375, 0,                !- X,Y,Z Vertex 1 {m}
+  73.10755, 36.5458375, -2.4384,          !- X,Y,Z Vertex 2 {m}
+  73.10755, 48.7378375, -2.4384,          !- X,Y,Z Vertex 3 {m}
+  73.10755, 48.7378375, 0;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {c079df91-f44f-42e7-98b3-19ab15e700b1}, !- Handle
-  Surface 136,                            !- Name
+  OpenOffice_Basement_ZN_2 - RoofCeiling_a, !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {316fddf4-8cea-4c27-b604-515fad8156a5}, !- Space Name
@@ -2674,10 +2659,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  73.10755, 36.5458375, 1.1528199228561e-014, !- X,Y,Z Vertex 1 {m}
-  73.10755, 42.6418375, -9.60286711260139e-015, !- X,Y,Z Vertex 2 {m}
-  56.388, 42.6418375, -3.07339334537638e-014, !- X,Y,Z Vertex 3 {m}
-  56.388, 36.5458375, -9.60286711260145e-015; !- X,Y,Z Vertex 4 {m}
+  73.10755, 36.5458375, 0,                !- X,Y,Z Vertex 1 {m}
+  73.10755, 42.6418375, 0,                !- X,Y,Z Vertex 2 {m}
+  56.388, 42.6418375, 0,                  !- X,Y,Z Vertex 3 {m}
+  56.388, 36.5458375, 0;                  !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {f6009d98-ae01-49dd-bf1f-f8d89b2e9054}, !- Handle
@@ -2688,7 +2673,7 @@ OS:Space,
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
   0,                                      !- Y Origin {m}
-  -3.17641024594195e-014,                 !- Z Origin {m}
+  0,                                      !- Z Origin {m}
   {c136f41b-5899-4461-9ab1-ce81a1bb07cd}, !- Building Story Name
   {b62acc88-274c-4612-852e-9fa6a521407b}, !- Thermal Zone Name
   ,                                       !- Part of Total Floor Area
@@ -2697,7 +2682,7 @@ OS:Space,
 
 OS:Surface,
   {2257f369-f9b8-48d0-9a38-8e68c2caee6a}, !- Handle
-  Surface 1,                              !- Name
+  DataCenter_Basement_ZN - Floor_a,       !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {f6009d98-ae01-49dd-bf1f-f8d89b2e9054}, !- Space Name
@@ -2714,7 +2699,7 @@ OS:Surface,
 
 OS:Surface,
   {8257920b-f3e4-4a13-bf23-04b663e46c5f}, !- Handle
-  Surface 2,                              !- Name
+  DataCenter_Basement_ZN - Wall 090_a,    !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f6009d98-ae01-49dd-bf1f-f8d89b2e9054}, !- Space Name
@@ -2724,14 +2709,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  16.0797875, 12.1618375, 2.31011654250324e-014, !- X,Y,Z Vertex 1 {m}
+  16.0797875, 12.1618375, 0,              !- X,Y,Z Vertex 1 {m}
   16.0797875, 12.1618375, -2.4384,        !- X,Y,Z Vertex 2 {m}
   16.0797875, 36.5458375, -2.4384,        !- X,Y,Z Vertex 3 {m}
-  16.0797875, 36.5458375, 2.15438017232475e-014; !- X,Y,Z Vertex 4 {m}
+  16.0797875, 36.5458375, 0;              !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {1185dc6e-1106-4f82-9bbc-0b44caa2e56f}, !- Handle
-  Surface 3,                              !- Name
+  DataCenter_Basement_ZN - RoofCeiling_b, !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {f6009d98-ae01-49dd-bf1f-f8d89b2e9054}, !- Space Name
@@ -2741,14 +2726,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  16.0797875, 36.5458375, 2.15453225862375e-014, !- X,Y,Z Vertex 1 {m}
-  16.0797875, 48.7378375, 2.25825511454341e-014, !- X,Y,Z Vertex 2 {m}
-  6.096, 48.7378375, 5.1861427959829e-016, !- X,Y,Z Vertex 3 {m}
-  6.096, 36.5458375, -5.18614279598302e-016; !- X,Y,Z Vertex 4 {m}
+  16.0797875, 36.5458375, 0,              !- X,Y,Z Vertex 1 {m}
+  16.0797875, 48.7378375, 0,              !- X,Y,Z Vertex 2 {m}
+  6.096, 48.7378375, 0,                   !- X,Y,Z Vertex 3 {m}
+  6.096, 36.5458375, 0;                   !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {04c6fbc7-3edf-46f9-ad26-42c71d21c04d}, !- Handle
-  Surface 4,                              !- Name
+  DataCenter_Basement_ZN - Wall 270_a,    !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f6009d98-ae01-49dd-bf1f-f8d89b2e9054}, !- Space Name
@@ -2758,14 +2743,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   0,                                      !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 48.7378375, 2.31011654250324e-014,   !- X,Y,Z Vertex 1 {m}
+  0, 48.7378375, 0,                       !- X,Y,Z Vertex 1 {m}
   0, 48.7378375, -2.4384,                 !- X,Y,Z Vertex 2 {m}
   0, 0, -2.4384,                          !- X,Y,Z Vertex 3 {m}
-  0, 0, 2.31011654250324e-014;            !- X,Y,Z Vertex 4 {m}
+  0, 0, 0;                                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {33ee62bb-25cf-45d3-abe4-e9641424068d}, !- Handle
-  Surface 5,                              !- Name
+  DataCenter_Basement_ZN - Wall 180_a,    !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f6009d98-ae01-49dd-bf1f-f8d89b2e9054}, !- Space Name
@@ -2775,14 +2760,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   0,                                      !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 0, 2.31011654250324e-014,            !- X,Y,Z Vertex 1 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 1 {m}
   0, 0, -2.4384,                          !- X,Y,Z Vertex 2 {m}
   16.0797875, 0, -2.4384,                 !- X,Y,Z Vertex 3 {m}
-  16.0797875, 0, 2.31011654250324e-014;   !- X,Y,Z Vertex 4 {m}
+  16.0797875, 0, 0;                       !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {15aaf2b1-eeaa-4fc5-9147-d943b0346627}, !- Handle
-  Surface 6,                              !- Name
+  DataCenter_Basement_ZN - Wall 000_a,    !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f6009d98-ae01-49dd-bf1f-f8d89b2e9054}, !- Space Name
@@ -2792,10 +2777,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   0,                                      !- View Factor to Ground
   ,                                       !- Number of Vertices
-  16.0797875, 48.7378375, 2.25840720084241e-014, !- X,Y,Z Vertex 1 {m}
+  16.0797875, 48.7378375, 0,              !- X,Y,Z Vertex 1 {m}
   16.0797875, 48.7378375, -2.4384,        !- X,Y,Z Vertex 2 {m}
   0, 48.7378375, -2.4384,                 !- X,Y,Z Vertex 3 {m}
-  0, 48.7378375, 2.31011654250324e-014;   !- X,Y,Z Vertex 4 {m}
+  0, 48.7378375, 0;                       !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {cbbf96a5-285c-4279-ba97-ba3b559ba2f2}, !- Handle
@@ -2805,7 +2790,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  3.41920936008933e-016,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {a180734a-4560-4f26-89f7-f51a27ba85ac}, !- Building Story Name
   {0295ea84-a10a-42b4-b473-9bf9b84edf88}, !- Thermal Zone Name
@@ -2814,7 +2799,7 @@ OS:Space,
 
 OS:Surface,
   {555aa524-2b42-48a8-8cb0-6c92d1024b72}, !- Handle
-  Surface 137,                            !- Name
+  Lobby_Bot_ZN_1 - Floor_a,               !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {cbbf96a5-285c-4279-ba97-ba3b559ba2f2}, !- Space Name
@@ -2824,14 +2809,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  16.0797875, 12.1618375, 2.31011654250324e-014, !- X,Y,Z Vertex 1 {m}
-  16.0797875, -3.41920936008933e-016, 2.31011654250324e-014, !- X,Y,Z Vertex 2 {m}
-  15.05712, -3.41920936008933e-016, 0,    !- X,Y,Z Vertex 3 {m}
+  16.0797875, 12.1618375, 0,              !- X,Y,Z Vertex 1 {m}
+  16.0797875, 0, 0,                       !- X,Y,Z Vertex 2 {m}
+  15.05712, 0, 0,                         !- X,Y,Z Vertex 3 {m}
   15.05712, 12.1618375, 0;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {dbd9f73a-f822-4cab-9a1b-178006e56952}, !- Handle
-  Surface 138,                            !- Name
+  Lobby_Bot_ZN_1 - Wall 180_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {cbbf96a5-285c-4279-ba97-ba3b559ba2f2}, !- Space Name
@@ -2841,14 +2826,14 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  15.05712, -3.48787818832913e-016, 2.7447875, !- X,Y,Z Vertex 1 {m}
-  15.05712, -3.40547559444137e-016, 4.12308025025034e-036, !- X,Y,Z Vertex 2 {m}
-  41.7576, -3.06361115639573e-017, 1.49652807072787e-034, !- X,Y,Z Vertex 3 {m}
-  41.7576, -3.88763709527333e-017, 2.7447875; !- X,Y,Z Vertex 4 {m}
+  15.05712, 0, 2.7447875,                 !- X,Y,Z Vertex 1 {m}
+  15.05712, 0, 0,                         !- X,Y,Z Vertex 2 {m}
+  41.7576, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  41.7576, 0, 2.7447875;                  !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {66b33c96-c702-49cf-9851-271edf475ab6}, !- Handle
-  Surface 139,                            !- Name
+  Lobby_Bot_ZN_1 - Wall 000_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {cbbf96a5-285c-4279-ba97-ba3b559ba2f2}, !- Space Name
@@ -2858,14 +2843,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  37.7952, 12.1618375, 2.74478749999999,  !- X,Y,Z Vertex 1 {m}
+  37.7952, 12.1618375, 2.7447875,         !- X,Y,Z Vertex 1 {m}
   37.7952, 12.1618375, 0,                 !- X,Y,Z Vertex 2 {m}
   35.3568, 12.1618375, 0,                 !- X,Y,Z Vertex 3 {m}
   35.3568, 12.1618375, 2.7447875;         !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {6e8c23b2-a218-4c07-a3be-abb9badfc318}, !- Handle
-  Surface 140,                            !- Name
+  Lobby_Bot_ZN_1 - Wall 270_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {cbbf96a5-285c-4279-ba97-ba3b559ba2f2}, !- Space Name
@@ -2877,12 +2862,12 @@ OS:Surface,
   ,                                       !- Number of Vertices
   15.05712, 12.1618375, 2.7447875,        !- X,Y,Z Vertex 1 {m}
   15.05712, 12.1618375, 0,                !- X,Y,Z Vertex 2 {m}
-  15.05712, -3.41920936008933e-016, 0,    !- X,Y,Z Vertex 3 {m}
-  15.05712, -3.47414442268117e-016, 2.7447875; !- X,Y,Z Vertex 4 {m}
+  15.05712, 0, 0,                         !- X,Y,Z Vertex 3 {m}
+  15.05712, 0, 2.7447875;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {5b7d662d-6760-451d-bc42-ba869c573aa2}, !- Handle
-  Surface 141,                            !- Name
+  Lobby_Bot_ZN_1 - Wall 090_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {cbbf96a5-285c-4279-ba97-ba3b559ba2f2}, !- Space Name
@@ -2892,14 +2877,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  41.7576, -4.0249747517529e-017, 2.7447875, !- X,Y,Z Vertex 1 {m}
-  41.7576, -2.9262734999161e-017, 1.53775887323038e-034, !- X,Y,Z Vertex 2 {m}
+  41.7576, 0, 2.7447875,                  !- X,Y,Z Vertex 1 {m}
+  41.7576, 0, 0,                          !- X,Y,Z Vertex 2 {m}
   41.7576, 12.1618375, 0,                 !- X,Y,Z Vertex 3 {m}
   41.7576, 12.1618375, 2.7447875;         !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {b2697166-2418-48a9-b41d-5549903450dd}, !- Handle
-  Surface 142,                            !- Name
+  Lobby_Bot_ZN_1 - RoofCeiling_a,         !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {cbbf96a5-285c-4279-ba97-ba3b559ba2f2}, !- Space Name
@@ -2909,10 +2894,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  41.7576, -4.0249747517529e-017, 2.7447875, !- X,Y,Z Vertex 1 {m}
+  41.7576, 0, 2.7447875,                  !- X,Y,Z Vertex 1 {m}
   41.7576, 12.1618375, 2.7447875,         !- X,Y,Z Vertex 2 {m}
   15.05712, 12.1618375, 2.7447875,        !- X,Y,Z Vertex 3 {m}
-  15.05712, -3.47414442268117e-016, 2.7447875; !- X,Y,Z Vertex 4 {m}
+  15.05712, 0, 2.7447875;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {e2cafd7f-5375-46c2-b573-96b1926c6b48}, !- Handle
@@ -2922,7 +2907,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  3.41920936008933e-016,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {a180734a-4560-4f26-89f7-f51a27ba85ac}, !- Building Story Name
   {99d3a714-8a43-4b6d-af79-9f26a7cf3039}, !- Thermal Zone Name
@@ -2932,7 +2917,7 @@ OS:Space,
 
 OS:Surface,
   {7aee5940-0f90-475a-93cb-7d557fb91a44}, !- Handle
-  Surface 143,                            !- Name
+  Atrium_Bot_ZN - Floor_a,                !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {e2cafd7f-5375-46c2-b573-96b1926c6b48}, !- Space Name
@@ -2943,13 +2928,13 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   56.388, 12.1618375, 0,                  !- X,Y,Z Vertex 1 {m}
-  56.388, -6.767919558115e-017, 0,        !- X,Y,Z Vertex 2 {m}
-  46.0416275, -3.41920936008933e-016, 2.31011654250324e-014, !- X,Y,Z Vertex 3 {m}
-  46.0416275, 12.1618375, 2.31011654250324e-014; !- X,Y,Z Vertex 4 {m}
+  56.388, 0, 0,                           !- X,Y,Z Vertex 2 {m}
+  46.0416275, 0, 0,                       !- X,Y,Z Vertex 3 {m}
+  46.0416275, 12.1618375, 0;              !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {14d1812c-9247-4cca-bc0e-fcbac34a6bbd}, !- Handle
-  Surface 144,                            !- Name
+  Atrium_Bot_ZN - Wall 270_a,             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e2cafd7f-5375-46c2-b573-96b1926c6b48}, !- Space Name
@@ -2961,12 +2946,12 @@ OS:Surface,
   ,                                       !- Number of Vertices
   41.7576, 12.1618375, 2.7447875,         !- X,Y,Z Vertex 1 {m}
   41.7576, 12.1618375, 0,                 !- X,Y,Z Vertex 2 {m}
-  41.7576, -6.767919558115e-017, 0,       !- X,Y,Z Vertex 3 {m}
-  41.7576, -6.767919558115e-017, 2.7447875; !- X,Y,Z Vertex 4 {m}
+  41.7576, 0, 0,                          !- X,Y,Z Vertex 3 {m}
+  41.7576, 0, 2.7447875;                  !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {a4cf66c2-cb92-47be-8e45-cd6c02e81f5b}, !- Handle
-  Surface 145,                            !- Name
+  Atrium_Bot_ZN - Wall 000_a,             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e2cafd7f-5375-46c2-b573-96b1926c6b48}, !- Space Name
@@ -2983,7 +2968,7 @@ OS:Surface,
 
 OS:Surface,
   {bcd19e90-fef5-4106-9baf-fba678065b87}, !- Handle
-  Surface 146,                            !- Name
+  Atrium_Bot_ZN - Wall 180_a,             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e2cafd7f-5375-46c2-b573-96b1926c6b48}, !- Space Name
@@ -2993,14 +2978,14 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  41.7576, -6.08218335652447e-017, 2.7447875, !- X,Y,Z Vertex 1 {m}
-  41.7576, -7.45365575970553e-017, 3.42637918725428e-035, !- X,Y,Z Vertex 2 {m}
-  56.388, -6.08218335652447e-017, -3.42637918725414e-035, !- X,Y,Z Vertex 3 {m}
-  56.388, -4.71071095334342e-017, 2.7447875; !- X,Y,Z Vertex 4 {m}
+  41.7576, 0, 2.7447875,                  !- X,Y,Z Vertex 1 {m}
+  41.7576, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  56.388, 0, 0,                           !- X,Y,Z Vertex 3 {m}
+  56.388, 0, 2.7447875;                   !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {e10a2927-adbb-4a77-835b-0a60dae05fd0}, !- Handle
-  Surface 147,                            !- Name
+  Atrium_Bot_ZN - RoofCeiling_a,          !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {e2cafd7f-5375-46c2-b573-96b1926c6b48}, !- Space Name
@@ -3010,14 +2995,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  56.388, -4.02497475175289e-017, 2.7447875, !- X,Y,Z Vertex 1 {m}
+  56.388, 0, 2.7447875,                   !- X,Y,Z Vertex 1 {m}
   56.388, 12.1618375, 2.7447875,          !- X,Y,Z Vertex 2 {m}
   41.7576, 12.1618375, 2.7447875,         !- X,Y,Z Vertex 3 {m}
-  41.7576, -6.767919558115e-017, 2.7447875; !- X,Y,Z Vertex 4 {m}
+  41.7576, 0, 2.7447875;                  !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {517538d2-99bf-4184-826a-8769b1b945c9}, !- Handle
-  Surface 148,                            !- Name
+  Atrium_Bot_ZN - Wall 090_a,             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e2cafd7f-5375-46c2-b573-96b1926c6b48}, !- Space Name
@@ -3040,7 +3025,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  3.41920936008933e-016,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {a180734a-4560-4f26-89f7-f51a27ba85ac}, !- Building Story Name
   {c3672bb6-703b-469c-82ed-0cd78429b563}, !- Thermal Zone Name
@@ -3050,7 +3035,7 @@ OS:Space,
 
 OS:Surface,
   {2b6f0403-51ab-4487-a85e-89ab1a90b363}, !- Handle
-  Surface 149,                            !- Name
+  Corridor_Bot_ZN_1 - Floor_a,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {41f9980d-cfc2-465a-805c-33077dfeb050}, !- Space Name
@@ -3060,14 +3045,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  35.3568, 36.5458375, -4.10359132008729e-029, !- X,Y,Z Vertex 1 {m}
-  35.3568, 35.0708215764634, -4.10359132008729e-029, !- X,Y,Z Vertex 2 {m}
-  30.4038, 35.0708215764634, 3.46517481375486e-014, !- X,Y,Z Vertex 3 {m}
-  30.4038, 36.5458375, 3.46517481375486e-014; !- X,Y,Z Vertex 4 {m}
+  35.3568, 36.5458375, 0,                 !- X,Y,Z Vertex 1 {m}
+  35.3568, 35.0218375, 0,                 !- X,Y,Z Vertex 2 {m}
+  30.4038, 35.0218375, 0,                 !- X,Y,Z Vertex 3 {m}
+  30.4038, 36.5458375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {0a089fe4-a623-4b46-9170-1e44f1a4b9fc}, !- Handle
-  Surface 150,                            !- Name
+  Corridor_Bot_ZN_1 - Wall 090_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {41f9980d-cfc2-465a-805c-33077dfeb050}, !- Space Name
@@ -3077,36 +3062,19 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  35.3568, 35.0708215764634, 2.7447875,   !- X,Y,Z Vertex 1 {m}
-  35.3568, 35.0708215764634, -4.10359132008729e-029, !- X,Y,Z Vertex 2 {m}
-  35.3568, 36.5458375, -4.10359132008729e-029, !- X,Y,Z Vertex 3 {m}
+  35.3568, 35.0218375, 2.7447875,         !- X,Y,Z Vertex 1 {m}
+  35.3568, 35.0218375, 0,                 !- X,Y,Z Vertex 2 {m}
+  35.3568, 36.5458375, 0,                 !- X,Y,Z Vertex 3 {m}
   35.3568, 36.5458375, 2.7447875;         !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {980d1566-0fbb-4621-8c36-bf3ddca6973e}, !- Handle
-  Surface 151,                            !- Name
-  Wall,                                   !- Surface Type
-  ,                                       !- Construction Name
-  {41f9980d-cfc2-465a-805c-33077dfeb050}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
-  ,                                       !- View Factor to Ground
-  ,                                       !- Number of Vertices
-  35.3568, 35.0218375, 2.7447875,         !- X,Y,Z Vertex 1 {m}
-  35.3568, 35.0218375, 0,                 !- X,Y,Z Vertex 2 {m}
-  35.3568, 35.0708215764634, -4.10359132008729e-029, !- X,Y,Z Vertex 3 {m}
-  35.3568, 35.0708215764634, 2.7447875;   !- X,Y,Z Vertex 4 {m}
-
-OS:Surface,
   {098699cb-1e26-4895-b5f8-cc5c61aff946}, !- Handle
-  Surface 152,                            !- Name
+  Corridor_Bot_ZN_1 - RoofCeiling_a,      !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {41f9980d-cfc2-465a-805c-33077dfeb050}, !- Space Name
   Surface,                                !- Outside Boundary Condition
-  {535a1742-fee0-480e-9f2e-86e7c201b10d}, !- Outside Boundary Condition Object
+  {456217b8-f8ec-4836-82ba-b608dd101279}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
@@ -3115,16 +3083,14 @@ OS:Surface,
   35.3568, 13.6858375, 2.7447875,         !- X,Y,Z Vertex 2 {m}
   16.58112, 13.6858375, 2.7447875,        !- X,Y,Z Vertex 3 {m}
   16.58112, 35.0218375, 2.7447875,        !- X,Y,Z Vertex 4 {m}
-  18.288, 35.0218375, 2.7447875,          !- X,Y,Z Vertex 5 {m}
-  18.288, 35.0708215764634, 2.7447875,    !- X,Y,Z Vertex 6 {m}
-  35.3568, 35.0708215764634, 2.7447875,   !- X,Y,Z Vertex 7 {m}
-  35.3568, 36.5458375, 2.7447875,         !- X,Y,Z Vertex 8 {m}
-  15.05712, 36.5458375, 2.7447875,        !- X,Y,Z Vertex 9 {m}
-  15.05712, 12.1618375, 2.7447875;        !- X,Y,Z Vertex 10 {m}
+  35.3568, 35.0218375, 2.7447875,         !- X,Y,Z Vertex 5 {m}
+  35.3568, 36.5458375, 2.7447875,         !- X,Y,Z Vertex 6 {m}
+  15.05712, 36.5458375, 2.7447875,        !- X,Y,Z Vertex 7 {m}
+  15.05712, 12.1618375, 2.7447875;        !- X,Y,Z Vertex 8 {m}
 
 OS:Surface,
   {54d4dbc4-a5db-492f-becf-fbbb13c51254}, !- Handle
-  Surface 153,                            !- Name
+  Corridor_Bot_ZN_1 - Wall 180_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {41f9980d-cfc2-465a-805c-33077dfeb050}, !- Space Name
@@ -3141,7 +3107,7 @@ OS:Surface,
 
 OS:Surface,
   {16c1db22-b4af-4f2a-bace-5e8fb6551085}, !- Handle
-  Surface 154,                            !- Name
+  Corridor_Bot_ZN_1 - Wall 000_b,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {41f9980d-cfc2-465a-805c-33077dfeb050}, !- Space Name
@@ -3152,13 +3118,13 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   35.3568, 36.5458375, 2.7447875,         !- X,Y,Z Vertex 1 {m}
-  35.3568, 36.5458375, -4.10359132008729e-029, !- X,Y,Z Vertex 2 {m}
+  35.3568, 36.5458375, 0,                 !- X,Y,Z Vertex 2 {m}
   15.05712, 36.5458375, 0,                !- X,Y,Z Vertex 3 {m}
   15.05712, 36.5458375, 2.7447875;        !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {7d1bf8f7-d54a-40a9-aab4-7b8cfb595e49}, !- Handle
-  Surface 155,                            !- Name
+  Corridor_Bot_ZN_1 - Wall 270_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {41f9980d-cfc2-465a-805c-33077dfeb050}, !- Space Name
@@ -3175,7 +3141,7 @@ OS:Surface,
 
 OS:Surface,
   {59ff5f1e-35ac-46b2-85fb-50a2ddfe1635}, !- Handle
-  Surface 156,                            !- Name
+  Corridor_Bot_ZN_1 - Wall 090_b,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {41f9980d-cfc2-465a-805c-33077dfeb050}, !- Space Name
@@ -3192,7 +3158,7 @@ OS:Surface,
 
 OS:Surface,
   {3305ce2c-60d5-4e8a-961b-30322878eaa8}, !- Handle
-  Surface 157,                            !- Name
+  Corridor_Bot_ZN_1 - Wall 000_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {41f9980d-cfc2-465a-805c-33077dfeb050}, !- Space Name
@@ -3209,7 +3175,7 @@ OS:Surface,
 
 OS:Surface,
   {9214aed6-330d-4b80-a3d8-ee7df63d874b}, !- Handle
-  Surface 158,                            !- Name
+  Corridor_Bot_ZN_1 - Wall 090_c,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {41f9980d-cfc2-465a-805c-33077dfeb050}, !- Space Name
@@ -3226,7 +3192,7 @@ OS:Surface,
 
 OS:Surface,
   {5f0d62b4-8ef5-4fc5-8d8a-ab69fe80e941}, !- Handle
-  Surface 159,                            !- Name
+  Corridor_Bot_ZN_1 - Wall 180_b,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {41f9980d-cfc2-465a-805c-33077dfeb050}, !- Space Name
@@ -3249,7 +3215,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  3.41920936008933e-016,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {a180734a-4560-4f26-89f7-f51a27ba85ac}, !- Building Story Name
   {e2fa0a8c-a81c-45c2-9f8f-f3c4898f7cb4}, !- Thermal Zone Name
@@ -3259,7 +3225,7 @@ OS:Space,
 
 OS:Surface,
   {e7724e1e-baa7-41c1-909c-72f233252644}, !- Handle
-  Surface 160,                            !- Name
+  Datacenter_Bot_ZN - Floor_b,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {93b905ad-f145-4ef5-b9be-878caa8e553d}, !- Space Name
@@ -3269,14 +3235,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  18.288, 29.8402375, 2.88764567812905e-015, !- X,Y,Z Vertex 1 {m}
-  18.288, 18.8674375, -2.88764567812913e-015, !- X,Y,Z Vertex 2 {m}
-  17.6037875, 18.8674375, 1.44382283906453e-014, !- X,Y,Z Vertex 3 {m}
-  17.6037875, 29.8402375, 2.02135197469035e-014; !- X,Y,Z Vertex 4 {m}
+  18.288, 29.8402375, 0,                  !- X,Y,Z Vertex 1 {m}
+  18.288, 18.8674375, 0,                  !- X,Y,Z Vertex 2 {m}
+  17.6037875, 18.8674375, 0,              !- X,Y,Z Vertex 3 {m}
+  17.6037875, 29.8402375, 0;              !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {951853f0-90af-46fd-b963-b7e5ec7f4c11}, !- Handle
-  Surface 161,                            !- Name
+  Datacenter_Bot_ZN - RoofCeiling_a,      !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {93b905ad-f145-4ef5-b9be-878caa8e553d}, !- Space Name
@@ -3293,7 +3259,7 @@ OS:Surface,
 
 OS:Surface,
   {8931584b-0be9-44ef-ac6a-1cab6fa0eaf8}, !- Handle
-  Surface 162,                            !- Name
+  Datacenter_Bot_ZN - Wall 090_b,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {93b905ad-f145-4ef5-b9be-878caa8e553d}, !- Space Name
@@ -3305,12 +3271,12 @@ OS:Surface,
   ,                                       !- Number of Vertices
   18.288, 13.6858375, 2.7447875,          !- X,Y,Z Vertex 1 {m}
   18.288, 13.6858375, 0,                  !- X,Y,Z Vertex 2 {m}
-  18.288, 18.8674375, -2.88764567812913e-015, !- X,Y,Z Vertex 3 {m}
+  18.288, 18.8674375, 0,                  !- X,Y,Z Vertex 3 {m}
   18.288, 18.8674375, 2.7447875;          !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {a92a5bb1-e4e9-457e-b97d-1f2fe9ba503d}, !- Handle
-  Surface 163,                            !- Name
+  Datacenter_Bot_ZN - Wall 000_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {93b905ad-f145-4ef5-b9be-878caa8e553d}, !- Space Name
@@ -3327,7 +3293,7 @@ OS:Surface,
 
 OS:Surface,
   {10eb4cd5-fbec-44c4-9d62-430f79977ef7}, !- Handle
-  Surface 164,                            !- Name
+  Datacenter_Bot_ZN - Wall 270_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {93b905ad-f145-4ef5-b9be-878caa8e553d}, !- Space Name
@@ -3344,7 +3310,7 @@ OS:Surface,
 
 OS:Surface,
   {52acdb2a-368f-4aa4-a001-a589db68c91f}, !- Handle
-  Surface 165,                            !- Name
+  Datacenter_Bot_ZN - Wall 180_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {93b905ad-f145-4ef5-b9be-878caa8e553d}, !- Space Name
@@ -3376,7 +3342,7 @@ OS:Space,
 
 OS:Surface,
   {7c12ed20-2255-41a8-b46b-8a745a6c7caf}, !- Handle
-  Surface 166,                            !- Name
+  EnclosedOffice_Bot_ZN_1 - Floor_a,      !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {a3536544-5466-431f-a4f6-b70e1e3388af}, !- Space Name
@@ -3393,7 +3359,7 @@ OS:Surface,
 
 OS:Surface,
   {abad876b-1879-418a-8a29-6491a31234ed}, !- Handle
-  Surface 167,                            !- Name
+  EnclosedOffice_Bot_ZN_1 - Wall 090_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {a3536544-5466-431f-a4f6-b70e1e3388af}, !- Space Name
@@ -3410,7 +3376,7 @@ OS:Surface,
 
 OS:Surface,
   {76bc2dce-00af-4cae-871f-053ec98352cc}, !- Handle
-  Surface 168,                            !- Name
+  EnclosedOffice_Bot_ZN_1 - Wall 000_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {a3536544-5466-431f-a4f6-b70e1e3388af}, !- Space Name
@@ -3420,14 +3386,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  25.4508, 18.8674375, 2.74478749999999,  !- X,Y,Z Vertex 1 {m}
+  25.4508, 18.8674375, 2.7447875,         !- X,Y,Z Vertex 1 {m}
   25.4508, 18.8674375, 0,                 !- X,Y,Z Vertex 2 {m}
   22.7076, 18.8674375, 0,                 !- X,Y,Z Vertex 3 {m}
-  22.7076, 18.8674375, 2.74478749999999;  !- X,Y,Z Vertex 4 {m}
+  22.7076, 18.8674375, 2.7447875;         !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {f13fb6c1-7012-43e4-b5b9-7f588486212b}, !- Handle
-  Surface 169,                            !- Name
+  EnclosedOffice_Bot_ZN_1 - RoofCeiling_a, !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {a3536544-5466-431f-a4f6-b70e1e3388af}, !- Space Name
@@ -3444,7 +3410,7 @@ OS:Surface,
 
 OS:Surface,
   {b307c7a4-1fc6-46c7-ac29-7c8ef1fa21d6}, !- Handle
-  Surface 170,                            !- Name
+  EnclosedOffice_Bot_ZN_1 - Wall 270_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {a3536544-5466-431f-a4f6-b70e1e3388af}, !- Space Name
@@ -3461,7 +3427,7 @@ OS:Surface,
 
 OS:Surface,
   {eae8d76f-fba6-4e26-9a84-fd209e7fb48a}, !- Handle
-  Surface 171,                            !- Name
+  EnclosedOffice_Bot_ZN_1 - Wall 180_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {a3536544-5466-431f-a4f6-b70e1e3388af}, !- Space Name
@@ -3484,7 +3450,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  3.41920936008933e-016,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {a180734a-4560-4f26-89f7-f51a27ba85ac}, !- Building Story Name
   {68ebc7b1-20b4-4059-9d8e-a12fc6a3ab55}, !- Thermal Zone Name
@@ -3493,7 +3459,7 @@ OS:Space,
 
 OS:Surface,
   {6925a2b6-0c7d-4ad9-a956-a482d02260b8}, !- Handle
-  Surface 172,                            !- Name
+  Mechanical_Bot_ZN_1 - Floor_a,          !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {93331eb4-c469-4653-b64b-52891a449aa0}, !- Space Name
@@ -3510,7 +3476,7 @@ OS:Surface,
 
 OS:Surface,
   {a3f7e6f1-8ffa-40fa-bd4c-eef99f3ebb0f}, !- Handle
-  Surface 173,                            !- Name
+  Mechanical_Bot_ZN_1 - Wall 090_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {93331eb4-c469-4653-b64b-52891a449aa0}, !- Space Name
@@ -3520,14 +3486,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  22.7076, 18.8674375, 2.74478750000001,  !- X,Y,Z Vertex 1 {m}
+  22.7076, 18.8674375, 2.7447875,         !- X,Y,Z Vertex 1 {m}
   22.7076, 18.8674375, 0,                 !- X,Y,Z Vertex 2 {m}
   22.7076, 29.8402375, 0,                 !- X,Y,Z Vertex 3 {m}
-  22.7076, 29.8402375, 2.74478750000001;  !- X,Y,Z Vertex 4 {m}
+  22.7076, 29.8402375, 2.7447875;         !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {d6aedc9c-6739-46b1-a3cf-40bb4ebc39f3}, !- Handle
-  Surface 174,                            !- Name
+  Mechanical_Bot_ZN_1 - Wall 000_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {93331eb4-c469-4653-b64b-52891a449aa0}, !- Space Name
@@ -3537,14 +3503,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  22.7076, 29.8402375, 2.74478750000001,  !- X,Y,Z Vertex 1 {m}
+  22.7076, 29.8402375, 2.7447875,         !- X,Y,Z Vertex 1 {m}
   22.7076, 29.8402375, 0,                 !- X,Y,Z Vertex 2 {m}
   18.288, 29.8402375, 0,                  !- X,Y,Z Vertex 3 {m}
-  18.288, 29.8402375, 2.74478750000001;   !- X,Y,Z Vertex 4 {m}
+  18.288, 29.8402375, 2.7447875;          !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {b514fbae-bb1f-4861-a5ae-b699609279de}, !- Handle
-  Surface 175,                            !- Name
+  Mechanical_Bot_ZN_1 - Wall 180_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {93331eb4-c469-4653-b64b-52891a449aa0}, !- Space Name
@@ -3554,14 +3520,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  18.288, 18.8674375, 2.74478750000001,   !- X,Y,Z Vertex 1 {m}
+  18.288, 18.8674375, 2.7447875,          !- X,Y,Z Vertex 1 {m}
   18.288, 18.8674375, 0,                  !- X,Y,Z Vertex 2 {m}
   22.7076, 18.8674375, 0,                 !- X,Y,Z Vertex 3 {m}
-  22.7076, 18.8674375, 2.74478750000001;  !- X,Y,Z Vertex 4 {m}
+  22.7076, 18.8674375, 2.7447875;         !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {431484af-8088-41f8-93f4-021afd4c13e1}, !- Handle
-  Surface 176,                            !- Name
+  Mechanical_Bot_ZN_1 - Wall 270_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {93331eb4-c469-4653-b64b-52891a449aa0}, !- Space Name
@@ -3571,14 +3537,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  18.288, 29.8402375, 2.74478750000001,   !- X,Y,Z Vertex 1 {m}
+  18.288, 29.8402375, 2.7447875,          !- X,Y,Z Vertex 1 {m}
   18.288, 29.8402375, 0,                  !- X,Y,Z Vertex 2 {m}
   18.288, 18.8674375, 0,                  !- X,Y,Z Vertex 3 {m}
-  18.288, 18.8674375, 2.74478750000001;   !- X,Y,Z Vertex 4 {m}
+  18.288, 18.8674375, 2.7447875;          !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {55803570-8113-494d-b8f1-e9edd7292f75}, !- Handle
-  Surface 177,                            !- Name
+  Mechanical_Bot_ZN_1 - RoofCeiling_a,    !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {93331eb4-c469-4653-b64b-52891a449aa0}, !- Space Name
@@ -3588,10 +3554,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  22.7076, 18.8674375, 2.74478750000001,  !- X,Y,Z Vertex 1 {m}
-  22.7076, 29.8402375, 2.74478750000001,  !- X,Y,Z Vertex 2 {m}
-  18.288, 29.8402375, 2.74478750000001,   !- X,Y,Z Vertex 3 {m}
-  18.288, 18.8674375, 2.74478750000001;   !- X,Y,Z Vertex 4 {m}
+  22.7076, 18.8674375, 2.7447875,         !- X,Y,Z Vertex 1 {m}
+  22.7076, 29.8402375, 2.7447875,         !- X,Y,Z Vertex 2 {m}
+  18.288, 29.8402375, 2.7447875,          !- X,Y,Z Vertex 3 {m}
+  18.288, 18.8674375, 2.7447875;          !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {a063560f-e3fb-4055-a428-e2eb011ef7ce}, !- Handle
@@ -3601,7 +3567,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  3.41920936008933e-016,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {a180734a-4560-4f26-89f7-f51a27ba85ac}, !- Building Story Name
   {d7b9b1eb-2d2f-4cf4-bd3d-82358c3aa9f9}, !- Thermal Zone Name
@@ -3610,7 +3576,7 @@ OS:Space,
 
 OS:Surface,
   {0fede042-d39b-48f1-a74f-4b3e027aa14b}, !- Handle
-  Surface 178,                            !- Name
+  Stair_Bot_ZN_1 - Floor_a,               !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {a063560f-e3fb-4055-a428-e2eb011ef7ce}, !- Space Name
@@ -3627,7 +3593,7 @@ OS:Surface,
 
 OS:Surface,
   {61fdfeb3-6d7e-4f29-b173-78d00c7f6c6a}, !- Handle
-  Surface 179,                            !- Name
+  Stair_Bot_ZN_1 - Wall 270_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {a063560f-e3fb-4055-a428-e2eb011ef7ce}, !- Space Name
@@ -3637,14 +3603,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  22.7076, 29.8402375, 2.74478749999999,  !- X,Y,Z Vertex 1 {m}
+  22.7076, 29.8402375, 2.7447875,         !- X,Y,Z Vertex 1 {m}
   22.7076, 29.8402375, 0,                 !- X,Y,Z Vertex 2 {m}
   22.7076, 18.8674375, 0,                 !- X,Y,Z Vertex 3 {m}
-  22.7076, 18.8674375, 2.74478749999999;  !- X,Y,Z Vertex 4 {m}
+  22.7076, 18.8674375, 2.7447875;         !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {66d173c2-57ef-4402-ac26-39194a1b54fd}, !- Handle
-  Surface 180,                            !- Name
+  Stair_Bot_ZN_1 - Wall 090_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {a063560f-e3fb-4055-a428-e2eb011ef7ce}, !- Space Name
@@ -3654,14 +3620,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  25.4508, 18.8674375, 2.74478749999999,  !- X,Y,Z Vertex 1 {m}
+  25.4508, 18.8674375, 2.7447875,         !- X,Y,Z Vertex 1 {m}
   25.4508, 18.8674375, 0,                 !- X,Y,Z Vertex 2 {m}
   25.4508, 29.8402375, 0,                 !- X,Y,Z Vertex 3 {m}
-  25.4508, 29.8402375, 2.74478749999999;  !- X,Y,Z Vertex 4 {m}
+  25.4508, 29.8402375, 2.7447875;         !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {9e119ea4-f834-4625-b7c9-d518a2a467a2}, !- Handle
-  Surface 181,                            !- Name
+  Stair_Bot_ZN_1 - RoofCeiling_a,         !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {a063560f-e3fb-4055-a428-e2eb011ef7ce}, !- Space Name
@@ -3671,14 +3637,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  25.4508, 18.8674375, 2.74478749999999,  !- X,Y,Z Vertex 1 {m}
-  25.4508, 29.8402375, 2.74478749999999,  !- X,Y,Z Vertex 2 {m}
-  22.7076, 29.8402375, 2.74478749999999,  !- X,Y,Z Vertex 3 {m}
-  22.7076, 18.8674375, 2.74478749999999;  !- X,Y,Z Vertex 4 {m}
+  25.4508, 18.8674375, 2.7447875,         !- X,Y,Z Vertex 1 {m}
+  25.4508, 29.8402375, 2.7447875,         !- X,Y,Z Vertex 2 {m}
+  22.7076, 29.8402375, 2.7447875,         !- X,Y,Z Vertex 3 {m}
+  22.7076, 18.8674375, 2.7447875;         !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {9abdce1c-dc5a-4687-8691-a3e8470f29ef}, !- Handle
-  Surface 182,                            !- Name
+  Stair_Bot_ZN_1 - Wall 180_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {a063560f-e3fb-4055-a428-e2eb011ef7ce}, !- Space Name
@@ -3688,14 +3654,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  22.7076, 18.8674375, 2.74478749999999,  !- X,Y,Z Vertex 1 {m}
+  22.7076, 18.8674375, 2.7447875,         !- X,Y,Z Vertex 1 {m}
   22.7076, 18.8674375, 0,                 !- X,Y,Z Vertex 2 {m}
   25.4508, 18.8674375, 0,                 !- X,Y,Z Vertex 3 {m}
-  25.4508, 18.8674375, 2.74478749999999;  !- X,Y,Z Vertex 4 {m}
+  25.4508, 18.8674375, 2.7447875;         !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {6e9d6e74-d8e5-45f6-bdd9-6c555280ce87}, !- Handle
-  Surface 183,                            !- Name
+  Stair_Bot_ZN_1 - Wall 000_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {a063560f-e3fb-4055-a428-e2eb011ef7ce}, !- Space Name
@@ -3705,10 +3671,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  25.4508, 29.8402375, 2.74478749999999,  !- X,Y,Z Vertex 1 {m}
+  25.4508, 29.8402375, 2.7447875,         !- X,Y,Z Vertex 1 {m}
   25.4508, 29.8402375, 0,                 !- X,Y,Z Vertex 2 {m}
   22.7076, 29.8402375, 0,                 !- X,Y,Z Vertex 3 {m}
-  22.7076, 29.8402375, 2.74478749999999;  !- X,Y,Z Vertex 4 {m}
+  22.7076, 29.8402375, 2.7447875;         !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {4a85c567-10e4-432d-b882-9dbda5ffac8e}, !- Handle
@@ -3718,7 +3684,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  3.41920936008933e-016,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {a180734a-4560-4f26-89f7-f51a27ba85ac}, !- Building Story Name
   {d8b3a51e-da18-4473-927d-48ad0b76ec34}, !- Thermal Zone Name
@@ -3727,7 +3693,7 @@ OS:Space,
 
 OS:Surface,
   {533c0131-21b1-46e3-ad3d-55c026158132}, !- Handle
-  Surface 184,                            !- Name
+  Restroom_Bot_ZN - Floor_b,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {4a85c567-10e4-432d-b882-9dbda5ffac8e}, !- Space Name
@@ -3737,14 +3703,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  35.3568, 27.7066375, 2.31011654250324e-014, !- X,Y,Z Vertex 1 {m}
+  35.3568, 27.7066375, 0,                 !- X,Y,Z Vertex 1 {m}
   35.3568, 18.8674375, 0,                 !- X,Y,Z Vertex 2 {m}
   25.4508, 18.8674375, 0,                 !- X,Y,Z Vertex 3 {m}
-  25.4508, 27.7066375, 2.31011654250324e-014; !- X,Y,Z Vertex 4 {m}
+  25.4508, 27.7066375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {5bb9168d-6657-488b-8e8c-1d5edb63c35e}, !- Handle
-  Surface 185,                            !- Name
+  Restroom_Bot_ZN - Wall 270_a,           !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {4a85c567-10e4-432d-b882-9dbda5ffac8e}, !- Space Name
@@ -3754,14 +3720,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  25.4508, 29.8402375, 2.74478749999999,  !- X,Y,Z Vertex 1 {m}
+  25.4508, 29.8402375, 2.7447875,         !- X,Y,Z Vertex 1 {m}
   25.4508, 29.8402375, 0,                 !- X,Y,Z Vertex 2 {m}
   25.4508, 18.8674375, 0,                 !- X,Y,Z Vertex 3 {m}
-  25.4508, 18.8674375, 2.74478749999999;  !- X,Y,Z Vertex 4 {m}
+  25.4508, 18.8674375, 2.7447875;         !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {281437e6-ac3c-46c6-a325-36e607fbf0f0}, !- Handle
-  Surface 186,                            !- Name
+  Restroom_Bot_ZN - Wall 180_a,           !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {4a85c567-10e4-432d-b882-9dbda5ffac8e}, !- Space Name
@@ -3771,14 +3737,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  25.4508, 18.8674375, 2.74478749999999,  !- X,Y,Z Vertex 1 {m}
+  25.4508, 18.8674375, 2.7447875,         !- X,Y,Z Vertex 1 {m}
   25.4508, 18.8674375, 0,                 !- X,Y,Z Vertex 2 {m}
   35.3568, 18.8674375, 0,                 !- X,Y,Z Vertex 3 {m}
-  35.3568, 18.8674375, 2.74478749999999;  !- X,Y,Z Vertex 4 {m}
+  35.3568, 18.8674375, 2.7447875;         !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {8b8e1ead-97c4-435f-99ae-64df8554ae31}, !- Handle
-  Surface 187,                            !- Name
+  Restroom_Bot_ZN - Wall 000_a,           !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {4a85c567-10e4-432d-b882-9dbda5ffac8e}, !- Space Name
@@ -3788,14 +3754,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  35.3568, 29.8402375, 2.74478749999999,  !- X,Y,Z Vertex 1 {m}
+  35.3568, 29.8402375, 2.7447875,         !- X,Y,Z Vertex 1 {m}
   35.3568, 29.8402375, 0,                 !- X,Y,Z Vertex 2 {m}
   25.4508, 29.8402375, 0,                 !- X,Y,Z Vertex 3 {m}
-  25.4508, 29.8402375, 2.74478749999999;  !- X,Y,Z Vertex 4 {m}
+  25.4508, 29.8402375, 2.7447875;         !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {6d28e2e9-2076-478c-94d0-d4a945a370db}, !- Handle
-  Surface 188,                            !- Name
+  Restroom_Bot_ZN - Wall 090_a,           !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {4a85c567-10e4-432d-b882-9dbda5ffac8e}, !- Space Name
@@ -3805,14 +3771,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  35.3568, 18.8674375, 2.74478749999999,  !- X,Y,Z Vertex 1 {m}
+  35.3568, 18.8674375, 2.7447875,         !- X,Y,Z Vertex 1 {m}
   35.3568, 18.8674375, 0,                 !- X,Y,Z Vertex 2 {m}
   35.3568, 29.8402375, 0,                 !- X,Y,Z Vertex 3 {m}
-  35.3568, 29.8402375, 2.74478749999999;  !- X,Y,Z Vertex 4 {m}
+  35.3568, 29.8402375, 2.7447875;         !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {8d3161ec-e498-437f-a596-a0e8a3d1bca0}, !- Handle
-  Surface 189,                            !- Name
+  Restroom_Bot_ZN - RoofCeiling_a,        !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {4a85c567-10e4-432d-b882-9dbda5ffac8e}, !- Space Name
@@ -3822,10 +3788,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  35.3568, 18.8674375, 2.74478749999999,  !- X,Y,Z Vertex 1 {m}
-  35.3568, 29.8402375, 2.74478749999999,  !- X,Y,Z Vertex 2 {m}
-  25.4508, 29.8402375, 2.74478749999999,  !- X,Y,Z Vertex 3 {m}
-  25.4508, 18.8674375, 2.74478749999999;  !- X,Y,Z Vertex 4 {m}
+  35.3568, 18.8674375, 2.7447875,         !- X,Y,Z Vertex 1 {m}
+  35.3568, 29.8402375, 2.7447875,         !- X,Y,Z Vertex 2 {m}
+  25.4508, 29.8402375, 2.7447875,         !- X,Y,Z Vertex 3 {m}
+  25.4508, 18.8674375, 2.7447875;         !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {23bb7aaa-6a7c-4d7a-826f-f4ffe1c733a5}, !- Handle
@@ -3835,33 +3801,17 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  3.41920936008933e-016,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {a180734a-4560-4f26-89f7-f51a27ba85ac}, !- Building Story Name
   {4c102e1a-d097-41f1-b771-1efd9f4489de}, !- Thermal Zone Name
   ,                                       !- Part of Total Floor Area
-  ;                                       !- Design Specification Outdoor Air Object Name
-
-OS:Surface,
-  {8d67959f-18b7-4b4f-a3fe-a6001210053e}, !- Handle
-  Surface 190,                            !- Name
-  Floor,                                  !- Surface Type
-  ,                                       !- Construction Name
-  {23bb7aaa-6a7c-4d7a-826f-f4ffe1c733a5}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  NoSun,                                  !- Sun Exposure
-  NoWind,                                 !- Wind Exposure
-  ,                                       !- View Factor to Ground
-  ,                                       !- Number of Vertices
-  35.3568, 35.0708215764634, 5.77529135625809e-015, !- X,Y,Z Vertex 1 {m}
-  35.3568, 35.0218375, -5.77529135625809e-015, !- X,Y,Z Vertex 2 {m}
-  30.4038, 35.0218375, 1.73258740687743e-014, !- X,Y,Z Vertex 3 {m}
-  30.4038, 35.0708215764634, 2.88764567812905e-014; !- X,Y,Z Vertex 4 {m}
+  ,                                       !- Design Specification Outdoor Air Object Name
+  ;                                       !- Building Unit Name
 
 OS:Surface,
   {8610fd9f-9201-4005-8fdc-ed52e018243d}, !- Handle
-  Surface 191,                            !- Name
+  EnclosedOffice_Bot_ZN_3 - RoofCeiling_a, !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {23bb7aaa-6a7c-4d7a-826f-f4ffe1c733a5}, !- Space Name
@@ -3877,25 +3827,8 @@ OS:Surface,
   18.288, 29.8402375, 2.7447875;          !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {edc9e7fd-78a6-4502-b981-04db64536cd6}, !- Handle
-  Surface 192,                            !- Name
-  Wall,                                   !- Surface Type
-  ,                                       !- Construction Name
-  {23bb7aaa-6a7c-4d7a-826f-f4ffe1c733a5}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
-  ,                                       !- View Factor to Ground
-  ,                                       !- Number of Vertices
-  18.288, 35.0708215764634, 2.7447875,    !- X,Y,Z Vertex 1 {m}
-  18.288, 35.0708215764634, 0,            !- X,Y,Z Vertex 2 {m}
-  18.288, 35.0218375, 0,                  !- X,Y,Z Vertex 3 {m}
-  18.288, 35.0218375, 2.7447875;          !- X,Y,Z Vertex 4 {m}
-
-OS:Surface,
   {52ad0aad-62ef-4448-92f8-7d415dc6b8a6}, !- Handle
-  Surface 193,                            !- Name
+  EnclosedOffice_Bot_ZN_3 - Wall 090_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {23bb7aaa-6a7c-4d7a-826f-f4ffe1c733a5}, !- Space Name
@@ -3907,29 +3840,12 @@ OS:Surface,
   ,                                       !- Number of Vertices
   35.3568, 29.8402375, 2.7447875,         !- X,Y,Z Vertex 1 {m}
   35.3568, 29.8402375, 0,                 !- X,Y,Z Vertex 2 {m}
-  35.3568, 35.0218375, -5.77529135625809e-015, !- X,Y,Z Vertex 3 {m}
+  35.3568, 35.0218375, 0,                 !- X,Y,Z Vertex 3 {m}
   35.3568, 35.0218375, 2.7447875;         !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {902448d8-f095-4964-9fa3-44cf3fc99feb}, !- Handle
-  Surface 194,                            !- Name
-  Wall,                                   !- Surface Type
-  ,                                       !- Construction Name
-  {23bb7aaa-6a7c-4d7a-826f-f4ffe1c733a5}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
-  ,                                       !- View Factor to Ground
-  ,                                       !- Number of Vertices
-  35.3568, 35.0708215764634, 2.7447875,   !- X,Y,Z Vertex 1 {m}
-  35.3568, 35.0708215764634, 5.77529135625809e-015, !- X,Y,Z Vertex 2 {m}
-  18.288, 35.0708215764634, 0,            !- X,Y,Z Vertex 3 {m}
-  18.288, 35.0708215764634, 2.7447875;    !- X,Y,Z Vertex 4 {m}
-
-OS:Surface,
   {b70f9c49-55b7-454c-8aaf-dec28e515d9a}, !- Handle
-  Surface 195,                            !- Name
+  EnclosedOffice_Bot_ZN_3 - Wall 180_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {23bb7aaa-6a7c-4d7a-826f-f4ffe1c733a5}, !- Space Name
@@ -3952,7 +3868,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  3.41920936008933e-016,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {a180734a-4560-4f26-89f7-f51a27ba85ac}, !- Building Story Name
   {d83bf3df-df79-43e4-badc-d44240a87a1e}, !- Thermal Zone Name
@@ -3961,7 +3877,7 @@ OS:Space,
 
 OS:Surface,
   {15eb40ff-7959-467c-aea1-1398347bf37c}, !- Handle
-  Surface 196,                            !- Name
+  Lobby_Bot_ZN_2 - Floor_a,               !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {abacaf7b-c009-4460-9c87-7ecf15da4216}, !- Space Name
@@ -3978,7 +3894,7 @@ OS:Surface,
 
 OS:Surface,
   {7e0c4bd4-3a63-462f-acdb-7db52579016a}, !- Handle
-  Surface 197,                            !- Name
+  Lobby_Bot_ZN_2 - Wall 180_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {abacaf7b-c009-4460-9c87-7ecf15da4216}, !- Space Name
@@ -3988,14 +3904,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  35.3568, 12.1618375, 2.74478749999999,  !- X,Y,Z Vertex 1 {m}
+  35.3568, 12.1618375, 2.7447875,         !- X,Y,Z Vertex 1 {m}
   35.3568, 12.1618375, 0,                 !- X,Y,Z Vertex 2 {m}
   37.7952, 12.1618375, 0,                 !- X,Y,Z Vertex 3 {m}
-  37.7952, 12.1618375, 2.74478749999999;  !- X,Y,Z Vertex 4 {m}
+  37.7952, 12.1618375, 2.7447875;         !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {e6b364bf-487d-4c59-9b37-f67b3aa28a86}, !- Handle
-  Surface 198,                            !- Name
+  Lobby_Bot_ZN_2 - Wall 270_c,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {abacaf7b-c009-4460-9c87-7ecf15da4216}, !- Space Name
@@ -4005,14 +3921,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  35.3568, 29.8402375, 2.74478749999999,  !- X,Y,Z Vertex 1 {m}
+  35.3568, 29.8402375, 2.7447875,         !- X,Y,Z Vertex 1 {m}
   35.3568, 29.8402375, 0,                 !- X,Y,Z Vertex 2 {m}
   35.3568, 18.8674375, 0,                 !- X,Y,Z Vertex 3 {m}
-  35.3568, 18.8674375, 2.74478749999999;  !- X,Y,Z Vertex 4 {m}
+  35.3568, 18.8674375, 2.7447875;         !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {e8184134-8219-43f9-a6d8-913cc859b873}, !- Handle
-  Surface 199,                            !- Name
+  Lobby_Bot_ZN_2 - Wall 090_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {abacaf7b-c009-4460-9c87-7ecf15da4216}, !- Space Name
@@ -4022,14 +3938,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  37.7952, 12.1618375, 2.74478749999999,  !- X,Y,Z Vertex 1 {m}
+  37.7952, 12.1618375, 2.7447875,         !- X,Y,Z Vertex 1 {m}
   37.7952, 12.1618375, 0,                 !- X,Y,Z Vertex 2 {m}
   37.7952, 13.6858375, 0,                 !- X,Y,Z Vertex 3 {m}
-  37.7952, 13.6858375, 2.74478749999999;  !- X,Y,Z Vertex 4 {m}
+  37.7952, 13.6858375, 2.7447875;         !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {0b022d50-03e8-477c-8f46-520b5f3840f6}, !- Handle
-  Surface 200,                            !- Name
+  Lobby_Bot_ZN_2 - Wall 000_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {abacaf7b-c009-4460-9c87-7ecf15da4216}, !- Space Name
@@ -4039,14 +3955,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  37.7952, 36.5458375, 2.74478749999999,  !- X,Y,Z Vertex 1 {m}
+  37.7952, 36.5458375, 2.7447875,         !- X,Y,Z Vertex 1 {m}
   37.7952, 36.5458375, 0,                 !- X,Y,Z Vertex 2 {m}
   35.3568, 36.5458375, 0,                 !- X,Y,Z Vertex 3 {m}
-  35.3568, 36.5458375, 2.74478749999999;  !- X,Y,Z Vertex 4 {m}
+  35.3568, 36.5458375, 2.7447875;         !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {dfdaac42-8dab-4487-8744-29aeccf2bf4a}, !- Handle
-  Surface 201,                            !- Name
+  Lobby_Bot_ZN_2 - RoofCeiling_a,         !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {abacaf7b-c009-4460-9c87-7ecf15da4216}, !- Space Name
@@ -4056,10 +3972,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  37.7952, 12.1618375, 2.74478749999999,  !- X,Y,Z Vertex 1 {m}
-  37.7952, 36.5458375, 2.74478749999999,  !- X,Y,Z Vertex 2 {m}
-  35.3568, 36.5458375, 2.74478749999999,  !- X,Y,Z Vertex 3 {m}
-  35.3568, 12.1618375, 2.74478749999999;  !- X,Y,Z Vertex 4 {m}
+  37.7952, 12.1618375, 2.7447875,         !- X,Y,Z Vertex 1 {m}
+  37.7952, 36.5458375, 2.7447875,         !- X,Y,Z Vertex 2 {m}
+  35.3568, 36.5458375, 2.7447875,         !- X,Y,Z Vertex 3 {m}
+  35.3568, 12.1618375, 2.7447875;         !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {e09dc351-b4b2-4c23-ac81-8f93ce202e4f}, !- Handle
@@ -4069,7 +3985,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  3.41920936008933e-016,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {a180734a-4560-4f26-89f7-f51a27ba85ac}, !- Building Story Name
   {65c7b380-960f-4d59-ab03-cbc64c1cfc05}, !- Thermal Zone Name
@@ -4079,7 +3995,7 @@ OS:Space,
 
 OS:Surface,
   {9ec04505-2975-4b76-9c98-a49cf0987c5a}, !- Handle
-  Surface 202,                            !- Name
+  Corridor_Bot_ZN_2 - Floor_a,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {e09dc351-b4b2-4c23-ac81-8f93ce202e4f}, !- Space Name
@@ -4089,16 +4005,16 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  56.388, 36.5458375, 1.23877409731665e-014, !- X,Y,Z Vertex 1 {m}
-  56.388, 12.1618375, -3.14534288226095e-015, !- X,Y,Z Vertex 2 {m}
-  46.0416275, 12.1618375, 2.34140347212532e-014, !- X,Y,Z Vertex 3 {m}
-  46.0416275, 13.6858375, 2.43848524622174e-014, !- X,Y,Z Vertex 4 {m}
-  54.864, 13.6858375, 1.7376181212579e-015, !- X,Y,Z Vertex 5 {m}
-  54.864, 36.5458375, 1.62998842357212e-014; !- X,Y,Z Vertex 6 {m}
+  56.388, 36.5458375, 0,                  !- X,Y,Z Vertex 1 {m}
+  56.388, 12.1618375, 0,                  !- X,Y,Z Vertex 2 {m}
+  46.0416275, 12.1618375, 0,              !- X,Y,Z Vertex 3 {m}
+  46.0416275, 13.6858375, 0,              !- X,Y,Z Vertex 4 {m}
+  54.864, 13.6858375, 0,                  !- X,Y,Z Vertex 5 {m}
+  54.864, 36.5458375, 0;                  !- X,Y,Z Vertex 6 {m}
 
 OS:Surface,
   {7cf83360-58b6-4576-b187-d7e83c2fabdb}, !- Handle
-  Surface 203,                            !- Name
+  Corridor_Bot_ZN_2 - Wall 090_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e09dc351-b4b2-4c23-ac81-8f93ce202e4f}, !- Space Name
@@ -4109,13 +4025,13 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   56.388, 12.1618375, 2.7447875,          !- X,Y,Z Vertex 1 {m}
-  56.388, 12.1618375, -3.14534288226095e-015, !- X,Y,Z Vertex 2 {m}
-  56.388, 36.5458375, 1.23877409731665e-014, !- X,Y,Z Vertex 3 {m}
+  56.388, 12.1618375, 0,                  !- X,Y,Z Vertex 2 {m}
+  56.388, 36.5458375, 0,                  !- X,Y,Z Vertex 3 {m}
   56.388, 36.5458375, 2.7447875;          !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {e86da813-37a2-4aa7-b7ed-db49fa877d44}, !- Handle
-  Surface 204,                            !- Name
+  Corridor_Bot_ZN_2 - Wall 000_b,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e09dc351-b4b2-4c23-ac81-8f93ce202e4f}, !- Space Name
@@ -4126,13 +4042,13 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   56.388, 36.5458375, 2.7447875,          !- X,Y,Z Vertex 1 {m}
-  56.388, 36.5458375, 1.23877409731665e-014, !- X,Y,Z Vertex 2 {m}
+  56.388, 36.5458375, 0,                  !- X,Y,Z Vertex 2 {m}
   46.3296, 36.5458375, 0,                 !- X,Y,Z Vertex 3 {m}
   46.3296, 36.5458375, 2.7447875;         !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {f880eaa6-465e-4b6f-9022-965486cb57ae}, !- Handle
-  Surface 205,                            !- Name
+  Corridor_Bot_ZN_2 - Wall 270_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e09dc351-b4b2-4c23-ac81-8f93ce202e4f}, !- Space Name
@@ -4149,7 +4065,7 @@ OS:Surface,
 
 OS:Surface,
   {951e9c00-1b74-4474-ba19-44025601c339}, !- Handle
-  Surface 206,                            !- Name
+  Corridor_Bot_ZN_2 - Wall 180_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e09dc351-b4b2-4c23-ac81-8f93ce202e4f}, !- Space Name
@@ -4161,12 +4077,12 @@ OS:Surface,
   ,                                       !- Number of Vertices
   41.7576, 12.1618375, 2.7447875,         !- X,Y,Z Vertex 1 {m}
   41.7576, 12.1618375, 0,                 !- X,Y,Z Vertex 2 {m}
-  56.388, 12.1618375, -3.14534288226095e-015, !- X,Y,Z Vertex 3 {m}
+  56.388, 12.1618375, 0,                  !- X,Y,Z Vertex 3 {m}
   56.388, 12.1618375, 2.7447875;          !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {90b99a6e-07f3-47ba-ac7e-2a5d80464ad0}, !- Handle
-  Surface 207,                            !- Name
+  Corridor_Bot_ZN_2 - Wall 270_c,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e09dc351-b4b2-4c23-ac81-8f93ce202e4f}, !- Space Name
@@ -4183,7 +4099,7 @@ OS:Surface,
 
 OS:Surface,
   {ee311446-602c-4c5a-942c-be85860f79c8}, !- Handle
-  Surface 208,                            !- Name
+  Corridor_Bot_ZN_2 - Wall 180_b,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e09dc351-b4b2-4c23-ac81-8f93ce202e4f}, !- Space Name
@@ -4200,7 +4116,7 @@ OS:Surface,
 
 OS:Surface,
   {dfc95147-0aaf-42e0-bafe-cd0f4d1b5fc8}, !- Handle
-  Surface 209,                            !- Name
+  Corridor_Bot_ZN_2 - RoofCeiling_a,      !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {e09dc351-b4b2-4c23-ac81-8f93ce202e4f}, !- Space Name
@@ -4221,7 +4137,7 @@ OS:Surface,
 
 OS:Surface,
   {3de62f7f-7143-464f-a5e0-182a500a5ee5}, !- Handle
-  Surface 210,                            !- Name
+  Corridor_Bot_ZN_2 - Wall 000_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e09dc351-b4b2-4c23-ac81-8f93ce202e4f}, !- Space Name
@@ -4232,13 +4148,13 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   54.864, 13.6858375, 2.7447875,          !- X,Y,Z Vertex 1 {m}
-  54.864, 13.6858375, 1.7376181212579e-015, !- X,Y,Z Vertex 2 {m}
+  54.864, 13.6858375, 0,                  !- X,Y,Z Vertex 2 {m}
   37.7952, 13.6858375, 0,                 !- X,Y,Z Vertex 3 {m}
   37.7952, 13.6858375, 2.7447875;         !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {619bc55f-1be2-4777-b724-15a2ac055ed6}, !- Handle
-  Surface 211,                            !- Name
+  Corridor_Bot_ZN_2 - Wall 270_b,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e09dc351-b4b2-4c23-ac81-8f93ce202e4f}, !- Space Name
@@ -4261,7 +4177,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  3.41920936008933e-016,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {a180734a-4560-4f26-89f7-f51a27ba85ac}, !- Building Story Name
   {424bc9a1-ef70-4a65-93b9-4f7304e5b038}, !- Thermal Zone Name
@@ -4270,7 +4186,7 @@ OS:Space,
 
 OS:Surface,
   {ad74aad6-9357-4ac6-acdc-4eb31457eb3c}, !- Handle
-  Surface 212,                            !- Name
+  EnclosedOffice_Bot_ZN_2 - Floor_a,      !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {60416a59-808a-4add-8341-053ce90af4d4}, !- Space Name
@@ -4280,14 +4196,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  52.7304, 18.8674375, 2.31011654250324e-014, !- X,Y,Z Vertex 1 {m}
-  52.7304, 13.6858375, 2.31011654250324e-014, !- X,Y,Z Vertex 2 {m}
+  52.7304, 18.8674375, 0,                 !- X,Y,Z Vertex 1 {m}
+  52.7304, 13.6858375, 0,                 !- X,Y,Z Vertex 2 {m}
   37.7952, 13.6858375, 0,                 !- X,Y,Z Vertex 3 {m}
   37.7952, 18.8674375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {1b261997-4331-4f4a-bee4-609167d3b512}, !- Handle
-  Surface 213,                            !- Name
+  EnclosedOffice_Bot_ZN_2 - Wall 090_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {60416a59-808a-4add-8341-053ce90af4d4}, !- Space Name
@@ -4304,7 +4220,7 @@ OS:Surface,
 
 OS:Surface,
   {9fcbca26-3d53-4b4c-85e5-0cc51e5e67a2}, !- Handle
-  Surface 214,                            !- Name
+  EnclosedOffice_Bot_ZN_2 - Wall 000_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {60416a59-808a-4add-8341-053ce90af4d4}, !- Space Name
@@ -4321,7 +4237,7 @@ OS:Surface,
 
 OS:Surface,
   {7dc8d24c-f936-43bd-92f0-5b00f244acc4}, !- Handle
-  Surface 215,                            !- Name
+  EnclosedOffice_Bot_ZN_2 - Wall 270_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {60416a59-808a-4add-8341-053ce90af4d4}, !- Space Name
@@ -4338,7 +4254,7 @@ OS:Surface,
 
 OS:Surface,
   {7643e4e8-2454-411b-8edf-43fde6f2e2ac}, !- Handle
-  Surface 216,                            !- Name
+  EnclosedOffice_Bot_ZN_2 - Wall 180_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {60416a59-808a-4add-8341-053ce90af4d4}, !- Space Name
@@ -4355,7 +4271,7 @@ OS:Surface,
 
 OS:Surface,
   {5f1ce670-a7cc-4732-9b7f-869f7615896f}, !- Handle
-  Surface 217,                            !- Name
+  EnclosedOffice_Bot_ZN_2 - RoofCeiling_a, !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {60416a59-808a-4add-8341-053ce90af4d4}, !- Space Name
@@ -4378,7 +4294,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  3.41920936008933e-016,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {a180734a-4560-4f26-89f7-f51a27ba85ac}, !- Building Story Name
   {aa9399c3-209e-4f80-bb79-ca799abc6ebb}, !- Thermal Zone Name
@@ -4388,7 +4304,7 @@ OS:Space,
 
 OS:Surface,
   {fe9759b6-1f11-47bb-bd6e-80af8f0390d2}, !- Handle
-  Surface 218,                            !- Name
+  ActiveStorage_Bot_ZN - Floor_a,         !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {91b98669-cd41-470b-98d1-1fe79dc773e4}, !- Space Name
@@ -4405,7 +4321,7 @@ OS:Surface,
 
 OS:Surface,
   {082e8722-67b3-4c38-92cd-2d6a19d85973}, !- Handle
-  Surface 219,                            !- Name
+  ActiveStorage_Bot_ZN - Wall 000_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {91b98669-cd41-470b-98d1-1fe79dc773e4}, !- Space Name
@@ -4422,7 +4338,7 @@ OS:Surface,
 
 OS:Surface,
   {fe5f093f-263b-4051-b19c-a204192a2f2d}, !- Handle
-  Surface 220,                            !- Name
+  ActiveStorage_Bot_ZN - Wall 270_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {91b98669-cd41-470b-98d1-1fe79dc773e4}, !- Space Name
@@ -4439,7 +4355,7 @@ OS:Surface,
 
 OS:Surface,
   {61a3c78a-418e-4ada-ae42-e2d332c6e427}, !- Handle
-  Surface 221,                            !- Name
+  ActiveStorage_Bot_ZN - RoofCeiling_a,   !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {91b98669-cd41-470b-98d1-1fe79dc773e4}, !- Space Name
@@ -4456,7 +4372,7 @@ OS:Surface,
 
 OS:Surface,
   {d19a1205-d1f5-4d16-bdfa-7234e6927466}, !- Handle
-  Surface 222,                            !- Name
+  ActiveStorage_Bot_ZN - Wall 180_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {91b98669-cd41-470b-98d1-1fe79dc773e4}, !- Space Name
@@ -4473,7 +4389,7 @@ OS:Surface,
 
 OS:Surface,
   {e2150836-2727-4747-8763-f1ad55baaa5f}, !- Handle
-  Surface 223,                            !- Name
+  ActiveStorage_Bot_ZN - Wall 090_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {91b98669-cd41-470b-98d1-1fe79dc773e4}, !- Space Name
@@ -4496,7 +4412,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  3.41920936008933e-016,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {a180734a-4560-4f26-89f7-f51a27ba85ac}, !- Building Story Name
   {6e389102-c296-4fca-9967-ea3fc04b7604}, !- Thermal Zone Name
@@ -4505,7 +4421,7 @@ OS:Space,
 
 OS:Surface,
   {9daf55fa-c57b-4fd2-ab35-c0864c64e495}, !- Handle
-  Surface 224,                            !- Name
+  Stair_Bot_ZN_2 - Floor_a,               !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {3d8ed588-3584-49ba-af9c-0b8115164e45}, !- Space Name
@@ -4522,7 +4438,7 @@ OS:Surface,
 
 OS:Surface,
   {f6e8640e-7ba5-409a-ab97-d4d472c1b2a3}, !- Handle
-  Surface 225,                            !- Name
+  Stair_Bot_ZN_2 - Wall 180_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3d8ed588-3584-49ba-af9c-0b8115164e45}, !- Space Name
@@ -4539,7 +4455,7 @@ OS:Surface,
 
 OS:Surface,
   {f5b256c5-ebfb-4485-937a-5e73ffc1d997}, !- Handle
-  Surface 226,                            !- Name
+  Stair_Bot_ZN_2 - Wall 090_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3d8ed588-3584-49ba-af9c-0b8115164e45}, !- Space Name
@@ -4556,7 +4472,7 @@ OS:Surface,
 
 OS:Surface,
   {56d9db90-68a3-4670-b2ec-9e5ff43dda68}, !- Handle
-  Surface 227,                            !- Name
+  Stair_Bot_ZN_2 - Wall 000_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3d8ed588-3584-49ba-af9c-0b8115164e45}, !- Space Name
@@ -4573,7 +4489,7 @@ OS:Surface,
 
 OS:Surface,
   {ad032a8d-d8ac-4055-90f2-eaaaeae69423}, !- Handle
-  Surface 228,                            !- Name
+  Stair_Bot_ZN_2 - Wall 270_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3d8ed588-3584-49ba-af9c-0b8115164e45}, !- Space Name
@@ -4590,7 +4506,7 @@ OS:Surface,
 
 OS:Surface,
   {84384965-6d78-4a70-964b-bc25a4e52ced}, !- Handle
-  Surface 229,                            !- Name
+  Stair_Bot_ZN_2 - RoofCeiling_a,         !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {3d8ed588-3584-49ba-af9c-0b8115164e45}, !- Space Name
@@ -4613,7 +4529,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  3.41920936008933e-016,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {a180734a-4560-4f26-89f7-f51a27ba85ac}, !- Building Story Name
   {f1391854-9c9c-47a6-a16c-84bb8f2b670b}, !- Thermal Zone Name
@@ -4622,7 +4538,7 @@ OS:Space,
 
 OS:Surface,
   {7d5ac865-193f-46b1-98fa-f69474e21792}, !- Handle
-  Surface 230,                            !- Name
+  Mechanical_Bot_ZN_2 - Floor_a,          !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {23a35a24-65e2-4d28-810b-59baec21104e}, !- Space Name
@@ -4633,13 +4549,13 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   46.3296, 29.8402375, 0,                 !- X,Y,Z Vertex 1 {m}
-  46.3296, 24.3538375, 2.31011654250324e-014, !- X,Y,Z Vertex 2 {m}
-  37.7952, 24.3538375, 2.31011654250324e-014, !- X,Y,Z Vertex 3 {m}
+  46.3296, 24.3538375, 0,                 !- X,Y,Z Vertex 2 {m}
+  37.7952, 24.3538375, 0,                 !- X,Y,Z Vertex 3 {m}
   37.7952, 29.8402375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {3cdabe9f-7fd4-4ded-b836-94a85059ef0e}, !- Handle
-  Surface 231,                            !- Name
+  Mechanical_Bot_ZN_2 - Wall 270_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {23a35a24-65e2-4d28-810b-59baec21104e}, !- Space Name
@@ -4656,7 +4572,7 @@ OS:Surface,
 
 OS:Surface,
   {ea801bea-4c79-428f-9785-c970d9109a08}, !- Handle
-  Surface 232,                            !- Name
+  Mechanical_Bot_ZN_2 - Wall 180_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {23a35a24-65e2-4d28-810b-59baec21104e}, !- Space Name
@@ -4673,7 +4589,7 @@ OS:Surface,
 
 OS:Surface,
   {3486711e-bbba-440c-8b76-5df5317906f5}, !- Handle
-  Surface 233,                            !- Name
+  Mechanical_Bot_ZN_2 - Wall 090_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {23a35a24-65e2-4d28-810b-59baec21104e}, !- Space Name
@@ -4690,7 +4606,7 @@ OS:Surface,
 
 OS:Surface,
   {eb360695-acd1-40ac-a23f-3124cd7298dd}, !- Handle
-  Surface 234,                            !- Name
+  Mechanical_Bot_ZN_2 - Wall 000_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {23a35a24-65e2-4d28-810b-59baec21104e}, !- Space Name
@@ -4707,7 +4623,7 @@ OS:Surface,
 
 OS:Surface,
   {c0412b6b-cc1b-474e-b313-6572be27e92f}, !- Handle
-  Surface 235,                            !- Name
+  Mechanical_Bot_ZN_2 - RoofCeiling_a,    !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {23a35a24-65e2-4d28-810b-59baec21104e}, !- Space Name
@@ -4730,7 +4646,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  3.41920936008933e-016,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {a180734a-4560-4f26-89f7-f51a27ba85ac}, !- Building Story Name
   {1802aa86-c46d-46e6-b4ea-4457bba4c853}, !- Thermal Zone Name
@@ -4740,7 +4656,7 @@ OS:Space,
 
 OS:Surface,
   {46192832-a389-4918-b43a-99b0abfc9621}, !- Handle
-  Surface 236,                            !- Name
+  Dining_Bot_ZN - Floor_a,                !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {2a82567c-0643-4fd1-b75a-f62205013e43}, !- Space Name
@@ -4750,14 +4666,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.3296, 35.0218375, 5.7752913562581e-015, !- X,Y,Z Vertex 1 {m}
-  46.3296, 29.8402375, -5.7752913562581e-015, !- X,Y,Z Vertex 2 {m}
-  37.7952, 29.8402375, 5.7752913562581e-015, !- X,Y,Z Vertex 3 {m}
-  37.7952, 35.0218375, 1.73258740687743e-014; !- X,Y,Z Vertex 4 {m}
+  46.3296, 35.0218375, 0,                 !- X,Y,Z Vertex 1 {m}
+  46.3296, 29.8402375, 0,                 !- X,Y,Z Vertex 2 {m}
+  37.7952, 29.8402375, 0,                 !- X,Y,Z Vertex 3 {m}
+  37.7952, 35.0218375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {6fd04597-8e9f-4b76-890e-4f099a7b057b}, !- Handle
-  Surface 237,                            !- Name
+  Dining_Bot_ZN - Wall 180_a,             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {2a82567c-0643-4fd1-b75a-f62205013e43}, !- Space Name
@@ -4768,13 +4684,13 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   37.7952, 29.8402375, 2.7447875,         !- X,Y,Z Vertex 1 {m}
-  37.7952, 29.8402375, 5.7752913562581e-015, !- X,Y,Z Vertex 2 {m}
-  46.3296, 29.8402375, -5.7752913562581e-015, !- X,Y,Z Vertex 3 {m}
+  37.7952, 29.8402375, 0,                 !- X,Y,Z Vertex 2 {m}
+  46.3296, 29.8402375, 0,                 !- X,Y,Z Vertex 3 {m}
   46.3296, 29.8402375, 2.7447875;         !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {611869bc-7dd0-4e2c-b987-7111a7b89064}, !- Handle
-  Surface 238,                            !- Name
+  Dining_Bot_ZN - Wall 090_a,             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {2a82567c-0643-4fd1-b75a-f62205013e43}, !- Space Name
@@ -4785,13 +4701,13 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   46.3296, 29.8402375, 2.7447875,         !- X,Y,Z Vertex 1 {m}
-  46.3296, 29.8402375, -5.7752913562581e-015, !- X,Y,Z Vertex 2 {m}
-  46.3296, 35.0218375, 5.7752913562581e-015, !- X,Y,Z Vertex 3 {m}
+  46.3296, 29.8402375, 0,                 !- X,Y,Z Vertex 2 {m}
+  46.3296, 35.0218375, 0,                 !- X,Y,Z Vertex 3 {m}
   46.3296, 35.0218375, 2.7447875;         !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {73577906-3b08-4e10-8e42-0139b8f03142}, !- Handle
-  Surface 239,                            !- Name
+  Dining_Bot_ZN - Wall 270_a,             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {2a82567c-0643-4fd1-b75a-f62205013e43}, !- Space Name
@@ -4803,12 +4719,12 @@ OS:Surface,
   ,                                       !- Number of Vertices
   37.7952, 36.5458375, 2.7447875,         !- X,Y,Z Vertex 1 {m}
   37.7952, 36.5458375, 0,                 !- X,Y,Z Vertex 2 {m}
-  37.7952, 29.8402375, 5.7752913562581e-015, !- X,Y,Z Vertex 3 {m}
+  37.7952, 29.8402375, 0,                 !- X,Y,Z Vertex 3 {m}
   37.7952, 29.8402375, 2.7447875;         !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {1d5b39b6-15e1-464a-beab-9fbeff9a8979}, !- Handle
-  Surface 240,                            !- Name
+  Dining_Bot_ZN - Wall 000_a,             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {2a82567c-0643-4fd1-b75a-f62205013e43}, !- Space Name
@@ -4825,7 +4741,7 @@ OS:Surface,
 
 OS:Surface,
   {eb989654-bad4-4819-bea3-b20db3780938}, !- Handle
-  Surface 241,                            !- Name
+  Dining_Bot_ZN - RoofCeiling_a,          !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {2a82567c-0643-4fd1-b75a-f62205013e43}, !- Space Name
@@ -4848,7 +4764,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  3.41920936008933e-016,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {a180734a-4560-4f26-89f7-f51a27ba85ac}, !- Building Story Name
   {c02e50e0-4509-4110-80f1-1402738fc471}, !- Thermal Zone Name
@@ -4857,7 +4773,7 @@ OS:Space,
 
 OS:Surface,
   {b5461c2c-dfc1-4447-95d2-9f428c0810cf}, !- Handle
-  Surface 242,                            !- Name
+  EnclosedOffice_Bot_ZN_4 - Floor_a,      !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {1815ea2c-e057-4b95-9cc0-7a623b32ba17}, !- Space Name
@@ -4874,7 +4790,7 @@ OS:Surface,
 
 OS:Surface,
   {0c272cbe-4811-4a3c-95d0-44ee25dae8cd}, !- Handle
-  Surface 243,                            !- Name
+  EnclosedOffice_Bot_ZN_4 - Wall 270_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {1815ea2c-e057-4b95-9cc0-7a623b32ba17}, !- Space Name
@@ -4891,7 +4807,7 @@ OS:Surface,
 
 OS:Surface,
   {025b6693-7e5b-42fe-a625-077a1e3463d9}, !- Handle
-  Surface 244,                            !- Name
+  EnclosedOffice_Bot_ZN_4 - Wall 090_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {1815ea2c-e057-4b95-9cc0-7a623b32ba17}, !- Space Name
@@ -4908,7 +4824,7 @@ OS:Surface,
 
 OS:Surface,
   {c6a4bd95-c65d-4a6c-8cbe-2b65ac2d4b35}, !- Handle
-  Surface 245,                            !- Name
+  EnclosedOffice_Bot_ZN_4 - RoofCeiling_a, !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {1815ea2c-e057-4b95-9cc0-7a623b32ba17}, !- Space Name
@@ -4925,7 +4841,7 @@ OS:Surface,
 
 OS:Surface,
   {baec769b-9caf-4a73-a6be-ddc242165777}, !- Handle
-  Surface 246,                            !- Name
+  EnclosedOffice_Bot_ZN_4 - Wall 000_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {1815ea2c-e057-4b95-9cc0-7a623b32ba17}, !- Space Name
@@ -4942,7 +4858,7 @@ OS:Surface,
 
 OS:Surface,
   {8a0d2d23-a6fa-491a-9471-6bd776bd5f2d}, !- Handle
-  Surface 247,                            !- Name
+  EnclosedOffice_Bot_ZN_4 - Wall 180_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {1815ea2c-e057-4b95-9cc0-7a623b32ba17}, !- Space Name
@@ -4965,7 +4881,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  3.41920936008933e-016,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {a180734a-4560-4f26-89f7-f51a27ba85ac}, !- Building Story Name
   {d7f7ca26-e041-449f-a36b-f2d3937a11cf}, !- Thermal Zone Name
@@ -4975,7 +4891,7 @@ OS:Space,
 
 OS:Surface,
   {253099d9-291a-49d0-8445-87ca51f261c3}, !- Handle
-  Surface 248,                            !- Name
+  Lounge_Bot_ZN - Floor_a,                !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {a14038e2-556d-43f1-b5f3-26bd442c3da8}, !- Space Name
@@ -4986,13 +4902,13 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   73.10755, 5.4864, 0,                    !- X,Y,Z Vertex 1 {m}
-  73.10755, -4.93494134445886e-017, 0,    !- X,Y,Z Vertex 2 {m}
-  56.388, -4.93494134445886e-017, 0,      !- X,Y,Z Vertex 3 {m}
+  73.10755, 0, 0,                         !- X,Y,Z Vertex 2 {m}
+  56.388, 0, 0,                           !- X,Y,Z Vertex 3 {m}
   56.388, 5.4864, 0;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {5253dd60-1db9-4939-a76e-cebe3921b278}, !- Handle
-  Surface 249,                            !- Name
+  Lounge_Bot_ZN - Wall 090_a,             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {a14038e2-556d-43f1-b5f3-26bd442c3da8}, !- Space Name
@@ -5002,14 +4918,14 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  73.10755, -4.93494134445886e-017, 2.7447875, !- X,Y,Z Vertex 1 {m}
-  73.10755, -4.93494134445886e-017, 0,    !- X,Y,Z Vertex 2 {m}
+  73.10755, 0, 2.7447875,                 !- X,Y,Z Vertex 1 {m}
+  73.10755, 0, 0,                         !- X,Y,Z Vertex 2 {m}
   73.10755, 5.4864, 0,                    !- X,Y,Z Vertex 3 {m}
   73.10755, 5.4864, 2.7447875;            !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {2250dd3d-b17e-47cf-864d-52ad24df5529}, !- Handle
-  Surface 250,                            !- Name
+  Lounge_Bot_ZN - Wall 270_a,             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {a14038e2-556d-43f1-b5f3-26bd442c3da8}, !- Space Name
@@ -5021,12 +4937,12 @@ OS:Surface,
   ,                                       !- Number of Vertices
   56.388, 5.4864, 2.7447875,              !- X,Y,Z Vertex 1 {m}
   56.388, 5.4864, 0,                      !- X,Y,Z Vertex 2 {m}
-  56.388, -4.93494134445886e-017, 0,      !- X,Y,Z Vertex 3 {m}
-  56.388, -4.93494134445886e-017, 2.7447875; !- X,Y,Z Vertex 4 {m}
+  56.388, 0, 0,                           !- X,Y,Z Vertex 3 {m}
+  56.388, 0, 2.7447875;                   !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {41a5bd6b-b372-482a-b68e-e1415733ed37}, !- Handle
-  Surface 251,                            !- Name
+  Lounge_Bot_ZN - RoofCeiling_a,          !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {a14038e2-556d-43f1-b5f3-26bd442c3da8}, !- Space Name
@@ -5036,14 +4952,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  73.10755, -4.93494134445886e-017, 2.7447875, !- X,Y,Z Vertex 1 {m}
+  73.10755, 0, 2.7447875,                 !- X,Y,Z Vertex 1 {m}
   73.10755, 5.4864, 2.7447875,            !- X,Y,Z Vertex 2 {m}
   56.388, 5.4864, 2.7447875,              !- X,Y,Z Vertex 3 {m}
-  56.388, -4.93494134445886e-017, 2.7447875; !- X,Y,Z Vertex 4 {m}
+  56.388, 0, 2.7447875;                   !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {c84d1212-91b2-4ab7-8016-72bcd8008009}, !- Handle
-  Surface 252,                            !- Name
+  Lounge_Bot_ZN - Wall 000_a,             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {a14038e2-556d-43f1-b5f3-26bd442c3da8}, !- Space Name
@@ -5060,7 +4976,7 @@ OS:Surface,
 
 OS:Surface,
   {ca069a8f-67b7-4d3a-aeb8-c321d5b27330}, !- Handle
-  Surface 253,                            !- Name
+  Lounge_Bot_ZN - Wall 180_a,             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {a14038e2-556d-43f1-b5f3-26bd442c3da8}, !- Space Name
@@ -5070,10 +4986,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  56.388, -4.93494134445886e-017, 2.7447875, !- X,Y,Z Vertex 1 {m}
-  56.388, -4.93494134445886e-017, 0,      !- X,Y,Z Vertex 2 {m}
-  73.10755, -4.93494134445886e-017, 0,    !- X,Y,Z Vertex 3 {m}
-  73.10755, -4.93494134445886e-017, 2.7447875; !- X,Y,Z Vertex 4 {m}
+  56.388, 0, 2.7447875,                   !- X,Y,Z Vertex 1 {m}
+  56.388, 0, 0,                           !- X,Y,Z Vertex 2 {m}
+  73.10755, 0, 0,                         !- X,Y,Z Vertex 3 {m}
+  73.10755, 0, 2.7447875;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {41bc5c33-b808-4a81-a4aa-5d35ca430a5f}, !- Handle
@@ -5083,7 +4999,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  3.41920936008933e-016,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {a180734a-4560-4f26-89f7-f51a27ba85ac}, !- Building Story Name
   {d05a5493-b71b-4933-8325-a1878b929030}, !- Thermal Zone Name
@@ -5092,7 +5008,7 @@ OS:Space,
 
 OS:Surface,
   {3c779685-39f2-4fb4-9e3f-48243321a3c0}, !- Handle
-  Surface 254,                            !- Name
+  OpenOffice_Bot_ZN_2 - Floor_a,          !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {41bc5c33-b808-4a81-a4aa-5d35ca430a5f}, !- Space Name
@@ -5102,14 +5018,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  73.10755, 42.6418375, 5.86553028369963e-015, !- X,Y,Z Vertex 1 {m}
-  73.10755, 36.5458375, 1.75965908510989e-014, !- X,Y,Z Vertex 2 {m}
-  56.388, 36.5458375, 5.86553028369963e-015, !- X,Y,Z Vertex 3 {m}
-  56.388, 42.6418375, -5.86553028369963e-015; !- X,Y,Z Vertex 4 {m}
+  73.10755, 42.6418375, 0,                !- X,Y,Z Vertex 1 {m}
+  73.10755, 36.5458375, 0,                !- X,Y,Z Vertex 2 {m}
+  56.388, 36.5458375, 0,                  !- X,Y,Z Vertex 3 {m}
+  56.388, 42.6418375, 0;                  !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {72068759-0295-4a7b-a7dc-dfa2df1f280b}, !- Handle
-  Surface 255,                            !- Name
+  OpenOffice_Bot_ZN_2 - Wall 270_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {41bc5c33-b808-4a81-a4aa-5d35ca430a5f}, !- Space Name
@@ -5126,7 +5042,7 @@ OS:Surface,
 
 OS:Surface,
   {1f7b2e72-26f5-4720-9973-a6c0a6a95678}, !- Handle
-  Surface 256,                            !- Name
+  OpenOffice_Bot_ZN_2 - Wall 090_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {41bc5c33-b808-4a81-a4aa-5d35ca430a5f}, !- Space Name
@@ -5138,12 +5054,12 @@ OS:Surface,
   ,                                       !- Number of Vertices
   73.10755, 5.4864, 2.7447875,            !- X,Y,Z Vertex 1 {m}
   73.10755, 5.4864, 0,                    !- X,Y,Z Vertex 2 {m}
-  73.10755, 42.6418375, 5.86553028369963e-015, !- X,Y,Z Vertex 3 {m}
+  73.10755, 42.6418375, 0,                !- X,Y,Z Vertex 3 {m}
   73.10755, 42.6418375, 2.7447875;        !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {786bee35-407a-4161-ad78-4ff1e0dd52eb}, !- Handle
-  Surface 257,                            !- Name
+  OpenOffice_Bot_ZN_2 - Wall 000_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {41bc5c33-b808-4a81-a4aa-5d35ca430a5f}, !- Space Name
@@ -5154,13 +5070,13 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   73.10755, 42.6418375, 2.7447875,        !- X,Y,Z Vertex 1 {m}
-  73.10755, 42.6418375, 5.86553028369963e-015, !- X,Y,Z Vertex 2 {m}
-  56.388, 42.6418375, -5.86553028369963e-015, !- X,Y,Z Vertex 3 {m}
+  73.10755, 42.6418375, 0,                !- X,Y,Z Vertex 2 {m}
+  56.388, 42.6418375, 0,                  !- X,Y,Z Vertex 3 {m}
   56.388, 42.6418375, 2.7447875;          !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {dde07129-26df-437a-8358-33168e4bfa01}, !- Handle
-  Surface 258,                            !- Name
+  OpenOffice_Bot_ZN_2 - RoofCeiling_a,    !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {41bc5c33-b808-4a81-a4aa-5d35ca430a5f}, !- Space Name
@@ -5177,7 +5093,7 @@ OS:Surface,
 
 OS:Surface,
   {d645119b-d78b-43e5-9678-15ce4703d7d1}, !- Handle
-  Surface 259,                            !- Name
+  OpenOffice_Bot_ZN_2 - Wall 180_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {41bc5c33-b808-4a81-a4aa-5d35ca430a5f}, !- Space Name
@@ -5200,7 +5116,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  3.41920936008933e-016,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {a180734a-4560-4f26-89f7-f51a27ba85ac}, !- Building Story Name
   {41d0029b-530c-44b1-81ff-bb402ce459d5}, !- Thermal Zone Name
@@ -5209,7 +5125,7 @@ OS:Space,
 
 OS:Surface,
   {7a787d19-218e-4e4d-b4bc-3dcf555542fb}, !- Handle
-  Surface 260,                            !- Name
+  EnclosedOffice_Bot_ZN_6 - Floor_a,      !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {31f8998a-b9bb-4272-b83c-15c712424d6b}, !- Space Name
@@ -5226,7 +5142,7 @@ OS:Surface,
 
 OS:Surface,
   {f5368d3d-8f7a-4065-922a-2b6aeac7ceb6}, !- Handle
-  Surface 261,                            !- Name
+  EnclosedOffice_Bot_ZN_6 - Wall 090_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {31f8998a-b9bb-4272-b83c-15c712424d6b}, !- Space Name
@@ -5243,7 +5159,7 @@ OS:Surface,
 
 OS:Surface,
   {98843775-12f5-436b-93c3-b5611b90e8c4}, !- Handle
-  Surface 262,                            !- Name
+  EnclosedOffice_Bot_ZN_6 - Wall 000_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {31f8998a-b9bb-4272-b83c-15c712424d6b}, !- Space Name
@@ -5260,7 +5176,7 @@ OS:Surface,
 
 OS:Surface,
   {818b0f84-6369-4b01-8049-a1b1f4387614}, !- Handle
-  Surface 263,                            !- Name
+  EnclosedOffice_Bot_ZN_6 - Wall 270_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {31f8998a-b9bb-4272-b83c-15c712424d6b}, !- Space Name
@@ -5277,7 +5193,7 @@ OS:Surface,
 
 OS:Surface,
   {e73d9f9d-1c5b-4eb7-b9e5-eca867611627}, !- Handle
-  Surface 264,                            !- Name
+  EnclosedOffice_Bot_ZN_6 - Wall 180_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {31f8998a-b9bb-4272-b83c-15c712424d6b}, !- Space Name
@@ -5294,7 +5210,7 @@ OS:Surface,
 
 OS:Surface,
   {ff4d5a76-8a36-4ad7-ac27-3b0c1563c275}, !- Handle
-  Surface 265,                            !- Name
+  EnclosedOffice_Bot_ZN_6 - RoofCeiling_a, !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {31f8998a-b9bb-4272-b83c-15c712424d6b}, !- Space Name
@@ -5317,7 +5233,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  3.41920936008933e-016,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {a180734a-4560-4f26-89f7-f51a27ba85ac}, !- Building Story Name
   {8d5d7697-b262-4ab7-960c-f0c2e27e12dc}, !- Thermal Zone Name
@@ -5327,7 +5243,7 @@ OS:Space,
 
 OS:Surface,
   {5bc471ae-69a2-4ca6-8412-c1eee0e8e085}, !- Handle
-  Surface 266,                            !- Name
+  ConfRoom_Bot_ZN_2 - Floor_a,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {7d4a3409-9835-4619-a59e-a9010b8e64d9}, !- Space Name
@@ -5344,7 +5260,7 @@ OS:Surface,
 
 OS:Surface,
   {04b3950c-0c83-485d-a3f3-99aab081aa5d}, !- Handle
-  Surface 267,                            !- Name
+  ConfRoom_Bot_ZN_2 - RoofCeiling_a,      !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {7d4a3409-9835-4619-a59e-a9010b8e64d9}, !- Space Name
@@ -5361,7 +5277,7 @@ OS:Surface,
 
 OS:Surface,
   {5b6207b8-627f-4638-869e-8972058936e8}, !- Handle
-  Surface 268,                            !- Name
+  ConfRoom_Bot_ZN_2 - Wall 000_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {7d4a3409-9835-4619-a59e-a9010b8e64d9}, !- Space Name
@@ -5378,7 +5294,7 @@ OS:Surface,
 
 OS:Surface,
   {8892748b-afa2-4561-92a2-f857d27a820f}, !- Handle
-  Surface 269,                            !- Name
+  ConfRoom_Bot_ZN_2 - Wall 090_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {7d4a3409-9835-4619-a59e-a9010b8e64d9}, !- Space Name
@@ -5395,7 +5311,7 @@ OS:Surface,
 
 OS:Surface,
   {bafeba10-4637-422e-9c7e-8762e3cb1df5}, !- Handle
-  Surface 270,                            !- Name
+  ConfRoom_Bot_ZN_2 - Wall 270_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {7d4a3409-9835-4619-a59e-a9010b8e64d9}, !- Space Name
@@ -5412,7 +5328,7 @@ OS:Surface,
 
 OS:Surface,
   {aa29807d-ba62-4ae9-a408-abce1dbed1e1}, !- Handle
-  Surface 271,                            !- Name
+  ConfRoom_Bot_ZN_2 - Wall 180_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {7d4a3409-9835-4619-a59e-a9010b8e64d9}, !- Space Name
@@ -5435,7 +5351,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  3.41920936008933e-016,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {a180734a-4560-4f26-89f7-f51a27ba85ac}, !- Building Story Name
   {3a0e0f76-22a1-40fc-8dc8-575feab053f3}, !- Thermal Zone Name
@@ -5445,7 +5361,7 @@ OS:Space,
 
 OS:Surface,
   {9575848a-d76d-46ac-9376-2a415d9f75d2}, !- Handle
-  Surface 272,                            !- Name
+  Classroom_Bot_ZN - Floor_a,             !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {b715f207-2b08-49aa-9fdb-a1cfedf8b085}, !- Space Name
@@ -5462,7 +5378,7 @@ OS:Surface,
 
 OS:Surface,
   {d47e1c25-e6dc-43d7-beba-6923f490cf2a}, !- Handle
-  Surface 273,                            !- Name
+  Classroom_Bot_ZN - Wall 090_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {b715f207-2b08-49aa-9fdb-a1cfedf8b085}, !- Space Name
@@ -5472,14 +5388,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  52.1208, 42.6418375, 2.74478750000001,  !- X,Y,Z Vertex 1 {m}
+  52.1208, 42.6418375, 2.7447875,         !- X,Y,Z Vertex 1 {m}
   52.1208, 42.6418375, 0,                 !- X,Y,Z Vertex 2 {m}
   52.1208, 48.7378375, 0,                 !- X,Y,Z Vertex 3 {m}
-  52.1208, 48.7378375, 2.74478750000001;  !- X,Y,Z Vertex 4 {m}
+  52.1208, 48.7378375, 2.7447875;         !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {e4e696fb-dce4-464b-a600-96814ebd50c0}, !- Handle
-  Surface 274,                            !- Name
+  Classroom_Bot_ZN - Wall 000_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {b715f207-2b08-49aa-9fdb-a1cfedf8b085}, !- Space Name
@@ -5489,14 +5405,14 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  52.1208, 48.7378375, 2.74478750000001,  !- X,Y,Z Vertex 1 {m}
+  52.1208, 48.7378375, 2.7447875,         !- X,Y,Z Vertex 1 {m}
   52.1208, 48.7378375, 0,                 !- X,Y,Z Vertex 2 {m}
   49.77384, 48.7378375, 0,                !- X,Y,Z Vertex 3 {m}
-  49.77384, 48.7378375, 2.74478750000001; !- X,Y,Z Vertex 4 {m}
+  49.77384, 48.7378375, 2.7447875;        !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {683c30da-6cdf-43d7-8393-e624c7807c61}, !- Handle
-  Surface 275,                            !- Name
+  Classroom_Bot_ZN - Wall 270_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {b715f207-2b08-49aa-9fdb-a1cfedf8b085}, !- Space Name
@@ -5506,14 +5422,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  49.77384, 48.7378375, 2.74478750000001, !- X,Y,Z Vertex 1 {m}
+  49.77384, 48.7378375, 2.7447875,        !- X,Y,Z Vertex 1 {m}
   49.77384, 48.7378375, 0,                !- X,Y,Z Vertex 2 {m}
   49.77384, 42.6418375, 0,                !- X,Y,Z Vertex 3 {m}
-  49.77384, 42.6418375, 2.74478750000001; !- X,Y,Z Vertex 4 {m}
+  49.77384, 42.6418375, 2.7447875;        !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {235e438a-0c87-4da8-b89d-8c925c140ed9}, !- Handle
-  Surface 276,                            !- Name
+  Classroom_Bot_ZN - Wall 180_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {b715f207-2b08-49aa-9fdb-a1cfedf8b085}, !- Space Name
@@ -5523,14 +5439,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  49.77384, 42.6418375, 2.74478750000001, !- X,Y,Z Vertex 1 {m}
+  49.77384, 42.6418375, 2.7447875,        !- X,Y,Z Vertex 1 {m}
   49.77384, 42.6418375, 0,                !- X,Y,Z Vertex 2 {m}
   52.1208, 42.6418375, 0,                 !- X,Y,Z Vertex 3 {m}
-  52.1208, 42.6418375, 2.74478750000001;  !- X,Y,Z Vertex 4 {m}
+  52.1208, 42.6418375, 2.7447875;         !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {8fc2d844-6965-4d1e-b6d2-1d3cbe1288be}, !- Handle
-  Surface 277,                            !- Name
+  Classroom_Bot_ZN - RoofCeiling_a,       !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {b715f207-2b08-49aa-9fdb-a1cfedf8b085}, !- Space Name
@@ -5540,10 +5456,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  52.1208, 42.6418375, 2.74478750000001,  !- X,Y,Z Vertex 1 {m}
-  52.1208, 48.7378375, 2.74478750000001,  !- X,Y,Z Vertex 2 {m}
-  49.77384, 48.7378375, 2.74478750000001, !- X,Y,Z Vertex 3 {m}
-  49.77384, 42.6418375, 2.74478750000001; !- X,Y,Z Vertex 4 {m}
+  52.1208, 42.6418375, 2.7447875,         !- X,Y,Z Vertex 1 {m}
+  52.1208, 48.7378375, 2.7447875,         !- X,Y,Z Vertex 2 {m}
+  49.77384, 48.7378375, 2.7447875,        !- X,Y,Z Vertex 3 {m}
+  49.77384, 42.6418375, 2.7447875;        !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {ffd260d7-1f04-492f-8a40-2e17ad9d6d3a}, !- Handle
@@ -5553,16 +5469,17 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  3.41920936008933e-016,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {a180734a-4560-4f26-89f7-f51a27ba85ac}, !- Building Story Name
   {6bdf15c4-10d1-4d09-a69c-1fe467193fcb}, !- Thermal Zone Name
   ,                                       !- Part of Total Floor Area
-  ;                                       !- Design Specification Outdoor Air Object Name
+  ,                                       !- Design Specification Outdoor Air Object Name
+  ;                                       !- Building Unit Name
 
 OS:Surface,
   {307f6e2a-11f5-444d-bae2-c9d3bbc12668}, !- Handle
-  Surface 278,                            !- Name
+  OpenOffice_Bot_ZN_3 - Floor_a,          !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {ffd260d7-1f04-492f-8a40-2e17ad9d6d3a}, !- Space Name
@@ -5572,16 +5489,16 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  49.77384, 48.7378375, 1.72514976389464e-015, !- X,Y,Z Vertex 1 {m}
-  49.77384, 42.6418375, 3.24635636736553e-015, !- X,Y,Z Vertex 2 {m}
-  56.388, 42.6418375, -2.83847004651795e-015, !- X,Y,Z Vertex 3 {m}
-  56.388, 36.5458375, -1.31726344304705e-015, !- X,Y,Z Vertex 4 {m}
-  16.0797875, 36.5458375, 3.57650684201719e-014, !- X,Y,Z Vertex 5 {m}
-  16.0797875, 48.7378375, 3.27226552132301e-014; !- X,Y,Z Vertex 6 {m}
+  49.77384, 48.7378375, 0,                !- X,Y,Z Vertex 1 {m}
+  49.77384, 42.6418375, 0,                !- X,Y,Z Vertex 2 {m}
+  56.388, 42.6418375, 0,                  !- X,Y,Z Vertex 3 {m}
+  56.388, 36.5458375, 0,                  !- X,Y,Z Vertex 4 {m}
+  16.0797875, 36.5458375, 0,              !- X,Y,Z Vertex 5 {m}
+  16.0797875, 48.7378375, 0;              !- X,Y,Z Vertex 6 {m}
 
 OS:Surface,
   {a2dab8d0-beab-4a33-ba7a-533c04b77bd3}, !- Handle
-  Surface 279,                            !- Name
+  OpenOffice_Bot_ZN_3 - Wall 000_b,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {ffd260d7-1f04-492f-8a40-2e17ad9d6d3a}, !- Space Name
@@ -5592,13 +5509,13 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   49.77384, 48.7378375, 2.7447875,        !- X,Y,Z Vertex 1 {m}
-  49.77384, 48.7378375, 1.72514976389464e-015, !- X,Y,Z Vertex 2 {m}
+  49.77384, 48.7378375, 0,                !- X,Y,Z Vertex 2 {m}
   6.096, 48.7378375, 0,                   !- X,Y,Z Vertex 3 {m}
   6.096, 48.7378375, 2.7447875;           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {6f018cb1-7e8f-4ca8-bee8-4474232376ef}, !- Handle
-  Surface 280,                            !- Name
+  OpenOffice_Bot_ZN_3 - RoofCeiling_a,    !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {ffd260d7-1f04-492f-8a40-2e17ad9d6d3a}, !- Space Name
@@ -5617,7 +5534,7 @@ OS:Surface,
 
 OS:Surface,
   {c761b440-cf41-4b07-af6d-239651e518f3}, !- Handle
-  Surface 281,                            !- Name
+  OpenOffice_Bot_ZN_3 - Wall 090_b,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {ffd260d7-1f04-492f-8a40-2e17ad9d6d3a}, !- Space Name
@@ -5628,13 +5545,13 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   56.388, 36.5458375, 2.7447875,          !- X,Y,Z Vertex 1 {m}
-  56.388, 36.5458375, -1.31726344304705e-015, !- X,Y,Z Vertex 2 {m}
-  56.388, 42.6418375, -2.83847004651795e-015, !- X,Y,Z Vertex 3 {m}
+  56.388, 36.5458375, 0,                  !- X,Y,Z Vertex 2 {m}
+  56.388, 42.6418375, 0,                  !- X,Y,Z Vertex 3 {m}
   56.388, 42.6418375, 2.7447875;          !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {2a4f7898-be5f-462b-b59d-04a0eb88aa03}, !- Handle
-  Surface 282,                            !- Name
+  OpenOffice_Bot_ZN_3 - Wall 000_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {ffd260d7-1f04-492f-8a40-2e17ad9d6d3a}, !- Space Name
@@ -5645,13 +5562,13 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   56.388, 42.6418375, 2.7447875,          !- X,Y,Z Vertex 1 {m}
-  56.388, 42.6418375, -2.83847004651795e-015, !- X,Y,Z Vertex 2 {m}
+  56.388, 42.6418375, 0,                  !- X,Y,Z Vertex 2 {m}
   52.1208, 42.6418375, 0,                 !- X,Y,Z Vertex 3 {m}
   52.1208, 42.6418375, 2.7447875;         !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {94f3dd1d-adda-4b1b-9370-45482a7bad51}, !- Handle
-  Surface 283,                            !- Name
+  OpenOffice_Bot_ZN_3 - Wall 090_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {ffd260d7-1f04-492f-8a40-2e17ad9d6d3a}, !- Space Name
@@ -5662,13 +5579,13 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   49.77384, 42.6418375, 2.7447875,        !- X,Y,Z Vertex 1 {m}
-  49.77384, 42.6418375, 3.24635636736553e-015, !- X,Y,Z Vertex 2 {m}
-  49.77384, 48.7378375, 1.72514976389464e-015, !- X,Y,Z Vertex 3 {m}
+  49.77384, 42.6418375, 0,                !- X,Y,Z Vertex 2 {m}
+  49.77384, 48.7378375, 0,                !- X,Y,Z Vertex 3 {m}
   49.77384, 48.7378375, 2.7447875;        !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {f59e606a-5e1b-4fe4-be21-e23bb3912ef6}, !- Handle
-  Surface 284,                            !- Name
+  OpenOffice_Bot_ZN_3 - Wall 270_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {ffd260d7-1f04-492f-8a40-2e17ad9d6d3a}, !- Space Name
@@ -5685,7 +5602,7 @@ OS:Surface,
 
 OS:Surface,
   {8ec43075-e6d7-425d-8309-4d91bf71cca0}, !- Handle
-  Surface 285,                            !- Name
+  OpenOffice_Bot_ZN_3 - Wall 180_d,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {ffd260d7-1f04-492f-8a40-2e17ad9d6d3a}, !- Space Name
@@ -5708,7 +5625,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  3.41920936008933e-016,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {a180734a-4560-4f26-89f7-f51a27ba85ac}, !- Building Story Name
   {4ce98111-f677-467d-aa00-25a8adc3bd7d}, !- Thermal Zone Name
@@ -5717,7 +5634,7 @@ OS:Space,
 
 OS:Surface,
   {9404a8f6-c48c-4b94-9265-5d855111166e}, !- Handle
-  Surface 286,                            !- Name
+  EnclosedOffice_Bot_ZN_5 - Floor_a,      !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {57158068-4f82-4b69-a937-f1f39359d9df}, !- Space Name
@@ -5734,7 +5651,7 @@ OS:Surface,
 
 OS:Surface,
   {bd25176a-4812-471f-bcd4-88571a85e192}, !- Handle
-  Surface 287,                            !- Name
+  EnclosedOffice_Bot_ZN_5 - Wall 090_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {57158068-4f82-4b69-a937-f1f39359d9df}, !- Space Name
@@ -5751,7 +5668,7 @@ OS:Surface,
 
 OS:Surface,
   {80ed3036-d1a7-419b-b5c7-03b3b61db5a2}, !- Handle
-  Surface 288,                            !- Name
+  EnclosedOffice_Bot_ZN_5 - Wall 000_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {57158068-4f82-4b69-a937-f1f39359d9df}, !- Space Name
@@ -5768,7 +5685,7 @@ OS:Surface,
 
 OS:Surface,
   {d122896e-8962-4d48-8239-5e0398939479}, !- Handle
-  Surface 289,                            !- Name
+  EnclosedOffice_Bot_ZN_5 - Wall 270_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {57158068-4f82-4b69-a937-f1f39359d9df}, !- Space Name
@@ -5785,7 +5702,7 @@ OS:Surface,
 
 OS:Surface,
   {d252aa11-0db9-48c8-83c1-d40f5c529549}, !- Handle
-  Surface 290,                            !- Name
+  EnclosedOffice_Bot_ZN_5 - Wall 180_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {57158068-4f82-4b69-a937-f1f39359d9df}, !- Space Name
@@ -5802,7 +5719,7 @@ OS:Surface,
 
 OS:Surface,
   {7da21a02-6526-4cb6-91a3-6c37449ccd12}, !- Handle
-  Surface 291,                            !- Name
+  EnclosedOffice_Bot_ZN_5 - RoofCeiling_a, !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {57158068-4f82-4b69-a937-f1f39359d9df}, !- Space Name
@@ -5825,7 +5742,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  3.41920936008933e-016,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {a180734a-4560-4f26-89f7-f51a27ba85ac}, !- Building Story Name
   {3f16b9d9-958d-412c-8555-c9731d3a7a8d}, !- Thermal Zone Name
@@ -5835,7 +5752,7 @@ OS:Space,
 
 OS:Surface,
   {c335a43e-b0c9-4250-91db-d5ddf4c8a354}, !- Handle
-  Surface 292,                            !- Name
+  ConfRoom_Bot_ZN_1 - Floor_a,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {60d2a0ac-2981-4a20-a6b8-4f0aa1a32652}, !- Space Name
@@ -5852,7 +5769,7 @@ OS:Surface,
 
 OS:Surface,
   {c1aeea34-8f7a-4322-9f0a-27dff754dd80}, !- Handle
-  Surface 293,                            !- Name
+  ConfRoom_Bot_ZN_1 - Wall 270_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {60d2a0ac-2981-4a20-a6b8-4f0aa1a32652}, !- Space Name
@@ -5862,14 +5779,14 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 36.5458375, 2.74478749999999,        !- X,Y,Z Vertex 1 {m}
+  0, 36.5458375, 2.7447875,               !- X,Y,Z Vertex 1 {m}
   0, 36.5458375, 0,                       !- X,Y,Z Vertex 2 {m}
   0, 32.8882375, 0,                       !- X,Y,Z Vertex 3 {m}
-  0, 32.8882375, 2.74478749999999;        !- X,Y,Z Vertex 4 {m}
+  0, 32.8882375, 2.7447875;               !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {c4e8f9c6-d65a-4de8-8429-78178ebe79e0}, !- Handle
-  Surface 294,                            !- Name
+  ConfRoom_Bot_ZN_1 - Wall 180_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {60d2a0ac-2981-4a20-a6b8-4f0aa1a32652}, !- Space Name
@@ -5879,14 +5796,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 32.8882375, 2.74478749999999,        !- X,Y,Z Vertex 1 {m}
+  0, 32.8882375, 2.7447875,               !- X,Y,Z Vertex 1 {m}
   0, 32.8882375, 0,                       !- X,Y,Z Vertex 2 {m}
   6.096, 32.8882375, 0,                   !- X,Y,Z Vertex 3 {m}
-  6.096, 32.8882375, 2.74478749999999;    !- X,Y,Z Vertex 4 {m}
+  6.096, 32.8882375, 2.7447875;           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {dbccd4f6-08f3-4787-9acd-b2aa031ebf36}, !- Handle
-  Surface 295,                            !- Name
+  ConfRoom_Bot_ZN_1 - RoofCeiling_a,      !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {60d2a0ac-2981-4a20-a6b8-4f0aa1a32652}, !- Space Name
@@ -5896,14 +5813,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  6.096, 32.8882375, 2.74478749999999,    !- X,Y,Z Vertex 1 {m}
-  6.096, 36.5458375, 2.74478749999999,    !- X,Y,Z Vertex 2 {m}
-  0, 36.5458375, 2.74478749999999,        !- X,Y,Z Vertex 3 {m}
-  0, 32.8882375, 2.74478749999999;        !- X,Y,Z Vertex 4 {m}
+  6.096, 32.8882375, 2.7447875,           !- X,Y,Z Vertex 1 {m}
+  6.096, 36.5458375, 2.7447875,           !- X,Y,Z Vertex 2 {m}
+  0, 36.5458375, 2.7447875,               !- X,Y,Z Vertex 3 {m}
+  0, 32.8882375, 2.7447875;               !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {a1429eee-2a8c-4b1a-b57d-409723125961}, !- Handle
-  Surface 296,                            !- Name
+  ConfRoom_Bot_ZN_1 - Wall 000_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {60d2a0ac-2981-4a20-a6b8-4f0aa1a32652}, !- Space Name
@@ -5913,14 +5830,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  6.096, 36.5458375, 2.74478749999999,    !- X,Y,Z Vertex 1 {m}
+  6.096, 36.5458375, 2.7447875,           !- X,Y,Z Vertex 1 {m}
   6.096, 36.5458375, 0,                   !- X,Y,Z Vertex 2 {m}
   0, 36.5458375, 0,                       !- X,Y,Z Vertex 3 {m}
-  0, 36.5458375, 2.74478749999999;        !- X,Y,Z Vertex 4 {m}
+  0, 36.5458375, 2.7447875;               !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {77c08dd3-ae67-47d6-9141-1009f0539275}, !- Handle
-  Surface 297,                            !- Name
+  ConfRoom_Bot_ZN_1 - Wall 090_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {60d2a0ac-2981-4a20-a6b8-4f0aa1a32652}, !- Space Name
@@ -5930,10 +5847,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  6.096, 32.8882375, 2.74478749999999,    !- X,Y,Z Vertex 1 {m}
+  6.096, 32.8882375, 2.7447875,           !- X,Y,Z Vertex 1 {m}
   6.096, 32.8882375, 0,                   !- X,Y,Z Vertex 2 {m}
   6.096, 36.5458375, 0,                   !- X,Y,Z Vertex 3 {m}
-  6.096, 36.5458375, 2.74478749999999;    !- X,Y,Z Vertex 4 {m}
+  6.096, 36.5458375, 2.7447875;           !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {ab2ed743-c6f4-4f2b-a191-e18a1ad9e992}, !- Handle
@@ -5943,7 +5860,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  3.41920936008933e-016,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {a180734a-4560-4f26-89f7-f51a27ba85ac}, !- Building Story Name
   {d3248960-ceca-431c-b9a3-62a5a70e26b8}, !- Thermal Zone Name
@@ -5952,7 +5869,7 @@ OS:Space,
 
 OS:Surface,
   {859e07df-6ffd-4ebe-b9bd-d86fc74dc151}, !- Handle
-  Surface 298,                            !- Name
+  OpenOffice_Bot_ZN_1 - Floor_a,          !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {ab2ed743-c6f4-4f2b-a191-e18a1ad9e992}, !- Space Name
@@ -5963,7 +5880,7 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   15.05712, 36.5458375, 0,                !- X,Y,Z Vertex 1 {m}
-  15.05712, -3.41920936008933e-016, 0,    !- X,Y,Z Vertex 2 {m}
+  15.05712, 0, 0,                         !- X,Y,Z Vertex 2 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
   0, 32.8882375, 0,                       !- X,Y,Z Vertex 4 {m}
   6.096, 32.8882375, 0,                   !- X,Y,Z Vertex 5 {m}
@@ -5971,7 +5888,7 @@ OS:Surface,
 
 OS:Surface,
   {eb1ae448-b161-4bf7-8b6c-47f3b024251f}, !- Handle
-  Surface 299,                            !- Name
+  OpenOffice_Bot_ZN_1 - Wall 180_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {ab2ed743-c6f4-4f2b-a191-e18a1ad9e992}, !- Space Name
@@ -5981,14 +5898,14 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  3.90937568793879e-034, 1.38287257909997e-017, 2.7447875, !- X,Y,Z Vertex 1 {m}
-  -7.14591976905242e-034, -4.15823772045842e-017, 8.3945492541206e-034, !- X,Y,Z Vertex 2 {m}
-  15.05712, -3.00338558804349e-016, -8.3945492541206e-034, !- X,Y,Z Vertex 3 {m}
-  15.05712, -2.44927455808765e-016, 2.7447875; !- X,Y,Z Vertex 4 {m}
+  0, 0, 2.7447875,                        !- X,Y,Z Vertex 1 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
+  15.05712, 0, 0,                         !- X,Y,Z Vertex 3 {m}
+  15.05712, 0, 2.7447875;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {163168e1-64f2-41c5-a75e-5b4de3709e9c}, !- Handle
-  Surface 300,                            !- Name
+  OpenOffice_Bot_ZN_1 - Wall 090_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {ab2ed743-c6f4-4f2b-a191-e18a1ad9e992}, !- Space Name
@@ -6005,7 +5922,7 @@ OS:Surface,
 
 OS:Surface,
   {26099a02-1ca1-4743-a6c2-c4a6a76c8384}, !- Handle
-  Surface 301,                            !- Name
+  OpenOffice_Bot_ZN_1 - Wall 000_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {ab2ed743-c6f4-4f2b-a191-e18a1ad9e992}, !- Space Name
@@ -6022,7 +5939,7 @@ OS:Surface,
 
 OS:Surface,
   {ee1e966e-d902-4e6a-a962-c727d590eabc}, !- Handle
-  Surface 302,                            !- Name
+  OpenOffice_Bot_ZN_1 - Wall 270_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {ab2ed743-c6f4-4f2b-a191-e18a1ad9e992}, !- Space Name
@@ -6039,7 +5956,7 @@ OS:Surface,
 
 OS:Surface,
   {77881ff3-3b50-4319-8ea4-619fb966876d}, !- Handle
-  Surface 303,                            !- Name
+  OpenOffice_Bot_ZN_1 - RoofCeiling_a,    !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {ab2ed743-c6f4-4f2b-a191-e18a1ad9e992}, !- Space Name
@@ -6049,16 +5966,16 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  15.05712, -2.03345078604181e-016, 2.7447875, !- X,Y,Z Vertex 1 {m}
+  15.05712, 0, 2.7447875,                 !- X,Y,Z Vertex 1 {m}
   15.05712, 36.5458375, 2.7447875,        !- X,Y,Z Vertex 2 {m}
   6.096, 36.5458375, 2.7447875,           !- X,Y,Z Vertex 3 {m}
   6.096, 32.8882375, 2.7447875,           !- X,Y,Z Vertex 4 {m}
   0, 32.8882375, 2.7447875,               !- X,Y,Z Vertex 5 {m}
-  -3.23654408111353e-034, -2.77536514135845e-017, 2.7447875; !- X,Y,Z Vertex 6 {m}
+  0, 0, 2.7447875;                        !- X,Y,Z Vertex 6 {m}
 
 OS:Surface,
   {01de1208-62b8-463a-ba6a-955a1699ca62}, !- Handle
-  Surface 304,                            !- Name
+  OpenOffice_Bot_ZN_1 - Wall 270_b,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {ab2ed743-c6f4-4f2b-a191-e18a1ad9e992}, !- Space Name
@@ -6068,14 +5985,14 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -8.09136020278383e-035, 32.8882375, 2.7447875, !- X,Y,Z Vertex 1 {m}
-  8.09136020278384e-035, 32.8882375, 4.7705048154871e-069, !- X,Y,Z Vertex 2 {m}
-  -8.09136020278382e-035, 3.98136932276738e-070, -4.77050481548709e-069, !- X,Y,Z Vertex 3 {m}
-  -2.42740806083515e-034, -2.77536514135845e-017, 2.7447875; !- X,Y,Z Vertex 4 {m}
+  0, 32.8882375, 2.7447875,               !- X,Y,Z Vertex 1 {m}
+  0, 32.8882375, 0,                       !- X,Y,Z Vertex 2 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
+  0, 0, 2.7447875;                        !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {d2053395-936a-4705-8f3e-b864b31a5a7f}, !- Handle
-  Surface 305,                            !- Name
+  OpenOffice_Bot_ZN_1 - Wall 000_b,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {ab2ed743-c6f4-4f2b-a191-e18a1ad9e992}, !- Space Name
@@ -6099,7 +6016,7 @@ OS:Space,
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
   0,                                      !- Y Origin {m}
-  -8.66293703438714e-015,                 !- Z Origin {m}
+  0,                                      !- Z Origin {m}
   {c136f41b-5899-4461-9ab1-ce81a1bb07cd}, !- Building Story Name
   {568cf90e-c7f1-497a-9e70-538619154ba5}, !- Thermal Zone Name
   ,                                       !- Part of Total Floor Area
@@ -6108,7 +6025,7 @@ OS:Space,
 
 OS:Surface,
   {44c21582-aa18-42fb-aa5f-ab1ce2bfa1af}, !- Handle
-  Surface 306,                            !- Name
+  Mechanical_Basement_ZN_1 - Floor_a,     !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {d3d3811d-bfc1-4455-b7ad-240f00545023}, !- Space Name
@@ -6118,16 +6035,16 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  73.10755, 36.5458375, -2.43840000000002, !- X,Y,Z Vertex 1 {m}
-  73.10755, 0, -2.43840000000002,         !- X,Y,Z Vertex 2 {m}
-  46.0416275, 0, -2.43840000000002,       !- X,Y,Z Vertex 3 {m}
-  46.0416275, 13.6858375, -2.43840000000002, !- X,Y,Z Vertex 4 {m}
-  54.864, 13.6858375, -2.43840000000002,  !- X,Y,Z Vertex 5 {m}
-  54.864, 36.5458375, -2.43840000000002;  !- X,Y,Z Vertex 6 {m}
+  73.10755, 36.5458375, -2.4384,          !- X,Y,Z Vertex 1 {m}
+  73.10755, 0, -2.4384,                   !- X,Y,Z Vertex 2 {m}
+  46.0416275, 0, -2.4384,                 !- X,Y,Z Vertex 3 {m}
+  46.0416275, 13.6858375, -2.4384,        !- X,Y,Z Vertex 4 {m}
+  54.864, 13.6858375, -2.4384,            !- X,Y,Z Vertex 5 {m}
+  54.864, 36.5458375, -2.4384;            !- X,Y,Z Vertex 6 {m}
 
 OS:Surface,
   {d2ee64f1-13c9-4606-899e-6b48b153ba26}, !- Handle
-  Surface 307,                            !- Name
+  Mechanical_Basement_ZN_1 - Wall 000_a,  !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d3d3811d-bfc1-4455-b7ad-240f00545023}, !- Space Name
@@ -6137,14 +6054,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  73.10755, 36.5458375, 3.60955709766105e-016, !- X,Y,Z Vertex 1 {m}
-  73.10755, 36.5458375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  54.864, 36.5458375, -2.43840000000002,  !- X,Y,Z Vertex 3 {m}
-  54.864, 36.5458375, 3.60955709766105e-016; !- X,Y,Z Vertex 4 {m}
+  73.10755, 36.5458375, 0,                !- X,Y,Z Vertex 1 {m}
+  73.10755, 36.5458375, -2.4384,          !- X,Y,Z Vertex 2 {m}
+  54.864, 36.5458375, -2.4384,            !- X,Y,Z Vertex 3 {m}
+  54.864, 36.5458375, 0;                  !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {da207c29-d9a8-4213-af34-1638dc7dbc1d}, !- Handle
-  Surface 308,                            !- Name
+  Mechanical_Basement_ZN_1 - RoofCeiling_c, !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {d3d3811d-bfc1-4455-b7ad-240f00545023}, !- Space Name
@@ -6154,14 +6071,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  56.388, -7.69297646937844e-017, -2.38230768445647e-014, !- X,Y,Z Vertex 1 {m}
-  56.388, 12.1618375, -2.23792540055001e-014, !- X,Y,Z Vertex 2 {m}
-  46.0416275, 12.1618375, -7.2191141953228e-016, !- X,Y,Z Vertex 3 {m}
-  46.0416275, -7.69297646937853e-017, -2.16573425859689e-015; !- X,Y,Z Vertex 4 {m}
+  56.388, 0, 0,                           !- X,Y,Z Vertex 1 {m}
+  56.388, 12.1618375, 0,                  !- X,Y,Z Vertex 2 {m}
+  46.0416275, 12.1618375, 0,              !- X,Y,Z Vertex 3 {m}
+  46.0416275, 0, 0;                       !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {698d9094-8c97-4927-a1a6-d89f765bab03}, !- Handle
-  Surface 309,                            !- Name
+  Mechanical_Basement_ZN_1 - Wall 270_c,  !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d3d3811d-bfc1-4455-b7ad-240f00545023}, !- Space Name
@@ -6171,14 +6088,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  54.864, 35.0218375, -2.31011654250324e-014, !- X,Y,Z Vertex 1 {m}
-  54.864, 35.0218375, -2.43840000000002,  !- X,Y,Z Vertex 2 {m}
-  54.864, 29.8402375, -2.43840000000002,  !- X,Y,Z Vertex 3 {m}
-  54.864, 29.8402375, -2.31011654250324e-014; !- X,Y,Z Vertex 4 {m}
+  54.864, 35.0218375, -0,                 !- X,Y,Z Vertex 1 {m}
+  54.864, 35.0218375, -2.4384,            !- X,Y,Z Vertex 2 {m}
+  54.864, 29.8402375, -2.4384,            !- X,Y,Z Vertex 3 {m}
+  54.864, 29.8402375, -0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {92df5f57-7c82-4e67-b891-643672369c51}, !- Handle
-  Surface 310,                            !- Name
+  Mechanical_Basement_ZN_1 - Wall 000_c,  !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d3d3811d-bfc1-4455-b7ad-240f00545023}, !- Space Name
@@ -6188,14 +6105,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  52.7304, 13.6858375, -4.24685105242912e-016, !- X,Y,Z Vertex 1 {m}
-  52.7304, 13.6858375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  46.0416275, 13.6858375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  46.0416275, 13.6858375, -2.88764567812907e-015; !- X,Y,Z Vertex 4 {m}
+  52.7304, 13.6858375, 0,                 !- X,Y,Z Vertex 1 {m}
+  52.7304, 13.6858375, -2.4384,           !- X,Y,Z Vertex 2 {m}
+  46.0416275, 13.6858375, -2.4384,        !- X,Y,Z Vertex 3 {m}
+  46.0416275, 13.6858375, 0;              !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {531edc43-7989-45d1-aece-8c986e7e151c}, !- Handle
-  Surface 311,                            !- Name
+  Mechanical_Basement_ZN_1 - Wall 180_a,  !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d3d3811d-bfc1-4455-b7ad-240f00545023}, !- Space Name
@@ -6205,14 +6122,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   0,                                      !- View Factor to Ground
   ,                                       !- Number of Vertices
-  73.10755, -7.69297646937852e-017, 3.60955709766105e-016, !- X,Y,Z Vertex 1 {m}
-  46.0416275, -7.69297646937853e-017, -2.16573425859689e-015, !- X,Y,Z Vertex 2 {m}
-  46.0416275, -1.30240935451989e-031, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  73.10755, 3.00556004889205e-032, -2.43840000000002; !- X,Y,Z Vertex 4 {m}
+  46.0416275, 0, 0,                       !- X,Y,Z Vertex 1 {m}
+  46.0416275, 0, -2.4384,                 !- X,Y,Z Vertex 2 {m}
+  73.10755, 0, -2.4384,                   !- X,Y,Z Vertex 3 {m}
+  73.10755, 0, 0;                         !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {9aeb3637-01cd-4e78-aa77-c49914ba1f5f}, !- Handle
-  Surface 312,                            !- Name
+  Mechanical_Basement_ZN_1 - Wall 270_d,  !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d3d3811d-bfc1-4455-b7ad-240f00545023}, !- Space Name
@@ -6222,14 +6139,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.0416275, 12.1618375, -7.2191141953228e-016, !- X,Y,Z Vertex 1 {m}
-  46.0416275, 12.1618375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  46.0416275, 0, -2.43840000000002,       !- X,Y,Z Vertex 3 {m}
-  46.0416275, -7.69297646937853e-017, -2.16573425859689e-015; !- X,Y,Z Vertex 4 {m}
+  46.0416275, 12.1618375, 0,              !- X,Y,Z Vertex 1 {m}
+  46.0416275, 12.1618375, -2.4384,        !- X,Y,Z Vertex 2 {m}
+  46.0416275, 0, -2.4384,                 !- X,Y,Z Vertex 3 {m}
+  46.0416275, 0, 0;                       !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {ca97ba81-d1bb-429b-a66c-98a42ce096bb}, !- Handle
-  Surface 313,                            !- Name
+  Mechanical_Basement_ZN_1 - Wall 090_a,  !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d3d3811d-bfc1-4455-b7ad-240f00545023}, !- Space Name
@@ -6239,14 +6156,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   0,                                      !- View Factor to Ground
   ,                                       !- Number of Vertices
-  73.10755, -7.69297646937852e-017, 3.60955709766105e-016, !- X,Y,Z Vertex 1 {m}
-  73.10755, 0, -2.43840000000002,         !- X,Y,Z Vertex 2 {m}
-  73.10755, 36.5458375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  73.10755, 36.5458375, 3.60955709766105e-016; !- X,Y,Z Vertex 4 {m}
+  73.10755, 0, 0,                         !- X,Y,Z Vertex 1 {m}
+  73.10755, 0, -2.4384,                   !- X,Y,Z Vertex 2 {m}
+  73.10755, 36.5458375, -2.4384,          !- X,Y,Z Vertex 3 {m}
+  73.10755, 36.5458375, 0;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {6c6a224d-4c3e-4bef-87dc-48bbcae9a7f5}, !- Handle
-  Surface 478,                            !- Name
+  OpenOffice_Bot_ZN_1 - Wall 090_b,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {ab2ed743-c6f4-4f2b-a191-e18a1ad9e992}, !- Space Name
@@ -6256,14 +6173,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  15.05712, -2.03345078604181e-016, 2.7447875, !- X,Y,Z Vertex 1 {m}
-  15.05712, -3.41920936008933e-016, 0,    !- X,Y,Z Vertex 2 {m}
+  15.05712, 0, 2.7447875,                 !- X,Y,Z Vertex 1 {m}
+  15.05712, 0, 0,                         !- X,Y,Z Vertex 2 {m}
   15.05712, 12.1618375, 0,                !- X,Y,Z Vertex 3 {m}
   15.05712, 12.1618375, 2.7447875;        !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {848bc082-58ab-45d3-b6b3-2471fc5fae48}, !- Handle
-  Surface 479,                            !- Name
+  OpenOffice_Bot_ZN_3 - Wall 180_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {ffd260d7-1f04-492f-8a40-2e17ad9d6d3a}, !- Space Name
@@ -6275,12 +6192,12 @@ OS:Surface,
   ,                                       !- Number of Vertices
   46.3296, 36.5458375, 2.7447875,         !- X,Y,Z Vertex 1 {m}
   46.3296, 36.5458375, 0,                 !- X,Y,Z Vertex 2 {m}
-  56.388, 36.5458375, -1.31726344304705e-015, !- X,Y,Z Vertex 3 {m}
+  56.388, 36.5458375, 0,                  !- X,Y,Z Vertex 3 {m}
   56.388, 36.5458375, 2.7447875;          !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {caf1b381-9d36-4691-87c7-c5d176660e5b}, !- Handle
-  Surface 480,                            !- Name
+  OpenOffice_Bot_ZN_3 - Wall 180_c,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {ffd260d7-1f04-492f-8a40-2e17ad9d6d3a}, !- Space Name
@@ -6297,7 +6214,7 @@ OS:Surface,
 
 OS:Surface,
   {d2b5c531-dd73-458b-b379-64488414ed71}, !- Handle
-  Surface 481,                            !- Name
+  OpenOffice_Bot_ZN_3 - Wall 180_b,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {ffd260d7-1f04-492f-8a40-2e17ad9d6d3a}, !- Space Name
@@ -6314,7 +6231,7 @@ OS:Surface,
 
 OS:Surface,
   {06e7f6c4-1bd8-456a-ae00-0cd8234ab994}, !- Handle
-  Surface 482,                            !- Name
+  OpenOffice_Bot_ZN_3 - Wall 180_e,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {ffd260d7-1f04-492f-8a40-2e17ad9d6d3a}, !- Space Name
@@ -6331,7 +6248,7 @@ OS:Surface,
 
 OS:Surface,
   {b751259b-42ec-4c7e-b182-7e43571c678d}, !- Handle
-  Surface 483,                            !- Name
+  OpenOffice_Bot_ZN_3 - Wall 000_c,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {ffd260d7-1f04-492f-8a40-2e17ad9d6d3a}, !- Space Name
@@ -6343,12 +6260,12 @@ OS:Surface,
   ,                                       !- Number of Vertices
   52.1208, 42.6418375, 2.7447875,         !- X,Y,Z Vertex 1 {m}
   52.1208, 42.6418375, 0,                 !- X,Y,Z Vertex 2 {m}
-  49.77384, 42.6418375, 3.24635636736553e-015, !- X,Y,Z Vertex 3 {m}
+  49.77384, 42.6418375, 0,                !- X,Y,Z Vertex 3 {m}
   49.77384, 42.6418375, 2.7447875;        !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {19da49aa-394d-4ecc-beaa-b06c617af807}, !- Handle
-  Surface 484,                            !- Name
+  OpenOffice_Bot_ZN_3 - Floor_b,          !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {ffd260d7-1f04-492f-8a40-2e17ad9d6d3a}, !- Space Name
@@ -6358,14 +6275,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  16.0797875, 48.7378375, 3.34832585149656e-014, !- X,Y,Z Vertex 1 {m}
-  16.0797875, 36.5458375, 3.50044651184365e-014, !- X,Y,Z Vertex 2 {m}
-  6.096, 36.5458375, 7.60603301735461e-016, !- X,Y,Z Vertex 3 {m}
-  6.096, 48.7378375, -7.60603301735446e-016; !- X,Y,Z Vertex 4 {m}
+  16.0797875, 48.7378375, 0,              !- X,Y,Z Vertex 1 {m}
+  16.0797875, 36.5458375, 0,              !- X,Y,Z Vertex 2 {m}
+  6.096, 36.5458375, 0,                   !- X,Y,Z Vertex 3 {m}
+  6.096, 48.7378375, 0;                   !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {268bc89d-d8aa-4cdc-80dc-acae8d7eb8ee}, !- Handle
-  Surface 485,                            !- Name
+  OpenOffice_Bot_ZN_2 - Wall 270_c,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {41bc5c33-b808-4a81-a4aa-5d35ca430a5f}, !- Space Name
@@ -6376,13 +6293,13 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   56.388, 36.5458375, 2.7447875,          !- X,Y,Z Vertex 1 {m}
-  56.388, 36.5458375, 5.86553028369963e-015, !- X,Y,Z Vertex 2 {m}
+  56.388, 36.5458375, 0,                  !- X,Y,Z Vertex 2 {m}
   56.388, 12.1618375, 0,                  !- X,Y,Z Vertex 3 {m}
   56.388, 12.1618375, 2.7447875;          !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {7dc3048e-43b4-4c69-8847-8b4a22149bd4}, !- Handle
-  Surface 486,                            !- Name
+  OpenOffice_Bot_ZN_2 - Wall 270_b,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {41bc5c33-b808-4a81-a4aa-5d35ca430a5f}, !- Space Name
@@ -6393,13 +6310,13 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   56.388, 42.6418375, 2.7447875,          !- X,Y,Z Vertex 1 {m}
-  56.388, 42.6418375, -5.86553028369963e-015, !- X,Y,Z Vertex 2 {m}
-  56.388, 36.5458375, 5.86553028369963e-015, !- X,Y,Z Vertex 3 {m}
+  56.388, 42.6418375, 0,                  !- X,Y,Z Vertex 2 {m}
+  56.388, 36.5458375, 0,                  !- X,Y,Z Vertex 3 {m}
   56.388, 36.5458375, 2.7447875;          !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {3ac5fa9a-e741-41b9-8e0d-26a43fcf20a2}, !- Handle
-  Surface 487,                            !- Name
+  OpenOffice_Bot_ZN_2 - Floor_b,          !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {41bc5c33-b808-4a81-a4aa-5d35ca430a5f}, !- Space Name
@@ -6409,14 +6326,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  73.10755, 36.5458375, 1.46638257092491e-014, !- X,Y,Z Vertex 1 {m}
-  73.10755, 5.4864, 2.93276514184984e-015, !- X,Y,Z Vertex 2 {m}
-  56.388, 5.4864, -2.93276514184983e-015, !- X,Y,Z Vertex 3 {m}
-  56.388, 36.5458375, 8.79829542554944e-015; !- X,Y,Z Vertex 4 {m}
+  73.10755, 36.5458375, 0,                !- X,Y,Z Vertex 1 {m}
+  73.10755, 5.4864, 0,                    !- X,Y,Z Vertex 2 {m}
+  56.388, 5.4864, 0,                      !- X,Y,Z Vertex 3 {m}
+  56.388, 36.5458375, 0;                  !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {6e8d1327-fc7a-489c-b91e-4d4a85223ac5}, !- Handle
-  Surface 488,                            !- Name
+  EnclosedOffice_Bot_ZN_4 - Wall 180_b,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {1815ea2c-e057-4b95-9cc0-7a623b32ba17}, !- Space Name
@@ -6433,7 +6350,7 @@ OS:Surface,
 
 OS:Surface,
   {90aceea6-9de3-4d59-a8e8-3ab222584113}, !- Handle
-  Surface 489,                            !- Name
+  Dining_Bot_ZN - Floor_b,                !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {2a82567c-0643-4fd1-b75a-f62205013e43}, !- Space Name
@@ -6443,14 +6360,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.3296, 36.5458375, -2.88764567812909e-015, !- X,Y,Z Vertex 1 {m}
-  46.3296, 35.0218375, 8.66293703438711e-015, !- X,Y,Z Vertex 2 {m}
-  37.7952, 35.0218375, 1.44382283906452e-014, !- X,Y,Z Vertex 3 {m}
-  37.7952, 36.5458375, 2.88764567812901e-015; !- X,Y,Z Vertex 4 {m}
+  46.3296, 36.5458375, 0,                 !- X,Y,Z Vertex 1 {m}
+  46.3296, 35.0218375, 0,                 !- X,Y,Z Vertex 2 {m}
+  37.7952, 35.0218375, 0,                 !- X,Y,Z Vertex 3 {m}
+  37.7952, 36.5458375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {889aee7c-7385-4ac4-b888-4cb5a13bf107}, !- Handle
-  Surface 490,                            !- Name
+  Dining_Bot_ZN - Wall 090_b,             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {2a82567c-0643-4fd1-b75a-f62205013e43}, !- Space Name
@@ -6461,13 +6378,13 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   46.3296, 35.0218375, 2.7447875,         !- X,Y,Z Vertex 1 {m}
-  46.3296, 35.0218375, 5.7752913562581e-015, !- X,Y,Z Vertex 2 {m}
+  46.3296, 35.0218375, 0,                 !- X,Y,Z Vertex 2 {m}
   46.3296, 36.5458375, 0,                 !- X,Y,Z Vertex 3 {m}
   46.3296, 36.5458375, 2.7447875;         !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {240d0d2d-4e67-47cc-a949-9efed07fd568}, !- Handle
-  Surface 491,                            !- Name
+  Mechanical_Bot_ZN_2 - Floor_b,          !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {23a35a24-65e2-4d28-810b-59baec21104e}, !- Space Name
@@ -6477,14 +6394,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.3296, 24.3538375, 2.31011654250324e-014, !- X,Y,Z Vertex 1 {m}
+  46.3296, 24.3538375, 0,                 !- X,Y,Z Vertex 1 {m}
   46.3296, 18.8674375, 0,                 !- X,Y,Z Vertex 2 {m}
   37.7952, 18.8674375, 0,                 !- X,Y,Z Vertex 3 {m}
-  37.7952, 24.3538375, 2.31011654250324e-014; !- X,Y,Z Vertex 4 {m}
+  37.7952, 24.3538375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {2415d01a-e8af-4b8f-aa82-a5fe73cada1f}, !- Handle
-  Surface 492,                            !- Name
+  EnclosedOffice_Bot_ZN_2 - Wall 000_c,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {60416a59-808a-4add-8341-053ce90af4d4}, !- Space Name
@@ -6501,7 +6418,7 @@ OS:Surface,
 
 OS:Surface,
   {3d44ef88-8593-44a1-9fb5-98304692f3b8}, !- Handle
-  Surface 493,                            !- Name
+  EnclosedOffice_Bot_ZN_2 - Floor_b,      !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {60416a59-808a-4add-8341-053ce90af4d4}, !- Space Name
@@ -6511,14 +6428,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  54.864, 18.8674375, 8.20718264017457e-029, !- X,Y,Z Vertex 1 {m}
-  54.864, 13.6858375, 8.20718264017457e-029, !- X,Y,Z Vertex 2 {m}
-  52.7304, 13.6858375, 2.31011654250325e-014, !- X,Y,Z Vertex 3 {m}
-  52.7304, 18.8674375, 2.31011654250325e-014; !- X,Y,Z Vertex 4 {m}
+  54.864, 18.8674375, 0,                  !- X,Y,Z Vertex 1 {m}
+  54.864, 13.6858375, 0,                  !- X,Y,Z Vertex 2 {m}
+  52.7304, 13.6858375, 0,                 !- X,Y,Z Vertex 3 {m}
+  52.7304, 18.8674375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {c01848cf-0bc9-456f-bf25-820f6326f78f}, !- Handle
-  Surface 494,                            !- Name
+  EnclosedOffice_Bot_ZN_2 - Wall 000_b,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {60416a59-808a-4add-8341-053ce90af4d4}, !- Space Name
@@ -6535,7 +6452,7 @@ OS:Surface,
 
 OS:Surface,
   {76fc4606-6804-4d83-94b4-7eee53bb38ea}, !- Handle
-  Surface 495,                            !- Name
+  Corridor_Bot_ZN_2 - Floor_b,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {e09dc351-b4b2-4c23-ac81-8f93ce202e4f}, !- Space Name
@@ -6545,14 +6462,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.0416275, 13.6858375, 2.41421480269763e-014, !- X,Y,Z Vertex 1 {m}
-  46.0416275, 12.1618375, 2.36567391564942e-014, !- X,Y,Z Vertex 2 {m}
-  37.7952, 12.1618375, -2.42704435241062e-016, !- X,Y,Z Vertex 3 {m}
-  37.7952, 13.6858375, 2.42704435241041e-016; !- X,Y,Z Vertex 4 {m}
+  46.0416275, 13.6858375, 0,              !- X,Y,Z Vertex 1 {m}
+  46.0416275, 12.1618375, 0,              !- X,Y,Z Vertex 2 {m}
+  37.7952, 12.1618375, 0,                 !- X,Y,Z Vertex 3 {m}
+  37.7952, 13.6858375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {e9840f59-7872-4bc3-9491-cc814e8db875}, !- Handle
-  Surface 496,                            !- Name
+  Corridor_Bot_ZN_2 - Wall 270_d,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e09dc351-b4b2-4c23-ac81-8f93ce202e4f}, !- Space Name
@@ -6564,12 +6481,12 @@ OS:Surface,
   ,                                       !- Number of Vertices
   54.864, 18.8674375, 2.7447875,          !- X,Y,Z Vertex 1 {m}
   54.864, 18.8674375, 0,                  !- X,Y,Z Vertex 2 {m}
-  54.864, 13.6858375, 1.7376181212579e-015, !- X,Y,Z Vertex 3 {m}
+  54.864, 13.6858375, 0,                  !- X,Y,Z Vertex 3 {m}
   54.864, 13.6858375, 2.7447875;          !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {c2aa437e-e68f-4524-b30f-f855f9f79b40}, !- Handle
-  Surface 497,                            !- Name
+  Corridor_Bot_ZN_2 - Floor_c,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {e09dc351-b4b2-4c23-ac81-8f93ce202e4f}, !- Space Name
@@ -6579,14 +6496,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  54.864, 36.5458375, 1.22249131767909e-014, !- X,Y,Z Vertex 1 {m}
-  54.864, 35.0218375, 4.07497105893028e-015, !- X,Y,Z Vertex 2 {m}
-  46.3296, 35.0218375, -4.07497105893032e-015, !- X,Y,Z Vertex 3 {m}
-  46.3296, 36.5458375, 4.07497105893028e-015; !- X,Y,Z Vertex 4 {m}
+  54.864, 36.5458375, 0,                  !- X,Y,Z Vertex 1 {m}
+  54.864, 35.0218375, 0,                  !- X,Y,Z Vertex 2 {m}
+  46.3296, 35.0218375, 0,                 !- X,Y,Z Vertex 3 {m}
+  46.3296, 36.5458375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {11dc3fb2-c31d-46e9-acdc-4b8195fbe790}, !- Handle
-  Surface 498,                            !- Name
+  Corridor_Bot_ZN_2 - Wall 180_c,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e09dc351-b4b2-4c23-ac81-8f93ce202e4f}, !- Space Name
@@ -6603,7 +6520,7 @@ OS:Surface,
 
 OS:Surface,
   {9908c616-4a20-44e3-9fd8-7e43e2b32749}, !- Handle
-  Surface 499,                            !- Name
+  Corridor_Bot_ZN_2 - Wall 270_e,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e09dc351-b4b2-4c23-ac81-8f93ce202e4f}, !- Space Name
@@ -6620,24 +6537,24 @@ OS:Surface,
 
 OS:Surface,
   {074ecd17-d6f3-494f-ae96-436d1b6ae471}, !- Handle
-  Surface 500,                            !- Name
+  Lobby_Bot_ZN_2 - Wall 270_b,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {abacaf7b-c009-4460-9c87-7ecf15da4216}, !- Space Name
-  Surface,                                !- Outside Boundary Condition
-  {4e7da34c-0ffd-4638-899c-91a5236c36a8}, !- Outside Boundary Condition Object
-  NoSun,                                  !- Sun Exposure
-  NoWind,                                 !- Wind Exposure
+  Outdoors,                               !- Outside Boundary Condition
+  ,                                       !- Outside Boundary Condition Object
+  SunExposed,                             !- Sun Exposure
+  WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  35.3568, 35.0708215764634, 2.74478749999999, !- X,Y,Z Vertex 1 {m}
-  35.3568, 35.0708215764634, 0,           !- X,Y,Z Vertex 2 {m}
+  35.3568, 35.07082158, 2.7447875,        !- X,Y,Z Vertex 1 {m}
+  35.3568, 35.07082158, 0,                !- X,Y,Z Vertex 2 {m}
   35.3568, 35.0218375, 0,                 !- X,Y,Z Vertex 3 {m}
   35.3568, 35.0218375, 2.7447875;         !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {2d490895-9047-4c44-b904-c103e57364ce}, !- Handle
-  Surface 501,                            !- Name
+  Lobby_Bot_ZN_2 - Wall 270_d,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {abacaf7b-c009-4460-9c87-7ecf15da4216}, !- Space Name
@@ -6647,14 +6564,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  35.3568, 36.5458375, 2.74478749999999,  !- X,Y,Z Vertex 1 {m}
+  35.3568, 36.5458375, 2.7447875,         !- X,Y,Z Vertex 1 {m}
   35.3568, 36.5458375, 0,                 !- X,Y,Z Vertex 2 {m}
-  35.3568, 35.0708215764634, 0,           !- X,Y,Z Vertex 3 {m}
-  35.3568, 35.0708215764634, 2.74478749999999; !- X,Y,Z Vertex 4 {m}
+  35.3568, 35.07082158, 0,                !- X,Y,Z Vertex 3 {m}
+  35.3568, 35.07082158, 2.7447875;        !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {7e699af3-83c6-4190-ac79-0ad126c02536}, !- Handle
-  Surface 502,                            !- Name
+  Lobby_Bot_ZN_2 - Wall 090_c,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {abacaf7b-c009-4460-9c87-7ecf15da4216}, !- Space Name
@@ -6664,14 +6581,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  37.7952, 29.8402375, 2.74478749999999,  !- X,Y,Z Vertex 1 {m}
+  37.7952, 29.8402375, 2.7447875,         !- X,Y,Z Vertex 1 {m}
   37.7952, 29.8402375, 0,                 !- X,Y,Z Vertex 2 {m}
   37.7952, 36.5458375, 0,                 !- X,Y,Z Vertex 3 {m}
-  37.7952, 36.5458375, 2.74478749999999;  !- X,Y,Z Vertex 4 {m}
+  37.7952, 36.5458375, 2.7447875;         !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {1d37a954-9e48-4682-87c7-0ff050e36c1f}, !- Handle
-  Surface 503,                            !- Name
+  Lobby_Bot_ZN_2 - Wall 090_b,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {abacaf7b-c009-4460-9c87-7ecf15da4216}, !- Space Name
@@ -6681,14 +6598,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  37.7952, 13.6858375, 2.74478749999999,  !- X,Y,Z Vertex 1 {m}
+  37.7952, 13.6858375, 2.7447875,         !- X,Y,Z Vertex 1 {m}
   37.7952, 13.6858375, 0,                 !- X,Y,Z Vertex 2 {m}
   37.7952, 18.8674375, 0,                 !- X,Y,Z Vertex 3 {m}
-  37.7952, 18.8674375, 2.74478749999999;  !- X,Y,Z Vertex 4 {m}
+  37.7952, 18.8674375, 2.7447875;         !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {110de51a-220e-4ba8-83ff-07681087f984}, !- Handle
-  Surface 504,                            !- Name
+  Lobby_Bot_ZN_2 - Wall 270_e,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {abacaf7b-c009-4460-9c87-7ecf15da4216}, !- Space Name
@@ -6698,14 +6615,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  35.3568, 18.8674375, 2.74478749999999,  !- X,Y,Z Vertex 1 {m}
+  35.3568, 18.8674375, 2.7447875,         !- X,Y,Z Vertex 1 {m}
   35.3568, 18.8674375, 0,                 !- X,Y,Z Vertex 2 {m}
   35.3568, 13.6858375, 0,                 !- X,Y,Z Vertex 3 {m}
-  35.3568, 13.6858375, 2.74478749999999;  !- X,Y,Z Vertex 4 {m}
+  35.3568, 13.6858375, 2.7447875;         !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {6bcee094-57c6-45b9-a057-afafe7fd6f83}, !- Handle
-  Surface 505,                            !- Name
+  Lobby_Bot_ZN_2 - Wall 090_d,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {abacaf7b-c009-4460-9c87-7ecf15da4216}, !- Space Name
@@ -6715,14 +6632,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  37.7952, 18.8674375, 2.74478749999999,  !- X,Y,Z Vertex 1 {m}
+  37.7952, 18.8674375, 2.7447875,         !- X,Y,Z Vertex 1 {m}
   37.7952, 18.8674375, 0,                 !- X,Y,Z Vertex 2 {m}
   37.7952, 29.8402375, 0,                 !- X,Y,Z Vertex 3 {m}
-  37.7952, 29.8402375, 2.74478749999999;  !- X,Y,Z Vertex 4 {m}
+  37.7952, 29.8402375, 2.7447875;         !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {4c22447e-c145-44da-998b-748aeae9c09c}, !- Handle
-  Surface 506,                            !- Name
+  Lobby_Bot_ZN_2 - Wall 270_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {abacaf7b-c009-4460-9c87-7ecf15da4216}, !- Space Name
@@ -6732,14 +6649,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  35.3568, 13.6858375, 2.74478749999999,  !- X,Y,Z Vertex 1 {m}
+  35.3568, 13.6858375, 2.7447875,         !- X,Y,Z Vertex 1 {m}
   35.3568, 13.6858375, 0,                 !- X,Y,Z Vertex 2 {m}
   35.3568, 12.1618375, 0,                 !- X,Y,Z Vertex 3 {m}
-  35.3568, 12.1618375, 2.74478749999999;  !- X,Y,Z Vertex 4 {m}
+  35.3568, 12.1618375, 2.7447875;         !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {ee6c61b5-f7f3-4554-9f0c-a7fc7d731e28}, !- Handle
-  Surface 507,                            !- Name
+  Lobby_Bot_ZN_2 - Wall 270_f,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {abacaf7b-c009-4460-9c87-7ecf15da4216}, !- Space Name
@@ -6752,45 +6669,11 @@ OS:Surface,
   35.3568, 35.0218375, 2.7447875,         !- X,Y,Z Vertex 1 {m}
   35.3568, 35.0218375, 0,                 !- X,Y,Z Vertex 2 {m}
   35.3568, 29.8402375, 0,                 !- X,Y,Z Vertex 3 {m}
-  35.3568, 29.8402375, 2.74478749999999;  !- X,Y,Z Vertex 4 {m}
-
-OS:Surface,
-  {ed10e14c-033c-4b99-a613-f596e8a5e0eb}, !- Handle
-  Surface 508,                            !- Name
-  RoofCeiling,                            !- Surface Type
-  ,                                       !- Construction Name
-  {23bb7aaa-6a7c-4d7a-826f-f4ffe1c733a5}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
-  ,                                       !- View Factor to Ground
-  ,                                       !- Number of Vertices
-  35.3568, 35.0218375, 2.7447875,         !- X,Y,Z Vertex 1 {m}
-  35.3568, 35.0708215764634, 2.7447875,   !- X,Y,Z Vertex 2 {m}
-  18.288, 35.0708215764634, 2.7447875,    !- X,Y,Z Vertex 3 {m}
-  18.288, 35.0218375, 2.7447875;          !- X,Y,Z Vertex 4 {m}
-
-OS:Surface,
-  {4e7da34c-0ffd-4638-899c-91a5236c36a8}, !- Handle
-  Surface 509,                            !- Name
-  Wall,                                   !- Surface Type
-  ,                                       !- Construction Name
-  {23bb7aaa-6a7c-4d7a-826f-f4ffe1c733a5}, !- Space Name
-  Surface,                                !- Outside Boundary Condition
-  {074ecd17-d6f3-494f-ae96-436d1b6ae471}, !- Outside Boundary Condition Object
-  NoSun,                                  !- Sun Exposure
-  NoWind,                                 !- Wind Exposure
-  ,                                       !- View Factor to Ground
-  ,                                       !- Number of Vertices
-  35.3568, 35.0218375, 2.7447875,         !- X,Y,Z Vertex 1 {m}
-  35.3568, 35.0218375, -5.77529135625809e-015, !- X,Y,Z Vertex 2 {m}
-  35.3568, 35.0708215764634, 5.77529135625809e-015, !- X,Y,Z Vertex 3 {m}
-  35.3568, 35.0708215764634, 2.7447875;   !- X,Y,Z Vertex 4 {m}
+  35.3568, 29.8402375, 2.7447875;         !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {b3ef813c-0b6e-4d47-92d0-f7167080d2ce}, !- Handle
-  Surface 510,                            !- Name
+  EnclosedOffice_Bot_ZN_3 - Wall 270_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {23bb7aaa-6a7c-4d7a-826f-f4ffe1c733a5}, !- Space Name
@@ -6807,7 +6690,7 @@ OS:Surface,
 
 OS:Surface,
   {12347198-18e8-463e-bf32-7b1c4bace388}, !- Handle
-  Surface 511,                            !- Name
+  EnclosedOffice_Bot_ZN_3 - Wall 180_b,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {23bb7aaa-6a7c-4d7a-826f-f4ffe1c733a5}, !- Space Name
@@ -6824,7 +6707,7 @@ OS:Surface,
 
 OS:Surface,
   {dbaac048-9b21-4cb5-bf84-02d69ff67d91}, !- Handle
-  Surface 512,                            !- Name
+  EnclosedOffice_Bot_ZN_3 - Wall 180_c,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {23bb7aaa-6a7c-4d7a-826f-f4ffe1c733a5}, !- Space Name
@@ -6841,7 +6724,7 @@ OS:Surface,
 
 OS:Surface,
   {f257db94-43d7-4a95-8a45-e71b1336bd50}, !- Handle
-  Surface 513,                            !- Name
+  EnclosedOffice_Bot_ZN_3 - Floor_b,      !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {23bb7aaa-6a7c-4d7a-826f-f4ffe1c733a5}, !- Space Name
@@ -6851,14 +6734,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  30.4038, 35.0218375, 1.82282633431897e-014, !- X,Y,Z Vertex 1 {m}
-  30.4038, 29.8402375, 1.82282633431897e-014, !- X,Y,Z Vertex 2 {m}
-  25.4508, 29.8402375, 9.02389274415348e-016, !- X,Y,Z Vertex 3 {m}
-  25.4508, 35.0218375, 9.02389274415333e-016; !- X,Y,Z Vertex 4 {m}
+  30.4038, 35.0218375, 0,                 !- X,Y,Z Vertex 1 {m}
+  30.4038, 29.8402375, 0,                 !- X,Y,Z Vertex 2 {m}
+  25.4508, 29.8402375, 0,                 !- X,Y,Z Vertex 3 {m}
+  25.4508, 35.0218375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {7986e99d-8e03-4445-8d50-334a027a1328}, !- Handle
-  Surface 514,                            !- Name
+  EnclosedOffice_Bot_ZN_3 - Floor_c,      !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {23bb7aaa-6a7c-4d7a-826f-f4ffe1c733a5}, !- Space Name
@@ -6868,48 +6751,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  25.4508, 35.0218375, 1.35358391162301e-015, !- X,Y,Z Vertex 1 {m}
-  25.4508, 29.8402375, 4.5119463720767e-016, !- X,Y,Z Vertex 2 {m}
-  18.288, 29.8402375, -4.5119463720767e-016, !- X,Y,Z Vertex 3 {m}
-  18.288, 35.0218375, 4.5119463720767e-016; !- X,Y,Z Vertex 4 {m}
-
-OS:Surface,
-  {4de7652b-18cc-4cd9-84b6-eb66270f6dd6}, !- Handle
-  Surface 515,                            !- Name
-  Floor,                                  !- Surface Type
-  ,                                       !- Construction Name
-  {23bb7aaa-6a7c-4d7a-826f-f4ffe1c733a5}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  NoSun,                                  !- Sun Exposure
-  NoWind,                                 !- Wind Exposure
-  ,                                       !- View Factor to Ground
-  ,                                       !- Number of Vertices
-  25.4508, 35.0708215764634, 1.49345424915737e-014, !- X,Y,Z Vertex 1 {m}
-  25.4508, 35.0218375, 6.18136652974502e-015, !- X,Y,Z Vertex 2 {m}
-  18.288, 35.0218375, -4.37658798091434e-015, !- X,Y,Z Vertex 3 {m}
-  18.288, 35.0708215764634, 4.37658798091434e-015; !- X,Y,Z Vertex 4 {m}
-
-OS:Surface,
-  {6bbcac4f-a114-494d-b50f-3b94120c1720}, !- Handle
-  Surface 516,                            !- Name
-  Floor,                                  !- Surface Type
-  ,                                       !- Construction Name
-  {23bb7aaa-6a7c-4d7a-826f-f4ffe1c733a5}, !- Space Name
-  Adiabatic,                              !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  NoSun,                                  !- Sun Exposure
-  NoWind,                                 !- Wind Exposure
-  ,                                       !- View Factor to Ground
-  ,                                       !- Number of Vertices
-  30.4038, 35.0708215764634, 3.03653990840758e-014, !- X,Y,Z Vertex 1 {m}
-  30.4038, 35.0218375, 1.5836931765989e-014, !- X,Y,Z Vertex 2 {m}
-  25.4508, 35.0218375, 3.29372085161597e-015, !- X,Y,Z Vertex 3 {m}
-  25.4508, 35.0708215764634, 1.78221881697027e-014; !- X,Y,Z Vertex 4 {m}
+  25.4508, 35.0218375, 0,                 !- X,Y,Z Vertex 1 {m}
+  25.4508, 29.8402375, 0,                 !- X,Y,Z Vertex 2 {m}
+  18.288, 29.8402375, 0,                  !- X,Y,Z Vertex 3 {m}
+  18.288, 35.0218375, 0;                  !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {9e30faaf-45f4-4374-8f8e-c4b6aac77a16}, !- Handle
-  Surface 517,                            !- Name
+  EnclosedOffice_Bot_ZN_3 - Floor_a,      !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {23bb7aaa-6a7c-4d7a-826f-f4ffe1c733a5}, !- Space Name
@@ -6919,14 +6768,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  35.3568, 35.0218375, -4.78266315440123e-015, !- X,Y,Z Vertex 1 {m}
-  35.3568, 29.8402375, -9.9262820185684e-016, !- X,Y,Z Vertex 2 {m}
-  30.4038, 29.8402375, 2.01232808194618e-014, !- X,Y,Z Vertex 3 {m}
-  30.4038, 35.0218375, 1.63332458669174e-014; !- X,Y,Z Vertex 4 {m}
+  35.3568, 35.0218375, 0,                 !- X,Y,Z Vertex 1 {m}
+  35.3568, 29.8402375, 0,                 !- X,Y,Z Vertex 2 {m}
+  30.4038, 29.8402375, 0,                 !- X,Y,Z Vertex 3 {m}
+  30.4038, 35.0218375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {940d66e5-c9c0-4e90-a0cc-3439cb91f21a}, !- Handle
-  Surface 518,                            !- Name
+  Restroom_Bot_ZN - Floor_c,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {4a85c567-10e4-432d-b882-9dbda5ffac8e}, !- Space Name
@@ -6936,14 +6785,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  35.3568, 29.8402375, 7.21911419532426e-016, !- X,Y,Z Vertex 1 {m}
-  35.3568, 27.7066375, 2.23792540055004e-014, !- X,Y,Z Vertex 2 {m}
-  30.4038, 27.7066375, 4.54804194305328e-014, !- X,Y,Z Vertex 3 {m}
-  30.4038, 29.8402375, 2.38230768445647e-014; !- X,Y,Z Vertex 4 {m}
+  35.3568, 29.8402375, 0,                 !- X,Y,Z Vertex 1 {m}
+  35.3568, 27.7066375, 0,                 !- X,Y,Z Vertex 2 {m}
+  30.4038, 27.7066375, 0,                 !- X,Y,Z Vertex 3 {m}
+  30.4038, 29.8402375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {3d4d9943-3783-4f62-9403-d0e4a9828f9e}, !- Handle
-  Surface 519,                            !- Name
+  Restroom_Bot_ZN - Floor_a,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {4a85c567-10e4-432d-b882-9dbda5ffac8e}, !- Space Name
@@ -6953,14 +6802,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  30.4038, 29.8402375, 2.38230768445648e-014, !- X,Y,Z Vertex 1 {m}
-  30.4038, 27.7066375, 4.54804194305328e-014, !- X,Y,Z Vertex 2 {m}
-  25.4508, 27.7066375, 2.23792540055002e-014, !- X,Y,Z Vertex 3 {m}
-  25.4508, 29.8402375, 7.21911419532221e-016; !- X,Y,Z Vertex 4 {m}
+  30.4038, 29.8402375, 0,                 !- X,Y,Z Vertex 1 {m}
+  30.4038, 27.7066375, 0,                 !- X,Y,Z Vertex 2 {m}
+  25.4508, 27.7066375, 0,                 !- X,Y,Z Vertex 3 {m}
+  25.4508, 29.8402375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {e68a1a9c-e4bc-440c-baba-c7433c43dbe0}, !- Handle
-  Surface 520,                            !- Name
+  EnclosedOffice_Bot_ZN_1 - Wall 000_b,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {a3536544-5466-431f-a4f6-b70e1e3388af}, !- Space Name
@@ -6970,14 +6819,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  22.7076, 18.8674375, 2.74478749999999,  !- X,Y,Z Vertex 1 {m}
+  22.7076, 18.8674375, 2.7447875,         !- X,Y,Z Vertex 1 {m}
   22.7076, 18.8674375, 0,                 !- X,Y,Z Vertex 2 {m}
   18.288, 18.8674375, 0,                  !- X,Y,Z Vertex 3 {m}
   18.288, 18.8674375, 2.7447875;          !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {51d8bd72-c274-469f-be49-90adc118e12e}, !- Handle
-  Surface 521,                            !- Name
+  EnclosedOffice_Bot_ZN_1 - Wall 000_c,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {a3536544-5466-431f-a4f6-b70e1e3388af}, !- Space Name
@@ -6990,11 +6839,11 @@ OS:Surface,
   35.3568, 18.8674375, 2.7447875,         !- X,Y,Z Vertex 1 {m}
   35.3568, 18.8674375, 0,                 !- X,Y,Z Vertex 2 {m}
   25.4508, 18.8674375, 0,                 !- X,Y,Z Vertex 3 {m}
-  25.4508, 18.8674375, 2.74478749999999;  !- X,Y,Z Vertex 4 {m}
+  25.4508, 18.8674375, 2.7447875;         !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {161c1246-4f7b-40fd-bfaa-d265ec569e0c}, !- Handle
-  Surface 522,                            !- Name
+  Datacenter_Bot_ZN - Wall 090_c,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {93b905ad-f145-4ef5-b9be-878caa8e553d}, !- Space Name
@@ -7005,13 +6854,13 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   18.288, 29.8402375, 2.7447875,          !- X,Y,Z Vertex 1 {m}
-  18.288, 29.8402375, 2.88764567812905e-015, !- X,Y,Z Vertex 2 {m}
+  18.288, 29.8402375, 0,                  !- X,Y,Z Vertex 2 {m}
   18.288, 35.0218375, 0,                  !- X,Y,Z Vertex 3 {m}
   18.288, 35.0218375, 2.7447875;          !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {ff56e4fb-fd50-4085-962d-fe4ddeb2dfdf}, !- Handle
-  Surface 523,                            !- Name
+  Datacenter_Bot_ZN - Floor_d,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {93b905ad-f145-4ef5-b9be-878caa8e553d}, !- Space Name
@@ -7021,14 +6870,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  18.288, 35.0218375, 8.12150346973795e-016, !- X,Y,Z Vertex 1 {m}
-  18.288, 29.8402375, 2.07549533115526e-015, !- X,Y,Z Vertex 2 {m}
-  17.6037875, 29.8402375, 2.10256700938773e-014, !- X,Y,Z Vertex 3 {m}
-  17.6037875, 35.0218375, 1.97623251096958e-014; !- X,Y,Z Vertex 4 {m}
+  18.288, 35.0218375, 0,                  !- X,Y,Z Vertex 1 {m}
+  18.288, 29.8402375, 0,                  !- X,Y,Z Vertex 2 {m}
+  17.6037875, 29.8402375, 0,              !- X,Y,Z Vertex 3 {m}
+  17.6037875, 35.0218375, 0;              !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {044b389f-c22e-452b-906e-d966a65c9c26}, !- Handle
-  Surface 524,                            !- Name
+  Datacenter_Bot_ZN - Floor_a,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {93b905ad-f145-4ef5-b9be-878caa8e553d}, !- Space Name
@@ -7038,14 +6887,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  18.288, 18.8674375, -3.29372085161594e-015, !- X,Y,Z Vertex 1 {m}
-  18.288, 13.6858375, 4.06075173486897e-016, !- X,Y,Z Vertex 2 {m}
-  17.6037875, 13.6858375, 1.85440995892351e-014, !- X,Y,Z Vertex 3 {m}
-  17.6037875, 18.8674375, 1.48443035641322e-014; !- X,Y,Z Vertex 4 {m}
+  18.288, 18.8674375, 0,                  !- X,Y,Z Vertex 1 {m}
+  18.288, 13.6858375, 0,                  !- X,Y,Z Vertex 2 {m}
+  17.6037875, 13.6858375, 0,              !- X,Y,Z Vertex 3 {m}
+  17.6037875, 18.8674375, 0;              !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {0c701422-f7fd-4435-ab4a-1aa0f281129d}, !- Handle
-  Surface 525,                            !- Name
+  Datacenter_Bot_ZN - Wall 090_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {93b905ad-f145-4ef5-b9be-878caa8e553d}, !- Space Name
@@ -7056,13 +6905,13 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   18.288, 18.8674375, 2.7447875,          !- X,Y,Z Vertex 1 {m}
-  18.288, 18.8674375, -2.88764567812913e-015, !- X,Y,Z Vertex 2 {m}
-  18.288, 29.8402375, 2.88764567812905e-015, !- X,Y,Z Vertex 3 {m}
+  18.288, 18.8674375, 0,                  !- X,Y,Z Vertex 2 {m}
+  18.288, 29.8402375, 0,                  !- X,Y,Z Vertex 3 {m}
   18.288, 29.8402375, 2.7447875;          !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {4a04c2ea-ee1f-4d41-b49b-045987d7a198}, !- Handle
-  Surface 526,                            !- Name
+  Datacenter_Bot_ZN - Floor_c,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {93b905ad-f145-4ef5-b9be-878caa8e553d}, !- Space Name
@@ -7072,31 +6921,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  17.6037875, 35.0218375, 2.01684002831827e-014, !- X,Y,Z Vertex 1 {m}
-  17.6037875, 13.6858375, 1.93562499362088e-014, !- X,Y,Z Vertex 2 {m}
-  16.58112, 13.6858375, -4.06075173486938e-016, !- X,Y,Z Vertex 3 {m}
-  16.58112, 35.0218375, 4.06075173486938e-016; !- X,Y,Z Vertex 4 {m}
+  17.6037875, 35.0218375, 0,              !- X,Y,Z Vertex 1 {m}
+  17.6037875, 13.6858375, 0,              !- X,Y,Z Vertex 2 {m}
+  16.58112, 13.6858375, 0,                !- X,Y,Z Vertex 3 {m}
+  16.58112, 35.0218375, 0;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {7b16efcd-c507-4dbc-96ac-212ca8fdef97}, !- Handle
-  Surface 527,                            !- Name
-  Floor,                                  !- Surface Type
-  ,                                       !- Construction Name
-  {41f9980d-cfc2-465a-805c-33077dfeb050}, !- Space Name
-  Surface,                                !- Outside Boundary Condition
-  {013e6080-210b-4cfd-9c5b-7ffc9329639d}, !- Outside Boundary Condition Object
-  NoSun,                                  !- Sun Exposure
-  NoWind,                                 !- Wind Exposure
-  ,                                       !- View Factor to Ground
-  ,                                       !- Number of Vertices
-  30.4038, 35.0708215764634, 3.46517481375486e-014, !- X,Y,Z Vertex 1 {m}
-  30.4038, 35.0218375, 3.46517481375486e-014, !- X,Y,Z Vertex 2 {m}
-  25.4508, 35.0218375, 3.46517481375486e-014, !- X,Y,Z Vertex 3 {m}
-  25.4508, 35.0708215764634, 3.46517481375486e-014; !- X,Y,Z Vertex 4 {m}
-
-OS:Surface,
-  {dc86a268-a30b-45e0-9537-cb72203cad5a}, !- Handle
-  Surface 528,                            !- Name
+  Corridor_Bot_ZN_1 - Floor_b,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {41f9980d-cfc2-465a-805c-33077dfeb050}, !- Space Name
@@ -7106,31 +6938,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  30.4038, 36.5458375, 3.46517481375486e-014, !- X,Y,Z Vertex 1 {m}
-  30.4038, 35.0708215764634, 3.46517481375486e-014, !- X,Y,Z Vertex 2 {m}
-  25.4508, 35.0708215764634, 3.46517481375486e-014, !- X,Y,Z Vertex 3 {m}
-  25.4508, 36.5458375, 3.46517481375486e-014; !- X,Y,Z Vertex 4 {m}
-
-OS:Surface,
-  {b39c2408-48c2-4cb3-837a-85da1e7dac85}, !- Handle
-  Surface 529,                            !- Name
-  Floor,                                  !- Surface Type
-  ,                                       !- Construction Name
-  {41f9980d-cfc2-465a-805c-33077dfeb050}, !- Space Name
-  Surface,                                !- Outside Boundary Condition
-  {c2c3dc8c-b7ae-4202-928d-9a688f00f117}, !- Outside Boundary Condition Object
-  NoSun,                                  !- Sun Exposure
-  NoWind,                                 !- Wind Exposure
-  ,                                       !- View Factor to Ground
-  ,                                       !- Number of Vertices
-  35.3568, 35.0708215764634, -4.10359132008729e-029, !- X,Y,Z Vertex 1 {m}
-  35.3568, 35.0218375, -4.10359132008729e-029, !- X,Y,Z Vertex 2 {m}
-  30.4038, 35.0218375, 3.46517481375486e-014, !- X,Y,Z Vertex 3 {m}
-  30.4038, 35.0708215764634, 3.46517481375486e-014; !- X,Y,Z Vertex 4 {m}
+  30.4038, 36.5458375, 0,                 !- X,Y,Z Vertex 1 {m}
+  30.4038, 35.0218375, 0,                 !- X,Y,Z Vertex 2 {m}
+  25.4508, 35.0218375, 0,                 !- X,Y,Z Vertex 3 {m}
+  25.4508, 36.5458375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {c87ffdf8-50bd-4a7c-82bd-ea96983deb0f}, !- Handle
-  Surface 530,                            !- Name
+  Corridor_Bot_ZN_1 - Floor_c,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {41f9980d-cfc2-465a-805c-33077dfeb050}, !- Space Name
@@ -7140,21 +6955,21 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  16.0797875, 36.5458375, 2.31011654250324e-014, !- X,Y,Z Vertex 1 {m}
-  16.0797875, 12.1618375, 2.31011654250324e-014, !- X,Y,Z Vertex 2 {m}
+  16.0797875, 36.5458375, 0,              !- X,Y,Z Vertex 1 {m}
+  16.0797875, 12.1618375, 0,              !- X,Y,Z Vertex 2 {m}
   15.05712, 12.1618375, 0,                !- X,Y,Z Vertex 3 {m}
   15.05712, 36.5458375, 0;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {6f368ef3-25e3-488f-9074-552a5e205dec}, !- Handle
-  Surface 531,                            !- Name
+  Corridor_Bot_ZN_1 - Wall 180_c,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {41f9980d-cfc2-465a-805c-33077dfeb050}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {629c4fc1-92d2-4230-aba3-6c2d402832a0}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   18.288, 35.0218375, 2.7447875,          !- X,Y,Z Vertex 1 {m}
@@ -7164,45 +6979,7 @@ OS:Surface,
 
 OS:Surface,
   {75470229-c6fb-4f6a-8ece-45e3c32d2385}, !- Handle
-  Surface 532,                            !- Name
-  Floor,                                  !- Surface Type
-  ,                                       !- Construction Name
-  {41f9980d-cfc2-465a-805c-33077dfeb050}, !- Space Name
-  Surface,                                !- Outside Boundary Condition
-  {1f8ce1b3-e3a8-41dc-afe6-814580993bab}, !- Outside Boundary Condition Object
-  NoSun,                                  !- Sun Exposure
-  NoWind,                                 !- Wind Exposure
-  ,                                       !- View Factor to Ground
-  ,                                       !- Number of Vertices
-  25.4508, 35.0708215764634, 3.46517481375486e-014, !- X,Y,Z Vertex 1 {m}
-  25.4508, 35.0218375, 3.46517481375486e-014, !- X,Y,Z Vertex 2 {m}
-  18.288, 35.0218375, -1.02589783002182e-029, !- X,Y,Z Vertex 3 {m}
-  18.288, 35.0708215764634, -1.02589783002182e-029; !- X,Y,Z Vertex 4 {m}
-
-OS:Surface,
-  {fb6916a0-6507-46ca-8f8e-ff04b10a7098}, !- Handle
-  Surface 533,                            !- Name
-  Floor,                                  !- Surface Type
-  ,                                       !- Construction Name
-  {41f9980d-cfc2-465a-805c-33077dfeb050}, !- Space Name
-  Surface,                                !- Outside Boundary Condition
-  {f69b0c19-0b5b-410f-ac8d-0b351edfd5b9}, !- Outside Boundary Condition Object
-  NoSun,                                  !- Sun Exposure
-  NoWind,                                 !- Wind Exposure
-  ,                                       !- View Factor to Ground
-  ,                                       !- Number of Vertices
-  17.6037875, 36.5458375, 1.22936707544579e-014, !- X,Y,Z Vertex 1 {m}
-  17.6037875, 35.0218375, 1.22071687438271e-014, !- X,Y,Z Vertex 2 {m}
-  16.58112, 35.0218375, 1.28496146002837e-014, !- X,Y,Z Vertex 3 {m}
-  16.58112, 13.6858375, 1.16385864514523e-014, !- X,Y,Z Vertex 4 {m}
-  35.3568, 13.6858375, -1.56408322660373e-016, !- X,Y,Z Vertex 5 {m}
-  35.3568, 12.1618375, -2.42910333291188e-016, !- X,Y,Z Vertex 6 {m}
-  16.0797875, 12.1618375, 1.18670245238221e-014, !- X,Y,Z Vertex 7 {m}
-  16.0797875, 36.5458375, 1.32510566939151e-014; !- X,Y,Z Vertex 8 {m}
-
-OS:Surface,
-  {32eafc25-47b9-4160-8513-7096696e10fe}, !- Handle
-  Surface 534,                            !- Name
+  Corridor_Bot_ZN_1 - Floor_d,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {41f9980d-cfc2-465a-805c-33077dfeb050}, !- Space Name
@@ -7212,16 +6989,35 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  25.4508, 36.5458375, 3.7352813179821e-014, !- X,Y,Z Vertex 1 {m}
-  25.4508, 35.0708215764634, 3.07870992203096e-014, !- X,Y,Z Vertex 2 {m}
-  18.288, 35.0708215764634, 6.7814051040026e-015, !- X,Y,Z Vertex 3 {m}
-  18.288, 35.0218375, 6.56336309544012e-015, !- X,Y,Z Vertex 4 {m}
-  17.6037875, 35.0218375, 4.2702659845961e-015, !- X,Y,Z Vertex 5 {m}
-  17.6037875, 36.5458375, 1.10540219526699e-014; !- X,Y,Z Vertex 6 {m}
+  25.4508, 36.5458375, 0,                 !- X,Y,Z Vertex 1 {m}
+  25.4508, 35.0218375, 0,                 !- X,Y,Z Vertex 2 {m}
+  17.6037875, 35.0218375, 0,              !- X,Y,Z Vertex 3 {m}
+  17.6037875, 36.5458375, 0;              !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {fb6916a0-6507-46ca-8f8e-ff04b10a7098}, !- Handle
+  Corridor_Bot_ZN_1 - Floor_e,            !- Name
+  Floor,                                  !- Surface Type
+  ,                                       !- Construction Name
+  {41f9980d-cfc2-465a-805c-33077dfeb050}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {f69b0c19-0b5b-410f-ac8d-0b351edfd5b9}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  17.6037875, 36.5458375, 0,              !- X,Y,Z Vertex 1 {m}
+  17.6037875, 35.0218375, 0,              !- X,Y,Z Vertex 2 {m}
+  16.58112, 35.0218375, 0,                !- X,Y,Z Vertex 3 {m}
+  16.58112, 13.6858375, 0,                !- X,Y,Z Vertex 4 {m}
+  35.3568, 13.6858375, 0,                 !- X,Y,Z Vertex 5 {m}
+  35.3568, 12.1618375, 0,                 !- X,Y,Z Vertex 6 {m}
+  16.0797875, 12.1618375, 0,              !- X,Y,Z Vertex 7 {m}
+  16.0797875, 36.5458375, 0;              !- X,Y,Z Vertex 8 {m}
 
 OS:Surface,
   {d5f1200f-c9f3-42e2-af41-03345addbc35}, !- Handle
-  Surface 535,                            !- Name
+  Corridor_Bot_ZN_1 - Wall 000_c,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {41f9980d-cfc2-465a-805c-33077dfeb050}, !- Space Name
@@ -7237,25 +7033,8 @@ OS:Surface,
   18.288, 13.6858375, 2.7447875;          !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
-  {9dbfea4c-071b-4cfe-a401-c1ca2384b360}, !- Handle
-  Surface 536,                            !- Name
-  RoofCeiling,                            !- Surface Type
-  ,                                       !- Construction Name
-  {41f9980d-cfc2-465a-805c-33077dfeb050}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
-  ,                                       !- View Factor to Ground
-  ,                                       !- Number of Vertices
-  35.3568, 35.0218375, 2.7447875,         !- X,Y,Z Vertex 1 {m}
-  35.3568, 35.0708215764634, 2.7447875,   !- X,Y,Z Vertex 2 {m}
-  18.288, 35.0708215764634, 2.7447875,    !- X,Y,Z Vertex 3 {m}
-  18.288, 35.0218375, 2.7447875;          !- X,Y,Z Vertex 4 {m}
-
-OS:Surface,
   {64227c49-25d2-4f12-9937-c9965bd0eed0}, !- Handle
-  Surface 537,                            !- Name
+  Atrium_Bot_ZN - Wall 090_b,             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e2cafd7f-5375-46c2-b573-96b1926c6b48}, !- Space Name
@@ -7265,14 +7044,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  56.388, -4.02497475175289e-017, 2.7447875, !- X,Y,Z Vertex 1 {m}
-  56.388, -6.767919558115e-017, 0,        !- X,Y,Z Vertex 2 {m}
+  56.388, 0, 2.7447875,                   !- X,Y,Z Vertex 1 {m}
+  56.388, 0, 0,                           !- X,Y,Z Vertex 2 {m}
   56.388, 5.4864, 0,                      !- X,Y,Z Vertex 3 {m}
   56.388, 5.4864, 2.7447875;              !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {d20033a3-c120-4f3c-b46d-c411b963c80d}, !- Handle
-  Surface 538,                            !- Name
+  Atrium_Bot_ZN - Floor_b,                !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {e2cafd7f-5375-46c2-b573-96b1926c6b48}, !- Space Name
@@ -7282,14 +7061,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.0416275, 12.1618375, 2.31011654250324e-014, !- X,Y,Z Vertex 1 {m}
-  46.0416275, -3.41920936008933e-016, 2.31011654250324e-014, !- X,Y,Z Vertex 2 {m}
-  41.7576, -6.767919558115e-017, 0,       !- X,Y,Z Vertex 3 {m}
+  46.0416275, 12.1618375, 0,              !- X,Y,Z Vertex 1 {m}
+  46.0416275, 0, 0,                       !- X,Y,Z Vertex 2 {m}
+  41.7576, 0, 0,                          !- X,Y,Z Vertex 3 {m}
   41.7576, 12.1618375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {f0a56a2c-b1be-41ad-a534-12d8458e8dee}, !- Handle
-  Surface 539,                            !- Name
+  Lobby_Bot_ZN_1 - Wall 000_b,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {cbbf96a5-285c-4279-ba97-ba3b559ba2f2}, !- Space Name
@@ -7306,7 +7085,7 @@ OS:Surface,
 
 OS:Surface,
   {7d8116e5-9135-4838-8524-2c75c1efe556}, !- Handle
-  Surface 540,                            !- Name
+  Lobby_Bot_ZN_1 - Wall 000_c,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {cbbf96a5-285c-4279-ba97-ba3b559ba2f2}, !- Space Name
@@ -7319,11 +7098,11 @@ OS:Surface,
   41.7576, 12.1618375, 2.7447875,         !- X,Y,Z Vertex 1 {m}
   41.7576, 12.1618375, 0,                 !- X,Y,Z Vertex 2 {m}
   37.7952, 12.1618375, 0,                 !- X,Y,Z Vertex 3 {m}
-  37.7952, 12.1618375, 2.74478749999999;  !- X,Y,Z Vertex 4 {m}
+  37.7952, 12.1618375, 2.7447875;         !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {e2dc74e3-f12e-47f7-85bb-fd5538679a03}, !- Handle
-  Surface 541,                            !- Name
+  Lobby_Bot_ZN_1 - Floor_b,               !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {cbbf96a5-285c-4279-ba97-ba3b559ba2f2}, !- Space Name
@@ -7333,14 +7112,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  41.7576, 12.1618375, -5.12948915010911e-030, !- X,Y,Z Vertex 1 {m}
-  41.7576, -2.9262734999161e-017, -5.12933537422178e-030, !- X,Y,Z Vertex 2 {m}
-  16.0797875, -3.41920936008933e-016, 2.31011654250324e-014, !- X,Y,Z Vertex 3 {m}
-  16.0797875, 12.1618375, 2.31011654250324e-014; !- X,Y,Z Vertex 4 {m}
+  41.7576, 12.1618375, 0,                 !- X,Y,Z Vertex 1 {m}
+  41.7576, 0, 0,                          !- X,Y,Z Vertex 2 {m}
+  16.0797875, 0, 0,                       !- X,Y,Z Vertex 3 {m}
+  16.0797875, 12.1618375, 0;              !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {f3cf21c1-4114-4381-80a5-a3d0b47a8a7f}, !- Handle
-  Surface 542,                            !- Name
+  DataCenter_Basement_ZN - Wall 090_b,    !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f6009d98-ae01-49dd-bf1f-f8d89b2e9054}, !- Space Name
@@ -7350,14 +7129,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  16.0797875, 36.5458375, 2.15438017232475e-014, !- X,Y,Z Vertex 1 {m}
+  16.0797875, 36.5458375, 0,              !- X,Y,Z Vertex 1 {m}
   16.0797875, 36.5458375, -2.4384,        !- X,Y,Z Vertex 2 {m}
   16.0797875, 48.7378375, -2.4384,        !- X,Y,Z Vertex 3 {m}
-  16.0797875, 48.7378375, 2.25840720084241e-014; !- X,Y,Z Vertex 4 {m}
+  16.0797875, 48.7378375, 0;              !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {0e5ca4dc-6773-4163-bfb5-1f8b0dccc1ea}, !- Handle
-  Surface 543,                            !- Name
+  DataCenter_Basement_ZN - RoofCeiling_d, !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {f6009d98-ae01-49dd-bf1f-f8d89b2e9054}, !- Space Name
@@ -7367,14 +7146,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  6.096, 36.5458375, -2.22276265809735e-015, !- X,Y,Z Vertex 1 {m}
-  6.096, 48.7378375, 2.22276265809735e-015, !- X,Y,Z Vertex 2 {m}
-  -5.36455739002954e-030, 48.7378375, 2.13954961835433e-014, !- X,Y,Z Vertex 3 {m}
-  4.11145102784516e-029, 36.5458375, 1.69499708673486e-014; !- X,Y,Z Vertex 4 {m}
+  6.096, 36.5458375, 0,                   !- X,Y,Z Vertex 1 {m}
+  6.096, 48.7378375, 0,                   !- X,Y,Z Vertex 2 {m}
+  0, 48.7378375, 0,                       !- X,Y,Z Vertex 3 {m}
+  0, 36.5458375, 0;                       !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {af34c54d-b3b9-41c7-bd8c-ebabfad9aae9}, !- Handle
-  Surface 544,                            !- Name
+  DataCenter_Basement_ZN - Wall 090_c,    !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f6009d98-ae01-49dd-bf1f-f8d89b2e9054}, !- Space Name
@@ -7384,14 +7163,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  16.0797875, 0, 2.31011654250324e-014,   !- X,Y,Z Vertex 1 {m}
+  16.0797875, 0, 0,                       !- X,Y,Z Vertex 1 {m}
   16.0797875, 0, -2.4384,                 !- X,Y,Z Vertex 2 {m}
   16.0797875, 12.1618375, -2.4384,        !- X,Y,Z Vertex 3 {m}
-  16.0797875, 12.1618375, 2.31011654250324e-014; !- X,Y,Z Vertex 4 {m}
+  16.0797875, 12.1618375, 0;              !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {be11670f-745f-4849-91b3-c89338709660}, !- Handle
-  Surface 545,                            !- Name
+  DataCenter_Basement_ZN - RoofCeiling_e, !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {f6009d98-ae01-49dd-bf1f-f8d89b2e9054}, !- Space Name
@@ -7401,14 +7180,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  6.096, 32.8882375, -6.46754515495985e-015, !- X,Y,Z Vertex 1 {m}
-  6.096, 36.5458375, 8.96058949665787e-016, !- X,Y,Z Vertex 2 {m}
-  3.27513876851032e-029, 36.5458375, 1.38311492595854e-014, !- X,Y,Z Vertex 3 {m}
-  8.59304925884491e-030, 32.8882375, 6.46754515495976e-015; !- X,Y,Z Vertex 4 {m}
+  6.096, 32.8882375, 0,                   !- X,Y,Z Vertex 1 {m}
+  6.096, 36.5458375, 0,                   !- X,Y,Z Vertex 2 {m}
+  0, 36.5458375, 0,                       !- X,Y,Z Vertex 3 {m}
+  0, 32.8882375, 0;                       !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {433fafff-bc42-4fb6-9c3e-1d9f4b9099dc}, !- Handle
-  Surface 546,                            !- Name
+  DataCenter_Basement_ZN - RoofCeiling_c, !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {f6009d98-ae01-49dd-bf1f-f8d89b2e9054}, !- Space Name
@@ -7418,16 +7197,16 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  15.05712, 4.16109570947537e-030, 1.03165953828542e-014, !- X,Y,Z Vertex 1 {m}
-  15.05712, 36.5458375, -1.04648340766328e-014, !- X,Y,Z Vertex 2 {m}
-  6.096, 36.5458375, -2.96588533783878e-015, !- X,Y,Z Vertex 3 {m}
-  6.096, 32.8882375, -8.86027231124994e-016, !- X,Y,Z Vertex 4 {m}
-  4.89230335753552e-030, 32.8882375, 4.215298441524e-015, !- X,Y,Z Vertex 5 {m}
-  -1.54224414768113e-031, -1.04797889768289e-031, 2.29168697942972e-014; !- X,Y,Z Vertex 6 {m}
+  15.05712, 0, 0,                         !- X,Y,Z Vertex 1 {m}
+  15.05712, 36.5458375, 0,                !- X,Y,Z Vertex 2 {m}
+  6.096, 36.5458375, 0,                   !- X,Y,Z Vertex 3 {m}
+  6.096, 32.8882375, 0,                   !- X,Y,Z Vertex 4 {m}
+  0, 32.8882375, 0,                       !- X,Y,Z Vertex 5 {m}
+  0, 0, 0;                                !- X,Y,Z Vertex 6 {m}
 
 OS:Surface,
   {9c709342-8672-4192-a47e-2c5257e1d0e7}, !- Handle
-  Surface 547,                            !- Name
+  DataCenter_Basement_ZN - RoofCeiling_a, !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {f6009d98-ae01-49dd-bf1f-f8d89b2e9054}, !- Space Name
@@ -7437,14 +7216,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  16.0797875, 3.12880827232874e-031, 2.44805141441154e-014, !- X,Y,Z Vertex 1 {m}
-  16.0797875, 12.1618375, 2.17218167059494e-014, !- X,Y,Z Vertex 2 {m}
-  15.05712, 12.1618375, 6.32745549177974e-015, !- X,Y,Z Vertex 3 {m}
-  15.05712, 3.9328889594635e-030, 9.08615292994571e-015; !- X,Y,Z Vertex 4 {m}
+  16.0797875, 0, 0,                       !- X,Y,Z Vertex 1 {m}
+  16.0797875, 12.1618375, 0,              !- X,Y,Z Vertex 2 {m}
+  15.05712, 12.1618375, 0,                !- X,Y,Z Vertex 3 {m}
+  15.05712, 0, 0;                         !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {5b0e4b3a-b13c-4210-9bde-91f54d9f84cc}, !- Handle
-  Surface 548,                            !- Name
+  DataCenter_Basement_ZN - RoofCeiling_f, !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {f6009d98-ae01-49dd-bf1f-f8d89b2e9054}, !- Space Name
@@ -7454,14 +7233,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  16.0797875, 12.1618375, 2.64282403638538e-014, !- X,Y,Z Vertex 1 {m}
-  16.0797875, 36.5458375, 1.8216726784426e-014, !- X,Y,Z Vertex 2 {m}
-  15.05712, 36.5458375, -6.59048174555262e-015, !- X,Y,Z Vertex 3 {m}
-  15.05712, 12.1618375, 1.62103183387526e-015; !- X,Y,Z Vertex 4 {m}
+  16.0797875, 12.1618375, 0,              !- X,Y,Z Vertex 1 {m}
+  16.0797875, 36.5458375, 0,              !- X,Y,Z Vertex 2 {m}
+  15.05712, 36.5458375, 0,                !- X,Y,Z Vertex 3 {m}
+  15.05712, 12.1618375, 0;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {8ee13eed-4448-419f-96f8-e03b9e840dfb}, !- Handle
-  Surface 549,                            !- Name
+  OpenOffice_Basement_ZN_2 - RoofCeiling_c, !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {316fddf4-8cea-4c27-b604-515fad8156a5}, !- Space Name
@@ -7471,14 +7250,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  73.10755, 42.6418375, -9.13889450226961e-015, !- X,Y,Z Vertex 1 {m}
-  73.10755, 48.7378375, 1.10642266182293e-014, !- X,Y,Z Vertex 2 {m}
-  56.388, 48.7378375, -1.09947849435966e-014, !- X,Y,Z Vertex 3 {m}
-  56.388, 42.6418375, -3.11979060640955e-014; !- X,Y,Z Vertex 4 {m}
+  73.10755, 42.6418375, 0,                !- X,Y,Z Vertex 1 {m}
+  73.10755, 48.7378375, 0,                !- X,Y,Z Vertex 2 {m}
+  56.388, 48.7378375, 0,                  !- X,Y,Z Vertex 3 {m}
+  56.388, 42.6418375, 0;                  !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {d8327dcf-8d73-4418-8c3f-4ab4ce0796e9}, !- Handle
-  Surface 550,                            !- Name
+  OpenOffice_Basement_ZN_2 - RoofCeiling_d, !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {316fddf4-8cea-4c27-b604-515fad8156a5}, !- Space Name
@@ -7488,16 +7267,16 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  56.388, 36.5458375, -1.80670643316878e-014, !- X,Y,Z Vertex 1 {m}
-  56.388, 42.6418375, -2.2289477209099e-014, !- X,Y,Z Vertex 2 {m}
-  49.77384, 42.6418375, -1.67369919616982e-014, !- X,Y,Z Vertex 3 {m}
-  49.77384, 48.7378375, -2.09594048391094e-014, !- X,Y,Z Vertex 4 {m}
-  16.0797875, 48.7378375, 7.32623225334068e-015, !- X,Y,Z Vertex 5 {m}
-  16.0797875, 36.5458375, 1.57710580081631e-014; !- X,Y,Z Vertex 6 {m}
+  56.388, 36.5458375, 0,                  !- X,Y,Z Vertex 1 {m}
+  56.388, 42.6418375, 0,                  !- X,Y,Z Vertex 2 {m}
+  49.77384, 42.6418375, 0,                !- X,Y,Z Vertex 3 {m}
+  49.77384, 48.7378375, 0,                !- X,Y,Z Vertex 4 {m}
+  16.0797875, 48.7378375, 0,              !- X,Y,Z Vertex 5 {m}
+  16.0797875, 36.5458375, 0;              !- X,Y,Z Vertex 6 {m}
 
 OS:Surface,
   {17a16b54-2216-4b7f-81e1-de6c4cfebd79}, !- Handle
-  Surface 551,                            !- Name
+  OpenOffice_Basement_ZN_2 - Wall 180_b,  !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {316fddf4-8cea-4c27-b604-515fad8156a5}, !- Space Name
@@ -7507,14 +7286,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  54.864, 36.5458375, 3.60955709766105e-016, !- X,Y,Z Vertex 1 {m}
-  54.864, 36.5458375, -2.43840000000002,  !- X,Y,Z Vertex 2 {m}
-  73.10755, 36.5458375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  73.10755, 36.5458375, 1.15505827125162e-014; !- X,Y,Z Vertex 4 {m}
+  54.864, 36.5458375, 0,                  !- X,Y,Z Vertex 1 {m}
+  54.864, 36.5458375, -2.4384,            !- X,Y,Z Vertex 2 {m}
+  73.10755, 36.5458375, -2.4384,          !- X,Y,Z Vertex 3 {m}
+  73.10755, 36.5458375, 0;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {8703efe1-007f-4967-aadd-d142fe810286}, !- Handle
-  Surface 552,                            !- Name
+  OpenOffice_Basement_ZN_2 - Wall 180_f,  !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {316fddf4-8cea-4c27-b604-515fad8156a5}, !- Space Name
@@ -7524,14 +7303,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  54.864, 36.5458375, 3.60955709766105e-016, !- X,Y,Z Vertex 1 {m}
-  37.7952, 36.5458375, 0,                 !- X,Y,Z Vertex 2 {m}
-  37.7952, 36.5458375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  54.864, 36.5458375, -2.43840000000002;  !- X,Y,Z Vertex 4 {m}
+  37.7952, 36.5458375, 0,                 !- X,Y,Z Vertex 1 {m}
+  37.7952, 36.5458375, -2.4384,           !- X,Y,Z Vertex 2 {m}
+  54.864, 36.5458375, -2.4384,            !- X,Y,Z Vertex 3 {m}
+  54.864, 36.5458375, 0;                  !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {f3c180ce-c722-4821-bb3d-0a07409bc7ab}, !- Handle
-  Surface 553,                            !- Name
+  OpenOffice_Basement_ZN_2 - Wall 180_g,  !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {316fddf4-8cea-4c27-b604-515fad8156a5}, !- Space Name
@@ -7541,14 +7320,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  37.7952, 36.5458375, 0,                 !- X,Y,Z Vertex 1 {m}
-  35.3568, 36.5458375, -2.31011654250324e-014, !- X,Y,Z Vertex 2 {m}
-  35.3568, 36.5458375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  37.7952, 36.5458375, -2.43840000000002; !- X,Y,Z Vertex 4 {m}
+  35.3568, 36.5458375, -0,                !- X,Y,Z Vertex 1 {m}
+  35.3568, 36.5458375, -2.4384,           !- X,Y,Z Vertex 2 {m}
+  37.7952, 36.5458375, -2.4384,           !- X,Y,Z Vertex 3 {m}
+  37.7952, 36.5458375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {cd5a4f57-e562-4356-8da7-16c6942c504c}, !- Handle
-  Surface 554,                            !- Name
+  OpenOffice_Basement_ZN_2 - RoofCeiling_b, !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {316fddf4-8cea-4c27-b604-515fad8156a5}, !- Space Name
@@ -7558,14 +7337,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  52.1208, 42.6418375, -2.11995680799857e-014, !- X,Y,Z Vertex 1 {m}
-  52.1208, 48.7378375, -2.50027627700792e-014, !- X,Y,Z Vertex 2 {m}
-  49.77384, 48.7378375, -2.07616038144255e-014, !- X,Y,Z Vertex 3 {m}
-  49.77384, 42.6418375, -1.69584091243321e-014; !- X,Y,Z Vertex 4 {m}
+  52.1208, 42.6418375, 0,                 !- X,Y,Z Vertex 1 {m}
+  52.1208, 48.7378375, 0,                 !- X,Y,Z Vertex 2 {m}
+  49.77384, 48.7378375, 0,                !- X,Y,Z Vertex 3 {m}
+  49.77384, 42.6418375, 0;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {fe00b1e7-5b7b-41ed-aeae-88b0fde0666b}, !- Handle
-  Surface 555,                            !- Name
+  OpenOffice_Basement_ZN_2 - RoofCeiling_e, !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {316fddf4-8cea-4c27-b604-515fad8156a5}, !- Space Name
@@ -7575,14 +7354,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  56.388, 42.6418375, -2.50535555864916e-014, !- X,Y,Z Vertex 1 {m}
-  56.388, 48.7378375, -1.71391354212006e-014, !- X,Y,Z Vertex 2 {m}
-  52.1208, 48.7378375, -1.9143955342387e-014, !- X,Y,Z Vertex 3 {m}
-  52.1208, 42.6418375, -2.7058375507678e-014; !- X,Y,Z Vertex 4 {m}
+  56.388, 42.6418375, 0,                  !- X,Y,Z Vertex 1 {m}
+  56.388, 48.7378375, 0,                  !- X,Y,Z Vertex 2 {m}
+  52.1208, 48.7378375, 0,                 !- X,Y,Z Vertex 3 {m}
+  52.1208, 42.6418375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {38823ac2-8439-4ec4-b1c9-2eb42ee3b887}, !- Handle
-  Surface 556,                            !- Name
+  OpenOffice_Basement_ZN_2 - Wall 180_e,  !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {316fddf4-8cea-4c27-b604-515fad8156a5}, !- Space Name
@@ -7592,14 +7371,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  17.6037875, 36.5458375, 1.15505827125162e-014, !- X,Y,Z Vertex 1 {m}
-  17.6037875, 36.5458375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  25.4508, 36.5458375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  25.4508, 36.5458375, 1.15505827125162e-014; !- X,Y,Z Vertex 4 {m}
+  17.6037875, 36.5458375, 0,              !- X,Y,Z Vertex 1 {m}
+  17.6037875, 36.5458375, -2.4384,        !- X,Y,Z Vertex 2 {m}
+  25.4508, 36.5458375, -2.4384,           !- X,Y,Z Vertex 3 {m}
+  25.4508, 36.5458375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {a5c6639e-98c3-43b2-ab86-54fb5f1341f5}, !- Handle
-  Surface 557,                            !- Name
+  OpenOffice_Basement_ZN_2 - Wall 180_a,  !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {316fddf4-8cea-4c27-b604-515fad8156a5}, !- Space Name
@@ -7609,14 +7388,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  16.0797875, 36.5458375, 1.15505827125162e-014, !- X,Y,Z Vertex 1 {m}
-  16.0797875, 36.5458375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  17.6037875, 36.5458375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  17.6037875, 36.5458375, 1.15505827125162e-014; !- X,Y,Z Vertex 4 {m}
+  16.0797875, 36.5458375, 0,              !- X,Y,Z Vertex 1 {m}
+  16.0797875, 36.5458375, -2.4384,        !- X,Y,Z Vertex 2 {m}
+  17.6037875, 36.5458375, -2.4384,        !- X,Y,Z Vertex 3 {m}
+  17.6037875, 36.5458375, 0;              !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {3c08a75f-91be-4920-80ee-c301eb061234}, !- Handle
-  Surface 558,                            !- Name
+  OpenOffice_Basement_ZN_2 - Wall 180_d,  !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {316fddf4-8cea-4c27-b604-515fad8156a5}, !- Space Name
@@ -7626,14 +7405,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  30.4038, 36.5458375, 1.15505827125162e-014, !- X,Y,Z Vertex 1 {m}
-  30.4038, 36.5458375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  35.3568, 36.5458375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  35.3568, 36.5458375, -2.31011654250324e-014; !- X,Y,Z Vertex 4 {m}
+  30.4038, 36.5458375, 0,                 !- X,Y,Z Vertex 1 {m}
+  30.4038, 36.5458375, -2.4384,           !- X,Y,Z Vertex 2 {m}
+  35.3568, 36.5458375, -2.4384,           !- X,Y,Z Vertex 3 {m}
+  35.3568, 36.5458375, -0;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {7b99eb4a-6ffa-4b6a-9ea8-86d8acaa2b6a}, !- Handle
-  Surface 567,                            !- Name
+  Corridor_Basement_ZN_2 - RoofCeiling_b, !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {d1bcd4f1-7920-4f82-a04e-3b6c9d4fab99}, !- Space Name
@@ -7643,14 +7422,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.3296, 35.0218375, -2.31011654250324e-014, !- X,Y,Z Vertex 1 {m}
-  46.3296, 36.5458375, -2.31011654250324e-014, !- X,Y,Z Vertex 2 {m}
-  37.7952, 36.5458375, 5.77529135625807e-015, !- X,Y,Z Vertex 3 {m}
-  37.7952, 35.0218375, 5.77529135625807e-015; !- X,Y,Z Vertex 4 {m}
+  46.3296, 35.0218375, 0,                 !- X,Y,Z Vertex 1 {m}
+  46.3296, 36.5458375, 0,                 !- X,Y,Z Vertex 2 {m}
+  37.7952, 36.5458375, 0,                 !- X,Y,Z Vertex 3 {m}
+  37.7952, 35.0218375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {18973b67-bb79-4fcf-ba28-18496f7613a0}, !- Handle
-  Surface 568,                            !- Name
+  EnclosedOffice_Basement_ZN_3 - RoofCeiling_b, !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {69c83deb-630e-462f-b9e7-bda39f8a372d}, !- Space Name
@@ -7660,14 +7439,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  54.864, 29.8402375, 2.31011654250324e-014, !- X,Y,Z Vertex 1 {m}
-  54.864, 35.0218375, 2.31011654250324e-014, !- X,Y,Z Vertex 2 {m}
-  46.3296, 35.0218375, 2.05179566004364e-029, !- X,Y,Z Vertex 3 {m}
-  46.3296, 29.8402375, 2.05179566004364e-029; !- X,Y,Z Vertex 4 {m}
+  54.864, 29.8402375, 0,                  !- X,Y,Z Vertex 1 {m}
+  54.864, 35.0218375, 0,                  !- X,Y,Z Vertex 2 {m}
+  46.3296, 35.0218375, 0,                 !- X,Y,Z Vertex 3 {m}
+  46.3296, 29.8402375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {0eef3099-af63-4dfb-9a27-b23a0f555dc7}, !- Handle
-  Surface 569,                            !- Name
+  EnclosedOffice_Basement_ZN_3 - Wall 180_a, !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {69c83deb-630e-462f-b9e7-bda39f8a372d}, !- Space Name
@@ -7677,14 +7456,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  49.0728, 29.8402375, 2.31011654250324e-014, !- X,Y,Z Vertex 1 {m}
+  49.0728, 29.8402375, 0,                 !- X,Y,Z Vertex 1 {m}
   49.0728, 29.8402375, -2.4384,           !- X,Y,Z Vertex 2 {m}
   54.864, 29.8402375, -2.4384,            !- X,Y,Z Vertex 3 {m}
-  54.864, 29.8402375, 2.31011654250324e-014; !- X,Y,Z Vertex 4 {m}
+  54.864, 29.8402375, 0;                  !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {85c3bd1b-ed2a-428a-aecd-d44bf1e4bb2a}, !- Handle
-  Surface 570,                            !- Name
+  EnclosedOffice_Basement_ZN_3 - Wall 180_c, !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {69c83deb-630e-462f-b9e7-bda39f8a372d}, !- Space Name
@@ -7694,14 +7473,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  37.7952, 29.8402375, 2.31011654250324e-014, !- X,Y,Z Vertex 1 {m}
+  37.7952, 29.8402375, 0,                 !- X,Y,Z Vertex 1 {m}
   37.7952, 29.8402375, -2.4384,           !- X,Y,Z Vertex 2 {m}
   46.3296, 29.8402375, -2.4384,           !- X,Y,Z Vertex 3 {m}
   46.3296, 29.8402375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {e21ff184-4c79-46c7-815b-3ef86030ae18}, !- Handle
-  Surface 571,                            !- Name
+  ActiveStorage_Basement_ZN - Wall 180_b, !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {703003c0-a8be-48e2-93b7-57710ac64710}, !- Space Name
@@ -7711,14 +7490,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  49.0728, 18.8674375, 2.31011654250324e-014, !- X,Y,Z Vertex 1 {m}
+  49.0728, 18.8674375, 0,                 !- X,Y,Z Vertex 1 {m}
   49.0728, 18.8674375, -2.4384,           !- X,Y,Z Vertex 2 {m}
   52.7304, 18.8674375, -2.4384,           !- X,Y,Z Vertex 3 {m}
-  52.7304, 18.8674375, 2.31011654250324e-014; !- X,Y,Z Vertex 4 {m}
+  52.7304, 18.8674375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {dd514a32-b720-44be-8b7f-0b38141429b0}, !- Handle
-  Surface 572,                            !- Name
+  Stair_Basement_ZN_2 - Wall 270_b,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f31d9b3a-b907-4dea-8a8a-2b5de88b7c35}, !- Space Name
@@ -7728,14 +7507,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.3296, 29.8402375, 2.31011654250324e-014, !- X,Y,Z Vertex 1 {m}
+  46.3296, 29.8402375, 0,                 !- X,Y,Z Vertex 1 {m}
   46.3296, 29.8402375, -2.4384,           !- X,Y,Z Vertex 2 {m}
   46.3296, 24.3538375, -2.4384,           !- X,Y,Z Vertex 3 {m}
-  46.3296, 24.3538375, 2.31011654250324e-014; !- X,Y,Z Vertex 4 {m}
+  46.3296, 24.3538375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {a7a4167e-26ea-420e-be72-26a14692b0c3}, !- Handle
-  Surface 573,                            !- Name
+  Mechanical_Basement_ZN_1 - RoofCeiling_b, !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {d3d3811d-bfc1-4455-b7ad-240f00545023}, !- Space Name
@@ -7745,14 +7524,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  73.10755, 5.4864, -1.52880957893232e-014, !- X,Y,Z Vertex 1 {m}
-  73.10755, 36.5458375, 3.38043482095331e-016, !- X,Y,Z Vertex 2 {m}
-  56.388, 36.5458375, -1.52880957893232e-014, !- X,Y,Z Vertex 3 {m}
-  56.388, 5.4864, -3.09142350607417e-014; !- X,Y,Z Vertex 4 {m}
+  73.10755, 5.4864, 0,                    !- X,Y,Z Vertex 1 {m}
+  73.10755, 36.5458375, 0,                !- X,Y,Z Vertex 2 {m}
+  56.388, 36.5458375, 0,                  !- X,Y,Z Vertex 3 {m}
+  56.388, 5.4864, 0;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {0d86e7e2-33a7-48d0-93db-054c523e1c55}, !- Handle
-  Surface 574,                            !- Name
+  Mechanical_Basement_ZN_1 - RoofCeiling_a, !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {d3d3811d-bfc1-4455-b7ad-240f00545023}, !- Space Name
@@ -7762,14 +7541,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  73.10755, -7.69297646937897e-017, -1.78997372479736e-015, !- X,Y,Z Vertex 1 {m}
-  73.10755, 5.4864, -1.31600785824305e-014, !- X,Y,Z Vertex 2 {m}
-  56.388, 5.4864, -3.30422522676344e-014, !- X,Y,Z Vertex 3 {m}
-  56.388, -7.69297646937799e-017, -2.16721474100013e-014; !- X,Y,Z Vertex 4 {m}
+  73.10755, 0, 0,                         !- X,Y,Z Vertex 1 {m}
+  73.10755, 5.4864, 0,                    !- X,Y,Z Vertex 2 {m}
+  56.388, 5.4864, 0,                      !- X,Y,Z Vertex 3 {m}
+  56.388, 0, 0;                           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {fc517969-93fc-4d1a-90ff-b3472a39452f}, !- Handle
-  Surface 575,                            !- Name
+  Mechanical_Basement_ZN_1 - RoofCeiling_d, !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {d3d3811d-bfc1-4455-b7ad-240f00545023}, !- Space Name
@@ -7779,16 +7558,16 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  56.388, 12.1618375, -2.29984640472642e-014, !- X,Y,Z Vertex 1 {m}
-  56.388, 36.5458375, -9.09462887787836e-015, !- X,Y,Z Vertex 2 {m}
-  54.864, 36.5458375, -5.96563257004841e-015, !- X,Y,Z Vertex 3 {m}
-  54.864, 13.6858375, -1.90004780413476e-014, !- X,Y,Z Vertex 4 {m}
-  46.0416275, 13.6858375, -8.86848790166182e-016, !- X,Y,Z Vertex 5 {m}
-  46.0416275, 12.1618375, -1.7558384882528e-015; !- X,Y,Z Vertex 6 {m}
+  56.388, 12.1618375, 0,                  !- X,Y,Z Vertex 1 {m}
+  56.388, 36.5458375, 0,                  !- X,Y,Z Vertex 2 {m}
+  54.864, 36.5458375, 0,                  !- X,Y,Z Vertex 3 {m}
+  54.864, 13.6858375, 0,                  !- X,Y,Z Vertex 4 {m}
+  46.0416275, 13.6858375, 0,              !- X,Y,Z Vertex 5 {m}
+  46.0416275, 12.1618375, 0;              !- X,Y,Z Vertex 6 {m}
 
 OS:Surface,
   {d18e1e38-bbda-43a6-a9ba-545269f89393}, !- Handle
-  Surface 576,                            !- Name
+  Mechanical_Basement_ZN_1 - Wall 270_a,  !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d3d3811d-bfc1-4455-b7ad-240f00545023}, !- Space Name
@@ -7798,14 +7577,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  54.864, 36.5458375, 3.60955709766105e-016, !- X,Y,Z Vertex 1 {m}
-  54.864, 36.5458375, -2.43840000000002,  !- X,Y,Z Vertex 2 {m}
-  54.864, 35.0218375, -2.43840000000002,  !- X,Y,Z Vertex 3 {m}
-  54.864, 35.0218375, -2.31011654250324e-014; !- X,Y,Z Vertex 4 {m}
+  54.864, 36.5458375, 0,                  !- X,Y,Z Vertex 1 {m}
+  54.864, 36.5458375, -2.4384,            !- X,Y,Z Vertex 2 {m}
+  54.864, 35.0218375, -2.4384,            !- X,Y,Z Vertex 3 {m}
+  54.864, 35.0218375, -0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {a85ff24b-4541-4796-8d35-d694b23ef338}, !- Handle
-  Surface 577,                            !- Name
+  Mechanical_Basement_ZN_1 - Wall 000_b,  !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d3d3811d-bfc1-4455-b7ad-240f00545023}, !- Space Name
@@ -7815,14 +7594,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  52.7304, 13.6858375, -4.24685105242912e-016, !- X,Y,Z Vertex 1 {m}
-  54.864, 13.6858375, -1.87630274045683e-014, !- X,Y,Z Vertex 2 {m}
-  54.864, 13.6858375, -2.43840000000002,  !- X,Y,Z Vertex 3 {m}
-  52.7304, 13.6858375, -2.43840000000002; !- X,Y,Z Vertex 4 {m}
+  54.864, 13.6858375, 0,                  !- X,Y,Z Vertex 1 {m}
+  54.864, 13.6858375, -2.4384,            !- X,Y,Z Vertex 2 {m}
+  52.7304, 13.6858375, -2.4384,           !- X,Y,Z Vertex 3 {m}
+  52.7304, 13.6858375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {9d06a861-d0f1-4140-8073-98ec491d181d}, !- Handle
-  Surface 578,                            !- Name
+  Mechanical_Basement_ZN_1 - Wall 270_e,  !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d3d3811d-bfc1-4455-b7ad-240f00545023}, !- Space Name
@@ -7832,14 +7611,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.0416275, 12.1618375, -7.2191141953228e-016, !- X,Y,Z Vertex 1 {m}
-  46.0416275, 13.6858375, -2.88764567812907e-015, !- X,Y,Z Vertex 2 {m}
-  46.0416275, 13.6858375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  46.0416275, 12.1618375, -2.43840000000002; !- X,Y,Z Vertex 4 {m}
+  46.0416275, 13.6858375, 0,              !- X,Y,Z Vertex 1 {m}
+  46.0416275, 13.6858375, -2.4384,        !- X,Y,Z Vertex 2 {m}
+  46.0416275, 12.1618375, -2.4384,        !- X,Y,Z Vertex 3 {m}
+  46.0416275, 12.1618375, 0;              !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {ca5e8949-123f-4e4b-ad78-3177f1ba6b8e}, !- Handle
-  Surface 579,                            !- Name
+  Mechanical_Basement_ZN_1 - Wall 270_f,  !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d3d3811d-bfc1-4455-b7ad-240f00545023}, !- Space Name
@@ -7849,14 +7628,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  54.864, 13.6858375, -1.87630274045683e-014, !- X,Y,Z Vertex 1 {m}
-  54.864, 18.8674375, -2.31011654250324e-014, !- X,Y,Z Vertex 2 {m}
-  54.864, 18.8674375, -2.43840000000002,  !- X,Y,Z Vertex 3 {m}
-  54.864, 13.6858375, -2.43840000000002;  !- X,Y,Z Vertex 4 {m}
+  54.864, 18.8674375, -0,                 !- X,Y,Z Vertex 1 {m}
+  54.864, 18.8674375, -2.4384,            !- X,Y,Z Vertex 2 {m}
+  54.864, 13.6858375, -2.4384,            !- X,Y,Z Vertex 3 {m}
+  54.864, 13.6858375, 0;                  !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {ca28bf13-6029-4f8a-85d5-5a6f4daa3d73}, !- Handle
-  Surface 580,                            !- Name
+  Mechanical_Basement_ZN_1 - Wall 270_b,  !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d3d3811d-bfc1-4455-b7ad-240f00545023}, !- Space Name
@@ -7866,14 +7645,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  54.864, 29.8402375, -2.31011654250324e-014, !- X,Y,Z Vertex 1 {m}
-  54.864, 29.8402375, -2.43840000000002,  !- X,Y,Z Vertex 2 {m}
-  54.864, 18.8674375, -2.43840000000002,  !- X,Y,Z Vertex 3 {m}
-  54.864, 18.8674375, -2.31011654250324e-014; !- X,Y,Z Vertex 4 {m}
+  54.864, 29.8402375, -0,                 !- X,Y,Z Vertex 1 {m}
+  54.864, 29.8402375, -2.4384,            !- X,Y,Z Vertex 2 {m}
+  54.864, 18.8674375, -2.4384,            !- X,Y,Z Vertex 3 {m}
+  54.864, 18.8674375, -0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {b1e70311-6ab3-4cbd-a2f1-fd87ec828b15}, !- Handle
-  Surface 581,                            !- Name
+  EnclosedOffice_Basement_ZN_2 - Wall 000_c, !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d98a7b10-1d11-48bd-a2e5-f333793a7830}, !- Space Name
@@ -7883,14 +7662,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.3296, 18.8674375, 2.31011654250324e-014, !- X,Y,Z Vertex 1 {m}
-  49.0728, 18.8674375, 0,                 !- X,Y,Z Vertex 2 {m}
-  49.0728, 18.8674375, -2.4384,           !- X,Y,Z Vertex 3 {m}
-  46.3296, 18.8674375, -2.4384;           !- X,Y,Z Vertex 4 {m}
+  49.0728, 18.8674375, 0,                 !- X,Y,Z Vertex 1 {m}
+  49.0728, 18.8674375, -2.4384,           !- X,Y,Z Vertex 2 {m}
+  46.3296, 18.8674375, -2.4384,           !- X,Y,Z Vertex 3 {m}
+  46.3296, 18.8674375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {75d26951-ec58-4c0e-b511-a4e78cd847a4}, !- Handle
-  Surface 582,                            !- Name
+  EnclosedOffice_Basement_ZN_2 - Wall 000_b, !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d98a7b10-1d11-48bd-a2e5-f333793a7830}, !- Space Name
@@ -7900,14 +7679,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.3296, 18.8674375, 2.31011654250324e-014, !- X,Y,Z Vertex 1 {m}
+  46.3296, 18.8674375, 0,                 !- X,Y,Z Vertex 1 {m}
   46.3296, 18.8674375, -2.4384,           !- X,Y,Z Vertex 2 {m}
   37.7952, 18.8674375, -2.4384,           !- X,Y,Z Vertex 3 {m}
-  37.7952, 18.8674375, 2.31011654250324e-014; !- X,Y,Z Vertex 4 {m}
+  37.7952, 18.8674375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {bd81dfaf-078f-4975-b027-d14a6fc362cb}, !- Handle
-  Surface 583,                            !- Name
+  EnclosedOffice_Basement_ZN_2 - Wall 180_b, !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d98a7b10-1d11-48bd-a2e5-f333793a7830}, !- Space Name
@@ -7917,14 +7696,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  37.7952, 13.6858375, 2.31011654250324e-014, !- X,Y,Z Vertex 1 {m}
+  37.7952, 13.6858375, 0,                 !- X,Y,Z Vertex 1 {m}
   37.7952, 13.6858375, -2.4384,           !- X,Y,Z Vertex 2 {m}
   46.0416275, 13.6858375, -2.4384,        !- X,Y,Z Vertex 3 {m}
-  46.0416275, 13.6858375, 2.31011654250324e-014; !- X,Y,Z Vertex 4 {m}
+  46.0416275, 13.6858375, 0;              !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {6dac7aad-ceb1-40d6-8758-823f033e7559}, !- Handle
-  Surface 584,                            !- Name
+  Lobby_Basement_ZN - Wall 270_b,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {2a9fe3f6-0245-47e1-83d4-2e202cf00843}, !- Space Name
@@ -7934,14 +7713,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  35.3568, 36.5458375, -2.56474457505455e-029, !- X,Y,Z Vertex 1 {m}
-  35.3568, 36.5458375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  35.3568, 27.7066375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  35.3568, 27.7066375, -2.56474457505455e-029; !- X,Y,Z Vertex 4 {m}
+  35.3568, 36.5458375, 0,                 !- X,Y,Z Vertex 1 {m}
+  35.3568, 36.5458375, -2.4384,           !- X,Y,Z Vertex 2 {m}
+  35.3568, 27.7066375, -2.4384,           !- X,Y,Z Vertex 3 {m}
+  35.3568, 27.7066375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {0eccc684-7cde-4237-a9fb-7bcbd5351b65}, !- Handle
-  Surface 585,                            !- Name
+  Lobby_Basement_ZN - Wall 270_c,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {2a9fe3f6-0245-47e1-83d4-2e202cf00843}, !- Space Name
@@ -7951,14 +7730,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  35.3568, 13.6858375, -2.31011654250324e-014, !- X,Y,Z Vertex 1 {m}
-  35.3568, 13.6858375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  35.3568, 12.1618375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  35.3568, 12.1618375, -2.56474457505455e-029; !- X,Y,Z Vertex 4 {m}
+  35.3568, 13.6858375, -0,                !- X,Y,Z Vertex 1 {m}
+  35.3568, 13.6858375, -2.4384,           !- X,Y,Z Vertex 2 {m}
+  35.3568, 12.1618375, -2.4384,           !- X,Y,Z Vertex 3 {m}
+  35.3568, 12.1618375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {8d24c753-7649-48cb-8519-66a801703a99}, !- Handle
-  Surface 586,                            !- Name
+  Lobby_Basement_ZN - Wall 270_d,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {2a9fe3f6-0245-47e1-83d4-2e202cf00843}, !- Space Name
@@ -7968,14 +7747,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  35.3568, 18.8674375, -1.15505827125162e-014, !- X,Y,Z Vertex 1 {m}
-  35.3568, 18.8674375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  35.3568, 13.6858375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  35.3568, 13.6858375, -2.31011654250324e-014; !- X,Y,Z Vertex 4 {m}
+  35.3568, 18.8674375, 0,                 !- X,Y,Z Vertex 1 {m}
+  35.3568, 18.8674375, -2.4384,           !- X,Y,Z Vertex 2 {m}
+  35.3568, 13.6858375, -2.4384,           !- X,Y,Z Vertex 3 {m}
+  35.3568, 13.6858375, -0;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {6e7f69b5-a166-4715-97a5-f9162e406d37}, !- Handle
-  Surface 587,                            !- Name
+  Lobby_Basement_ZN - Wall 090_d,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {2a9fe3f6-0245-47e1-83d4-2e202cf00843}, !- Space Name
@@ -7985,14 +7764,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  37.7952, 29.8402375, -2.31011654250324e-014, !- X,Y,Z Vertex 1 {m}
-  37.7952, 29.8402375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  37.7952, 35.0218375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  37.7952, 35.0218375, 5.77529135625807e-015; !- X,Y,Z Vertex 4 {m}
+  37.7952, 29.8402375, 0,                 !- X,Y,Z Vertex 1 {m}
+  37.7952, 29.8402375, -2.4384,           !- X,Y,Z Vertex 2 {m}
+  37.7952, 35.0218375, -2.4384,           !- X,Y,Z Vertex 3 {m}
+  37.7952, 35.0218375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {5372e978-3469-4150-8da0-c77376a250e3}, !- Handle
-  Surface 588,                            !- Name
+  Lobby_Basement_ZN - Wall 090_e,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {2a9fe3f6-0245-47e1-83d4-2e202cf00843}, !- Space Name
@@ -8002,14 +7781,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  37.7952, 18.8674375, -2.31011654250324e-014, !- X,Y,Z Vertex 1 {m}
-  37.7952, 18.8674375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  37.7952, 24.3538375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  37.7952, 24.3538375, -2.56474457505455e-029; !- X,Y,Z Vertex 4 {m}
+  37.7952, 18.8674375, 0,                 !- X,Y,Z Vertex 1 {m}
+  37.7952, 18.8674375, -2.4384,           !- X,Y,Z Vertex 2 {m}
+  37.7952, 24.3538375, -2.4384,           !- X,Y,Z Vertex 3 {m}
+  37.7952, 24.3538375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {6db6379a-460b-4a21-b748-54e8bdcc7d8d}, !- Handle
-  Surface 589,                            !- Name
+  Lobby_Basement_ZN - Wall 090_f,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {2a9fe3f6-0245-47e1-83d4-2e202cf00843}, !- Space Name
@@ -8019,14 +7798,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  37.7952, 12.1618375, -2.56474457505455e-029, !- X,Y,Z Vertex 1 {m}
-  37.7952, 12.1618375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  37.7952, 13.6858375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  37.7952, 13.6858375, -2.31011654250324e-014; !- X,Y,Z Vertex 4 {m}
+  37.7952, 12.1618375, 0,                 !- X,Y,Z Vertex 1 {m}
+  37.7952, 12.1618375, -2.4384,           !- X,Y,Z Vertex 2 {m}
+  37.7952, 13.6858375, -2.4384,           !- X,Y,Z Vertex 3 {m}
+  37.7952, 13.6858375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {14a1b9dd-4de7-4346-8444-a93643dbb43f}, !- Handle
-  Surface 590,                            !- Name
+  Lobby_Basement_ZN - Wall 090_b,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {2a9fe3f6-0245-47e1-83d4-2e202cf00843}, !- Space Name
@@ -8036,14 +7815,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  37.7952, 13.6858375, -2.31011654250324e-014, !- X,Y,Z Vertex 1 {m}
-  37.7952, 13.6858375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  37.7952, 18.8674375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  37.7952, 18.8674375, -2.31011654250324e-014; !- X,Y,Z Vertex 4 {m}
+  37.7952, 13.6858375, 0,                 !- X,Y,Z Vertex 1 {m}
+  37.7952, 13.6858375, -2.4384,           !- X,Y,Z Vertex 2 {m}
+  37.7952, 18.8674375, -2.4384,           !- X,Y,Z Vertex 3 {m}
+  37.7952, 18.8674375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {1cfb4c26-f8eb-4a88-a42f-2411443ace28}, !- Handle
-  Surface 591,                            !- Name
+  Lobby_Basement_ZN - Wall 090_c,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {2a9fe3f6-0245-47e1-83d4-2e202cf00843}, !- Space Name
@@ -8053,14 +7832,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  37.7952, 24.3538375, -2.56474457505455e-029, !- X,Y,Z Vertex 1 {m}
-  37.7952, 24.3538375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  37.7952, 29.8402375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  37.7952, 29.8402375, -2.31011654250324e-014; !- X,Y,Z Vertex 4 {m}
+  37.7952, 24.3538375, 0,                 !- X,Y,Z Vertex 1 {m}
+  37.7952, 24.3538375, -2.4384,           !- X,Y,Z Vertex 2 {m}
+  37.7952, 29.8402375, -2.4384,           !- X,Y,Z Vertex 3 {m}
+  37.7952, 29.8402375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {30c0e7c4-57a8-4644-a458-f7c6ee2410ad}, !- Handle
-  Surface 592,                            !- Name
+  Dining_Basement_ZN - RoofCeiling_b,     !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {5222a123-fcee-4465-a1d8-1fe3a55ed431}, !- Space Name
@@ -8070,31 +7849,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  35.3568, 27.7066375, 2.02135197469033e-014, !- X,Y,Z Vertex 1 {m}
-  35.3568, 29.8402375, 1.44382283906452e-014, !- X,Y,Z Vertex 2 {m}
-  30.4038, 29.8402375, 2.02135197469033e-014, !- X,Y,Z Vertex 3 {m}
-  30.4038, 27.7066375, 2.59888111031615e-014; !- X,Y,Z Vertex 4 {m}
-
-OS:Surface,
-  {c2c3dc8c-b7ae-4202-928d-9a688f00f117}, !- Handle
-  Surface 593,                            !- Name
-  RoofCeiling,                            !- Surface Type
-  ,                                       !- Construction Name
-  {5222a123-fcee-4465-a1d8-1fe3a55ed431}, !- Space Name
-  Surface,                                !- Outside Boundary Condition
-  {b39c2408-48c2-4cb3-837a-85da1e7dac85}, !- Outside Boundary Condition Object
-  NoSun,                                  !- Sun Exposure
-  NoWind,                                 !- Wind Exposure
-  ,                                       !- View Factor to Ground
-  ,                                       !- Number of Vertices
-  35.3568, 35.0218375, 1.19115384222823e-014, !- X,Y,Z Vertex 1 {m}
-  35.3568, 35.0708215764634, 1.19115384222823e-014, !- X,Y,Z Vertex 2 {m}
-  30.4038, 35.0708215764634, 2.27402097152662e-014, !- X,Y,Z Vertex 3 {m}
-  30.4038, 35.0218375, 2.27402097152662e-014; !- X,Y,Z Vertex 4 {m}
+  35.3568, 27.7066375, 0,                 !- X,Y,Z Vertex 1 {m}
+  35.3568, 29.8402375, 0,                 !- X,Y,Z Vertex 2 {m}
+  30.4038, 29.8402375, 0,                 !- X,Y,Z Vertex 3 {m}
+  30.4038, 27.7066375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {9e899b39-27a7-413a-a7dd-f3d82cc73584}, !- Handle
-  Surface 594,                            !- Name
+  Dining_Basement_ZN - RoofCeiling_c,     !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {5222a123-fcee-4465-a1d8-1fe3a55ed431}, !- Space Name
@@ -8104,65 +7866,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  35.3568, 29.8402375, 1.26334498418146e-014, !- X,Y,Z Vertex 1 {m}
-  35.3568, 35.0218375, 1.26334498418146e-014, !- X,Y,Z Vertex 2 {m}
-  30.4038, 35.0218375, 2.20182982957339e-014, !- X,Y,Z Vertex 3 {m}
-  30.4038, 29.8402375, 2.2018298295734e-014; !- X,Y,Z Vertex 4 {m}
+  35.3568, 29.8402375, 0,                 !- X,Y,Z Vertex 1 {m}
+  35.3568, 35.0218375, 0,                 !- X,Y,Z Vertex 2 {m}
+  30.4038, 35.0218375, 0,                 !- X,Y,Z Vertex 3 {m}
+  30.4038, 29.8402375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {ff4e0461-a02d-4abd-b67b-b386d35b5dbf}, !- Handle
-  Surface 595,                            !- Name
-  RoofCeiling,                            !- Surface Type
-  ,                                       !- Construction Name
-  {0389314a-0c21-4461-800d-cffcf0fed6e9}, !- Space Name
-  Surface,                                !- Outside Boundary Condition
-  {dc86a268-a30b-45e0-9537-cb72203cad5a}, !- Outside Boundary Condition Object
-  NoSun,                                  !- Sun Exposure
-  NoWind,                                 !- Wind Exposure
-  ,                                       !- View Factor to Ground
-  ,                                       !- Number of Vertices
-  30.4038, 35.0708215764634, 3.46517481375486e-014, !- X,Y,Z Vertex 1 {m}
-  30.4038, 36.5458375, 3.46517481375486e-014, !- X,Y,Z Vertex 2 {m}
-  25.4508, 36.5458375, 3.46517481375486e-014, !- X,Y,Z Vertex 3 {m}
-  25.4508, 35.0708215764634, 3.46517481375486e-014; !- X,Y,Z Vertex 4 {m}
-
-OS:Surface,
-  {0a802777-aa4e-42b0-a10c-2f82cddf0736}, !- Handle
-  Surface 596,                            !- Name
-  Wall,                                   !- Surface Type
-  ,                                       !- Construction Name
-  {0389314a-0c21-4461-800d-cffcf0fed6e9}, !- Space Name
-  Surface,                                !- Outside Boundary Condition
-  {dadd9e2f-bed4-45ad-8f50-89c545d9e04d}, !- Outside Boundary Condition Object
-  NoSun,                                  !- Sun Exposure
-  NoWind,                                 !- Wind Exposure
-  ,                                       !- View Factor to Ground
-  ,                                       !- Number of Vertices
-  25.4508, 36.5458375, 3.46517481375486e-014, !- X,Y,Z Vertex 1 {m}
-  25.4508, 36.5458375, -2.4384,           !- X,Y,Z Vertex 2 {m}
-  25.4508, 29.8402375, -2.4384,           !- X,Y,Z Vertex 3 {m}
-  25.4508, 29.8402375, 5.77529135625807e-015; !- X,Y,Z Vertex 4 {m}
-
-OS:Surface,
-  {f9f1d592-4484-4db7-9b2b-dee1f6a606cf}, !- Handle
-  Surface 597,                            !- Name
-  RoofCeiling,                            !- Surface Type
-  ,                                       !- Construction Name
-  {0389314a-0c21-4461-800d-cffcf0fed6e9}, !- Space Name
-  Surface,                                !- Outside Boundary Condition
-  {3d4d9943-3783-4f62-9403-d0e4a9828f9e}, !- Outside Boundary Condition Object
-  NoSun,                                  !- Sun Exposure
-  NoWind,                                 !- Wind Exposure
-  ,                                       !- View Factor to Ground
-  ,                                       !- Number of Vertices
-  30.4038, 27.7066375, 4.04044797619463e-014, !- X,Y,Z Vertex 1 {m}
-  30.4038, 29.8402375, 1.73484338006347e-014, !- X,Y,Z Vertex 2 {m}
-  25.4508, 29.8402375, 5.84297055183942e-015, !- X,Y,Z Vertex 3 {m}
-  25.4508, 27.7066375, 2.88990165131511e-014; !- X,Y,Z Vertex 4 {m}
-
-OS:Surface,
-  {013e6080-210b-4cfd-9c5b-7ffc9329639d}, !- Handle
-  Surface 598,                            !- Name
+  FoodPrep_Basement_ZN - RoofCeiling_b,   !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {0389314a-0c21-4461-800d-cffcf0fed6e9}, !- Space Name
@@ -8172,14 +7883,48 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  30.4038, 35.0218375, 3.50127038473147e-014, !- X,Y,Z Vertex 1 {m}
-  30.4038, 35.0708215764634, 3.50127038473147e-014, !- X,Y,Z Vertex 2 {m}
-  25.4508, 35.0708215764634, 3.42907924277825e-014, !- X,Y,Z Vertex 3 {m}
-  25.4508, 35.0218375, 3.42907924277824e-014; !- X,Y,Z Vertex 4 {m}
+  30.4038, 35.0218375, 0,                 !- X,Y,Z Vertex 1 {m}
+  30.4038, 36.5458375, 0,                 !- X,Y,Z Vertex 2 {m}
+  25.4508, 36.5458375, 0,                 !- X,Y,Z Vertex 3 {m}
+  25.4508, 35.0218375, 0;                 !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {0a802777-aa4e-42b0-a10c-2f82cddf0736}, !- Handle
+  FoodPrep_Basement_ZN - Wall 270_b,      !- Name
+  Wall,                                   !- Surface Type
+  ,                                       !- Construction Name
+  {0389314a-0c21-4461-800d-cffcf0fed6e9}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {dadd9e2f-bed4-45ad-8f50-89c545d9e04d}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  25.4508, 36.5458375, 0,                 !- X,Y,Z Vertex 1 {m}
+  25.4508, 36.5458375, -2.4384,           !- X,Y,Z Vertex 2 {m}
+  25.4508, 29.8402375, -2.4384,           !- X,Y,Z Vertex 3 {m}
+  25.4508, 29.8402375, 0;                 !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {f9f1d592-4484-4db7-9b2b-dee1f6a606cf}, !- Handle
+  FoodPrep_Basement_ZN - RoofCeiling_c,   !- Name
+  RoofCeiling,                            !- Surface Type
+  ,                                       !- Construction Name
+  {0389314a-0c21-4461-800d-cffcf0fed6e9}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {3d4d9943-3783-4f62-9403-d0e4a9828f9e}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  30.4038, 27.7066375, 0,                 !- X,Y,Z Vertex 1 {m}
+  30.4038, 29.8402375, 0,                 !- X,Y,Z Vertex 2 {m}
+  25.4508, 29.8402375, 0,                 !- X,Y,Z Vertex 3 {m}
+  25.4508, 27.7066375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {664f2eb0-1766-4044-b31f-fcf76fb112a6}, !- Handle
-  Surface 599,                            !- Name
+  Restroom_Basement_ZN - Wall 000_b,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {b14c3df4-6d5f-4e37-a007-3f230581586d}, !- Space Name
@@ -8189,14 +7934,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  30.4038, 27.7066375, 1.15505827125162e-014, !- X,Y,Z Vertex 1 {m}
-  35.3568, 27.7066375, -2.56474457505455e-029, !- X,Y,Z Vertex 2 {m}
-  35.3568, 27.7066375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  30.4038, 27.7066375, -2.43840000000002; !- X,Y,Z Vertex 4 {m}
+  35.3568, 27.7066375, 0,                 !- X,Y,Z Vertex 1 {m}
+  35.3568, 27.7066375, -2.4384,           !- X,Y,Z Vertex 2 {m}
+  30.4038, 27.7066375, -2.4384,           !- X,Y,Z Vertex 3 {m}
+  30.4038, 27.7066375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {85ef02ba-d3d1-4578-9c48-623afbf674b0}, !- Handle
-  Surface 600,                            !- Name
+  Stair_Basement_ZN_1 - Wall 090_b,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {beb9ddd0-3c85-46de-b2b6-f852dfd94f00}, !- Space Name
@@ -8206,14 +7951,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  25.4508, 18.8674375, -2.56474457505455e-029, !- X,Y,Z Vertex 1 {m}
-  25.4508, 18.8674375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  25.4508, 27.7066375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  25.4508, 27.7066375, -2.56474457505455e-029; !- X,Y,Z Vertex 4 {m}
+  25.4508, 18.8674375, 0,                 !- X,Y,Z Vertex 1 {m}
+  25.4508, 18.8674375, -2.4384,           !- X,Y,Z Vertex 2 {m}
+  25.4508, 27.7066375, -2.4384,           !- X,Y,Z Vertex 3 {m}
+  25.4508, 27.7066375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {553331b7-301e-4a88-83b3-214f3d4815cf}, !- Handle
-  Surface 601,                            !- Name
+  ConfRoom_Basement_ZN - RoofCeiling_b,   !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {7cdb8a9e-d879-43e9-9157-d878397b9413}, !- Space Name
@@ -8223,14 +7968,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  25.4508, 29.8402375, 1.15505827125162e-014, !- X,Y,Z Vertex 1 {m}
-  25.4508, 35.0218375, 1.15505827125162e-014, !- X,Y,Z Vertex 2 {m}
-  18.288, 35.0218375, -2.31011654250324e-014, !- X,Y,Z Vertex 3 {m}
-  18.288, 29.8402375, -2.31011654250324e-014; !- X,Y,Z Vertex 4 {m}
+  25.4508, 29.8402375, 0,                 !- X,Y,Z Vertex 1 {m}
+  25.4508, 35.0218375, 0,                 !- X,Y,Z Vertex 2 {m}
+  18.288, 35.0218375, 0,                  !- X,Y,Z Vertex 3 {m}
+  18.288, 29.8402375, 0;                  !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {0c1140cf-a16d-476c-8fec-eaecc89f9df3}, !- Handle
-  Surface 602,                            !- Name
+  ConfRoom_Basement_ZN - Wall 180_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {7cdb8a9e-d879-43e9-9157-d878397b9413}, !- Space Name
@@ -8240,33 +7985,31 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  17.6037875, 29.8402375, 1.15505827125162e-014, !- X,Y,Z Vertex 1 {m}
-  17.6037875, 29.8402375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  22.7076, 29.8402375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  22.7076, 29.8402375, 1.15505827125162e-014; !- X,Y,Z Vertex 4 {m}
+  17.6037875, 29.8402375, 0,              !- X,Y,Z Vertex 1 {m}
+  17.6037875, 29.8402375, -2.4384,        !- X,Y,Z Vertex 2 {m}
+  22.7076, 29.8402375, -2.4384,           !- X,Y,Z Vertex 3 {m}
+  22.7076, 29.8402375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {f4c480e0-c199-4b78-ad66-35021dccf5b7}, !- Handle
-  Surface 603,                            !- Name
+  ConfRoom_Basement_ZN - RoofCeiling_c,   !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {7cdb8a9e-d879-43e9-9157-d878397b9413}, !- Space Name
   Surface,                                !- Outside Boundary Condition
-  {32eafc25-47b9-4160-8513-7096696e10fe}, !- Outside Boundary Condition Object
+  {75470229-c6fb-4f6a-8ece-45e3c32d2385}, !- Outside Boundary Condition Object
   NoSun,                                  !- Sun Exposure
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  18.288, 35.0218375, -2.01996225864634e-014, !- X,Y,Z Vertex 1 {m}
-  18.288, 35.0708215764634, -1.9444158518841e-014, !- X,Y,Z Vertex 2 {m}
-  25.4508, 35.0708215764634, -8.9779734016756e-016, !- X,Y,Z Vertex 3 {m}
-  25.4508, 36.5458375, 2.18508509932428e-014, !- X,Y,Z Vertex 4 {m}
-  17.6037875, 36.5458375, 1.53288483495757e-015, !- X,Y,Z Vertex 5 {m}
-  17.6037875, 35.0218375, -2.19712275660752e-014; !- X,Y,Z Vertex 6 {m}
+  25.4508, 35.0218375, 0,                 !- X,Y,Z Vertex 1 {m}
+  25.4508, 36.5458375, 0,                 !- X,Y,Z Vertex 2 {m}
+  17.6037875, 36.5458375, 0,              !- X,Y,Z Vertex 3 {m}
+  17.6037875, 35.0218375, 0;              !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {647f3336-6ec1-4e88-83bf-b3246bcd2982}, !- Handle
-  Surface 604,                            !- Name
+  ConfRoom_Basement_ZN - RoofCeiling_a,   !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {7cdb8a9e-d879-43e9-9157-d878397b9413}, !- Space Name
@@ -8276,14 +8019,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  18.288, 29.8402375, -1.50355355858844e-014, !- X,Y,Z Vertex 1 {m}
-  18.288, 35.0218375, -3.11667952641803e-014, !- X,Y,Z Vertex 2 {m}
-  17.6037875, 35.0218375, -1.26463068049276e-014, !- X,Y,Z Vertex 3 {m}
-  17.6037875, 29.8402375, 3.48495287336831e-015; !- X,Y,Z Vertex 4 {m}
+  18.288, 29.8402375, 0,                  !- X,Y,Z Vertex 1 {m}
+  18.288, 35.0218375, 0,                  !- X,Y,Z Vertex 2 {m}
+  17.6037875, 35.0218375, 0,              !- X,Y,Z Vertex 3 {m}
+  17.6037875, 29.8402375, 0;              !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {8d26e30e-5c6c-4260-9b90-0a6323196bbc}, !- Handle
-  Surface 605,                            !- Name
+  Locker_Basement_ZN - RoofCeiling_b,     !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {f3f01a65-ee28-4594-ace9-a07c8a1f8e53}, !- Space Name
@@ -8293,14 +8036,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  18.288, 18.8674375, -2.38230768445646e-014, !- X,Y,Z Vertex 1 {m}
-  18.288, 29.8402375, -2.23792540055001e-014, !- X,Y,Z Vertex 2 {m}
-  17.6037875, 29.8402375, 7.21911419532236e-016, !- X,Y,Z Vertex 3 {m}
-  17.6037875, 18.8674375, -7.21911419532287e-016; !- X,Y,Z Vertex 4 {m}
+  18.288, 18.8674375, 0,                  !- X,Y,Z Vertex 1 {m}
+  18.288, 29.8402375, 0,                  !- X,Y,Z Vertex 2 {m}
+  17.6037875, 29.8402375, 0,              !- X,Y,Z Vertex 3 {m}
+  17.6037875, 18.8674375, 0;              !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {190aa9c0-20d2-48f5-9d7c-31f2b171ed0b}, !- Handle
-  Surface 606,                            !- Name
+  EnclosedOffice_Basement_ZN_1 - Wall 000_a, !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {6e08b2d6-7428-43a2-bb23-1dba7f241ea7}, !- Space Name
@@ -8310,14 +8053,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  25.4508, 18.8674375, -1.15505827125162e-014, !- X,Y,Z Vertex 1 {m}
-  25.4508, 18.8674375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  22.7076, 18.8674375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  22.7076, 18.8674375, -2.56474457505455e-029; !- X,Y,Z Vertex 4 {m}
+  25.4508, 18.8674375, 0,                 !- X,Y,Z Vertex 1 {m}
+  25.4508, 18.8674375, -2.4384,           !- X,Y,Z Vertex 2 {m}
+  22.7076, 18.8674375, -2.4384,           !- X,Y,Z Vertex 3 {m}
+  22.7076, 18.8674375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {c9b107f7-3a92-4c8a-be63-fa742fa6a3fb}, !- Handle
-  Surface 607,                            !- Name
+  EnclosedOffice_Basement_ZN_1 - Wall 000_c, !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {6e08b2d6-7428-43a2-bb23-1dba7f241ea7}, !- Space Name
@@ -8327,14 +8070,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  22.7076, 18.8674375, -2.56474457505455e-029, !- X,Y,Z Vertex 1 {m}
-  22.7076, 18.8674375, -2.43840000000002, !- X,Y,Z Vertex 2 {m}
-  17.6037875, 18.8674375, -2.43840000000002, !- X,Y,Z Vertex 3 {m}
-  17.6037875, 18.8674375, -1.15505827125162e-014; !- X,Y,Z Vertex 4 {m}
+  22.7076, 18.8674375, 0,                 !- X,Y,Z Vertex 1 {m}
+  22.7076, 18.8674375, -2.4384,           !- X,Y,Z Vertex 2 {m}
+  17.6037875, 18.8674375, -2.4384,        !- X,Y,Z Vertex 3 {m}
+  17.6037875, 18.8674375, 0;              !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {1c6ab0ec-bd7e-43ee-9c9a-d4640215399b}, !- Handle
-  Surface 608,                            !- Name
+  EnclosedOffice_Basement_ZN_1 - RoofCeiling_a, !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {6e08b2d6-7428-43a2-bb23-1dba7f241ea7}, !- Space Name
@@ -8344,14 +8087,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  35.3568, 13.6858375, -1.08286712929839e-014, !- X,Y,Z Vertex 1 {m}
-  35.3568, 18.8674375, -1.22724941320485e-014, !- X,Y,Z Vertex 2 {m}
-  18.288, 18.8674375, -2.38230768445646e-014, !- X,Y,Z Vertex 3 {m}
-  18.288, 13.6858375, -2.23792540055001e-014; !- X,Y,Z Vertex 4 {m}
+  35.3568, 13.6858375, 0,                 !- X,Y,Z Vertex 1 {m}
+  35.3568, 18.8674375, 0,                 !- X,Y,Z Vertex 2 {m}
+  18.288, 18.8674375, 0,                  !- X,Y,Z Vertex 3 {m}
+  18.288, 13.6858375, 0;                  !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {6b64ec53-66a7-4a48-8e89-c9d782bcd7da}, !- Handle
-  Surface 609,                            !- Name
+  Corridor_Basement_ZN_1 - Wall 090_c,    !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {221e8adf-462f-4102-abb1-0bbedcc1010c}, !- Space Name
@@ -8361,14 +8104,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  17.6037875, 18.8674375, 2.31011654250324e-014, !- X,Y,Z Vertex 1 {m}
+  17.6037875, 18.8674375, 0,              !- X,Y,Z Vertex 1 {m}
   17.6037875, 18.8674375, -2.4384,        !- X,Y,Z Vertex 2 {m}
   17.6037875, 29.8402375, -2.4384,        !- X,Y,Z Vertex 3 {m}
-  17.6037875, 29.8402375, 2.31011654250324e-014; !- X,Y,Z Vertex 4 {m}
+  17.6037875, 29.8402375, 0;              !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {937dcf26-2252-45c9-b9cc-f22031fb0a0f}, !- Handle
-  Surface 610,                            !- Name
+  Corridor_Basement_ZN_1 - Wall 090_d,    !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {221e8adf-462f-4102-abb1-0bbedcc1010c}, !- Space Name
@@ -8378,14 +8121,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  17.6037875, 29.8402375, 2.31011654250324e-014, !- X,Y,Z Vertex 1 {m}
+  17.6037875, 29.8402375, 0,              !- X,Y,Z Vertex 1 {m}
   17.6037875, 29.8402375, -2.4384,        !- X,Y,Z Vertex 2 {m}
   17.6037875, 36.5458375, -2.4384,        !- X,Y,Z Vertex 3 {m}
-  17.6037875, 36.5458375, 2.31011654250324e-014; !- X,Y,Z Vertex 4 {m}
+  17.6037875, 36.5458375, 0;              !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {f69b0c19-0b5b-410f-ac8d-0b351edfd5b9}, !- Handle
-  Surface 611,                            !- Name
+  Corridor_Basement_ZN_1 - RoofCeiling_b, !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {221e8adf-462f-4102-abb1-0bbedcc1010c}, !- Space Name
@@ -8395,18 +8138,18 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  35.3568, 12.1618375, 2.29759334952628e-014, !- X,Y,Z Vertex 1 {m}
-  35.3568, 13.6858375, 2.37017588444759e-014, !- X,Y,Z Vertex 2 {m}
-  16.58112, 13.6858375, 1.06097177537745e-014, !- X,Y,Z Vertex 3 {m}
-  16.58112, 35.0218375, 2.07712726427576e-014, !- X,Y,Z Vertex 4 {m}
-  17.6037875, 35.0218375, 2.14843655870411e-014, !- X,Y,Z Vertex 5 {m}
-  17.6037875, 36.5458375, 2.22101909362542e-014, !- X,Y,Z Vertex 6 {m}
-  16.0797875, 36.5458375, 2.11475252633077e-014, !- X,Y,Z Vertex 7 {m}
-  16.0797875, 12.1618375, 9.53431967589839e-015; !- X,Y,Z Vertex 8 {m}
+  35.3568, 12.1618375, 0,                 !- X,Y,Z Vertex 1 {m}
+  35.3568, 13.6858375, 0,                 !- X,Y,Z Vertex 2 {m}
+  16.58112, 13.6858375, 0,                !- X,Y,Z Vertex 3 {m}
+  16.58112, 35.0218375, 0,                !- X,Y,Z Vertex 4 {m}
+  17.6037875, 35.0218375, 0,              !- X,Y,Z Vertex 5 {m}
+  17.6037875, 36.5458375, 0,              !- X,Y,Z Vertex 6 {m}
+  16.0797875, 36.5458375, 0,              !- X,Y,Z Vertex 7 {m}
+  16.0797875, 12.1618375, 0;              !- X,Y,Z Vertex 8 {m}
 
 OS:Surface,
   {640e0d85-ed1c-4903-900a-e325388c85e3}, !- Handle
-  Surface 612,                            !- Name
+  OpenOffice_Basement_ZN_1 - RoofCeiling_b, !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {028af023-65bd-494f-805d-65623355f305}, !- Space Name
@@ -8416,14 +8159,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  41.7576, -9.9636129237382e-017, -5.12948915010911e-030, !- X,Y,Z Vertex 1 {m}
-  41.7576, 12.1618375, -5.12948915010911e-030, !- X,Y,Z Vertex 2 {m}
-  16.0797875, 12.1618375, 2.31011654250324e-014, !- X,Y,Z Vertex 3 {m}
-  16.0797875, 0, 2.31011654250324e-014;   !- X,Y,Z Vertex 4 {m}
+  41.7576, 0, 0,                          !- X,Y,Z Vertex 1 {m}
+  41.7576, 12.1618375, 0,                 !- X,Y,Z Vertex 2 {m}
+  16.0797875, 12.1618375, 0,              !- X,Y,Z Vertex 3 {m}
+  16.0797875, 0, 0;                       !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {8b2d59d0-5f7b-488a-9f92-8e2387d4d171}, !- Handle
-  Surface 613,                            !- Name
+  OpenOffice_Basement_ZN_1 - Wall 000_c,  !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {028af023-65bd-494f-805d-65623355f305}, !- Space Name
@@ -8433,14 +8176,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.0416275, 12.1618375, 2.31011654250324e-014, !- X,Y,Z Vertex 1 {m}
+  46.0416275, 12.1618375, 0,              !- X,Y,Z Vertex 1 {m}
   46.0416275, 12.1618375, -2.4384,        !- X,Y,Z Vertex 2 {m}
   37.7952, 12.1618375, -2.4384,           !- X,Y,Z Vertex 3 {m}
-  37.7952, 12.1618375, 2.31011654250324e-014; !- X,Y,Z Vertex 4 {m}
+  37.7952, 12.1618375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {ba114291-51e5-4517-987a-7330d65a882b}, !- Handle
-  Surface 614,                            !- Name
+  OpenOffice_Basement_ZN_1 - Wall 000_b,  !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {028af023-65bd-494f-805d-65623355f305}, !- Space Name
@@ -8450,10 +8193,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  37.7952, 12.1618375, 2.31011654250324e-014, !- X,Y,Z Vertex 1 {m}
+  37.7952, 12.1618375, 0,                 !- X,Y,Z Vertex 1 {m}
   37.7952, 12.1618375, -2.4384,           !- X,Y,Z Vertex 2 {m}
   35.3568, 12.1618375, -2.4384,           !- X,Y,Z Vertex 3 {m}
-  35.3568, 12.1618375, 2.31011654250324e-014; !- X,Y,Z Vertex 4 {m}
+  35.3568, 12.1618375, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {70e73e41-8c3d-4e8e-9e20-04877f0b91f9}, !- Handle
@@ -8464,7 +8207,7 @@ OS:Space,
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
   0,                                      !- Y Origin {m}
-  1.98525640371372e-014,                  !- Z Origin {m}
+  0,                                      !- Z Origin {m}
   ,                                       !- Building Story Name
   {edbf4a78-3b20-49cb-aba5-c49f767c67ad}, !- Thermal Zone Name
   No,                                     !- Part of Total Floor Area
@@ -8473,7 +8216,7 @@ OS:Space,
 
 OS:Surface,
   {813f2065-30bd-45c2-97c2-6200350a2592}, !- Handle
-  Surface 314,                            !- Name
+  GroundFloor_Plenum - Floor_c,           !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {70e73e41-8c3d-4e8e-9e20-04877f0b91f9}, !- Space Name
@@ -8483,14 +8226,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  56.388, 12.1618375, 2.74478749999998,   !- X,Y,Z Vertex 1 {m}
-  56.388, 2.42284806771551e-016, 2.74478749999998, !- X,Y,Z Vertex 2 {m}
-  41.7576, 2.42284806771551e-016, 2.74478749999998, !- X,Y,Z Vertex 3 {m}
-  41.7576, 12.1618375, 2.74478749999998;  !- X,Y,Z Vertex 4 {m}
+  56.388, 12.1618375, 2.7447875,          !- X,Y,Z Vertex 1 {m}
+  56.388, 0, 2.7447875,                   !- X,Y,Z Vertex 2 {m}
+  41.7576, 0, 2.7447875,                  !- X,Y,Z Vertex 3 {m}
+  41.7576, 12.1618375, 2.7447875;         !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {6c27d05c-3bcb-416c-8038-3cf1e3331046}, !- Handle
-  Surface 315,                            !- Name
+  GroundFloor_Plenum - Wall 270_a,        !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {70e73e41-8c3d-4e8e-9e20-04877f0b91f9}, !- Space Name
@@ -8500,14 +8243,14 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 48.7378375, 3.96398749999998,        !- X,Y,Z Vertex 1 {m}
-  0, 48.7378375, 2.74478749999998,        !- X,Y,Z Vertex 2 {m}
-  0, 2.42284806771551e-016, 2.74478749999998, !- X,Y,Z Vertex 3 {m}
-  0, 2.42284806771551e-016, 3.96398749999998; !- X,Y,Z Vertex 4 {m}
+  0, 48.7378375, 3.9639875,               !- X,Y,Z Vertex 1 {m}
+  0, 48.7378375, 2.7447875,               !- X,Y,Z Vertex 2 {m}
+  0, 0, 2.7447875,                        !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.9639875;                        !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {bf4b1df6-f957-4900-909c-92335069834d}, !- Handle
-  Surface 316,                            !- Name
+  GroundFloor_Plenum - Wall 090_a,        !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {70e73e41-8c3d-4e8e-9e20-04877f0b91f9}, !- Space Name
@@ -8517,14 +8260,14 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  73.10755, 2.42284806771551e-016, 3.96398749999998, !- X,Y,Z Vertex 1 {m}
-  73.10755, 2.42284806771551e-016, 2.74478749999998, !- X,Y,Z Vertex 2 {m}
-  73.10755, 48.7378375, 2.74478749999998, !- X,Y,Z Vertex 3 {m}
-  73.10755, 48.7378375, 3.96398749999998; !- X,Y,Z Vertex 4 {m}
+  73.10755, 0, 3.9639875,                 !- X,Y,Z Vertex 1 {m}
+  73.10755, 0, 2.7447875,                 !- X,Y,Z Vertex 2 {m}
+  73.10755, 48.7378375, 2.7447875,        !- X,Y,Z Vertex 3 {m}
+  73.10755, 48.7378375, 3.9639875;        !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {fe49b55f-209d-45f2-babf-9cdb903f0a29}, !- Handle
-  Surface 318,                            !- Name
+  GroundFloor_Plenum - Wall 180_a,        !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {70e73e41-8c3d-4e8e-9e20-04877f0b91f9}, !- Space Name
@@ -8534,14 +8277,14 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 2.42284806771551e-016, 3.96398749999998, !- X,Y,Z Vertex 1 {m}
-  0, 2.42284806771551e-016, 2.74478749999998, !- X,Y,Z Vertex 2 {m}
-  73.10755, 2.42284806771551e-016, 2.74478749999998, !- X,Y,Z Vertex 3 {m}
-  73.10755, 2.42284806771551e-016, 3.96398749999998; !- X,Y,Z Vertex 4 {m}
+  0, 0, 3.9639875,                        !- X,Y,Z Vertex 1 {m}
+  0, 0, 2.7447875,                        !- X,Y,Z Vertex 2 {m}
+  73.10755, 0, 2.7447875,                 !- X,Y,Z Vertex 3 {m}
+  73.10755, 0, 3.9639875;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {cfa5b02a-0c94-494c-95d4-1100e37f57ce}, !- Handle
-  Surface 319,                            !- Name
+  GroundFloor_Plenum - Wall 000_a,        !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {70e73e41-8c3d-4e8e-9e20-04877f0b91f9}, !- Space Name
@@ -8551,14 +8294,14 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  73.10755, 48.7378375, 3.96398749999998, !- X,Y,Z Vertex 1 {m}
-  73.10755, 48.7378375, 2.74478749999998, !- X,Y,Z Vertex 2 {m}
-  0, 48.7378375, 2.74478749999998,        !- X,Y,Z Vertex 3 {m}
-  0, 48.7378375, 3.96398749999998;        !- X,Y,Z Vertex 4 {m}
+  73.10755, 48.7378375, 3.9639875,        !- X,Y,Z Vertex 1 {m}
+  73.10755, 48.7378375, 2.7447875,        !- X,Y,Z Vertex 2 {m}
+  0, 48.7378375, 2.7447875,               !- X,Y,Z Vertex 3 {m}
+  0, 48.7378375, 3.9639875;               !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {19578a5f-6e71-4371-b183-cc66cfb08c46}, !- Handle
-  Surface 320,                            !- Name
+  GroundFloor_Plenum - RoofCeiling_b,     !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {70e73e41-8c3d-4e8e-9e20-04877f0b91f9}, !- Space Name
@@ -8568,14 +8311,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  73.10755, 2.42284806771551e-016, 3.96398749999998, !- X,Y,Z Vertex 1 {m}
-  73.10755, 48.7378375, 3.96398749999998, !- X,Y,Z Vertex 2 {m}
-  0, 48.7378375, 3.96398749999998,        !- X,Y,Z Vertex 3 {m}
-  0, 2.42284806771551e-016, 3.96398749999998; !- X,Y,Z Vertex 4 {m}
+  73.10755, 0, 3.9639875,                 !- X,Y,Z Vertex 1 {m}
+  73.10755, 48.7378375, 3.9639875,        !- X,Y,Z Vertex 2 {m}
+  0, 48.7378375, 3.9639875,               !- X,Y,Z Vertex 3 {m}
+  0, 0, 3.9639875;                        !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {5c6e786b-b654-47c0-9274-1c2cea5cbb35}, !- Handle
-  Surface 615,                            !- Name
+  GroundFloor_Plenum - Floor_q,           !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {70e73e41-8c3d-4e8e-9e20-04877f0b91f9}, !- Space Name
@@ -8585,14 +8328,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  73.10755, 48.7378375, 2.74478749999998, !- X,Y,Z Vertex 1 {m}
-  73.10755, 42.6418375, 2.74478749999998, !- X,Y,Z Vertex 2 {m}
-  56.388, 42.6418375, 2.74478749999998,   !- X,Y,Z Vertex 3 {m}
-  56.388, 48.7378375, 2.74478749999998;   !- X,Y,Z Vertex 4 {m}
+  73.10755, 48.7378375, 2.7447875,        !- X,Y,Z Vertex 1 {m}
+  73.10755, 42.6418375, 2.7447875,        !- X,Y,Z Vertex 2 {m}
+  56.388, 42.6418375, 2.7447875,          !- X,Y,Z Vertex 3 {m}
+  56.388, 48.7378375, 2.7447875;          !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {d931804d-78fd-4160-8fc2-e3648c618f6b}, !- Handle
-  Surface 616,                            !- Name
+  GroundFloor_Plenum - Floor_r,           !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {70e73e41-8c3d-4e8e-9e20-04877f0b91f9}, !- Space Name
@@ -8602,31 +8345,35 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  41.7576, 12.1618375, 2.74478749999998,  !- X,Y,Z Vertex 1 {m}
-  41.7576, 2.42284806771551e-016, 2.74478749999998, !- X,Y,Z Vertex 2 {m}
-  15.05712, 2.42284806771551e-016, 2.74478749999998, !- X,Y,Z Vertex 3 {m}
-  15.05712, 12.1618375, 2.74478749999998; !- X,Y,Z Vertex 4 {m}
+  41.7576, 12.1618375, 2.7447875,         !- X,Y,Z Vertex 1 {m}
+  41.7576, 0, 2.7447875,                  !- X,Y,Z Vertex 2 {m}
+  15.05712, 0, 2.7447875,                 !- X,Y,Z Vertex 3 {m}
+  15.05712, 12.1618375, 2.7447875;        !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {456217b8-f8ec-4836-82ba-b608dd101279}, !- Handle
-  Surface 617,                            !- Name
+  GroundFloor_Plenum - RoofCeiling_a,     !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {70e73e41-8c3d-4e8e-9e20-04877f0b91f9}, !- Space Name
-  Outdoors,                               !- Outside Boundary Condition
-  ,                                       !- Outside Boundary Condition Object
-  SunExposed,                             !- Sun Exposure
-  WindExposed,                            !- Wind Exposure
+  Surface,                                !- Outside Boundary Condition
+  {098699cb-1e26-4895-b5f8-cc5c61aff946}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  35.3568, 35.0218375, 2.74478749999998,  !- X,Y,Z Vertex 1 {m}
-  35.3568, 35.0708215764634, 2.74478749999998, !- X,Y,Z Vertex 2 {m}
-  18.288, 35.0708215764634, 2.74478749999998, !- X,Y,Z Vertex 3 {m}
-  18.288, 35.0218375, 2.74478749999998;   !- X,Y,Z Vertex 4 {m}
+  35.3568, 12.1618375, 2.7447875,         !- X,Y,Z Vertex 1 {m}
+  35.3568, 13.6858375, 2.7447875,         !- X,Y,Z Vertex 2 {m}
+  16.58112, 13.6858375, 2.7447875,        !- X,Y,Z Vertex 3 {m}
+  16.58112, 35.0218375, 2.7447875,        !- X,Y,Z Vertex 4 {m}
+  35.3568, 35.0218375, 2.7447875,         !- X,Y,Z Vertex 5 {m}
+  35.3568, 36.5458375, 2.7447875,         !- X,Y,Z Vertex 6 {m}
+  15.05712, 36.5458375, 2.7447875,        !- X,Y,Z Vertex 7 {m}
+  15.05712, 12.1618375, 2.7447875;        !- X,Y,Z Vertex 8 {m}
 
 OS:Surface,
   {718c0768-17fd-46b9-8eed-a7b38a24f9f6}, !- Handle
-  Surface 618,                            !- Name
+  GroundFloor_Plenum - Floor_s,           !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {70e73e41-8c3d-4e8e-9e20-04877f0b91f9}, !- Space Name
@@ -8636,14 +8383,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  56.388, 48.7378375, 2.74478749999998,   !- X,Y,Z Vertex 1 {m}
-  56.388, 42.6418375, 2.74478749999998,   !- X,Y,Z Vertex 2 {m}
-  52.1208, 42.6418375, 2.74478749999998,  !- X,Y,Z Vertex 3 {m}
-  52.1208, 48.7378375, 2.74478749999998;  !- X,Y,Z Vertex 4 {m}
+  56.388, 48.7378375, 2.7447875,          !- X,Y,Z Vertex 1 {m}
+  56.388, 42.6418375, 2.7447875,          !- X,Y,Z Vertex 2 {m}
+  52.1208, 42.6418375, 2.7447875,         !- X,Y,Z Vertex 3 {m}
+  52.1208, 48.7378375, 2.7447875;         !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {a88ba48d-12bc-4a8d-b192-c8a986ba2e0f}, !- Handle
-  Surface 619,                            !- Name
+  GroundFloor_Plenum - Floor_t,           !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {70e73e41-8c3d-4e8e-9e20-04877f0b91f9}, !- Space Name
@@ -8653,14 +8400,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  18.288, 35.0218375, 2.74478749999998,   !- X,Y,Z Vertex 1 {m}
-  18.288, 13.6858375, 2.74478749999998,   !- X,Y,Z Vertex 2 {m}
-  16.58112, 13.6858375, 2.74478749999998, !- X,Y,Z Vertex 3 {m}
-  16.58112, 35.0218375, 2.74478749999998; !- X,Y,Z Vertex 4 {m}
+  18.288, 35.0218375, 2.7447875,          !- X,Y,Z Vertex 1 {m}
+  18.288, 13.6858375, 2.7447875,          !- X,Y,Z Vertex 2 {m}
+  16.58112, 13.6858375, 2.7447875,        !- X,Y,Z Vertex 3 {m}
+  16.58112, 35.0218375, 2.7447875;        !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {ed09e8b3-de4a-4b1f-ae9d-126ae4158c4f}, !- Handle
-  Surface 620,                            !- Name
+  GroundFloor_Plenum - Floor_u,           !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {70e73e41-8c3d-4e8e-9e20-04877f0b91f9}, !- Space Name
@@ -8670,14 +8417,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  6.096, 48.7378375, 2.74478749999998,    !- X,Y,Z Vertex 1 {m}
-  6.096, 36.5458375, 2.74478749999998,    !- X,Y,Z Vertex 2 {m}
-  0, 36.5458375, 2.74478749999998,        !- X,Y,Z Vertex 3 {m}
-  0, 48.7378375, 2.74478749999998;        !- X,Y,Z Vertex 4 {m}
+  6.096, 48.7378375, 2.7447875,           !- X,Y,Z Vertex 1 {m}
+  6.096, 36.5458375, 2.7447875,           !- X,Y,Z Vertex 2 {m}
+  0, 36.5458375, 2.7447875,               !- X,Y,Z Vertex 3 {m}
+  0, 48.7378375, 2.7447875;               !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {2e3541c4-3dd1-4b72-af02-e9f92c86ab16}, !- Handle
-  Surface 621,                            !- Name
+  GroundFloor_Plenum - Floor_a,           !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {70e73e41-8c3d-4e8e-9e20-04877f0b91f9}, !- Space Name
@@ -8687,16 +8434,16 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  15.05712, 36.5458375, 2.74478749999998, !- X,Y,Z Vertex 1 {m}
-  15.05712, 2.42284806771551e-016, 2.74478749999998, !- X,Y,Z Vertex 2 {m}
-  0, 2.42284806771551e-016, 2.74478749999998, !- X,Y,Z Vertex 3 {m}
-  0, 32.8882375, 2.74478749999998,        !- X,Y,Z Vertex 4 {m}
-  6.096, 32.8882375, 2.74478749999998,    !- X,Y,Z Vertex 5 {m}
-  6.096, 36.5458375, 2.74478749999998;    !- X,Y,Z Vertex 6 {m}
+  15.05712, 36.5458375, 2.7447875,        !- X,Y,Z Vertex 1 {m}
+  15.05712, 0, 2.7447875,                 !- X,Y,Z Vertex 2 {m}
+  0, 0, 2.7447875,                        !- X,Y,Z Vertex 3 {m}
+  0, 32.8882375, 2.7447875,               !- X,Y,Z Vertex 4 {m}
+  6.096, 32.8882375, 2.7447875,           !- X,Y,Z Vertex 5 {m}
+  6.096, 36.5458375, 2.7447875;           !- X,Y,Z Vertex 6 {m}
 
 OS:Surface,
   {fd32ce58-ae34-47cf-97dc-49e8cbc903ed}, !- Handle
-  Surface 622,                            !- Name
+  GroundFloor_Plenum - Floor_k,           !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {70e73e41-8c3d-4e8e-9e20-04877f0b91f9}, !- Space Name
@@ -8706,14 +8453,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.3296, 36.5458375, 2.74478749999998,  !- X,Y,Z Vertex 1 {m}
-  46.3296, 29.8402375, 2.74478749999998,  !- X,Y,Z Vertex 2 {m}
-  37.7952, 29.8402375, 2.74478749999998,  !- X,Y,Z Vertex 3 {m}
-  37.7952, 36.5458375, 2.74478749999998;  !- X,Y,Z Vertex 4 {m}
+  46.3296, 36.5458375, 2.7447875,         !- X,Y,Z Vertex 1 {m}
+  46.3296, 29.8402375, 2.7447875,         !- X,Y,Z Vertex 2 {m}
+  37.7952, 29.8402375, 2.7447875,         !- X,Y,Z Vertex 3 {m}
+  37.7952, 36.5458375, 2.7447875;         !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {ae8f278c-1e1d-4f8b-b725-459d69c67c0c}, !- Handle
-  Surface 623,                            !- Name
+  GroundFloor_Plenum - Floor_m,           !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {70e73e41-8c3d-4e8e-9e20-04877f0b91f9}, !- Space Name
@@ -8723,18 +8470,18 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  56.388, 36.5458375, 2.74478749999998,   !- X,Y,Z Vertex 1 {m}
-  56.388, 12.1618375, 2.74478749999998,   !- X,Y,Z Vertex 2 {m}
-  37.7952, 12.1618375, 2.74478749999998,  !- X,Y,Z Vertex 3 {m}
-  37.7952, 13.6858375, 2.74478749999998,  !- X,Y,Z Vertex 4 {m}
-  54.864, 13.6858375, 2.74478749999998,   !- X,Y,Z Vertex 5 {m}
-  54.864, 35.0218375, 2.74478749999998,   !- X,Y,Z Vertex 6 {m}
-  46.3296, 35.0218375, 2.74478749999998,  !- X,Y,Z Vertex 7 {m}
-  46.3296, 36.5458375, 2.74478749999998;  !- X,Y,Z Vertex 8 {m}
+  56.388, 36.5458375, 2.7447875,          !- X,Y,Z Vertex 1 {m}
+  56.388, 12.1618375, 2.7447875,          !- X,Y,Z Vertex 2 {m}
+  37.7952, 12.1618375, 2.7447875,         !- X,Y,Z Vertex 3 {m}
+  37.7952, 13.6858375, 2.7447875,         !- X,Y,Z Vertex 4 {m}
+  54.864, 13.6858375, 2.7447875,          !- X,Y,Z Vertex 5 {m}
+  54.864, 35.0218375, 2.7447875,          !- X,Y,Z Vertex 6 {m}
+  46.3296, 35.0218375, 2.7447875,         !- X,Y,Z Vertex 7 {m}
+  46.3296, 36.5458375, 2.7447875;         !- X,Y,Z Vertex 8 {m}
 
 OS:Surface,
   {2cf13593-76de-4621-94ec-91bdf7793500}, !- Handle
-  Surface 624,                            !- Name
+  GroundFloor_Plenum - Floor_b,           !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {70e73e41-8c3d-4e8e-9e20-04877f0b91f9}, !- Space Name
@@ -8744,14 +8491,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  35.3568, 35.0218375, 2.74478749999998,  !- X,Y,Z Vertex 1 {m}
-  35.3568, 29.8402375, 2.74478749999998,  !- X,Y,Z Vertex 2 {m}
-  18.288, 29.8402375, 2.74478749999998,   !- X,Y,Z Vertex 3 {m}
-  18.288, 35.0218375, 2.74478749999998;   !- X,Y,Z Vertex 4 {m}
+  35.3568, 35.0218375, 2.7447875,         !- X,Y,Z Vertex 1 {m}
+  35.3568, 29.8402375, 2.7447875,         !- X,Y,Z Vertex 2 {m}
+  18.288, 29.8402375, 2.7447875,          !- X,Y,Z Vertex 3 {m}
+  18.288, 35.0218375, 2.7447875;          !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {74ef846c-7660-4352-b17a-66e62a97a6d9}, !- Handle
-  Surface 625,                            !- Name
+  GroundFloor_Plenum - Floor_h,           !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {70e73e41-8c3d-4e8e-9e20-04877f0b91f9}, !- Space Name
@@ -8761,14 +8508,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  73.10755, 5.4864, 2.74478749999998,     !- X,Y,Z Vertex 1 {m}
-  73.10755, 2.42284806771551e-016, 2.74478749999998, !- X,Y,Z Vertex 2 {m}
-  56.388, 2.42284806771551e-016, 2.74478749999998, !- X,Y,Z Vertex 3 {m}
-  56.388, 5.4864, 2.74478749999998;       !- X,Y,Z Vertex 4 {m}
+  73.10755, 5.4864, 2.7447875,            !- X,Y,Z Vertex 1 {m}
+  73.10755, 0, 2.7447875,                 !- X,Y,Z Vertex 2 {m}
+  56.388, 0, 2.7447875,                   !- X,Y,Z Vertex 3 {m}
+  56.388, 5.4864, 2.7447875;              !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {db17f66c-fc0d-4604-bc99-da99cec0cd4e}, !- Handle
-  Surface 626,                            !- Name
+  GroundFloor_Plenum - Floor_d,           !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {70e73e41-8c3d-4e8e-9e20-04877f0b91f9}, !- Space Name
@@ -8778,14 +8525,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  37.7952, 36.5458375, 2.74478749999998,  !- X,Y,Z Vertex 1 {m}
-  37.7952, 12.1618375, 2.74478749999998,  !- X,Y,Z Vertex 2 {m}
-  35.3568, 12.1618375, 2.74478749999998,  !- X,Y,Z Vertex 3 {m}
-  35.3568, 36.5458375, 2.74478749999998;  !- X,Y,Z Vertex 4 {m}
+  37.7952, 36.5458375, 2.7447875,         !- X,Y,Z Vertex 1 {m}
+  37.7952, 12.1618375, 2.7447875,         !- X,Y,Z Vertex 2 {m}
+  35.3568, 12.1618375, 2.7447875,         !- X,Y,Z Vertex 3 {m}
+  35.3568, 36.5458375, 2.7447875;         !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {ce021267-91ef-43f1-89e9-656ab590a483}, !- Handle
-  Surface 627,                            !- Name
+  GroundFloor_Plenum - Floor_l,           !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {70e73e41-8c3d-4e8e-9e20-04877f0b91f9}, !- Space Name
@@ -8795,14 +8542,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  52.1208, 48.7378375, 2.74478749999998,  !- X,Y,Z Vertex 1 {m}
-  52.1208, 42.6418375, 2.74478749999998,  !- X,Y,Z Vertex 2 {m}
-  49.77384, 42.6418375, 2.74478749999998, !- X,Y,Z Vertex 3 {m}
-  49.77384, 48.7378375, 2.74478749999999; !- X,Y,Z Vertex 4 {m}
+  52.1208, 48.7378375, 2.7447875,         !- X,Y,Z Vertex 1 {m}
+  52.1208, 42.6418375, 2.7447875,         !- X,Y,Z Vertex 2 {m}
+  49.77384, 42.6418375, 2.7447875,        !- X,Y,Z Vertex 3 {m}
+  49.77384, 48.7378375, 2.7447875;        !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {2ccbdc57-9228-4cb3-87ff-4e9f6c6a2e95}, !- Handle
-  Surface 628,                            !- Name
+  GroundFloor_Plenum - Floor_v,           !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {70e73e41-8c3d-4e8e-9e20-04877f0b91f9}, !- Space Name
@@ -8812,14 +8559,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  35.3568, 18.8674375, 2.74478749999998,  !- X,Y,Z Vertex 1 {m}
-  35.3568, 13.6858375, 2.74478749999998,  !- X,Y,Z Vertex 2 {m}
-  18.288, 13.6858375, 2.74478749999998,   !- X,Y,Z Vertex 3 {m}
-  18.288, 18.8674375, 2.74478749999998;   !- X,Y,Z Vertex 4 {m}
+  35.3568, 18.8674375, 2.7447875,         !- X,Y,Z Vertex 1 {m}
+  35.3568, 13.6858375, 2.7447875,         !- X,Y,Z Vertex 2 {m}
+  18.288, 13.6858375, 2.7447875,          !- X,Y,Z Vertex 3 {m}
+  18.288, 18.8674375, 2.7447875;          !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {fe0b4329-3ff7-47c9-bccd-14db6b11f62d}, !- Handle
-  Surface 629,                            !- Name
+  GroundFloor_Plenum - Floor_p,           !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {70e73e41-8c3d-4e8e-9e20-04877f0b91f9}, !- Space Name
@@ -8829,14 +8576,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  54.864, 35.0218375, 2.74478749999998,   !- X,Y,Z Vertex 1 {m}
-  54.864, 29.8402375, 2.74478749999998,   !- X,Y,Z Vertex 2 {m}
-  46.3296, 29.8402375, 2.74478749999998,  !- X,Y,Z Vertex 3 {m}
-  46.3296, 35.0218375, 2.74478749999998;  !- X,Y,Z Vertex 4 {m}
+  54.864, 35.0218375, 2.7447875,          !- X,Y,Z Vertex 1 {m}
+  54.864, 29.8402375, 2.7447875,          !- X,Y,Z Vertex 2 {m}
+  46.3296, 29.8402375, 2.7447875,         !- X,Y,Z Vertex 3 {m}
+  46.3296, 35.0218375, 2.7447875;         !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {5332d6fe-d177-4d3b-a1b1-c078b1b9326a}, !- Handle
-  Surface 630,                            !- Name
+  GroundFloor_Plenum - Floor_w,           !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {70e73e41-8c3d-4e8e-9e20-04877f0b91f9}, !- Space Name
@@ -8846,14 +8593,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  54.864, 29.8402375, 2.74478749999998,   !- X,Y,Z Vertex 1 {m}
-  54.864, 18.8674375, 2.74478749999998,   !- X,Y,Z Vertex 2 {m}
-  49.0728, 18.8674375, 2.74478749999998,  !- X,Y,Z Vertex 3 {m}
-  49.0728, 29.8402375, 2.74478749999998;  !- X,Y,Z Vertex 4 {m}
+  54.864, 29.8402375, 2.7447875,          !- X,Y,Z Vertex 1 {m}
+  54.864, 18.8674375, 2.7447875,          !- X,Y,Z Vertex 2 {m}
+  49.0728, 18.8674375, 2.7447875,         !- X,Y,Z Vertex 3 {m}
+  49.0728, 29.8402375, 2.7447875;         !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {a598955e-93f3-4240-88e4-2c1a3548c50e}, !- Handle
-  Surface 631,                            !- Name
+  GroundFloor_Plenum - Floor_e,           !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {70e73e41-8c3d-4e8e-9e20-04877f0b91f9}, !- Space Name
@@ -8863,14 +8610,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  6.096, 36.5458375, 2.74478749999998,    !- X,Y,Z Vertex 1 {m}
-  6.096, 32.8882375, 2.74478749999998,    !- X,Y,Z Vertex 2 {m}
-  0, 32.8882375, 2.74478749999998,        !- X,Y,Z Vertex 3 {m}
-  0, 36.5458375, 2.74478749999998;        !- X,Y,Z Vertex 4 {m}
+  6.096, 36.5458375, 2.7447875,           !- X,Y,Z Vertex 1 {m}
+  6.096, 32.8882375, 2.7447875,           !- X,Y,Z Vertex 2 {m}
+  0, 32.8882375, 2.7447875,               !- X,Y,Z Vertex 3 {m}
+  0, 36.5458375, 2.7447875;               !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {fced715d-7c1e-4efd-a350-b049473ea395}, !- Handle
-  Surface 632,                            !- Name
+  GroundFloor_Plenum - Floor_o,           !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {70e73e41-8c3d-4e8e-9e20-04877f0b91f9}, !- Space Name
@@ -8880,14 +8627,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  54.864, 18.8674375, 2.74478749999998,   !- X,Y,Z Vertex 1 {m}
-  54.864, 13.6858375, 2.74478749999998,   !- X,Y,Z Vertex 2 {m}
-  37.7952, 13.6858375, 2.74478749999998,  !- X,Y,Z Vertex 3 {m}
-  37.7952, 18.8674375, 2.74478749999998;  !- X,Y,Z Vertex 4 {m}
+  54.864, 18.8674375, 2.7447875,          !- X,Y,Z Vertex 1 {m}
+  54.864, 13.6858375, 2.7447875,          !- X,Y,Z Vertex 2 {m}
+  37.7952, 13.6858375, 2.7447875,         !- X,Y,Z Vertex 3 {m}
+  37.7952, 18.8674375, 2.7447875;         !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {b53ab10e-f31a-4329-9b71-82d0c08de5e8}, !- Handle
-  Surface 633,                            !- Name
+  GroundFloor_Plenum - Floor_n,           !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {70e73e41-8c3d-4e8e-9e20-04877f0b91f9}, !- Space Name
@@ -8897,14 +8644,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  35.3568, 29.8402375, 2.74478749999998,  !- X,Y,Z Vertex 1 {m}
-  35.3568, 18.8674375, 2.74478749999998,  !- X,Y,Z Vertex 2 {m}
-  25.4508, 18.8674375, 2.74478749999998,  !- X,Y,Z Vertex 3 {m}
-  25.4508, 29.8402375, 2.74478749999998;  !- X,Y,Z Vertex 4 {m}
+  35.3568, 29.8402375, 2.7447875,         !- X,Y,Z Vertex 1 {m}
+  35.3568, 18.8674375, 2.7447875,         !- X,Y,Z Vertex 2 {m}
+  25.4508, 18.8674375, 2.7447875,         !- X,Y,Z Vertex 3 {m}
+  25.4508, 29.8402375, 2.7447875;         !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {cedb7f28-6bfc-4f25-a202-aecf631e9185}, !- Handle
-  Surface 634,                            !- Name
+  GroundFloor_Plenum - Floor_i,           !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {70e73e41-8c3d-4e8e-9e20-04877f0b91f9}, !- Space Name
@@ -8914,14 +8661,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  49.0728, 29.8402375, 2.74478749999998,  !- X,Y,Z Vertex 1 {m}
-  49.0728, 18.8674375, 2.74478749999998,  !- X,Y,Z Vertex 2 {m}
-  46.3296, 18.8674375, 2.74478749999998,  !- X,Y,Z Vertex 3 {m}
-  46.3296, 29.8402375, 2.74478749999998;  !- X,Y,Z Vertex 4 {m}
+  49.0728, 29.8402375, 2.7447875,         !- X,Y,Z Vertex 1 {m}
+  49.0728, 18.8674375, 2.7447875,         !- X,Y,Z Vertex 2 {m}
+  46.3296, 18.8674375, 2.7447875,         !- X,Y,Z Vertex 3 {m}
+  46.3296, 29.8402375, 2.7447875;         !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {82cec615-902d-4ce0-8598-ee16205234cc}, !- Handle
-  Surface 635,                            !- Name
+  GroundFloor_Plenum - Floor_x,           !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {70e73e41-8c3d-4e8e-9e20-04877f0b91f9}, !- Space Name
@@ -8931,14 +8678,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  22.7076, 29.8402375, 2.74478749999998,  !- X,Y,Z Vertex 1 {m}
-  22.7076, 18.8674375, 2.74478749999998,  !- X,Y,Z Vertex 2 {m}
-  18.288, 18.8674375, 2.74478749999998,   !- X,Y,Z Vertex 3 {m}
-  18.288, 29.8402375, 2.74478749999998;   !- X,Y,Z Vertex 4 {m}
+  22.7076, 29.8402375, 2.7447875,         !- X,Y,Z Vertex 1 {m}
+  22.7076, 18.8674375, 2.7447875,         !- X,Y,Z Vertex 2 {m}
+  18.288, 18.8674375, 2.7447875,          !- X,Y,Z Vertex 3 {m}
+  18.288, 29.8402375, 2.7447875;          !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {4232133d-c89d-40b1-998f-9ed8b8821f03}, !- Handle
-  Surface 636,                            !- Name
+  GroundFloor_Plenum - Floor_g,           !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {70e73e41-8c3d-4e8e-9e20-04877f0b91f9}, !- Space Name
@@ -8948,14 +8695,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  25.4508, 29.8402375, 2.74478749999998,  !- X,Y,Z Vertex 1 {m}
-  25.4508, 18.8674375, 2.74478749999998,  !- X,Y,Z Vertex 2 {m}
-  22.7076, 18.8674375, 2.74478749999998,  !- X,Y,Z Vertex 3 {m}
-  22.7076, 29.8402375, 2.74478749999998;  !- X,Y,Z Vertex 4 {m}
+  25.4508, 29.8402375, 2.7447875,         !- X,Y,Z Vertex 1 {m}
+  25.4508, 18.8674375, 2.7447875,         !- X,Y,Z Vertex 2 {m}
+  22.7076, 18.8674375, 2.7447875,         !- X,Y,Z Vertex 3 {m}
+  22.7076, 29.8402375, 2.7447875;         !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {d927f0c8-c23c-447c-91d2-f3db574b7501}, !- Handle
-  Surface 637,                            !- Name
+  GroundFloor_Plenum - Floor_f,           !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {70e73e41-8c3d-4e8e-9e20-04877f0b91f9}, !- Space Name
@@ -8965,14 +8712,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  46.3296, 29.8402375, 2.74478749999998,  !- X,Y,Z Vertex 1 {m}
-  46.3296, 18.8674375, 2.74478749999998,  !- X,Y,Z Vertex 2 {m}
-  37.7952, 18.8674375, 2.74478749999998,  !- X,Y,Z Vertex 3 {m}
-  37.7952, 29.8402375, 2.74478749999998;  !- X,Y,Z Vertex 4 {m}
+  46.3296, 29.8402375, 2.7447875,         !- X,Y,Z Vertex 1 {m}
+  46.3296, 18.8674375, 2.7447875,         !- X,Y,Z Vertex 2 {m}
+  37.7952, 18.8674375, 2.7447875,         !- X,Y,Z Vertex 3 {m}
+  37.7952, 29.8402375, 2.7447875;         !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {afc52295-59c8-4085-9d1d-1c2f16b7d465}, !- Handle
-  Surface 638,                            !- Name
+  GroundFloor_Plenum - Floor_y,           !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {70e73e41-8c3d-4e8e-9e20-04877f0b91f9}, !- Space Name
@@ -8982,16 +8729,16 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  49.77384, 48.7378375, 2.74478749999998, !- X,Y,Z Vertex 1 {m}
-  49.77384, 42.6418375, 2.74478749999998, !- X,Y,Z Vertex 2 {m}
-  56.388, 42.6418375, 2.74478749999998,   !- X,Y,Z Vertex 3 {m}
-  56.388, 36.5458375, 2.74478749999998,   !- X,Y,Z Vertex 4 {m}
-  6.096, 36.5458375, 2.74478749999998,    !- X,Y,Z Vertex 5 {m}
-  6.096, 48.7378375, 2.74478749999998;    !- X,Y,Z Vertex 6 {m}
+  49.77384, 48.7378375, 2.7447875,        !- X,Y,Z Vertex 1 {m}
+  49.77384, 42.6418375, 2.7447875,        !- X,Y,Z Vertex 2 {m}
+  56.388, 42.6418375, 2.7447875,          !- X,Y,Z Vertex 3 {m}
+  56.388, 36.5458375, 2.7447875,          !- X,Y,Z Vertex 4 {m}
+  6.096, 36.5458375, 2.7447875,           !- X,Y,Z Vertex 5 {m}
+  6.096, 48.7378375, 2.7447875;           !- X,Y,Z Vertex 6 {m}
 
 OS:Surface,
   {0ccc849f-ed85-48fd-95fe-2e1816657d93}, !- Handle
-  Surface 639,                            !- Name
+  GroundFloor_Plenum - Floor_j,           !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {70e73e41-8c3d-4e8e-9e20-04877f0b91f9}, !- Space Name
@@ -9001,33 +8748,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  73.10755, 42.6418375, 2.74478749999998, !- X,Y,Z Vertex 1 {m}
-  73.10755, 5.4864, 2.74478749999998,     !- X,Y,Z Vertex 2 {m}
-  56.388, 5.4864, 2.74478749999998,       !- X,Y,Z Vertex 3 {m}
-  56.388, 42.6418375, 2.74478749999998;   !- X,Y,Z Vertex 4 {m}
-
-OS:Surface,
-  {535a1742-fee0-480e-9f2e-86e7c201b10d}, !- Handle
-  Surface 640,                            !- Name
-  Floor,                                  !- Surface Type
-  ,                                       !- Construction Name
-  {70e73e41-8c3d-4e8e-9e20-04877f0b91f9}, !- Space Name
-  Surface,                                !- Outside Boundary Condition
-  {098699cb-1e26-4895-b5f8-cc5c61aff946}, !- Outside Boundary Condition Object
-  NoSun,                                  !- Sun Exposure
-  NoWind,                                 !- Wind Exposure
-  ,                                       !- View Factor to Ground
-  ,                                       !- Number of Vertices
-  35.3568, 36.5458375, 2.74478749999998,  !- X,Y,Z Vertex 1 {m}
-  35.3568, 35.0708215764634, 2.74478749999998, !- X,Y,Z Vertex 2 {m}
-  18.288, 35.0708215764634, 2.74478749999998, !- X,Y,Z Vertex 3 {m}
-  18.288, 35.0218375, 2.74478749999998,   !- X,Y,Z Vertex 4 {m}
-  16.58112, 35.0218375, 2.74478749999998, !- X,Y,Z Vertex 5 {m}
-  16.58112, 13.6858375, 2.74478749999998, !- X,Y,Z Vertex 6 {m}
-  35.3568, 13.6858375, 2.74478749999998,  !- X,Y,Z Vertex 7 {m}
-  35.3568, 12.1618375, 2.74478749999998,  !- X,Y,Z Vertex 8 {m}
-  15.05712, 12.1618375, 2.74478749999998, !- X,Y,Z Vertex 9 {m}
-  15.05712, 36.5458375, 2.74478749999998; !- X,Y,Z Vertex 10 {m}
+  73.10755, 42.6418375, 2.7447875,        !- X,Y,Z Vertex 1 {m}
+  73.10755, 5.4864, 2.7447875,            !- X,Y,Z Vertex 2 {m}
+  56.388, 5.4864, 2.7447875,              !- X,Y,Z Vertex 3 {m}
+  56.388, 42.6418375, 2.7447875;          !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {baa0d6e9-3f43-4779-b886-9b809196ab7b}, !- Handle
@@ -9037,8 +8761,8 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  9.9636129237382e-017,                   !- Y Origin {m}
-  2.31011654250324e-014,                  !- Z Origin {m}
+  0,                                      !- Y Origin {m}
+  0,                                      !- Z Origin {m}
   {1d8b4970-d4e9-45ae-815d-7e03b0f996ab}, !- Building Story Name
   {936a55f7-16a1-49ce-8b99-91f0947c37e5}, !- Thermal Zone Name
   ,                                       !- Part of Total Floor Area
@@ -9047,7 +8771,7 @@ OS:Space,
 
 OS:Surface,
   {f1eea7f9-753c-4ba2-b7a4-7ace25e2d209}, !- Handle
-  Surface 321,                            !- Name
+  Corridor_Mid_ZN_1 - Floor_a,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {baa0d6e9-3f43-4779-b886-9b809196ab7b}, !- Space Name
@@ -9068,7 +8792,7 @@ OS:Surface,
 
 OS:Surface,
   {17cab915-bfa5-4d60-9fbd-98676fe298cf}, !- Handle
-  Surface 322,                            !- Name
+  Corridor_Mid_ZN_1 - Wall 000_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {baa0d6e9-3f43-4779-b886-9b809196ab7b}, !- Space Name
@@ -9085,7 +8809,7 @@ OS:Surface,
 
 OS:Surface,
   {b7ba48ab-a562-43a7-9f24-18fa4c501abe}, !- Handle
-  Surface 323,                            !- Name
+  Corridor_Mid_ZN_1 - Wall 090_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {baa0d6e9-3f43-4779-b886-9b809196ab7b}, !- Space Name
@@ -9102,7 +8826,7 @@ OS:Surface,
 
 OS:Surface,
   {627acac9-203f-4683-9c24-29fe374ef12e}, !- Handle
-  Surface 324,                            !- Name
+  Corridor_Mid_ZN_1 - Wall 090_b,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {baa0d6e9-3f43-4779-b886-9b809196ab7b}, !- Space Name
@@ -9119,7 +8843,7 @@ OS:Surface,
 
 OS:Surface,
   {806d02f7-6431-4af9-ac2a-ab94518216cd}, !- Handle
-  Surface 325,                            !- Name
+  Corridor_Mid_ZN_1 - Wall 180_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {baa0d6e9-3f43-4779-b886-9b809196ab7b}, !- Space Name
@@ -9136,7 +8860,7 @@ OS:Surface,
 
 OS:Surface,
   {3dc8d26a-ef30-47fe-9a06-046a157ae387}, !- Handle
-  Surface 326,                            !- Name
+  Corridor_Mid_ZN_1 - Wall 270_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {baa0d6e9-3f43-4779-b886-9b809196ab7b}, !- Space Name
@@ -9153,7 +8877,7 @@ OS:Surface,
 
 OS:Surface,
   {f14a3790-f0bf-4d74-b913-a2b6880f4dd2}, !- Handle
-  Surface 327,                            !- Name
+  Corridor_Mid_ZN_1 - Wall 180_b,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {baa0d6e9-3f43-4779-b886-9b809196ab7b}, !- Space Name
@@ -9170,7 +8894,7 @@ OS:Surface,
 
 OS:Surface,
   {60e1d99f-2d70-4841-9858-3cdd45b8dfe0}, !- Handle
-  Surface 328,                            !- Name
+  Corridor_Mid_ZN_1 - Wall 090_c,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {baa0d6e9-3f43-4779-b886-9b809196ab7b}, !- Space Name
@@ -9187,7 +8911,7 @@ OS:Surface,
 
 OS:Surface,
   {2a1513bf-a6d1-4e00-9c28-ba23d939f895}, !- Handle
-  Surface 329,                            !- Name
+  Corridor_Mid_ZN_1 - Wall 000_b,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {baa0d6e9-3f43-4779-b886-9b809196ab7b}, !- Space Name
@@ -9204,7 +8928,7 @@ OS:Surface,
 
 OS:Surface,
   {238526db-233b-43b8-96b2-6d9d6bb53df5}, !- Handle
-  Surface 330,                            !- Name
+  Corridor_Mid_ZN_1 - RoofCeiling_a,      !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {baa0d6e9-3f43-4779-b886-9b809196ab7b}, !- Space Name
@@ -9231,7 +8955,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  3.41920936008933e-016,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {1d8b4970-d4e9-45ae-815d-7e03b0f996ab}, !- Building Story Name
   {2081e7e1-6d73-4a57-8b17-c9a892cebd15}, !- Thermal Zone Name
@@ -9241,7 +8965,7 @@ OS:Space,
 
 OS:Surface,
   {c55f998d-409d-461a-86e9-2b67c2562f06}, !- Handle
-  Surface 331,                            !- Name
+  Datacenter_Mid_ZN - Floor_a,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {756ce787-864a-4417-9732-79cbb8afc5a1}, !- Space Name
@@ -9258,7 +8982,7 @@ OS:Surface,
 
 OS:Surface,
   {29f287c3-95a1-417e-be4d-6541a071f64b}, !- Handle
-  Surface 332,                            !- Name
+  Datacenter_Mid_ZN - Wall 270_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {756ce787-864a-4417-9732-79cbb8afc5a1}, !- Space Name
@@ -9275,7 +8999,7 @@ OS:Surface,
 
 OS:Surface,
   {844397dd-d3ba-4a5c-b26f-34970c662807}, !- Handle
-  Surface 333,                            !- Name
+  Datacenter_Mid_ZN - Wall 000_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {756ce787-864a-4417-9732-79cbb8afc5a1}, !- Space Name
@@ -9292,7 +9016,7 @@ OS:Surface,
 
 OS:Surface,
   {46fcef79-3a5c-4500-ac0d-c8e7da01a639}, !- Handle
-  Surface 334,                            !- Name
+  Datacenter_Mid_ZN - Wall 180_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {756ce787-864a-4417-9732-79cbb8afc5a1}, !- Space Name
@@ -9309,7 +9033,7 @@ OS:Surface,
 
 OS:Surface,
   {dc8cd755-1d3e-474a-82bf-bb86460fd48f}, !- Handle
-  Surface 335,                            !- Name
+  Datacenter_Mid_ZN - RoofCeiling_a,      !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {756ce787-864a-4417-9732-79cbb8afc5a1}, !- Space Name
@@ -9326,7 +9050,7 @@ OS:Surface,
 
 OS:Surface,
   {46466f5f-d199-4391-8311-0778f77a3987}, !- Handle
-  Surface 336,                            !- Name
+  Datacenter_Mid_ZN - Wall 090_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {756ce787-864a-4417-9732-79cbb8afc5a1}, !- Space Name
@@ -9349,8 +9073,8 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  9.9636129237382e-017,                   !- Y Origin {m}
-  2.31011654250324e-014,                  !- Z Origin {m}
+  0,                                      !- Y Origin {m}
+  0,                                      !- Z Origin {m}
   {1d8b4970-d4e9-45ae-815d-7e03b0f996ab}, !- Building Story Name
   {a0083f4e-c7e2-4e71-b0dc-d47245c95b78}, !- Thermal Zone Name
   ,                                       !- Part of Total Floor Area
@@ -9358,7 +9082,7 @@ OS:Space,
 
 OS:Surface,
   {05eb57a2-2dc5-4bc4-ab7b-a97ac1284c17}, !- Handle
-  Surface 337,                            !- Name
+  Mechanical_Mid_ZN_1 - Floor_a,          !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {5714c59a-3f1c-47eb-985f-58729e902ed7}, !- Space Name
@@ -9375,7 +9099,7 @@ OS:Surface,
 
 OS:Surface,
   {2c7f4e35-32ce-4b9c-a6c6-f5b563560e61}, !- Handle
-  Surface 338,                            !- Name
+  Mechanical_Mid_ZN_1 - Wall 000_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {5714c59a-3f1c-47eb-985f-58729e902ed7}, !- Space Name
@@ -9392,7 +9116,7 @@ OS:Surface,
 
 OS:Surface,
   {d4f4933b-85cd-4f3a-bda2-7f5ec58c5c00}, !- Handle
-  Surface 339,                            !- Name
+  Mechanical_Mid_ZN_1 - RoofCeiling_a,    !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {5714c59a-3f1c-47eb-985f-58729e902ed7}, !- Space Name
@@ -9409,7 +9133,7 @@ OS:Surface,
 
 OS:Surface,
   {d3dd8c37-d52c-4115-8cab-94c765374121}, !- Handle
-  Surface 340,                            !- Name
+  Mechanical_Mid_ZN_1 - Wall 180_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {5714c59a-3f1c-47eb-985f-58729e902ed7}, !- Space Name
@@ -9426,7 +9150,7 @@ OS:Surface,
 
 OS:Surface,
   {0d897bf8-3523-4cad-83b8-b53c36712e92}, !- Handle
-  Surface 341,                            !- Name
+  Mechanical_Mid_ZN_1 - Wall 090_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {5714c59a-3f1c-47eb-985f-58729e902ed7}, !- Space Name
@@ -9443,7 +9167,7 @@ OS:Surface,
 
 OS:Surface,
   {bdd94161-5033-41c3-a6d6-0fcec5766174}, !- Handle
-  Surface 342,                            !- Name
+  Mechanical_Mid_ZN_1 - Wall 270_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {5714c59a-3f1c-47eb-985f-58729e902ed7}, !- Space Name
@@ -9466,7 +9190,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  3.41920936008933e-016,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {1d8b4970-d4e9-45ae-815d-7e03b0f996ab}, !- Building Story Name
   {ec6c973d-c668-4b43-91d9-3d24f85bf2a1}, !- Thermal Zone Name
@@ -9475,7 +9199,7 @@ OS:Space,
 
 OS:Surface,
   {77da8afe-b481-4adc-93cf-530953c91258}, !- Handle
-  Surface 343,                            !- Name
+  Stair_Mid_ZN_1 - Floor_a,               !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {677d2f9b-cd1b-46f7-8041-52545a4f1a89}, !- Space Name
@@ -9492,7 +9216,7 @@ OS:Surface,
 
 OS:Surface,
   {4f18fc83-af29-4545-8e04-3aacb124c781}, !- Handle
-  Surface 344,                            !- Name
+  Stair_Mid_ZN_1 - Wall 000_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {677d2f9b-cd1b-46f7-8041-52545a4f1a89}, !- Space Name
@@ -9509,7 +9233,7 @@ OS:Surface,
 
 OS:Surface,
   {de0dd6d1-1470-4e58-91b6-76e44ab0023c}, !- Handle
-  Surface 345,                            !- Name
+  Stair_Mid_ZN_1 - Wall 270_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {677d2f9b-cd1b-46f7-8041-52545a4f1a89}, !- Space Name
@@ -9526,7 +9250,7 @@ OS:Surface,
 
 OS:Surface,
   {d03139e3-4d55-4989-9497-2631b2f05fb6}, !- Handle
-  Surface 346,                            !- Name
+  Stair_Mid_ZN_1 - Wall 180_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {677d2f9b-cd1b-46f7-8041-52545a4f1a89}, !- Space Name
@@ -9543,7 +9267,7 @@ OS:Surface,
 
 OS:Surface,
   {3e4a2336-151d-404f-b376-50a61f5adfff}, !- Handle
-  Surface 347,                            !- Name
+  Stair_Mid_ZN_1 - RoofCeiling_a,         !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {677d2f9b-cd1b-46f7-8041-52545a4f1a89}, !- Space Name
@@ -9560,7 +9284,7 @@ OS:Surface,
 
 OS:Surface,
   {983c88ad-70d0-4446-bd1f-779d4b25448d}, !- Handle
-  Surface 348,                            !- Name
+  Stair_Mid_ZN_1 - Wall 090_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {677d2f9b-cd1b-46f7-8041-52545a4f1a89}, !- Space Name
@@ -9583,8 +9307,8 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  9.9636129237382e-017,                   !- Y Origin {m}
-  2.31011654250324e-014,                  !- Z Origin {m}
+  0,                                      !- Y Origin {m}
+  0,                                      !- Z Origin {m}
   {1d8b4970-d4e9-45ae-815d-7e03b0f996ab}, !- Building Story Name
   {5bb83625-d5c0-43e8-8305-bb70beb1ffdd}, !- Thermal Zone Name
   ,                                       !- Part of Total Floor Area
@@ -9592,7 +9316,7 @@ OS:Space,
 
 OS:Surface,
   {80e59d6b-54dc-40c6-a447-a42aa0253686}, !- Handle
-  Surface 349,                            !- Name
+  Restroom_Mid_ZN - Floor_a,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {3a28082f-ea67-4957-96d1-66e62b31f842}, !- Space Name
@@ -9609,7 +9333,7 @@ OS:Surface,
 
 OS:Surface,
   {b03dcdd1-9252-4214-8caf-3cd70980a2f1}, !- Handle
-  Surface 350,                            !- Name
+  Restroom_Mid_ZN - Wall 090_a,           !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3a28082f-ea67-4957-96d1-66e62b31f842}, !- Space Name
@@ -9626,7 +9350,7 @@ OS:Surface,
 
 OS:Surface,
   {ae52d223-420e-4e1f-92b4-ed910d132514}, !- Handle
-  Surface 351,                            !- Name
+  Restroom_Mid_ZN - Wall 000_a,           !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3a28082f-ea67-4957-96d1-66e62b31f842}, !- Space Name
@@ -9643,7 +9367,7 @@ OS:Surface,
 
 OS:Surface,
   {a8e4c514-68ca-4e56-a030-3d4afc189c23}, !- Handle
-  Surface 352,                            !- Name
+  Restroom_Mid_ZN - Wall 270_a,           !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3a28082f-ea67-4957-96d1-66e62b31f842}, !- Space Name
@@ -9660,7 +9384,7 @@ OS:Surface,
 
 OS:Surface,
   {0f36ee64-1cf7-4e15-9eac-aa021ef24ae5}, !- Handle
-  Surface 353,                            !- Name
+  Restroom_Mid_ZN - RoofCeiling_a,        !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {3a28082f-ea67-4957-96d1-66e62b31f842}, !- Space Name
@@ -9677,7 +9401,7 @@ OS:Surface,
 
 OS:Surface,
   {c403d9c9-c005-4a16-aca6-0702b1029620}, !- Handle
-  Surface 354,                            !- Name
+  Restroom_Mid_ZN - Wall 180_a,           !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3a28082f-ea67-4957-96d1-66e62b31f842}, !- Space Name
@@ -9700,8 +9424,8 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  9.9636129237382e-017,                   !- Y Origin {m}
-  2.31011654250324e-014,                  !- Z Origin {m}
+  0,                                      !- Y Origin {m}
+  0,                                      !- Z Origin {m}
   {1d8b4970-d4e9-45ae-815d-7e03b0f996ab}, !- Building Story Name
   {cdda4c5c-bfd6-400d-aa35-f24afcab1d50}, !- Thermal Zone Name
   ,                                       !- Part of Total Floor Area
@@ -9709,7 +9433,7 @@ OS:Space,
 
 OS:Surface,
   {ed968f60-74f6-4302-84e0-e9edd35d2147}, !- Handle
-  Surface 355,                            !- Name
+  EnclosedOffice_Mid_ZN_1 - Floor_a,      !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {bccc9f2d-d256-41af-a2b2-ac258b3e84ed}, !- Space Name
@@ -9726,7 +9450,7 @@ OS:Surface,
 
 OS:Surface,
   {655c408e-a673-49bd-a5a4-90ff95a6502a}, !- Handle
-  Surface 356,                            !- Name
+  EnclosedOffice_Mid_ZN_1 - Wall 000_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {bccc9f2d-d256-41af-a2b2-ac258b3e84ed}, !- Space Name
@@ -9743,7 +9467,7 @@ OS:Surface,
 
 OS:Surface,
   {0fba9a4b-0230-4112-8d1d-914b5fee5782}, !- Handle
-  Surface 357,                            !- Name
+  EnclosedOffice_Mid_ZN_1 - Wall 270_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {bccc9f2d-d256-41af-a2b2-ac258b3e84ed}, !- Space Name
@@ -9760,7 +9484,7 @@ OS:Surface,
 
 OS:Surface,
   {b601413a-d327-4c06-9128-3f3bab46c093}, !- Handle
-  Surface 358,                            !- Name
+  EnclosedOffice_Mid_ZN_1 - RoofCeiling_a, !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {bccc9f2d-d256-41af-a2b2-ac258b3e84ed}, !- Space Name
@@ -9777,7 +9501,7 @@ OS:Surface,
 
 OS:Surface,
   {78ce7028-7b9e-4ac7-aa40-be831200cd91}, !- Handle
-  Surface 359,                            !- Name
+  EnclosedOffice_Mid_ZN_1 - Wall 090_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {bccc9f2d-d256-41af-a2b2-ac258b3e84ed}, !- Space Name
@@ -9794,7 +9518,7 @@ OS:Surface,
 
 OS:Surface,
   {9b94edb5-c331-4529-8759-d4bb3f6f5861}, !- Handle
-  Surface 360,                            !- Name
+  EnclosedOffice_Mid_ZN_1 - Wall 180_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {bccc9f2d-d256-41af-a2b2-ac258b3e84ed}, !- Space Name
@@ -9817,8 +9541,8 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  9.9636129237382e-017,                   !- Y Origin {m}
-  2.31011654250324e-014,                  !- Z Origin {m}
+  0,                                      !- Y Origin {m}
+  0,                                      !- Z Origin {m}
   {1d8b4970-d4e9-45ae-815d-7e03b0f996ab}, !- Building Story Name
   {3bb39094-57ff-4e7d-a64b-a39f1374aff0}, !- Thermal Zone Name
   ,                                       !- Part of Total Floor Area
@@ -9826,7 +9550,7 @@ OS:Space,
 
 OS:Surface,
   {fa833d77-95b7-4c0b-87fc-e1731e335b32}, !- Handle
-  Surface 361,                            !- Name
+  Lobby_Mid_ZN - Floor_a,                 !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {3348a82a-51b6-42f2-8ff4-895a73eb0ae8}, !- Space Name
@@ -9843,7 +9567,7 @@ OS:Surface,
 
 OS:Surface,
   {b337bb6f-5316-4cfe-8629-ddaca3072710}, !- Handle
-  Surface 362,                            !- Name
+  Lobby_Mid_ZN - Wall 270_b,              !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3348a82a-51b6-42f2-8ff4-895a73eb0ae8}, !- Space Name
@@ -9860,7 +9584,7 @@ OS:Surface,
 
 OS:Surface,
   {51df4bc0-c520-4b41-b764-88ea894a5408}, !- Handle
-  Surface 363,                            !- Name
+  Lobby_Mid_ZN - Wall 180_a,              !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3348a82a-51b6-42f2-8ff4-895a73eb0ae8}, !- Space Name
@@ -9877,7 +9601,7 @@ OS:Surface,
 
 OS:Surface,
   {639a5257-39d7-4223-89a9-00065df76295}, !- Handle
-  Surface 364,                            !- Name
+  Lobby_Mid_ZN - Wall 090_b,              !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3348a82a-51b6-42f2-8ff4-895a73eb0ae8}, !- Space Name
@@ -9894,7 +9618,7 @@ OS:Surface,
 
 OS:Surface,
   {2d85151b-107d-4b9e-8a36-23f2e28fa736}, !- Handle
-  Surface 365,                            !- Name
+  Lobby_Mid_ZN - Wall 000_a,              !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3348a82a-51b6-42f2-8ff4-895a73eb0ae8}, !- Space Name
@@ -9911,7 +9635,7 @@ OS:Surface,
 
 OS:Surface,
   {5f640ade-798a-4d8e-a50b-1457a70f09ca}, !- Handle
-  Surface 366,                            !- Name
+  Lobby_Mid_ZN - RoofCeiling_a,           !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {3348a82a-51b6-42f2-8ff4-895a73eb0ae8}, !- Space Name
@@ -9934,7 +9658,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  3.41920936008933e-016,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {1d8b4970-d4e9-45ae-815d-7e03b0f996ab}, !- Building Story Name
   {941a09c6-44e2-4638-85dd-3a03927bcce5}, !- Thermal Zone Name
@@ -9944,7 +9668,7 @@ OS:Space,
 
 OS:Surface,
   {f693bc92-eb67-4b14-b12e-ab5bcdb16b25}, !- Handle
-  Surface 367,                            !- Name
+  Corridor_Mid_ZN_2 - Floor_a,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {4dfb84c8-5601-4d2a-a442-f696a1779b89}, !- Space Name
@@ -9965,7 +9689,7 @@ OS:Surface,
 
 OS:Surface,
   {7c91a68f-b4a4-4c9c-a4b2-bc5d84cfb0ad}, !- Handle
-  Surface 368,                            !- Name
+  Corridor_Mid_ZN_2 - Wall 270_b,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {4dfb84c8-5601-4d2a-a442-f696a1779b89}, !- Space Name
@@ -9982,7 +9706,7 @@ OS:Surface,
 
 OS:Surface,
   {c7d412b0-e1ca-40b0-8779-b373c714ac1d}, !- Handle
-  Surface 369,                            !- Name
+  Corridor_Mid_ZN_2 - Wall 180_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {4dfb84c8-5601-4d2a-a442-f696a1779b89}, !- Space Name
@@ -9999,7 +9723,7 @@ OS:Surface,
 
 OS:Surface,
   {1d662a44-22ec-4531-a2c7-e65947435cc6}, !- Handle
-  Surface 370,                            !- Name
+  Corridor_Mid_ZN_2 - Wall 270_c,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {4dfb84c8-5601-4d2a-a442-f696a1779b89}, !- Space Name
@@ -10016,7 +9740,7 @@ OS:Surface,
 
 OS:Surface,
   {3646a665-8838-4fd2-971f-459236e8787a}, !- Handle
-  Surface 371,                            !- Name
+  Corridor_Mid_ZN_2 - Wall 000_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {4dfb84c8-5601-4d2a-a442-f696a1779b89}, !- Space Name
@@ -10033,7 +9757,7 @@ OS:Surface,
 
 OS:Surface,
   {8494fe15-7bd4-4aaf-b60a-8334d7489288}, !- Handle
-  Surface 372,                            !- Name
+  Corridor_Mid_ZN_2 - Wall 270_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {4dfb84c8-5601-4d2a-a442-f696a1779b89}, !- Space Name
@@ -10050,7 +9774,7 @@ OS:Surface,
 
 OS:Surface,
   {175ecfd8-3e9b-406b-bdca-0985bb3b0212}, !- Handle
-  Surface 373,                            !- Name
+  Corridor_Mid_ZN_2 - RoofCeiling_a,      !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {4dfb84c8-5601-4d2a-a442-f696a1779b89}, !- Space Name
@@ -10071,7 +9795,7 @@ OS:Surface,
 
 OS:Surface,
   {5f509883-ae45-4a54-bce4-ad1913666f4d}, !- Handle
-  Surface 374,                            !- Name
+  Corridor_Mid_ZN_2 - Wall 180_b,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {4dfb84c8-5601-4d2a-a442-f696a1779b89}, !- Space Name
@@ -10088,7 +9812,7 @@ OS:Surface,
 
 OS:Surface,
   {84b891d6-7181-4299-94da-58a4bb56c485}, !- Handle
-  Surface 375,                            !- Name
+  Corridor_Mid_ZN_2 - Wall 000_b,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {4dfb84c8-5601-4d2a-a442-f696a1779b89}, !- Space Name
@@ -10105,7 +9829,7 @@ OS:Surface,
 
 OS:Surface,
   {c4c95599-63b5-4375-9656-5c4f2bdd064b}, !- Handle
-  Surface 376,                            !- Name
+  Corridor_Mid_ZN_2 - Wall 090_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {4dfb84c8-5601-4d2a-a442-f696a1779b89}, !- Space Name
@@ -10128,7 +9852,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  3.41920936008933e-016,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {1d8b4970-d4e9-45ae-815d-7e03b0f996ab}, !- Building Story Name
   {194fb585-e74b-4317-9963-0bfc9ab085f2}, !- Thermal Zone Name
@@ -10137,7 +9861,7 @@ OS:Space,
 
 OS:Surface,
   {128ca15a-98ce-4f29-b45f-ae0f00c3bd64}, !- Handle
-  Surface 377,                            !- Name
+  Mechanical_Mid_ZN_2 - Floor_a,          !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {f5834508-c596-4990-bf7b-d2d64a985d1d}, !- Space Name
@@ -10154,7 +9878,7 @@ OS:Surface,
 
 OS:Surface,
   {f325a020-c434-488c-890f-6b9e90f67175}, !- Handle
-  Surface 378,                            !- Name
+  Mechanical_Mid_ZN_2 - Wall 090_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f5834508-c596-4990-bf7b-d2d64a985d1d}, !- Space Name
@@ -10171,7 +9895,7 @@ OS:Surface,
 
 OS:Surface,
   {4110ecfc-dfd1-4091-982f-c7f324472a0c}, !- Handle
-  Surface 379,                            !- Name
+  Mechanical_Mid_ZN_2 - Wall 000_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f5834508-c596-4990-bf7b-d2d64a985d1d}, !- Space Name
@@ -10188,7 +9912,7 @@ OS:Surface,
 
 OS:Surface,
   {09562cbd-264e-4f63-9885-a774e1bc979b}, !- Handle
-  Surface 380,                            !- Name
+  Mechanical_Mid_ZN_2 - RoofCeiling_a,    !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {f5834508-c596-4990-bf7b-d2d64a985d1d}, !- Space Name
@@ -10205,7 +9929,7 @@ OS:Surface,
 
 OS:Surface,
   {93fc68eb-271c-487f-a8ec-d06f49e78ce9}, !- Handle
-  Surface 381,                            !- Name
+  Mechanical_Mid_ZN_2 - Wall 270_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f5834508-c596-4990-bf7b-d2d64a985d1d}, !- Space Name
@@ -10222,7 +9946,7 @@ OS:Surface,
 
 OS:Surface,
   {01661e2f-f87f-476c-b6fe-609937899e61}, !- Handle
-  Surface 382,                            !- Name
+  Mechanical_Mid_ZN_2 - Wall 180_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f5834508-c596-4990-bf7b-d2d64a985d1d}, !- Space Name
@@ -10245,8 +9969,8 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  9.9636129237382e-017,                   !- Y Origin {m}
-  2.31011654250324e-014,                  !- Z Origin {m}
+  0,                                      !- Y Origin {m}
+  0,                                      !- Z Origin {m}
   {1d8b4970-d4e9-45ae-815d-7e03b0f996ab}, !- Building Story Name
   {549ea789-7ede-45ee-8e8d-fb85d5233efd}, !- Thermal Zone Name
   ,                                       !- Part of Total Floor Area
@@ -10254,7 +9978,7 @@ OS:Space,
 
 OS:Surface,
   {39e6af0f-d8ef-451e-acf4-aa6dfa155650}, !- Handle
-  Surface 383,                            !- Name
+  Stair_Mid_ZN_2 - Floor_a,               !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {d61faaa4-b081-4233-b2f8-6829dcc5eb70}, !- Space Name
@@ -10271,7 +9995,7 @@ OS:Surface,
 
 OS:Surface,
   {99fb7176-63ef-47ac-a858-d644c3a0854c}, !- Handle
-  Surface 384,                            !- Name
+  Stair_Mid_ZN_2 - RoofCeiling_a,         !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {d61faaa4-b081-4233-b2f8-6829dcc5eb70}, !- Space Name
@@ -10288,7 +10012,7 @@ OS:Surface,
 
 OS:Surface,
   {1f14af86-53d8-40f7-8f0d-9eb4ed571319}, !- Handle
-  Surface 385,                            !- Name
+  Stair_Mid_ZN_2 - Wall 090_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d61faaa4-b081-4233-b2f8-6829dcc5eb70}, !- Space Name
@@ -10305,7 +10029,7 @@ OS:Surface,
 
 OS:Surface,
   {e90100f4-3f0d-4d47-a74b-985126a59ffb}, !- Handle
-  Surface 386,                            !- Name
+  Stair_Mid_ZN_2 - Wall 270_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d61faaa4-b081-4233-b2f8-6829dcc5eb70}, !- Space Name
@@ -10322,7 +10046,7 @@ OS:Surface,
 
 OS:Surface,
   {850558fc-fc9a-4a19-8b7e-dbe09a403bb5}, !- Handle
-  Surface 387,                            !- Name
+  Stair_Mid_ZN_2 - Wall 180_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d61faaa4-b081-4233-b2f8-6829dcc5eb70}, !- Space Name
@@ -10339,7 +10063,7 @@ OS:Surface,
 
 OS:Surface,
   {7dc8e4ab-e975-45f9-96a9-39e4ab427072}, !- Handle
-  Surface 388,                            !- Name
+  Stair_Mid_ZN_2 - Wall 000_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d61faaa4-b081-4233-b2f8-6829dcc5eb70}, !- Space Name
@@ -10362,7 +10086,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  3.41920936008933e-016,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {1d8b4970-d4e9-45ae-815d-7e03b0f996ab}, !- Building Story Name
   {804edf1f-dec3-4f20-8602-d6f249cfe881}, !- Thermal Zone Name
@@ -10372,7 +10096,7 @@ OS:Space,
 
 OS:Surface,
   {6afdcb33-d769-4b8a-9ce0-13851e4b8a4f}, !- Handle
-  Surface 389,                            !- Name
+  ActiveStorage_Mid_ZN - Floor_a,         !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {30125f00-7b3c-4685-a9a7-10c1134cb5c5}, !- Space Name
@@ -10389,7 +10113,7 @@ OS:Surface,
 
 OS:Surface,
   {d2c4c1ee-9365-48be-a330-dcd675670605}, !- Handle
-  Surface 390,                            !- Name
+  ActiveStorage_Mid_ZN - Wall 270_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {30125f00-7b3c-4685-a9a7-10c1134cb5c5}, !- Space Name
@@ -10406,7 +10130,7 @@ OS:Surface,
 
 OS:Surface,
   {5b8629ae-d5e4-4768-b95c-8f0cfa471322}, !- Handle
-  Surface 391,                            !- Name
+  ActiveStorage_Mid_ZN - RoofCeiling_a,   !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {30125f00-7b3c-4685-a9a7-10c1134cb5c5}, !- Space Name
@@ -10423,7 +10147,7 @@ OS:Surface,
 
 OS:Surface,
   {af4e5037-0e65-4ef1-a65c-1fe83f22e3c8}, !- Handle
-  Surface 392,                            !- Name
+  ActiveStorage_Mid_ZN - Wall 180_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {30125f00-7b3c-4685-a9a7-10c1134cb5c5}, !- Space Name
@@ -10440,7 +10164,7 @@ OS:Surface,
 
 OS:Surface,
   {3f49a3ba-eba3-4c30-b7e2-f7e83d877b14}, !- Handle
-  Surface 393,                            !- Name
+  ActiveStorage_Mid_ZN - Wall 090_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {30125f00-7b3c-4685-a9a7-10c1134cb5c5}, !- Space Name
@@ -10457,7 +10181,7 @@ OS:Surface,
 
 OS:Surface,
   {506749b2-0206-47a8-8a1c-04d2f5321342}, !- Handle
-  Surface 394,                            !- Name
+  ActiveStorage_Mid_ZN - Wall 000_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {30125f00-7b3c-4685-a9a7-10c1134cb5c5}, !- Space Name
@@ -10480,7 +10204,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  3.41920936008933e-016,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {1d8b4970-d4e9-45ae-815d-7e03b0f996ab}, !- Building Story Name
   {7ca8262d-f153-4ffd-9b7b-3877f5ae6d91}, !- Thermal Zone Name
@@ -10489,7 +10213,7 @@ OS:Space,
 
 OS:Surface,
   {367bb403-775b-4c79-90dd-62bebe525d58}, !- Handle
-  Surface 395,                            !- Name
+  Dining_Mid_ZN - Floor_a,                !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {91c486ce-bc13-4366-ad03-8d53ad8d382a}, !- Space Name
@@ -10506,7 +10230,7 @@ OS:Surface,
 
 OS:Surface,
   {bbef9c00-a6d5-4b57-8b09-6df41a4c20b6}, !- Handle
-  Surface 396,                            !- Name
+  Dining_Mid_ZN - Wall 090_a,             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {91c486ce-bc13-4366-ad03-8d53ad8d382a}, !- Space Name
@@ -10523,7 +10247,7 @@ OS:Surface,
 
 OS:Surface,
   {eb989fe6-6f5b-4ac4-9960-53de5981fe11}, !- Handle
-  Surface 397,                            !- Name
+  Dining_Mid_ZN - Wall 270_a,             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {91c486ce-bc13-4366-ad03-8d53ad8d382a}, !- Space Name
@@ -10540,7 +10264,7 @@ OS:Surface,
 
 OS:Surface,
   {5560773d-fa3d-407c-bb97-68a4669b4cf4}, !- Handle
-  Surface 398,                            !- Name
+  Dining_Mid_ZN - RoofCeiling_a,          !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {91c486ce-bc13-4366-ad03-8d53ad8d382a}, !- Space Name
@@ -10557,7 +10281,7 @@ OS:Surface,
 
 OS:Surface,
   {45aa80c1-73e5-4968-88bb-b31b0bb68e15}, !- Handle
-  Surface 399,                            !- Name
+  Dining_Mid_ZN - Wall 180_a,             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {91c486ce-bc13-4366-ad03-8d53ad8d382a}, !- Space Name
@@ -10574,7 +10298,7 @@ OS:Surface,
 
 OS:Surface,
   {5de13373-1e8a-424b-8aa5-4ad1d7b36dc3}, !- Handle
-  Surface 400,                            !- Name
+  Dining_Mid_ZN - Wall 000_a,             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {91c486ce-bc13-4366-ad03-8d53ad8d382a}, !- Space Name
@@ -10597,8 +10321,8 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  9.9636129237382e-017,                   !- Y Origin {m}
-  2.31011654250324e-014,                  !- Z Origin {m}
+  0,                                      !- Y Origin {m}
+  0,                                      !- Z Origin {m}
   {1d8b4970-d4e9-45ae-815d-7e03b0f996ab}, !- Building Story Name
   {891b7832-0aaa-4acd-84c3-02859cdcd2e8}, !- Thermal Zone Name
   ,                                       !- Part of Total Floor Area
@@ -10606,7 +10330,7 @@ OS:Space,
 
 OS:Surface,
   {16cfa94a-c676-4a5a-b74c-780d4a3cbba6}, !- Handle
-  Surface 401,                            !- Name
+  EnclosedOffice_Mid_ZN_2 - Floor_a,      !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {27343577-e985-47e3-a2b6-a9640b76547a}, !- Space Name
@@ -10623,7 +10347,7 @@ OS:Surface,
 
 OS:Surface,
   {5a5446f4-f090-4a2d-bc8b-8c6650431207}, !- Handle
-  Surface 402,                            !- Name
+  EnclosedOffice_Mid_ZN_2 - RoofCeiling_a, !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {27343577-e985-47e3-a2b6-a9640b76547a}, !- Space Name
@@ -10640,7 +10364,7 @@ OS:Surface,
 
 OS:Surface,
   {f5adef42-0107-40fb-a3f8-251cbdbdd8d2}, !- Handle
-  Surface 403,                            !- Name
+  EnclosedOffice_Mid_ZN_2 - Wall 180_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {27343577-e985-47e3-a2b6-a9640b76547a}, !- Space Name
@@ -10657,7 +10381,7 @@ OS:Surface,
 
 OS:Surface,
   {60652235-74a4-40a3-be6b-08dc6da9d30b}, !- Handle
-  Surface 404,                            !- Name
+  EnclosedOffice_Mid_ZN_2 - Wall 000_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {27343577-e985-47e3-a2b6-a9640b76547a}, !- Space Name
@@ -10674,7 +10398,7 @@ OS:Surface,
 
 OS:Surface,
   {390a2400-5ca7-4a83-9259-459d1cb18a05}, !- Handle
-  Surface 405,                            !- Name
+  EnclosedOffice_Mid_ZN_2 - Wall 270_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {27343577-e985-47e3-a2b6-a9640b76547a}, !- Space Name
@@ -10691,7 +10415,7 @@ OS:Surface,
 
 OS:Surface,
   {da8f4a09-0147-4770-aa1f-9cb712eb2410}, !- Handle
-  Surface 406,                            !- Name
+  EnclosedOffice_Mid_ZN_2 - Wall 090_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {27343577-e985-47e3-a2b6-a9640b76547a}, !- Space Name
@@ -10714,7 +10438,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  3.41920936008933e-016,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {1d8b4970-d4e9-45ae-815d-7e03b0f996ab}, !- Building Story Name
   {10f9fd89-8360-4455-aea7-dc0dce9b9d40}, !- Thermal Zone Name
@@ -10723,7 +10447,7 @@ OS:Space,
 
 OS:Surface,
   {74f325b4-fbc7-446d-a1fb-092a63c29f20}, !- Handle
-  Surface 407,                            !- Name
+  EnclosedOffice_Mid_ZN_3 - Floor_a,      !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {e35b13b3-4426-4fc8-aa91-a545783151d8}, !- Space Name
@@ -10740,7 +10464,7 @@ OS:Surface,
 
 OS:Surface,
   {d7937df2-f728-4292-a5d9-26974a510b2d}, !- Handle
-  Surface 408,                            !- Name
+  EnclosedOffice_Mid_ZN_3 - RoofCeiling_a, !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {e35b13b3-4426-4fc8-aa91-a545783151d8}, !- Space Name
@@ -10757,7 +10481,7 @@ OS:Surface,
 
 OS:Surface,
   {6ab5dd82-cde3-419d-8574-3b6dfeac0ac0}, !- Handle
-  Surface 409,                            !- Name
+  EnclosedOffice_Mid_ZN_3 - Wall 180_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e35b13b3-4426-4fc8-aa91-a545783151d8}, !- Space Name
@@ -10774,7 +10498,7 @@ OS:Surface,
 
 OS:Surface,
   {135876e2-1faa-4f75-a088-4a0d9e86dbaf}, !- Handle
-  Surface 410,                            !- Name
+  EnclosedOffice_Mid_ZN_3 - Wall 270_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e35b13b3-4426-4fc8-aa91-a545783151d8}, !- Space Name
@@ -10791,7 +10515,7 @@ OS:Surface,
 
 OS:Surface,
   {11c2a11a-c573-4e2b-88e0-beefa23b5143}, !- Handle
-  Surface 411,                            !- Name
+  EnclosedOffice_Mid_ZN_3 - Wall 000_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e35b13b3-4426-4fc8-aa91-a545783151d8}, !- Space Name
@@ -10808,7 +10532,7 @@ OS:Surface,
 
 OS:Surface,
   {12cb71a6-f245-49be-956b-8a41f1f32e9c}, !- Handle
-  Surface 412,                            !- Name
+  EnclosedOffice_Mid_ZN_3 - Wall 090_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e35b13b3-4426-4fc8-aa91-a545783151d8}, !- Space Name
@@ -10831,7 +10555,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  3.41920936008933e-016,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {1d8b4970-d4e9-45ae-815d-7e03b0f996ab}, !- Building Story Name
   {65410c3e-92e4-4b8f-98ab-8f1f031a8b56}, !- Thermal Zone Name
@@ -10840,7 +10564,7 @@ OS:Space,
 
 OS:Surface,
   {5d54d71c-d1d5-4c78-aaa6-39d22d5e519c}, !- Handle
-  Surface 413,                            !- Name
+  EnclosedOffice_Mid_ZN_4 - Floor_a,      !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {681c1394-1896-4260-aea6-9ed4ee420b8e}, !- Space Name
@@ -10857,7 +10581,7 @@ OS:Surface,
 
 OS:Surface,
   {e0af86e1-df49-4fcb-96ab-3786c19a4fc3}, !- Handle
-  Surface 414,                            !- Name
+  EnclosedOffice_Mid_ZN_4 - Wall 000_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {681c1394-1896-4260-aea6-9ed4ee420b8e}, !- Space Name
@@ -10874,7 +10598,7 @@ OS:Surface,
 
 OS:Surface,
   {ad13b040-147b-43f1-a634-b494eaa954c7}, !- Handle
-  Surface 415,                            !- Name
+  EnclosedOffice_Mid_ZN_4 - Wall 090_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {681c1394-1896-4260-aea6-9ed4ee420b8e}, !- Space Name
@@ -10891,7 +10615,7 @@ OS:Surface,
 
 OS:Surface,
   {9a125256-54e5-452c-8985-714645709def}, !- Handle
-  Surface 416,                            !- Name
+  EnclosedOffice_Mid_ZN_4 - Wall 180_b,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {681c1394-1896-4260-aea6-9ed4ee420b8e}, !- Space Name
@@ -10908,7 +10632,7 @@ OS:Surface,
 
 OS:Surface,
   {44b15c09-b3ec-4714-b09f-5d399d373399}, !- Handle
-  Surface 417,                            !- Name
+  EnclosedOffice_Mid_ZN_4 - Wall 270_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {681c1394-1896-4260-aea6-9ed4ee420b8e}, !- Space Name
@@ -10925,7 +10649,7 @@ OS:Surface,
 
 OS:Surface,
   {76b5e002-2603-42c2-84c1-78ef9041dae5}, !- Handle
-  Surface 418,                            !- Name
+  EnclosedOffice_Mid_ZN_4 - RoofCeiling_a, !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {681c1394-1896-4260-aea6-9ed4ee420b8e}, !- Space Name
@@ -10948,7 +10672,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  3.41920936008933e-016,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {1d8b4970-d4e9-45ae-815d-7e03b0f996ab}, !- Building Story Name
   {85c37285-4cbd-4d3a-b7c1-5f8d9ec7a39e}, !- Thermal Zone Name
@@ -10958,7 +10682,7 @@ OS:Space,
 
 OS:Surface,
   {f667c2b5-2dc7-4f1e-a110-08d83914758b}, !- Handle
-  Surface 419,                            !- Name
+  EnclosedOffice_Mid_ZN_5 - Floor_a,      !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {a5014003-1280-459c-9e8d-7f99107f9db8}, !- Space Name
@@ -10969,13 +10693,13 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   15.05712, 6.096, 16.7683,               !- X,Y,Z Vertex 1 {m}
-  15.05712, -1.70960468004467e-016, 16.7683, !- X,Y,Z Vertex 2 {m}
-  0, -1.70960468004467e-016, 16.7683,     !- X,Y,Z Vertex 3 {m}
+  15.05712, 0, 16.7683,                   !- X,Y,Z Vertex 2 {m}
+  0, 0, 16.7683,                          !- X,Y,Z Vertex 3 {m}
   0, 6.096, 16.7683;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {ed59eb43-911f-488c-9eaf-cc1a709a20ff}, !- Handle
-  Surface 420,                            !- Name
+  EnclosedOffice_Mid_ZN_5 - Wall 270_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {a5014003-1280-459c-9e8d-7f99107f9db8}, !- Space Name
@@ -10987,12 +10711,12 @@ OS:Surface,
   ,                                       !- Number of Vertices
   0, 6.096, 19.5130875,                   !- X,Y,Z Vertex 1 {m}
   0, 6.096, 16.7683,                      !- X,Y,Z Vertex 2 {m}
-  0, -1.70960468004467e-016, 16.7683,     !- X,Y,Z Vertex 3 {m}
-  0, -1.70960468004467e-016, 19.5130875;  !- X,Y,Z Vertex 4 {m}
+  0, 0, 16.7683,                          !- X,Y,Z Vertex 3 {m}
+  0, 0, 19.5130875;                       !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {46c94b0d-2180-4964-8a85-6ce1831a2773}, !- Handle
-  Surface 421,                            !- Name
+  EnclosedOffice_Mid_ZN_5 - Wall 000_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {a5014003-1280-459c-9e8d-7f99107f9db8}, !- Space Name
@@ -11009,7 +10733,7 @@ OS:Surface,
 
 OS:Surface,
   {a9c48ae2-9952-4173-8c15-855493c9c5ee}, !- Handle
-  Surface 422,                            !- Name
+  EnclosedOffice_Mid_ZN_5 - Wall 090_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {a5014003-1280-459c-9e8d-7f99107f9db8}, !- Space Name
@@ -11019,14 +10743,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  15.05712, -1.70960468004467e-016, 19.5130875, !- X,Y,Z Vertex 1 {m}
-  15.05712, -1.70960468004467e-016, 16.7683, !- X,Y,Z Vertex 2 {m}
+  15.05712, 0, 19.5130875,                !- X,Y,Z Vertex 1 {m}
+  15.05712, 0, 16.7683,                   !- X,Y,Z Vertex 2 {m}
   15.05712, 6.096, 16.7683,               !- X,Y,Z Vertex 3 {m}
   15.05712, 6.096, 19.5130875;            !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {1f4256c5-2b64-4815-a8a2-ccb301b75613}, !- Handle
-  Surface 423,                            !- Name
+  EnclosedOffice_Mid_ZN_5 - RoofCeiling_a, !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {a5014003-1280-459c-9e8d-7f99107f9db8}, !- Space Name
@@ -11036,14 +10760,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  15.05712, -1.70960468004467e-016, 19.5130875, !- X,Y,Z Vertex 1 {m}
+  15.05712, 0, 19.5130875,                !- X,Y,Z Vertex 1 {m}
   15.05712, 6.096, 19.5130875,            !- X,Y,Z Vertex 2 {m}
   0, 6.096, 19.5130875,                   !- X,Y,Z Vertex 3 {m}
-  0, -1.70960468004467e-016, 19.5130875;  !- X,Y,Z Vertex 4 {m}
+  0, 0, 19.5130875;                       !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {52c80dc1-1b26-4930-bec2-a3521812e7de}, !- Handle
-  Surface 424,                            !- Name
+  EnclosedOffice_Mid_ZN_5 - Wall 180_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {a5014003-1280-459c-9e8d-7f99107f9db8}, !- Space Name
@@ -11053,10 +10777,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, -1.70960468004467e-016, 19.5130875,  !- X,Y,Z Vertex 1 {m}
-  0, -1.70960468004467e-016, 16.7683,     !- X,Y,Z Vertex 2 {m}
-  15.05712, -1.70960468004467e-016, 16.7683, !- X,Y,Z Vertex 3 {m}
-  15.05712, -1.70960468004467e-016, 19.5130875; !- X,Y,Z Vertex 4 {m}
+  0, 0, 19.5130875,                       !- X,Y,Z Vertex 1 {m}
+  0, 0, 16.7683,                          !- X,Y,Z Vertex 2 {m}
+  15.05712, 0, 16.7683,                   !- X,Y,Z Vertex 3 {m}
+  15.05712, 0, 19.5130875;                !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {d82b9c46-996b-4c57-940e-f75e74848cfb}, !- Handle
@@ -11066,8 +10790,8 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  9.9636129237382e-017,                   !- Y Origin {m}
-  2.31011654250324e-014,                  !- Z Origin {m}
+  0,                                      !- Y Origin {m}
+  0,                                      !- Z Origin {m}
   {1d8b4970-d4e9-45ae-815d-7e03b0f996ab}, !- Building Story Name
   {6c2e50cd-662c-4795-866c-0aa0e38b1a47}, !- Thermal Zone Name
   ,                                       !- Part of Total Floor Area
@@ -11076,7 +10800,7 @@ OS:Space,
 
 OS:Surface,
   {fae5d5a9-3df7-42bc-8506-b0f2b8919899}, !- Handle
-  Surface 425,                            !- Name
+  ConfRoom_Mid_ZN_1 - Floor_a,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {d82b9c46-996b-4c57-940e-f75e74848cfb}, !- Space Name
@@ -11087,13 +10811,13 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   19.32432, 6.096, 16.7683,               !- X,Y,Z Vertex 1 {m}
-  19.32432, 7.13243387670845e-017, 16.7683, !- X,Y,Z Vertex 2 {m}
-  15.05712, 7.13243387670845e-017, 16.7683, !- X,Y,Z Vertex 3 {m}
+  19.32432, 0, 16.7683,                   !- X,Y,Z Vertex 2 {m}
+  15.05712, 0, 16.7683,                   !- X,Y,Z Vertex 3 {m}
   15.05712, 6.096, 16.7683;               !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {27c7c614-1663-48cd-9b5f-30bdf7a1c9e7}, !- Handle
-  Surface 426,                            !- Name
+  ConfRoom_Mid_ZN_1 - RoofCeiling_a,      !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {d82b9c46-996b-4c57-940e-f75e74848cfb}, !- Space Name
@@ -11103,14 +10827,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  19.32432, 7.13243387670845e-017, 19.5130875, !- X,Y,Z Vertex 1 {m}
+  19.32432, 0, 19.5130875,                !- X,Y,Z Vertex 1 {m}
   19.32432, 6.096, 19.5130875,            !- X,Y,Z Vertex 2 {m}
   15.05712, 6.096, 19.5130875,            !- X,Y,Z Vertex 3 {m}
-  15.05712, 7.13243387670845e-017, 19.5130875; !- X,Y,Z Vertex 4 {m}
+  15.05712, 0, 19.5130875;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {fcf6d12b-c4b3-4603-b984-d11fa069ed9b}, !- Handle
-  Surface 427,                            !- Name
+  ConfRoom_Mid_ZN_1 - Wall 090_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d82b9c46-996b-4c57-940e-f75e74848cfb}, !- Space Name
@@ -11120,14 +10844,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  19.32432, 7.13243387670845e-017, 19.5130875, !- X,Y,Z Vertex 1 {m}
-  19.32432, 7.13243387670845e-017, 16.7683, !- X,Y,Z Vertex 2 {m}
+  19.32432, 0, 19.5130875,                !- X,Y,Z Vertex 1 {m}
+  19.32432, 0, 16.7683,                   !- X,Y,Z Vertex 2 {m}
   19.32432, 6.096, 16.7683,               !- X,Y,Z Vertex 3 {m}
   19.32432, 6.096, 19.5130875;            !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {19d6bf15-1d85-44eb-a794-b42fdaa63767}, !- Handle
-  Surface 428,                            !- Name
+  ConfRoom_Mid_ZN_1 - Wall 180_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d82b9c46-996b-4c57-940e-f75e74848cfb}, !- Space Name
@@ -11137,14 +10861,14 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  15.05712, 7.13243387670845e-017, 19.5130875, !- X,Y,Z Vertex 1 {m}
-  15.05712, 7.13243387670845e-017, 16.7683, !- X,Y,Z Vertex 2 {m}
-  19.32432, 7.13243387670845e-017, 16.7683, !- X,Y,Z Vertex 3 {m}
-  19.32432, 7.13243387670845e-017, 19.5130875; !- X,Y,Z Vertex 4 {m}
+  15.05712, 0, 19.5130875,                !- X,Y,Z Vertex 1 {m}
+  15.05712, 0, 16.7683,                   !- X,Y,Z Vertex 2 {m}
+  19.32432, 0, 16.7683,                   !- X,Y,Z Vertex 3 {m}
+  19.32432, 0, 19.5130875;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {c6d5c2ac-6007-4235-b2f7-25d592a619be}, !- Handle
-  Surface 429,                            !- Name
+  ConfRoom_Mid_ZN_1 - Wall 000_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d82b9c46-996b-4c57-940e-f75e74848cfb}, !- Space Name
@@ -11161,7 +10885,7 @@ OS:Surface,
 
 OS:Surface,
   {fcafe01e-9bff-4cf4-9f80-b6c9395cc6f3}, !- Handle
-  Surface 430,                            !- Name
+  ConfRoom_Mid_ZN_1 - Wall 270_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d82b9c46-996b-4c57-940e-f75e74848cfb}, !- Space Name
@@ -11173,8 +10897,8 @@ OS:Surface,
   ,                                       !- Number of Vertices
   15.05712, 6.096, 19.5130875,            !- X,Y,Z Vertex 1 {m}
   15.05712, 6.096, 16.7683,               !- X,Y,Z Vertex 2 {m}
-  15.05712, 7.13243387670845e-017, 16.7683, !- X,Y,Z Vertex 3 {m}
-  15.05712, 7.13243387670845e-017, 19.5130875; !- X,Y,Z Vertex 4 {m}
+  15.05712, 0, 16.7683,                   !- X,Y,Z Vertex 3 {m}
+  15.05712, 0, 19.5130875;                !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {229a7bbf-bc1e-4953-9017-a5dc9b8a0efa}, !- Handle
@@ -11184,8 +10908,8 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  9.9636129237382e-017,                   !- Y Origin {m}
-  2.31011654250324e-014,                  !- Z Origin {m}
+  0,                                      !- Y Origin {m}
+  0,                                      !- Z Origin {m}
   {1d8b4970-d4e9-45ae-815d-7e03b0f996ab}, !- Building Story Name
   {974cee9e-d85a-4263-ac03-1347234a56f9}, !- Thermal Zone Name
   ,                                       !- Part of Total Floor Area
@@ -11194,7 +10918,7 @@ OS:Space,
 
 OS:Surface,
   {670ce663-185e-4482-a3fb-10545644cec2}, !- Handle
-  Surface 434,                            !- Name
+  EnclosedOffice_Mid_ZN_6 - RoofCeiling_a, !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {229a7bbf-bc1e-4953-9017-a5dc9b8a0efa}, !- Space Name
@@ -11204,14 +10928,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  73.10755, 7.93235758299346e-016, 19.5130875, !- X,Y,Z Vertex 1 {m}
+  73.10755, 0, 19.5130875,                !- X,Y,Z Vertex 1 {m}
   73.10755, 15.8194375, 19.5130875,       !- X,Y,Z Vertex 2 {m}
   67.01155, 15.8194375, 19.5130875,       !- X,Y,Z Vertex 3 {m}
-  67.01155, -9.9636129237382e-017, 19.5130875; !- X,Y,Z Vertex 4 {m}
+  67.01155, 0, 19.5130875;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {ce8899ff-9177-4c39-8473-f7f92fa3843a}, !- Handle
-  Surface 436,                            !- Name
+  EnclosedOffice_Mid_ZN_6 - Wall 000_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {229a7bbf-bc1e-4953-9017-a5dc9b8a0efa}, !- Space Name
@@ -11234,7 +10958,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  3.41920936008933e-016,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {1d8b4970-d4e9-45ae-815d-7e03b0f996ab}, !- Building Story Name
   {c00c1a55-e8c8-4e94-9afd-c184119f5273}, !- Thermal Zone Name
@@ -11243,7 +10967,7 @@ OS:Space,
 
 OS:Surface,
   {ab3268e8-3fb7-4c79-ae3f-6f1805517169}, !- Handle
-  Surface 437,                            !- Name
+  EnclosedOffice_Mid_ZN_7 - Floor_a,      !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {c2a116d6-f802-420c-8232-4c04fea53728}, !- Space Name
@@ -11260,7 +10984,7 @@ OS:Surface,
 
 OS:Surface,
   {9b1e9dd6-5d3d-48b9-b7c1-78f445095d21}, !- Handle
-  Surface 438,                            !- Name
+  EnclosedOffice_Mid_ZN_7 - Wall 000_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c2a116d6-f802-420c-8232-4c04fea53728}, !- Space Name
@@ -11277,7 +11001,7 @@ OS:Surface,
 
 OS:Surface,
   {18d3752f-f4d4-4c19-b86b-b337467ee7c4}, !- Handle
-  Surface 439,                            !- Name
+  EnclosedOffice_Mid_ZN_7 - Wall 090_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c2a116d6-f802-420c-8232-4c04fea53728}, !- Space Name
@@ -11294,7 +11018,7 @@ OS:Surface,
 
 OS:Surface,
   {e5d54db8-6e08-439d-96e9-0924e1ad50fc}, !- Handle
-  Surface 440,                            !- Name
+  EnclosedOffice_Mid_ZN_7 - Wall 180_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c2a116d6-f802-420c-8232-4c04fea53728}, !- Space Name
@@ -11311,7 +11035,7 @@ OS:Surface,
 
 OS:Surface,
   {e2ac903a-d5c2-447b-9aec-9b0e09c0119b}, !- Handle
-  Surface 441,                            !- Name
+  EnclosedOffice_Mid_ZN_7 - Wall 270_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c2a116d6-f802-420c-8232-4c04fea53728}, !- Space Name
@@ -11328,7 +11052,7 @@ OS:Surface,
 
 OS:Surface,
   {2b933424-84fe-4c19-a0b3-10fc34826b60}, !- Handle
-  Surface 442,                            !- Name
+  EnclosedOffice_Mid_ZN_7 - RoofCeiling_a, !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {c2a116d6-f802-420c-8232-4c04fea53728}, !- Space Name
@@ -11351,8 +11075,8 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  9.9636129237382e-017,                   !- Y Origin {m}
-  2.31011654250324e-014,                  !- Z Origin {m}
+  0,                                      !- Y Origin {m}
+  0,                                      !- Z Origin {m}
   {1d8b4970-d4e9-45ae-815d-7e03b0f996ab}, !- Building Story Name
   {2b842f84-562d-4c0f-9af7-69cee978cdb9}, !- Thermal Zone Name
   ,                                       !- Part of Total Floor Area
@@ -11361,7 +11085,7 @@ OS:Space,
 
 OS:Surface,
   {03011397-7818-4367-9b1e-9df298b9c113}, !- Handle
-  Surface 443,                            !- Name
+  ConfRoom_Mid_ZN_2 - Floor_a,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {540ac7f9-33ab-4617-9a4d-3afbebf97410}, !- Space Name
@@ -11378,7 +11102,7 @@ OS:Surface,
 
 OS:Surface,
   {3260ecb1-20e3-450a-a80d-417d9ecad948}, !- Handle
-  Surface 444,                            !- Name
+  ConfRoom_Mid_ZN_2 - Wall 000_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {540ac7f9-33ab-4617-9a4d-3afbebf97410}, !- Space Name
@@ -11395,7 +11119,7 @@ OS:Surface,
 
 OS:Surface,
   {62f930bd-b371-4e3f-aec7-212673143e5e}, !- Handle
-  Surface 445,                            !- Name
+  ConfRoom_Mid_ZN_2 - Wall 270_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {540ac7f9-33ab-4617-9a4d-3afbebf97410}, !- Space Name
@@ -11412,7 +11136,7 @@ OS:Surface,
 
 OS:Surface,
   {83428b5b-a1c0-4d48-96f1-badf9bb24248}, !- Handle
-  Surface 446,                            !- Name
+  ConfRoom_Mid_ZN_2 - Wall 180_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {540ac7f9-33ab-4617-9a4d-3afbebf97410}, !- Space Name
@@ -11429,7 +11153,7 @@ OS:Surface,
 
 OS:Surface,
   {561aaf9e-1fac-4ff0-82f5-82e44a37cc2b}, !- Handle
-  Surface 447,                            !- Name
+  ConfRoom_Mid_ZN_2 - Wall 090_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {540ac7f9-33ab-4617-9a4d-3afbebf97410}, !- Space Name
@@ -11446,7 +11170,7 @@ OS:Surface,
 
 OS:Surface,
   {c3204b49-5b59-43d0-b1df-534003b09d88}, !- Handle
-  Surface 448,                            !- Name
+  ConfRoom_Mid_ZN_2 - RoofCeiling_a,      !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {540ac7f9-33ab-4617-9a4d-3afbebf97410}, !- Space Name
@@ -11469,7 +11193,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  3.41920936008933e-016,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {1d8b4970-d4e9-45ae-815d-7e03b0f996ab}, !- Building Story Name
   {0495627f-0734-4036-b2ca-1fcaa67fe801}, !- Thermal Zone Name
@@ -11479,7 +11203,7 @@ OS:Space,
 
 OS:Surface,
   {73cdb0ef-c442-4040-aae7-1fbffdff786f}, !- Handle
-  Surface 449,                            !- Name
+  Classroom_Mid_ZN - Floor_a,             !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {a3dfebf6-922a-4dc6-8cf5-e7c78e76ea93}, !- Space Name
@@ -11496,7 +11220,7 @@ OS:Surface,
 
 OS:Surface,
   {ad17b3a2-3e32-48df-81d1-8a0214621178}, !- Handle
-  Surface 450,                            !- Name
+  Classroom_Mid_ZN - Wall 090_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {a3dfebf6-922a-4dc6-8cf5-e7c78e76ea93}, !- Space Name
@@ -11513,7 +11237,7 @@ OS:Surface,
 
 OS:Surface,
   {60cccc8c-0ebc-4163-b68a-110733495890}, !- Handle
-  Surface 452,                            !- Name
+  Classroom_Mid_ZN - RoofCeiling_a,       !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {a3dfebf6-922a-4dc6-8cf5-e7c78e76ea93}, !- Space Name
@@ -11530,7 +11254,7 @@ OS:Surface,
 
 OS:Surface,
   {6927c782-3c6d-48af-beb3-c57d1d238249}, !- Handle
-  Surface 453,                            !- Name
+  Classroom_Mid_ZN - Wall 180_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {a3dfebf6-922a-4dc6-8cf5-e7c78e76ea93}, !- Space Name
@@ -11547,7 +11271,7 @@ OS:Surface,
 
 OS:Surface,
   {eee09aa3-ab77-42dc-9dfc-f48e9b8dd80c}, !- Handle
-  Surface 454,                            !- Name
+  Classroom_Mid_ZN - Wall 270_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {a3dfebf6-922a-4dc6-8cf5-e7c78e76ea93}, !- Space Name
@@ -11570,7 +11294,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  3.41920936008933e-016,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {1d8b4970-d4e9-45ae-815d-7e03b0f996ab}, !- Building Story Name
   {0ad96d5c-fdc1-45fb-9d99-6a8328408ca2}, !- Thermal Zone Name
@@ -11579,7 +11303,7 @@ OS:Space,
 
 OS:Surface,
   {9367e364-614b-43da-ac09-ae739c355e97}, !- Handle
-  Surface 455,                            !- Name
+  EnclosedOffice_Mid_ZN_8 - Floor_a,      !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {aceaf852-6a17-4647-a5bc-ffe90e228da1}, !- Space Name
@@ -11596,7 +11320,7 @@ OS:Surface,
 
 OS:Surface,
   {1af7e6df-516b-406c-8604-90ce9e69e43e}, !- Handle
-  Surface 456,                            !- Name
+  EnclosedOffice_Mid_ZN_8 - Wall 090_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {aceaf852-6a17-4647-a5bc-ffe90e228da1}, !- Space Name
@@ -11613,7 +11337,7 @@ OS:Surface,
 
 OS:Surface,
   {33927ae5-787f-42cb-81a4-866ba984f6f9}, !- Handle
-  Surface 457,                            !- Name
+  EnclosedOffice_Mid_ZN_8 - RoofCeiling_a, !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {aceaf852-6a17-4647-a5bc-ffe90e228da1}, !- Space Name
@@ -11630,7 +11354,7 @@ OS:Surface,
 
 OS:Surface,
   {91bf7310-3d04-4b1d-9adf-9472a949d267}, !- Handle
-  Surface 458,                            !- Name
+  EnclosedOffice_Mid_ZN_8 - Wall 180_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {aceaf852-6a17-4647-a5bc-ffe90e228da1}, !- Space Name
@@ -11647,7 +11371,7 @@ OS:Surface,
 
 OS:Surface,
   {28ab6aae-1332-4971-b2f3-06269f3e7b9e}, !- Handle
-  Surface 460,                            !- Name
+  EnclosedOffice_Mid_ZN_8 - Wall 000_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {aceaf852-6a17-4647-a5bc-ffe90e228da1}, !- Space Name
@@ -11670,7 +11394,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  3.41920936008933e-016,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {1d8b4970-d4e9-45ae-815d-7e03b0f996ab}, !- Building Story Name
   {52788c4b-3ae7-47ee-969b-e7036e401a0f}, !- Thermal Zone Name
@@ -11679,7 +11403,7 @@ OS:Space,
 
 OS:Surface,
   {75c5d2f1-d910-4f19-a0dc-5aefd3359dcf}, !- Handle
-  Surface 461,                            !- Name
+  OpenOffice_Mid_ZN_1 - Floor_a,          !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {ee9b2385-604c-4843-a475-0156ae9bfa29}, !- Space Name
@@ -11690,15 +11414,15 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   67.01155, 12.1618375, 16.7683,          !- X,Y,Z Vertex 1 {m}
-  67.01155, -1.70960468004467e-016, 16.7683, !- X,Y,Z Vertex 2 {m}
-  19.32432, 1.89995241761664e-016, 16.7683, !- X,Y,Z Vertex 3 {m}
+  67.01155, 0, 16.7683,                   !- X,Y,Z Vertex 2 {m}
+  19.32432, 0, 16.7683,                   !- X,Y,Z Vertex 3 {m}
   19.32432, 6.096, 16.7683,               !- X,Y,Z Vertex 4 {m}
   15.05712, 6.096, 16.7683,               !- X,Y,Z Vertex 5 {m}
   15.05712, 12.1618375, 16.7683;          !- X,Y,Z Vertex 6 {m}
 
 OS:Surface,
   {1bdc17b4-55b1-40ac-8557-a47188340fe0}, !- Handle
-  Surface 462,                            !- Name
+  OpenOffice_Mid_ZN_1 - RoofCeiling_a,    !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {ee9b2385-604c-4843-a475-0156ae9bfa29}, !- Space Name
@@ -11708,16 +11432,16 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  67.01155, -1.70960468004467e-016, 19.5130875, !- X,Y,Z Vertex 1 {m}
+  67.01155, 0, 19.5130875,                !- X,Y,Z Vertex 1 {m}
   67.01155, 12.1618375, 19.5130875,       !- X,Y,Z Vertex 2 {m}
   15.05712, 12.1618375, 19.5130875,       !- X,Y,Z Vertex 3 {m}
   15.05712, 6.096, 19.5130875,            !- X,Y,Z Vertex 4 {m}
   19.32432, 6.096, 19.5130875,            !- X,Y,Z Vertex 5 {m}
-  19.32432, 1.89995241761664e-016, 19.5130875; !- X,Y,Z Vertex 6 {m}
+  19.32432, 0, 19.5130875;                !- X,Y,Z Vertex 6 {m}
 
 OS:Surface,
   {6897b940-7303-4754-9a75-d960f99aa855}, !- Handle
-  Surface 463,                            !- Name
+  OpenOffice_Mid_ZN_1 - Wall 180_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {ee9b2385-604c-4843-a475-0156ae9bfa29}, !- Space Name
@@ -11734,7 +11458,7 @@ OS:Surface,
 
 OS:Surface,
   {24b93784-cce3-4dda-bb6a-04461145c6d4}, !- Handle
-  Surface 464,                            !- Name
+  OpenOffice_Mid_ZN_1 - Wall 180_b,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {ee9b2385-604c-4843-a475-0156ae9bfa29}, !- Space Name
@@ -11744,14 +11468,14 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  19.32432, 1.89995241761664e-016, 19.5130875, !- X,Y,Z Vertex 1 {m}
-  19.32432, 1.89995241761664e-016, 16.7683, !- X,Y,Z Vertex 2 {m}
-  67.01155, -1.70960468004467e-016, 16.7683, !- X,Y,Z Vertex 3 {m}
-  67.01155, -1.70960468004467e-016, 19.5130875; !- X,Y,Z Vertex 4 {m}
+  19.32432, 0, 19.5130875,                !- X,Y,Z Vertex 1 {m}
+  19.32432, 0, 16.7683,                   !- X,Y,Z Vertex 2 {m}
+  67.01155, 0, 16.7683,                   !- X,Y,Z Vertex 3 {m}
+  67.01155, 0, 19.5130875;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {5b6f67e8-c181-428e-8691-fcff5b7fd291}, !- Handle
-  Surface 465,                            !- Name
+  OpenOffice_Mid_ZN_1 - Wall 270_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {ee9b2385-604c-4843-a475-0156ae9bfa29}, !- Space Name
@@ -11763,12 +11487,12 @@ OS:Surface,
   ,                                       !- Number of Vertices
   19.32432, 6.096, 19.5130875,            !- X,Y,Z Vertex 1 {m}
   19.32432, 6.096, 16.7683,               !- X,Y,Z Vertex 2 {m}
-  19.32432, 1.89995241761664e-016, 16.7683, !- X,Y,Z Vertex 3 {m}
-  19.32432, 1.89995241761664e-016, 19.5130875; !- X,Y,Z Vertex 4 {m}
+  19.32432, 0, 16.7683,                   !- X,Y,Z Vertex 3 {m}
+  19.32432, 0, 19.5130875;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {5a282588-73ad-445a-ae49-b717fa40ad0c}, !- Handle
-  Surface 466,                            !- Name
+  OpenOffice_Mid_ZN_1 - Wall 270_b,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {ee9b2385-604c-4843-a475-0156ae9bfa29}, !- Space Name
@@ -11785,7 +11509,7 @@ OS:Surface,
 
 OS:Surface,
   {37bf10dc-c9a4-4312-82cd-dfd1b248ac03}, !- Handle
-  Surface 467,                            !- Name
+  OpenOffice_Mid_ZN_1 - Wall 000_b,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {ee9b2385-604c-4843-a475-0156ae9bfa29}, !- Space Name
@@ -11802,7 +11526,7 @@ OS:Surface,
 
 OS:Surface,
   {2dad2b16-8f32-404a-9528-174724029877}, !- Handle
-  Surface 468,                            !- Name
+  OpenOffice_Mid_ZN_1 - Wall 090_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {ee9b2385-604c-4843-a475-0156ae9bfa29}, !- Space Name
@@ -11812,8 +11536,8 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  67.01155, -1.70960468004467e-016, 19.5130875, !- X,Y,Z Vertex 1 {m}
-  67.01155, -1.70960468004467e-016, 16.7683, !- X,Y,Z Vertex 2 {m}
+  67.01155, 0, 19.5130875,                !- X,Y,Z Vertex 1 {m}
+  67.01155, 0, 16.7683,                   !- X,Y,Z Vertex 2 {m}
   67.01155, 12.1618375, 16.7683,          !- X,Y,Z Vertex 3 {m}
   67.01155, 12.1618375, 19.5130875;       !- X,Y,Z Vertex 4 {m}
 
@@ -11825,8 +11549,8 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  9.9636129237382e-017,                   !- Y Origin {m}
-  2.31011654250324e-014,                  !- Z Origin {m}
+  0,                                      !- Y Origin {m}
+  0,                                      !- Z Origin {m}
   {1d8b4970-d4e9-45ae-815d-7e03b0f996ab}, !- Building Story Name
   {dd651187-a70a-4292-8d7d-4edb1153137c}, !- Thermal Zone Name
   ,                                       !- Part of Total Floor Area
@@ -11835,7 +11559,7 @@ OS:Space,
 
 OS:Surface,
   {1b5fed2d-f4b7-4148-b5ad-7835250ff352}, !- Handle
-  Surface 469,                            !- Name
+  OpenOffice_Mid_ZN_2 - Floor_a,          !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {d1ed72a5-9e44-4fc9-bc9d-8f2f4eb275bb}, !- Space Name
@@ -11854,7 +11578,7 @@ OS:Surface,
 
 OS:Surface,
   {1cfad667-8270-4c7b-b176-da54fb0fa63c}, !- Handle
-  Surface 470,                            !- Name
+  OpenOffice_Mid_ZN_2 - Wall 090_b,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d1ed72a5-9e44-4fc9-bc9d-8f2f4eb275bb}, !- Space Name
@@ -11871,7 +11595,7 @@ OS:Surface,
 
 OS:Surface,
   {38e66f87-88d4-4a37-b041-c8b116e620c0}, !- Handle
-  Surface 471,                            !- Name
+  OpenOffice_Mid_ZN_2 - Wall 090_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d1ed72a5-9e44-4fc9-bc9d-8f2f4eb275bb}, !- Space Name
@@ -11888,7 +11612,7 @@ OS:Surface,
 
 OS:Surface,
   {e43c0000-1df6-4886-87ba-b19e022aa729}, !- Handle
-  Surface 472,                            !- Name
+  OpenOffice_Mid_ZN_2 - Wall 180_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d1ed72a5-9e44-4fc9-bc9d-8f2f4eb275bb}, !- Space Name
@@ -11905,7 +11629,7 @@ OS:Surface,
 
 OS:Surface,
   {23bf0b96-ce3f-4b12-aac8-5c002ebdc6e7}, !- Handle
-  Surface 473,                            !- Name
+  OpenOffice_Mid_ZN_2 - Wall 180_b,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d1ed72a5-9e44-4fc9-bc9d-8f2f4eb275bb}, !- Space Name
@@ -11922,7 +11646,7 @@ OS:Surface,
 
 OS:Surface,
   {420d414e-66ab-4c77-923a-8db08fb2c2c4}, !- Handle
-  Surface 474,                            !- Name
+  OpenOffice_Mid_ZN_2 - RoofCeiling_a,    !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {d1ed72a5-9e44-4fc9-bc9d-8f2f4eb275bb}, !- Space Name
@@ -11941,7 +11665,7 @@ OS:Surface,
 
 OS:Surface,
   {62752cfe-fcfc-4d9a-b9d6-56d5ae2e4875}, !- Handle
-  Surface 475,                            !- Name
+  OpenOffice_Mid_ZN_2 - Wall 270_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d1ed72a5-9e44-4fc9-bc9d-8f2f4eb275bb}, !- Space Name
@@ -11958,7 +11682,7 @@ OS:Surface,
 
 OS:Surface,
   {a2bf5f07-39e9-4eff-b191-9b48c2d84330}, !- Handle
-  Surface 476,                            !- Name
+  OpenOffice_Mid_ZN_2 - Wall 000_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d1ed72a5-9e44-4fc9-bc9d-8f2f4eb275bb}, !- Space Name
@@ -11981,7 +11705,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  3.41920936008933e-016,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {1d8b4970-d4e9-45ae-815d-7e03b0f996ab}, !- Building Story Name
   {37f4b4df-4f90-4579-b048-9de2bec29218}, !- Thermal Zone Name
@@ -11990,7 +11714,7 @@ OS:Space,
 
 OS:Surface,
   {a79bbf1d-efd3-41c2-8080-a08288e8de0d}, !- Handle
-  Surface 641,                            !- Name
+  OpenOffice_Mid_ZN_3 - Floor_a,          !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {980ebac3-2e2f-454b-93cc-518ecfdce4c4}, !- Space Name
@@ -12009,7 +11733,7 @@ OS:Surface,
 
 OS:Surface,
   {6448cd30-a57d-41ec-81aa-a4ba44c5bcdd}, !- Handle
-  Surface 642,                            !- Name
+  OpenOffice_Mid_ZN_3 - Wall 090_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {980ebac3-2e2f-454b-93cc-518ecfdce4c4}, !- Space Name
@@ -12026,7 +11750,7 @@ OS:Surface,
 
 OS:Surface,
   {3384242f-3c80-4fa7-8eda-5b3d97ce6f18}, !- Handle
-  Surface 643,                            !- Name
+  OpenOffice_Mid_ZN_3 - Wall 000_c,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {980ebac3-2e2f-454b-93cc-518ecfdce4c4}, !- Space Name
@@ -12043,7 +11767,7 @@ OS:Surface,
 
 OS:Surface,
   {d873e56c-e34c-4172-8d22-1c6edc5fcab2}, !- Handle
-  Surface 644,                            !- Name
+  OpenOffice_Mid_ZN_3 - Wall 270_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {980ebac3-2e2f-454b-93cc-518ecfdce4c4}, !- Space Name
@@ -12060,7 +11784,7 @@ OS:Surface,
 
 OS:Surface,
   {d9a43562-4a75-4b72-8c0f-372d33a894a4}, !- Handle
-  Surface 645,                            !- Name
+  OpenOffice_Mid_ZN_3 - Wall 180_c,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {980ebac3-2e2f-454b-93cc-518ecfdce4c4}, !- Space Name
@@ -12073,11 +11797,11 @@ OS:Surface,
   6.096, 36.5458375, 19.5130875,          !- X,Y,Z Vertex 1 {m}
   6.096, 36.5458375, 16.7683,             !- X,Y,Z Vertex 2 {m}
   15.05712, 36.5458375, 16.7683,          !- X,Y,Z Vertex 3 {m}
-  15.05712, 36.5458375, 19.5130875000001; !- X,Y,Z Vertex 4 {m}
+  15.05712, 36.5458375, 19.5130875;       !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {cb42923a-b458-4265-9f4e-956412e33d49}, !- Handle
-  Surface 646,                            !- Name
+  OpenOffice_Mid_ZN_3 - Wall 090_b,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {980ebac3-2e2f-454b-93cc-518ecfdce4c4}, !- Space Name
@@ -12094,7 +11818,7 @@ OS:Surface,
 
 OS:Surface,
   {ec663817-152a-4c86-a3f9-08102bc7c099}, !- Handle
-  Surface 647,                            !- Name
+  OpenOffice_Mid_ZN_3 - Wall 000_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {980ebac3-2e2f-454b-93cc-518ecfdce4c4}, !- Space Name
@@ -12111,7 +11835,7 @@ OS:Surface,
 
 OS:Surface,
   {96964764-8399-4d47-91d5-30b0e029b934}, !- Handle
-  Surface 648,                            !- Name
+  OpenOffice_Mid_ZN_3 - RoofCeiling_a,    !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {980ebac3-2e2f-454b-93cc-518ecfdce4c4}, !- Space Name
@@ -12136,7 +11860,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  3.41920936008933e-016,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {1d8b4970-d4e9-45ae-815d-7e03b0f996ab}, !- Building Story Name
   {ff689a62-e983-41e2-acef-45e3a396488e}, !- Thermal Zone Name
@@ -12145,7 +11869,7 @@ OS:Space,
 
 OS:Surface,
   {c3846b7e-19a6-4c83-a60d-de0a3d9364ab}, !- Handle
-  Surface 649,                            !- Name
+  OpenOffice_Mid_ZN_4 - Floor_a,          !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {c1f78e47-4343-4125-824d-d0c656baa79a}, !- Space Name
@@ -12164,7 +11888,7 @@ OS:Surface,
 
 OS:Surface,
   {f612f286-dd3e-4848-ae9c-4f8c3f9fedd0}, !- Handle
-  Surface 650,                            !- Name
+  OpenOffice_Mid_ZN_4 - RoofCeiling_a,    !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {c1f78e47-4343-4125-824d-d0c656baa79a}, !- Space Name
@@ -12174,16 +11898,16 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  15.05712, 6.096, 19.5130875000001,      !- X,Y,Z Vertex 1 {m}
-  15.05712, 36.5458375, 19.5130875000001, !- X,Y,Z Vertex 2 {m}
-  6.096, 36.5458375, 19.5130875000001,    !- X,Y,Z Vertex 3 {m}
-  6.096, 32.8882375, 19.5130875000001,    !- X,Y,Z Vertex 4 {m}
-  0, 32.8882375, 19.5130875000001,        !- X,Y,Z Vertex 5 {m}
-  0, 6.096, 19.5130875000001;             !- X,Y,Z Vertex 6 {m}
+  15.05712, 6.096, 19.5130875,            !- X,Y,Z Vertex 1 {m}
+  15.05712, 36.5458375, 19.5130875,       !- X,Y,Z Vertex 2 {m}
+  6.096, 36.5458375, 19.5130875,          !- X,Y,Z Vertex 3 {m}
+  6.096, 32.8882375, 19.5130875,          !- X,Y,Z Vertex 4 {m}
+  0, 32.8882375, 19.5130875,              !- X,Y,Z Vertex 5 {m}
+  0, 6.096, 19.5130875;                   !- X,Y,Z Vertex 6 {m}
 
 OS:Surface,
   {1dd021e6-6738-4cad-ad35-2d09240b8805}, !- Handle
-  Surface 651,                            !- Name
+  OpenOffice_Mid_ZN_4 - Wall 000_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c1f78e47-4343-4125-824d-d0c656baa79a}, !- Space Name
@@ -12193,14 +11917,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  6.096, 32.8882375, 19.5130875000001,    !- X,Y,Z Vertex 1 {m}
+  6.096, 32.8882375, 19.5130875,          !- X,Y,Z Vertex 1 {m}
   6.096, 32.8882375, 16.7683,             !- X,Y,Z Vertex 2 {m}
   0, 32.8882375, 16.7683,                 !- X,Y,Z Vertex 3 {m}
-  0, 32.8882375, 19.5130875000001;        !- X,Y,Z Vertex 4 {m}
+  0, 32.8882375, 19.5130875;              !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {71156053-3106-44ed-bcd5-6c6b20cdc7f8}, !- Handle
-  Surface 652,                            !- Name
+  OpenOffice_Mid_ZN_4 - Wall 000_b,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c1f78e47-4343-4125-824d-d0c656baa79a}, !- Space Name
@@ -12210,14 +11934,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  15.05712, 36.5458375, 19.5130875000001, !- X,Y,Z Vertex 1 {m}
+  15.05712, 36.5458375, 19.5130875,       !- X,Y,Z Vertex 1 {m}
   15.05712, 36.5458375, 16.7683,          !- X,Y,Z Vertex 2 {m}
   6.096, 36.5458375, 16.7683,             !- X,Y,Z Vertex 3 {m}
-  6.096, 36.5458375, 19.5130875000001;    !- X,Y,Z Vertex 4 {m}
+  6.096, 36.5458375, 19.5130875;          !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {2795c3c3-5106-4685-8ab0-af61e1469172}, !- Handle
-  Surface 653,                            !- Name
+  OpenOffice_Mid_ZN_4 - Wall 180_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c1f78e47-4343-4125-824d-d0c656baa79a}, !- Space Name
@@ -12227,14 +11951,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 6.096, 19.5130875000001,             !- X,Y,Z Vertex 1 {m}
+  0, 6.096, 19.5130875,                   !- X,Y,Z Vertex 1 {m}
   0, 6.096, 16.7683,                      !- X,Y,Z Vertex 2 {m}
   15.05712, 6.096, 16.7683,               !- X,Y,Z Vertex 3 {m}
-  15.05712, 6.096, 19.5130875000001;      !- X,Y,Z Vertex 4 {m}
+  15.05712, 6.096, 19.5130875;            !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {312e815e-f2a3-41d6-a926-c050a2ec3c52}, !- Handle
-  Surface 654,                            !- Name
+  OpenOffice_Mid_ZN_4 - Wall 270_b,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c1f78e47-4343-4125-824d-d0c656baa79a}, !- Space Name
@@ -12244,14 +11968,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  6.096, 36.5458375, 19.5130875000001,    !- X,Y,Z Vertex 1 {m}
+  6.096, 36.5458375, 19.5130875,          !- X,Y,Z Vertex 1 {m}
   6.096, 36.5458375, 16.7683,             !- X,Y,Z Vertex 2 {m}
   6.096, 32.8882375, 16.7683,             !- X,Y,Z Vertex 3 {m}
-  6.096, 32.8882375, 19.5130875000001;    !- X,Y,Z Vertex 4 {m}
+  6.096, 32.8882375, 19.5130875;          !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {858310de-2948-45a8-bc04-a7fe8f8cb8b9}, !- Handle
-  Surface 655,                            !- Name
+  OpenOffice_Mid_ZN_4 - Wall 270_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c1f78e47-4343-4125-824d-d0c656baa79a}, !- Space Name
@@ -12261,14 +11985,14 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 32.8882375, 19.5130875000001,        !- X,Y,Z Vertex 1 {m}
+  0, 32.8882375, 19.5130875,              !- X,Y,Z Vertex 1 {m}
   0, 32.8882375, 16.7683,                 !- X,Y,Z Vertex 2 {m}
   0, 6.096, 16.7683,                      !- X,Y,Z Vertex 3 {m}
-  0, 6.096, 19.5130875000001;             !- X,Y,Z Vertex 4 {m}
+  0, 6.096, 19.5130875;                   !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {8af9208d-2eb0-463d-813d-a777b7bf8408}, !- Handle
-  Surface 656,                            !- Name
+  OpenOffice_Mid_ZN_4 - Wall 090_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c1f78e47-4343-4125-824d-d0c656baa79a}, !- Space Name
@@ -12281,7 +12005,7 @@ OS:Surface,
   15.05712, 12.1618375, 19.5130875,       !- X,Y,Z Vertex 1 {m}
   15.05712, 12.1618375, 16.7683,          !- X,Y,Z Vertex 2 {m}
   15.05712, 36.5458375, 16.7683,          !- X,Y,Z Vertex 3 {m}
-  15.05712, 36.5458375, 19.5130875000001; !- X,Y,Z Vertex 4 {m}
+  15.05712, 36.5458375, 19.5130875;       !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {4164458d-6d0e-4def-8d66-bd5380676698}, !- Handle
@@ -12301,7 +12025,7 @@ OS:Space,
 
 OS:Surface,
   {fce1f050-14e5-4184-a1ce-7fa5e04e4412}, !- Handle
-  Surface 657,                            !- Name
+  MidFloor_Plenum - Floor_p,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {4164458d-6d0e-4def-8d66-bd5380676698}, !- Space Name
@@ -12320,7 +12044,7 @@ OS:Surface,
 
 OS:Surface,
   {d5e7434c-e982-44d5-b2f8-7aff4d343727}, !- Handle
-  Surface 658,                            !- Name
+  MidFloor_Plenum - Wall 180_a,           !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {4164458d-6d0e-4def-8d66-bd5380676698}, !- Space Name
@@ -12330,14 +12054,14 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -1.92626759385313e-016, 1.89307146982042e-016, 20.7322875, !- X,Y,Z Vertex 1 {m}
-  6.41186143763638e-031, -9.96361292373826e-017, 19.5130875, !- X,Y,Z Vertex 2 {m}
-  73.10755, 7.93235758299345e-016, 19.5130875, !- X,Y,Z Vertex 3 {m}
-  73.10755, 1.08217903451877e-015, 20.7322875; !- X,Y,Z Vertex 4 {m}
+  0, 0, 20.7322875,                       !- X,Y,Z Vertex 1 {m}
+  0, 0, 19.5130875,                       !- X,Y,Z Vertex 2 {m}
+  73.10755, 0, 19.5130875,                !- X,Y,Z Vertex 3 {m}
+  73.10755, 0, 20.7322875;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {c13519e1-b645-4154-acf8-f670537d22f8}, !- Handle
-  Surface 659,                            !- Name
+  MidFloor_Plenum - Wall 090_a,           !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {4164458d-6d0e-4def-8d66-bd5380676698}, !- Space Name
@@ -12347,14 +12071,14 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  73.10755, 1.08217903451877e-015, 20.7322875, !- X,Y,Z Vertex 1 {m}
-  73.10755, 7.93235758299345e-016, 19.5130875, !- X,Y,Z Vertex 2 {m}
+  73.10755, 0, 20.7322875,                !- X,Y,Z Vertex 1 {m}
+  73.10755, 0, 19.5130875,                !- X,Y,Z Vertex 2 {m}
   73.10755, 48.7378375, 19.5130875,       !- X,Y,Z Vertex 3 {m}
   73.10755, 48.7378375, 20.7322875;       !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {9a5e32e4-9d7a-4650-b933-48922960035d}, !- Handle
-  Surface 660,                            !- Name
+  MidFloor_Plenum - Wall 000_a,           !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {4164458d-6d0e-4def-8d66-bd5380676698}, !- Space Name
@@ -12366,12 +12090,12 @@ OS:Surface,
   ,                                       !- Number of Vertices
   73.10755, 48.7378375, 20.7322875,       !- X,Y,Z Vertex 1 {m}
   73.10755, 48.7378375, 19.5130875,       !- X,Y,Z Vertex 2 {m}
-  6.41186143763638e-031, 48.7378375, 19.5130875, !- X,Y,Z Vertex 3 {m}
-  -1.92626759385313e-016, 48.7378375, 20.7322875; !- X,Y,Z Vertex 4 {m}
+  0, 48.7378375, 19.5130875,              !- X,Y,Z Vertex 3 {m}
+  0, 48.7378375, 20.7322875;              !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {274a442a-6b1b-4d63-a100-e6aaf83eb66d}, !- Handle
-  Surface 661,                            !- Name
+  MidFloor_Plenum - RoofCeiling_a,        !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {4164458d-6d0e-4def-8d66-bd5380676698}, !- Space Name
@@ -12381,14 +12105,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  73.10755, 1.08217903451877e-015, 20.7322875, !- X,Y,Z Vertex 1 {m}
+  73.10755, 0, 20.7322875,                !- X,Y,Z Vertex 1 {m}
   73.10755, 48.7378375, 20.7322875,       !- X,Y,Z Vertex 2 {m}
-  -1.92626759385313e-016, 48.7378375, 20.7322875, !- X,Y,Z Vertex 3 {m}
-  -1.92626759385313e-016, 1.89307146982042e-016, 20.7322875; !- X,Y,Z Vertex 4 {m}
+  0, 48.7378375, 20.7322875,              !- X,Y,Z Vertex 3 {m}
+  0, 0, 20.7322875;                       !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {48e3a84f-ca81-46bb-9800-bcf9c77a54ef}, !- Handle
-  Surface 662,                            !- Name
+  MidFloor_Plenum - Wall 270_a,           !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {4164458d-6d0e-4def-8d66-bd5380676698}, !- Space Name
@@ -12398,14 +12122,14 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -1.92626759385313e-016, 48.7378375, 20.7322875, !- X,Y,Z Vertex 1 {m}
-  6.41186143763638e-031, 48.7378375, 19.5130875, !- X,Y,Z Vertex 2 {m}
-  6.41186143763638e-031, -9.96361292373826e-017, 19.5130875, !- X,Y,Z Vertex 3 {m}
-  -1.92626759385313e-016, 1.89307146982042e-016, 20.7322875; !- X,Y,Z Vertex 4 {m}
+  0, 48.7378375, 20.7322875,              !- X,Y,Z Vertex 1 {m}
+  0, 48.7378375, 19.5130875,              !- X,Y,Z Vertex 2 {m}
+  0, 0, 19.5130875,                       !- X,Y,Z Vertex 3 {m}
+  0, 0, 20.7322875;                       !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {11349ba0-a269-46ab-aa9d-b546b3f08392}, !- Handle
-  Surface 663,                            !- Name
+  OpenOffice_Mid_ZN_4 - Wall 090_b,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c1f78e47-4343-4125-824d-d0c656baa79a}, !- Space Name
@@ -12415,14 +12139,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  15.05712, 6.096, 19.5130875000001,      !- X,Y,Z Vertex 1 {m}
+  15.05712, 6.096, 19.5130875,            !- X,Y,Z Vertex 1 {m}
   15.05712, 6.096, 16.7683,               !- X,Y,Z Vertex 2 {m}
   15.05712, 12.1618375, 16.7683,          !- X,Y,Z Vertex 3 {m}
   15.05712, 12.1618375, 19.5130875;       !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {32da5e47-6411-4ba0-b8ec-40cbbb594cb6}, !- Handle
-  Surface 664,                            !- Name
+  OpenOffice_Mid_ZN_3 - Wall 180_d,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {980ebac3-2e2f-454b-93cc-518ecfdce4c4}, !- Space Name
@@ -12439,7 +12163,7 @@ OS:Surface,
 
 OS:Surface,
   {fb54410e-0a18-46a7-9064-546e211ec8bf}, !- Handle
-  Surface 665,                            !- Name
+  OpenOffice_Mid_ZN_3 - Wall 000_b,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {980ebac3-2e2f-454b-93cc-518ecfdce4c4}, !- Space Name
@@ -12456,7 +12180,7 @@ OS:Surface,
 
 OS:Surface,
   {435563b0-849a-4164-881a-6ccb52263d61}, !- Handle
-  Surface 666,                            !- Name
+  OpenOffice_Mid_ZN_3 - Wall 180_e,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {980ebac3-2e2f-454b-93cc-518ecfdce4c4}, !- Space Name
@@ -12466,14 +12190,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  15.05712, 36.5458375, 19.5130875000001, !- X,Y,Z Vertex 1 {m}
+  15.05712, 36.5458375, 19.5130875,       !- X,Y,Z Vertex 1 {m}
   15.05712, 36.5458375, 16.7683,          !- X,Y,Z Vertex 2 {m}
   35.3568, 36.5458375, 16.7683,           !- X,Y,Z Vertex 3 {m}
   35.3568, 36.5458375, 19.5130875;        !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {57a88936-4f51-43aa-932b-bb44e55f0cb3}, !- Handle
-  Surface 667,                            !- Name
+  OpenOffice_Mid_ZN_3 - Wall 180_b,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {980ebac3-2e2f-454b-93cc-518ecfdce4c4}, !- Space Name
@@ -12490,7 +12214,7 @@ OS:Surface,
 
 OS:Surface,
   {9061c805-e338-485c-a12b-72e5597941fd}, !- Handle
-  Surface 668,                            !- Name
+  OpenOffice_Mid_ZN_3 - Wall 180_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {980ebac3-2e2f-454b-93cc-518ecfdce4c4}, !- Space Name
@@ -12507,7 +12231,7 @@ OS:Surface,
 
 OS:Surface,
   {9bb0b4bb-52d5-4641-b08d-0d31c702a2ad}, !- Handle
-  Surface 669,                            !- Name
+  OpenOffice_Mid_ZN_2 - Wall 270_b,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d1ed72a5-9e44-4fc9-bc9d-8f2f4eb275bb}, !- Space Name
@@ -12524,7 +12248,7 @@ OS:Surface,
 
 OS:Surface,
   {9cb9597e-e8a9-4658-9d76-f444566baa9a}, !- Handle
-  Surface 670,                            !- Name
+  OpenOffice_Mid_ZN_1 - Wall 000_c,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {ee9b2385-604c-4843-a475-0156ae9bfa29}, !- Space Name
@@ -12541,7 +12265,7 @@ OS:Surface,
 
 OS:Surface,
   {764b1c8b-49fa-4863-91d6-1baf5024252e}, !- Handle
-  Surface 671,                            !- Name
+  OpenOffice_Mid_ZN_1 - Wall 000_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {ee9b2385-604c-4843-a475-0156ae9bfa29}, !- Space Name
@@ -12558,7 +12282,7 @@ OS:Surface,
 
 OS:Surface,
   {41d50ed0-0dbb-49f5-ab90-4a350978b7ce}, !- Handle
-  Surface 672,                            !- Name
+  OpenOffice_Mid_ZN_1 - Wall 000_d,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {ee9b2385-604c-4843-a475-0156ae9bfa29}, !- Space Name
@@ -12575,7 +12299,7 @@ OS:Surface,
 
 OS:Surface,
   {b25b0776-6486-4439-b86a-ca342d9b307e}, !- Handle
-  Surface 673,                            !- Name
+  EnclosedOffice_Mid_ZN_8 - Wall 090_b,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {aceaf852-6a17-4647-a5bc-ffe90e228da1}, !- Space Name
@@ -12592,7 +12316,7 @@ OS:Surface,
 
 OS:Surface,
   {35c831f7-03e8-43ae-a974-56c401994721}, !- Handle
-  Surface 674,                            !- Name
+  EnclosedOffice_Mid_ZN_6 - Wall 270_b,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {229a7bbf-bc1e-4953-9017-a5dc9b8a0efa}, !- Space Name
@@ -12609,7 +12333,7 @@ OS:Surface,
 
 OS:Surface,
   {a2e4fe03-cf53-464c-80b4-e6211286dcba}, !- Handle
-  Surface 675,                            !- Name
+  EnclosedOffice_Mid_ZN_4 - Wall 180_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {681c1394-1896-4260-aea6-9ed4ee420b8e}, !- Space Name
@@ -12626,7 +12350,7 @@ OS:Surface,
 
 OS:Surface,
   {83cf28e8-b2a1-4f38-b663-c873c526fd3e}, !- Handle
-  Surface 676,                            !- Name
+  EnclosedOffice_Mid_ZN_3 - Wall 180_b,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e35b13b3-4426-4fc8-aa91-a545783151d8}, !- Space Name
@@ -12643,7 +12367,7 @@ OS:Surface,
 
 OS:Surface,
   {e1e646d7-ec3a-487f-abbe-44192d43afed}, !- Handle
-  Surface 677,                            !- Name
+  EnclosedOffice_Mid_ZN_3 - Wall 180_c,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e35b13b3-4426-4fc8-aa91-a545783151d8}, !- Space Name
@@ -12660,7 +12384,7 @@ OS:Surface,
 
 OS:Surface,
   {2ea02136-8cf7-4da6-b56e-b1b2e81e2689}, !- Handle
-  Surface 678,                            !- Name
+  EnclosedOffice_Mid_ZN_2 - Wall 000_b,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {27343577-e985-47e3-a2b6-a9640b76547a}, !- Space Name
@@ -12677,7 +12401,7 @@ OS:Surface,
 
 OS:Surface,
   {fcc08c41-53b3-4d5d-a16a-6bab45b82796}, !- Handle
-  Surface 679,                            !- Name
+  EnclosedOffice_Mid_ZN_2 - Wall 000_c,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {27343577-e985-47e3-a2b6-a9640b76547a}, !- Space Name
@@ -12694,7 +12418,7 @@ OS:Surface,
 
 OS:Surface,
   {c9aed9e1-51b7-4db2-8132-a7d1c04efde4}, !- Handle
-  Surface 680,                            !- Name
+  Dining_Mid_ZN - Wall 090_b,             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {91c486ce-bc13-4366-ad03-8d53ad8d382a}, !- Space Name
@@ -12711,7 +12435,7 @@ OS:Surface,
 
 OS:Surface,
   {6171dae5-0f26-4fe5-a122-19e7cf25c3cf}, !- Handle
-  Surface 681,                            !- Name
+  Corridor_Mid_ZN_2 - Wall 270_e,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {4dfb84c8-5601-4d2a-a442-f696a1779b89}, !- Space Name
@@ -12728,7 +12452,7 @@ OS:Surface,
 
 OS:Surface,
   {11c10b23-4285-4b68-831f-ee141c38e56f}, !- Handle
-  Surface 682,                            !- Name
+  Corridor_Mid_ZN_2 - Wall 270_d,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {4dfb84c8-5601-4d2a-a442-f696a1779b89}, !- Space Name
@@ -12745,7 +12469,7 @@ OS:Surface,
 
 OS:Surface,
   {8801a342-baf5-45ec-9760-acd2e93cb942}, !- Handle
-  Surface 683,                            !- Name
+  Lobby_Mid_ZN - Wall 090_c,              !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3348a82a-51b6-42f2-8ff4-895a73eb0ae8}, !- Space Name
@@ -12762,7 +12486,7 @@ OS:Surface,
 
 OS:Surface,
   {14d46a0f-54ef-4146-a3ec-d9d492e9b5b9}, !- Handle
-  Surface 684,                            !- Name
+  Lobby_Mid_ZN - Wall 270_d,              !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3348a82a-51b6-42f2-8ff4-895a73eb0ae8}, !- Space Name
@@ -12779,7 +12503,7 @@ OS:Surface,
 
 OS:Surface,
   {de4bb818-8101-481f-8b8b-4492a1e1d4fa}, !- Handle
-  Surface 685,                            !- Name
+  Lobby_Mid_ZN - Wall 270_a,              !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3348a82a-51b6-42f2-8ff4-895a73eb0ae8}, !- Space Name
@@ -12796,7 +12520,7 @@ OS:Surface,
 
 OS:Surface,
   {d90ce9a8-d54b-47c4-a5f4-3cc05cfb5ed3}, !- Handle
-  Surface 686,                            !- Name
+  Lobby_Mid_ZN - Wall 090_a,              !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3348a82a-51b6-42f2-8ff4-895a73eb0ae8}, !- Space Name
@@ -12813,7 +12537,7 @@ OS:Surface,
 
 OS:Surface,
   {3f6ad8f0-25fc-4cd5-814a-fb532b8de9b2}, !- Handle
-  Surface 687,                            !- Name
+  Lobby_Mid_ZN - Wall 270_c,              !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3348a82a-51b6-42f2-8ff4-895a73eb0ae8}, !- Space Name
@@ -12830,7 +12554,7 @@ OS:Surface,
 
 OS:Surface,
   {850a9f40-9954-41aa-bc09-79ab423b2602}, !- Handle
-  Surface 688,                            !- Name
+  Lobby_Mid_ZN - Wall 090_d,              !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3348a82a-51b6-42f2-8ff4-895a73eb0ae8}, !- Space Name
@@ -12847,7 +12571,7 @@ OS:Surface,
 
 OS:Surface,
   {32d6c4d3-b08d-4a67-9021-f97cb0c2b7aa}, !- Handle
-  Surface 689,                            !- Name
+  Lobby_Mid_ZN - Wall 270_e,              !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3348a82a-51b6-42f2-8ff4-895a73eb0ae8}, !- Space Name
@@ -12864,7 +12588,7 @@ OS:Surface,
 
 OS:Surface,
   {6482f198-8b4e-4412-8b74-19e0d474e3f3}, !- Handle
-  Surface 690,                            !- Name
+  EnclosedOffice_Mid_ZN_1 - Wall 000_b,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {bccc9f2d-d256-41af-a2b2-ac258b3e84ed}, !- Space Name
@@ -12881,7 +12605,7 @@ OS:Surface,
 
 OS:Surface,
   {c5a31067-b2d8-421b-8938-40cd51460853}, !- Handle
-  Surface 691,                            !- Name
+  EnclosedOffice_Mid_ZN_1 - Wall 000_c,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {bccc9f2d-d256-41af-a2b2-ac258b3e84ed}, !- Space Name
@@ -12898,7 +12622,7 @@ OS:Surface,
 
 OS:Surface,
   {a90377fb-3c3e-40cc-a00f-e856015daad1}, !- Handle
-  Surface 692,                            !- Name
+  Datacenter_Mid_ZN - Wall 090_b,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {756ce787-864a-4417-9732-79cbb8afc5a1}, !- Space Name
@@ -12915,7 +12639,7 @@ OS:Surface,
 
 OS:Surface,
   {949dece9-7dfa-4ca0-ad04-5f33d0d6c88b}, !- Handle
-  Surface 693,                            !- Name
+  Datacenter_Mid_ZN - Wall 090_c,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {756ce787-864a-4417-9732-79cbb8afc5a1}, !- Space Name
@@ -12932,7 +12656,7 @@ OS:Surface,
 
 OS:Surface,
   {1154fc93-ff7e-4db8-81a3-748f3c75494e}, !- Handle
-  Surface 694,                            !- Name
+  Corridor_Mid_ZN_1 - Wall 180_c,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {baa0d6e9-3f43-4779-b886-9b809196ab7b}, !- Space Name
@@ -12949,7 +12673,7 @@ OS:Surface,
 
 OS:Surface,
   {009f00ea-4623-4a62-8ac3-97858c44a729}, !- Handle
-  Surface 695,                            !- Name
+  Corridor_Mid_ZN_1 - Wall 000_c,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {baa0d6e9-3f43-4779-b886-9b809196ab7b}, !- Space Name
@@ -12966,7 +12690,7 @@ OS:Surface,
 
 OS:Surface,
   {31ea2422-d7ed-4b46-afd0-950bb7b99ad0}, !- Handle
-  Surface 696,                            !- Name
+  MidFloor_Plenum - Floor_d,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {4164458d-6d0e-4def-8d66-bd5380676698}, !- Space Name
@@ -12977,15 +12701,15 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   67.01155, 12.1618375, 19.5130875,       !- X,Y,Z Vertex 1 {m}
-  67.01155, 7.18784528208557e-016, 19.5130875, !- X,Y,Z Vertex 2 {m}
-  19.32432, 1.3637427015042e-016, 19.5130875, !- X,Y,Z Vertex 3 {m}
+  67.01155, 0, 19.5130875,                !- X,Y,Z Vertex 2 {m}
+  19.32432, 0, 19.5130875,                !- X,Y,Z Vertex 3 {m}
   19.32432, 6.096, 19.5130875,            !- X,Y,Z Vertex 4 {m}
   15.05712, 6.096, 19.5130875,            !- X,Y,Z Vertex 5 {m}
   15.05712, 12.1618375, 19.5130875;       !- X,Y,Z Vertex 6 {m}
 
 OS:Surface,
   {bc4bf379-3f13-4ff4-b6ce-bf5e8fd3ea99}, !- Handle
-  Surface 697,                            !- Name
+  MidFloor_Plenum - Floor_g,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {4164458d-6d0e-4def-8d66-bd5380676698}, !- Space Name
@@ -13004,7 +12728,7 @@ OS:Surface,
 
 OS:Surface,
   {c4bb6c28-5938-4ca0-956a-d0a323a730a0}, !- Handle
-  Surface 698,                            !- Name
+  MidFloor_Plenum - Floor_q,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {4164458d-6d0e-4def-8d66-bd5380676698}, !- Space Name
@@ -13021,7 +12745,7 @@ OS:Surface,
 
 OS:Surface,
   {6facbfd1-8aff-4fbd-a141-685af3b6080e}, !- Handle
-  Surface 699,                            !- Name
+  MidFloor_Plenum - Floor_n,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {4164458d-6d0e-4def-8d66-bd5380676698}, !- Space Name
@@ -13042,7 +12766,7 @@ OS:Surface,
 
 OS:Surface,
   {421e7eb8-e8b3-4492-8b0a-99325efc60ba}, !- Handle
-  Surface 700,                            !- Name
+  MidFloor_Plenum - Floor_o,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {4164458d-6d0e-4def-8d66-bd5380676698}, !- Space Name
@@ -13059,7 +12783,7 @@ OS:Surface,
 
 OS:Surface,
   {e3eb1718-a5f8-4857-8b34-39149a1df9d5}, !- Handle
-  Surface 701,                            !- Name
+  MidFloor_Plenum - Floor_h,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {4164458d-6d0e-4def-8d66-bd5380676698}, !- Space Name
@@ -13070,13 +12794,13 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   19.32432, 6.096, 19.5130875,            !- X,Y,Z Vertex 1 {m}
-  19.32432, 1.3637427015042e-016, 19.5130875, !- X,Y,Z Vertex 2 {m}
-  15.05712, 8.42584090868624e-017, 19.5130875, !- X,Y,Z Vertex 3 {m}
+  19.32432, 0, 19.5130875,                !- X,Y,Z Vertex 2 {m}
+  15.05712, 0, 19.5130875,                !- X,Y,Z Vertex 3 {m}
   15.05712, 6.096, 19.5130875;            !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {04856b94-c133-4106-8188-171b0a0f464d}, !- Handle
-  Surface 702,                            !- Name
+  MidFloor_Plenum - Floor_e,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {4164458d-6d0e-4def-8d66-bd5380676698}, !- Space Name
@@ -13097,7 +12821,7 @@ OS:Surface,
 
 OS:Surface,
   {8b7bdc5c-ddf4-4850-9158-a2c761a404f4}, !- Handle
-  Surface 703,                            !- Name
+  MidFloor_Plenum - Floor_r,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {4164458d-6d0e-4def-8d66-bd5380676698}, !- Space Name
@@ -13108,13 +12832,13 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   15.05712, 6.096, 19.5130875,            !- X,Y,Z Vertex 1 {m}
-  15.05712, 8.42584090868624e-017, 19.5130875, !- X,Y,Z Vertex 2 {m}
-  6.41186143763638e-031, -9.96361292373826e-017, 19.5130875, !- X,Y,Z Vertex 3 {m}
-  4.48830300634547e-030, 6.096, 19.5130875; !- X,Y,Z Vertex 4 {m}
+  15.05712, 0, 19.5130875,                !- X,Y,Z Vertex 2 {m}
+  0, 0, 19.5130875,                       !- X,Y,Z Vertex 3 {m}
+  0, 6.096, 19.5130875;                   !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {45117aaf-abea-4138-a217-b41f545dd465}, !- Handle
-  Surface 704,                            !- Name
+  MidFloor_Plenum - Floor_k,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {4164458d-6d0e-4def-8d66-bd5380676698}, !- Space Name
@@ -13131,7 +12855,7 @@ OS:Surface,
 
 OS:Surface,
   {5d2dbe89-14b5-4476-ae93-10a509a9c37c}, !- Handle
-  Surface 705,                            !- Name
+  MidFloor_Plenum - Floor_f,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {4164458d-6d0e-4def-8d66-bd5380676698}, !- Space Name
@@ -13143,12 +12867,12 @@ OS:Surface,
   ,                                       !- Number of Vertices
   6.096, 48.7378375, 19.5130875,          !- X,Y,Z Vertex 1 {m}
   6.096, 32.8882375, 19.5130875,          !- X,Y,Z Vertex 2 {m}
-  4.48830300634547e-030, 32.8882375, 19.5130875, !- X,Y,Z Vertex 3 {m}
-  6.41186143763638e-031, 48.7378375, 19.5130875; !- X,Y,Z Vertex 4 {m}
+  0, 32.8882375, 19.5130875,              !- X,Y,Z Vertex 3 {m}
+  0, 48.7378375, 19.5130875;              !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {2fbc152f-7617-4779-bb09-fb2d9116f6fd}, !- Handle
-  Surface 706,                            !- Name
+  MidFloor_Plenum - Floor_s,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {4164458d-6d0e-4def-8d66-bd5380676698}, !- Space Name
@@ -13160,14 +12884,14 @@ OS:Surface,
   ,                                       !- Number of Vertices
   15.05712, 36.5458375, 19.5130875,       !- X,Y,Z Vertex 1 {m}
   15.05712, 6.096, 19.5130875,            !- X,Y,Z Vertex 2 {m}
-  4.48830300634547e-030, 6.096, 19.5130875, !- X,Y,Z Vertex 3 {m}
-  4.48830300634547e-030, 32.8882375, 19.5130875, !- X,Y,Z Vertex 4 {m}
+  0, 6.096, 19.5130875,                   !- X,Y,Z Vertex 3 {m}
+  0, 32.8882375, 19.5130875,              !- X,Y,Z Vertex 4 {m}
   6.096, 32.8882375, 19.5130875,          !- X,Y,Z Vertex 5 {m}
   6.096, 36.5458375, 19.5130875;          !- X,Y,Z Vertex 6 {m}
 
 OS:Surface,
   {a5463108-b7b5-4b54-ae20-6eda164c2c7b}, !- Handle
-  Surface 707,                            !- Name
+  MidFloor_Plenum - Floor_t,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {4164458d-6d0e-4def-8d66-bd5380676698}, !- Space Name
@@ -13184,7 +12908,7 @@ OS:Surface,
 
 OS:Surface,
   {0c638b8f-e092-4da8-9f25-59bf5f3ad61b}, !- Handle
-  Surface 708,                            !- Name
+  MidFloor_Plenum - Floor_j,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {4164458d-6d0e-4def-8d66-bd5380676698}, !- Space Name
@@ -13195,13 +12919,13 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   73.10755, 15.8194375, 19.5130875,       !- X,Y,Z Vertex 1 {m}
-  73.10755, 7.93235758299345e-016, 19.5130875, !- X,Y,Z Vertex 2 {m}
-  67.01155, 7.18784528208557e-016, 19.5130875, !- X,Y,Z Vertex 3 {m}
+  73.10755, 0, 19.5130875,                !- X,Y,Z Vertex 2 {m}
+  67.01155, 0, 19.5130875,                !- X,Y,Z Vertex 3 {m}
   67.01155, 15.8194375, 19.5130875;       !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {6809dc9f-0b13-418a-a409-219af852c846}, !- Handle
-  Surface 709,                            !- Name
+  MidFloor_Plenum - Floor_b,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {4164458d-6d0e-4def-8d66-bd5380676698}, !- Space Name
@@ -13218,7 +12942,7 @@ OS:Surface,
 
 OS:Surface,
   {cfcf9ba0-f108-4485-aa01-0a61bd6fc81d}, !- Handle
-  Surface 710,                            !- Name
+  MidFloor_Plenum - Floor_l,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {4164458d-6d0e-4def-8d66-bd5380676698}, !- Space Name
@@ -13235,7 +12959,7 @@ OS:Surface,
 
 OS:Surface,
   {077e7acf-8c43-4695-ac8b-3e2d032fdc30}, !- Handle
-  Surface 711,                            !- Name
+  MidFloor_Plenum - Floor_u,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {4164458d-6d0e-4def-8d66-bd5380676698}, !- Space Name
@@ -13252,7 +12976,7 @@ OS:Surface,
 
 OS:Surface,
   {c5cae2e9-de8d-42b8-83c6-ff2cd317a565}, !- Handle
-  Surface 712,                            !- Name
+  MidFloor_Plenum - Floor_i,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {4164458d-6d0e-4def-8d66-bd5380676698}, !- Space Name
@@ -13269,7 +12993,7 @@ OS:Surface,
 
 OS:Surface,
   {ed09a892-69b5-49a1-819a-e31fdb6059b4}, !- Handle
-  Surface 713,                            !- Name
+  MidFloor_Plenum - Floor_m,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {4164458d-6d0e-4def-8d66-bd5380676698}, !- Space Name
@@ -13286,7 +13010,7 @@ OS:Surface,
 
 OS:Surface,
   {4bb1ea57-bdce-42be-9c9e-021c9cceaa44}, !- Handle
-  Surface 714,                            !- Name
+  MidFloor_Plenum - Floor_v,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {4164458d-6d0e-4def-8d66-bd5380676698}, !- Space Name
@@ -13303,7 +13027,7 @@ OS:Surface,
 
 OS:Surface,
   {5e5c4e23-8c3e-45b9-80e9-d2f05d7d68de}, !- Handle
-  Surface 715,                            !- Name
+  MidFloor_Plenum - Floor_w,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {4164458d-6d0e-4def-8d66-bd5380676698}, !- Space Name
@@ -13320,7 +13044,7 @@ OS:Surface,
 
 OS:Surface,
   {2edc2874-5779-4897-8dd2-0c2aced9bfcb}, !- Handle
-  Surface 716,                            !- Name
+  MidFloor_Plenum - Floor_x,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {4164458d-6d0e-4def-8d66-bd5380676698}, !- Space Name
@@ -13337,7 +13061,7 @@ OS:Surface,
 
 OS:Surface,
   {544d49d6-ec8d-495e-a442-9968f911febc}, !- Handle
-  Surface 717,                            !- Name
+  MidFloor_Plenum - Floor_c,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {4164458d-6d0e-4def-8d66-bd5380676698}, !- Space Name
@@ -13354,7 +13078,7 @@ OS:Surface,
 
 OS:Surface,
   {97285752-c65f-43db-be88-47cf164fd2d3}, !- Handle
-  Surface 718,                            !- Name
+  MidFloor_Plenum - Floor_y,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {4164458d-6d0e-4def-8d66-bd5380676698}, !- Space Name
@@ -13371,7 +13095,7 @@ OS:Surface,
 
 OS:Surface,
   {a0fbdffb-c909-4756-b018-2020de731330}, !- Handle
-  Surface 719,                            !- Name
+  MidFloor_Plenum - Floor_z,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {4164458d-6d0e-4def-8d66-bd5380676698}, !- Space Name
@@ -13388,7 +13112,7 @@ OS:Surface,
 
 OS:Surface,
   {567904db-9edf-4b88-8740-e873aff11da9}, !- Handle
-  Surface 720,                            !- Name
+  MidFloor_Plenum - Floor_a,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {4164458d-6d0e-4def-8d66-bd5380676698}, !- Space Name
@@ -13405,7 +13129,7 @@ OS:Surface,
 
 OS:SubSurface,
   {007b227f-ee1e-4418-bbd2-7a208f5cb2f4}, !- Handle
-  Sub Surface 1,                          !- Name
+  EnclosedOffice_Mid_ZN_5 - Wall 180_a - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {52c80dc1-1b26-4930-bec2-a3521812e7de}, !- Surface Name
@@ -13422,7 +13146,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {16c7931b-0f4d-4ca1-9bfd-c756b2467088}, !- Handle
-  Sub Surface 4,                          !- Name
+  EnclosedOffice_Mid_ZN_5 - Wall 270_a - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {ed59eb43-911f-488c-9eaf-cc1a709a20ff}, !- Surface Name
@@ -13439,7 +13163,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {fc802338-b7d8-4951-a530-b5e66b00b88c}, !- Handle
-  Sub Surface 5,                          !- Name
+  OpenOffice_Mid_ZN_4 - Wall 270_a - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {858310de-2948-45a8-bc04-a7fe8f8cb8b9}, !- Surface Name
@@ -13456,7 +13180,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {336365fd-c18f-4136-8233-2a7d014f4f5d}, !- Handle
-  Sub Surface 8,                          !- Name
+  OpenOffice_Mid_ZN_3 - Wall 000_a - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {ec663817-152a-4c86-a3f9-08102bc7c099}, !- Surface Name
@@ -13473,7 +13197,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {ce38ac6d-c204-4767-a3e5-26505fee9225}, !- Handle
-  Sub Surface 9,                          !- Name
+  ConfRoom_Mid_ZN_2 - Wall 000_a - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {3260ecb1-20e3-450a-a80d-417d9ecad948}, !- Surface Name
@@ -13490,7 +13214,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {eb79e335-c692-42e6-9217-79745d1f80c6}, !- Handle
-  Sub Surface 10,                         !- Name
+  EnclosedOffice_Mid_ZN_7 - Wall 000_a - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {9b1e9dd6-5d3d-48b9-b7c1-78f445095d21}, !- Surface Name
@@ -13507,7 +13231,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {50f8cba9-a717-4bd7-b4eb-2ba253082867}, !- Handle
-  Sub Surface 11,                         !- Name
+  EnclosedOffice_Mid_ZN_7 - Wall 090_a - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {18d3752f-f4d4-4c19-b86b-b337467ee7c4}, !- Surface Name
@@ -13524,7 +13248,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {dead2691-3af9-4a67-8a2d-eabf5611304e}, !- Handle
-  Sub Surface 12,                         !- Name
+  OpenOffice_Mid_ZN_2 - Wall 090_b - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {1cfad667-8270-4c7b-b176-da54fb0fa63c}, !- Surface Name
@@ -13541,7 +13265,7 @@ OS:SubSurface,
 
 OS:Surface,
   {f18c6efa-a3a8-473d-82ea-27e6d90852b8}, !- Handle
-  Surface 451,                            !- Name
+  Classroom_Mid_ZN - Wall 000_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {a3dfebf6-922a-4dc6-8cf5-e7c78e76ea93}, !- Space Name
@@ -13558,7 +13282,7 @@ OS:Surface,
 
 OS:SubSurface,
   {d8717f44-6be4-4644-9f58-77b7f934cb09}, !- Handle
-  Sub Surface 14,                         !- Name
+  Classroom_Mid_ZN - Wall 000_a - Sub:a,  !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {f18c6efa-a3a8-473d-82ea-27e6d90852b8}, !- Surface Name
@@ -13575,7 +13299,7 @@ OS:SubSurface,
 
 OS:Surface,
   {942fb10f-3135-44a3-a3a5-2eb8f8cd9f56}, !- Handle
-  Surface 431,                            !- Name
+  EnclosedOffice_Mid_ZN_6 - Floor_a,      !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {229a7bbf-bc1e-4953-9017-a5dc9b8a0efa}, !- Space Name
@@ -13586,13 +13310,13 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   73.10755, 15.8194375, 16.7683,          !- X,Y,Z Vertex 1 {m}
-  73.10755, 4.60135460920404e-016, 16.7683, !- X,Y,Z Vertex 2 {m}
-  67.01155, -1.47269058998881e-016, 16.7683, !- X,Y,Z Vertex 3 {m}
+  73.10755, 0, 16.7683,                   !- X,Y,Z Vertex 2 {m}
+  67.01155, 0, 16.7683,                   !- X,Y,Z Vertex 3 {m}
   67.01155, 15.8194375, 16.7683;          !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {c608f005-5148-4552-938e-3c979e5158ba}, !- Handle
-  Surface 435,                            !- Name
+  EnclosedOffice_Mid_ZN_6 - Wall 270_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {229a7bbf-bc1e-4953-9017-a5dc9b8a0efa}, !- Space Name
@@ -13604,12 +13328,12 @@ OS:Surface,
   ,                                       !- Number of Vertices
   67.01155, 12.1618375, 19.5130875,       !- X,Y,Z Vertex 1 {m}
   67.01155, 12.1618375, 16.7683,          !- X,Y,Z Vertex 2 {m}
-  67.01155, -1.47269058998881e-016, 16.7683, !- X,Y,Z Vertex 3 {m}
-  67.01155, -9.9636129237382e-017, 19.5130875; !- X,Y,Z Vertex 4 {m}
+  67.01155, 0, 16.7683,                   !- X,Y,Z Vertex 3 {m}
+  67.01155, -0, 19.5130875;               !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {cea5a155-7d9a-4904-985e-19ffca5df6a1}, !- Handle
-  Surface 432,                            !- Name
+  EnclosedOffice_Mid_ZN_6 - Wall 090_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {229a7bbf-bc1e-4953-9017-a5dc9b8a0efa}, !- Space Name
@@ -13619,8 +13343,8 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  73.10755, 7.93235758299346e-016, 19.5130875, !- X,Y,Z Vertex 1 {m}
-  73.10755, 4.60135460920404e-016, 16.7683, !- X,Y,Z Vertex 2 {m}
+  73.10755, 0, 19.5130875,                !- X,Y,Z Vertex 1 {m}
+  73.10755, 0, 16.7683,                   !- X,Y,Z Vertex 2 {m}
   73.10755, 15.8194375, 16.7683,          !- X,Y,Z Vertex 3 {m}
   73.10755, 15.8194375, 19.5130875;       !- X,Y,Z Vertex 4 {m}
 
@@ -13631,8 +13355,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  -6.41186143763638e-031,                 !- X Origin {m}
-  9.96361292373826e-017,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   16.769225,                              !- Z Origin {m}
   {c6dc659b-0ea6-49c7-9aee-b48d6c13ab59}, !- Building Story Name
   {ad12b5c8-865a-4507-a9f3-377d3070acf9}, !- Thermal Zone Name
@@ -13642,7 +13366,7 @@ OS:Space,
 
 OS:Surface,
   {7b4cc373-0b62-4e3e-a4fc-729416956eae}, !- Handle
-  Surface 724,                            !- Name
+  TopFloor_Plenum - Floor_i,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {4d77c79d-adfd-4d53-b3b4-88154ee2c76c}, !- Space Name
@@ -13661,7 +13385,7 @@ OS:Surface,
 
 OS:Surface,
   {0e8018f3-4584-4099-87bc-8224796c88b8}, !- Handle
-  Surface 725,                            !- Name
+  TopFloor_Plenum - Wall 180_a,           !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {4d77c79d-adfd-4d53-b3b4-88154ee2c76c}, !- Space Name
@@ -13671,14 +13395,14 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -1.92626759385313e-016, 1.89307146982042e-016, 20.7322875, !- X,Y,Z Vertex 1 {m}
-  6.41186143763638e-031, -9.96361292373826e-017, 19.5130875, !- X,Y,Z Vertex 2 {m}
-  73.10755, 7.93235758299345e-016, 19.5130875, !- X,Y,Z Vertex 3 {m}
-  73.10755, 1.08217903451877e-015, 20.7322875; !- X,Y,Z Vertex 4 {m}
+  0, 0, 20.7322875,                       !- X,Y,Z Vertex 1 {m}
+  0, 0, 19.5130875,                       !- X,Y,Z Vertex 2 {m}
+  73.10755, 0, 19.5130875,                !- X,Y,Z Vertex 3 {m}
+  73.10755, 0, 20.7322875;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {54052e8d-6fe1-4757-9e14-fd2af9342658}, !- Handle
-  Surface 726,                            !- Name
+  TopFloor_Plenum - Wall 090_a,           !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {4d77c79d-adfd-4d53-b3b4-88154ee2c76c}, !- Space Name
@@ -13688,14 +13412,14 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  73.10755, 1.08217903451877e-015, 20.7322875, !- X,Y,Z Vertex 1 {m}
-  73.10755, 7.93235758299345e-016, 19.5130875, !- X,Y,Z Vertex 2 {m}
+  73.10755, 0, 20.7322875,                !- X,Y,Z Vertex 1 {m}
+  73.10755, 0, 19.5130875,                !- X,Y,Z Vertex 2 {m}
   73.10755, 48.7378375, 19.5130875,       !- X,Y,Z Vertex 3 {m}
   73.10755, 48.7378375, 20.7322875;       !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {3d3e85c2-ffbe-4032-b449-85bd67630aa3}, !- Handle
-  Surface 727,                            !- Name
+  TopFloor_Plenum - Wall 000_a,           !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {4d77c79d-adfd-4d53-b3b4-88154ee2c76c}, !- Space Name
@@ -13707,12 +13431,12 @@ OS:Surface,
   ,                                       !- Number of Vertices
   73.10755, 48.7378375, 20.7322875,       !- X,Y,Z Vertex 1 {m}
   73.10755, 48.7378375, 19.5130875,       !- X,Y,Z Vertex 2 {m}
-  6.41186143763638e-031, 48.7378375, 19.5130875, !- X,Y,Z Vertex 3 {m}
-  -1.92626759385313e-016, 48.7378375, 20.7322875; !- X,Y,Z Vertex 4 {m}
+  0, 48.7378375, 19.5130875,              !- X,Y,Z Vertex 3 {m}
+  0, 48.7378375, 20.7322875;              !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {2ba37a7c-3a7b-4729-a129-fb07ac24f423}, !- Handle
-  Surface 728,                            !- Name
+  TopFloor_Plenum - RoofCeiling_a,        !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {4d77c79d-adfd-4d53-b3b4-88154ee2c76c}, !- Space Name
@@ -13722,14 +13446,14 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  73.10755, 1.08217903451877e-015, 20.7322875, !- X,Y,Z Vertex 1 {m}
+  73.10755, 0, 20.7322875,                !- X,Y,Z Vertex 1 {m}
   73.10755, 48.7378375, 20.7322875,       !- X,Y,Z Vertex 2 {m}
-  -1.92626759385313e-016, 48.7378375, 20.7322875, !- X,Y,Z Vertex 3 {m}
-  -1.92626759385313e-016, 1.89307146982042e-016, 20.7322875; !- X,Y,Z Vertex 4 {m}
+  0, 48.7378375, 20.7322875,              !- X,Y,Z Vertex 3 {m}
+  0, 0, 20.7322875;                       !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {400187db-3529-403a-9b46-2949f4fd4b11}, !- Handle
-  Surface 729,                            !- Name
+  TopFloor_Plenum - Wall 270_a,           !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {4d77c79d-adfd-4d53-b3b4-88154ee2c76c}, !- Space Name
@@ -13739,14 +13463,14 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -1.92626759385313e-016, 48.7378375, 20.7322875, !- X,Y,Z Vertex 1 {m}
-  6.41186143763638e-031, 48.7378375, 19.5130875, !- X,Y,Z Vertex 2 {m}
-  6.41186143763638e-031, -9.96361292373826e-017, 19.5130875, !- X,Y,Z Vertex 3 {m}
-  -1.92626759385313e-016, 1.89307146982042e-016, 20.7322875; !- X,Y,Z Vertex 4 {m}
+  0, 48.7378375, 20.7322875,              !- X,Y,Z Vertex 1 {m}
+  0, 48.7378375, 19.5130875,              !- X,Y,Z Vertex 2 {m}
+  0, 0, 19.5130875,                       !- X,Y,Z Vertex 3 {m}
+  0, 0, 20.7322875;                       !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {b146bec5-c719-424b-b513-7749c13863f7}, !- Handle
-  Surface 730,                            !- Name
+  TopFloor_Plenum - Floor_l,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {4d77c79d-adfd-4d53-b3b4-88154ee2c76c}, !- Space Name
@@ -13757,15 +13481,15 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   67.01155, 12.1618375, 19.5130875,       !- X,Y,Z Vertex 1 {m}
-  67.01155, 7.18784528208557e-016, 19.5130875, !- X,Y,Z Vertex 2 {m}
-  19.32432, 1.3637427015042e-016, 19.5130875, !- X,Y,Z Vertex 3 {m}
+  67.01155, 0, 19.5130875,                !- X,Y,Z Vertex 2 {m}
+  19.32432, 0, 19.5130875,                !- X,Y,Z Vertex 3 {m}
   19.32432, 6.096, 19.5130875,            !- X,Y,Z Vertex 4 {m}
   15.05712, 6.096, 19.5130875,            !- X,Y,Z Vertex 5 {m}
   15.05712, 12.1618375, 19.5130875;       !- X,Y,Z Vertex 6 {m}
 
 OS:Surface,
   {7e93e2c4-5823-4ce2-89dc-fde443480342}, !- Handle
-  Surface 731,                            !- Name
+  TopFloor_Plenum - Floor_m,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {4d77c79d-adfd-4d53-b3b4-88154ee2c76c}, !- Space Name
@@ -13784,7 +13508,7 @@ OS:Surface,
 
 OS:Surface,
   {ec3e0180-84b9-4031-8329-f7c2a02444f1}, !- Handle
-  Surface 732,                            !- Name
+  TopFloor_Plenum - Floor_e,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {4d77c79d-adfd-4d53-b3b4-88154ee2c76c}, !- Space Name
@@ -13801,7 +13525,7 @@ OS:Surface,
 
 OS:Surface,
   {d8d6d99b-a9a1-460a-b91c-93605293cd1a}, !- Handle
-  Surface 733,                            !- Name
+  TopFloor_Plenum - Floor_h,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {4d77c79d-adfd-4d53-b3b4-88154ee2c76c}, !- Space Name
@@ -13822,7 +13546,7 @@ OS:Surface,
 
 OS:Surface,
   {bad0b8e1-994e-4fd0-873c-f742a05f723a}, !- Handle
-  Surface 734,                            !- Name
+  TopFloor_Plenum - Floor_n,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {4d77c79d-adfd-4d53-b3b4-88154ee2c76c}, !- Space Name
@@ -13839,7 +13563,7 @@ OS:Surface,
 
 OS:Surface,
   {bfcf9b50-9142-40c3-88a0-408ae487ae2b}, !- Handle
-  Surface 735,                            !- Name
+  TopFloor_Plenum - Floor_o,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {4d77c79d-adfd-4d53-b3b4-88154ee2c76c}, !- Space Name
@@ -13850,13 +13574,13 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   19.32432, 6.096, 19.5130875,            !- X,Y,Z Vertex 1 {m}
-  19.32432, 1.3637427015042e-016, 19.5130875, !- X,Y,Z Vertex 2 {m}
-  15.05712, 8.42584090868624e-017, 19.5130875, !- X,Y,Z Vertex 3 {m}
+  19.32432, 0, 19.5130875,                !- X,Y,Z Vertex 2 {m}
+  15.05712, 0, 19.5130875,                !- X,Y,Z Vertex 3 {m}
   15.05712, 6.096, 19.5130875;            !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {ed237b28-e593-46f6-bfaf-c7c60dbbe0b4}, !- Handle
-  Surface 736,                            !- Name
+  TopFloor_Plenum - Floor_p,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {4d77c79d-adfd-4d53-b3b4-88154ee2c76c}, !- Space Name
@@ -13877,7 +13601,7 @@ OS:Surface,
 
 OS:Surface,
   {9b15a7a6-d6ea-4ac3-aadb-850828effa1a}, !- Handle
-  Surface 737,                            !- Name
+  TopFloor_Plenum - Floor_q,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {4d77c79d-adfd-4d53-b3b4-88154ee2c76c}, !- Space Name
@@ -13888,13 +13612,13 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   15.05712, 6.096, 19.5130875,            !- X,Y,Z Vertex 1 {m}
-  15.05712, 8.42584090868624e-017, 19.5130875, !- X,Y,Z Vertex 2 {m}
-  6.41186143763638e-031, -9.96361292373826e-017, 19.5130875, !- X,Y,Z Vertex 3 {m}
-  4.48830300634547e-030, 6.096, 19.5130875; !- X,Y,Z Vertex 4 {m}
+  15.05712, 0, 19.5130875,                !- X,Y,Z Vertex 2 {m}
+  0, 0, 19.5130875,                       !- X,Y,Z Vertex 3 {m}
+  0, 6.096, 19.5130875;                   !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {45f74438-5476-4347-b80f-4f2441930a5c}, !- Handle
-  Surface 738,                            !- Name
+  TopFloor_Plenum - Floor_r,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {4d77c79d-adfd-4d53-b3b4-88154ee2c76c}, !- Space Name
@@ -13911,7 +13635,7 @@ OS:Surface,
 
 OS:Surface,
   {fe2244cc-f9ca-42f3-bb29-b9d91d1edb53}, !- Handle
-  Surface 739,                            !- Name
+  TopFloor_Plenum - Floor_s,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {4d77c79d-adfd-4d53-b3b4-88154ee2c76c}, !- Space Name
@@ -13923,12 +13647,12 @@ OS:Surface,
   ,                                       !- Number of Vertices
   6.096, 48.7378375, 19.5130875,          !- X,Y,Z Vertex 1 {m}
   6.096, 32.8882375, 19.5130875,          !- X,Y,Z Vertex 2 {m}
-  4.48830300634547e-030, 32.8882375, 19.5130875, !- X,Y,Z Vertex 3 {m}
-  6.41186143763638e-031, 48.7378375, 19.5130875; !- X,Y,Z Vertex 4 {m}
+  0, 32.8882375, 19.5130875,              !- X,Y,Z Vertex 3 {m}
+  0, 48.7378375, 19.5130875;              !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {b0e7effa-e997-4932-8a57-8ac49bcd5eb8}, !- Handle
-  Surface 740,                            !- Name
+  TopFloor_Plenum - Floor_d,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {4d77c79d-adfd-4d53-b3b4-88154ee2c76c}, !- Space Name
@@ -13940,14 +13664,14 @@ OS:Surface,
   ,                                       !- Number of Vertices
   15.05712, 36.5458375, 19.5130875,       !- X,Y,Z Vertex 1 {m}
   15.05712, 6.096, 19.5130875,            !- X,Y,Z Vertex 2 {m}
-  4.48830300634547e-030, 6.096, 19.5130875, !- X,Y,Z Vertex 3 {m}
-  4.48830300634547e-030, 32.8882375, 19.5130875, !- X,Y,Z Vertex 4 {m}
+  0, 6.096, 19.5130875,                   !- X,Y,Z Vertex 3 {m}
+  0, 32.8882375, 19.5130875,              !- X,Y,Z Vertex 4 {m}
   6.096, 32.8882375, 19.5130875,          !- X,Y,Z Vertex 5 {m}
   6.096, 36.5458375, 19.5130875;          !- X,Y,Z Vertex 6 {m}
 
 OS:Surface,
   {bba445c5-0be0-4c08-9c1e-b0465ab68ca1}, !- Handle
-  Surface 741,                            !- Name
+  TopFloor_Plenum - Floor_g,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {4d77c79d-adfd-4d53-b3b4-88154ee2c76c}, !- Space Name
@@ -13964,7 +13688,7 @@ OS:Surface,
 
 OS:Surface,
   {f28e984f-0d47-425e-9917-e6a3cc5bc336}, !- Handle
-  Surface 742,                            !- Name
+  TopFloor_Plenum - Floor_t,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {4d77c79d-adfd-4d53-b3b4-88154ee2c76c}, !- Space Name
@@ -13975,13 +13699,13 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   73.10755, 15.8194375, 19.5130875,       !- X,Y,Z Vertex 1 {m}
-  73.10755, 7.93235758299345e-016, 19.5130875, !- X,Y,Z Vertex 2 {m}
-  67.01155, 7.18784528208557e-016, 19.5130875, !- X,Y,Z Vertex 3 {m}
+  73.10755, 0, 19.5130875,                !- X,Y,Z Vertex 2 {m}
+  67.01155, 0, 19.5130875,                !- X,Y,Z Vertex 3 {m}
   67.01155, 15.8194375, 19.5130875;       !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {a996ecdc-ad56-439d-9e37-181c913b73e5}, !- Handle
-  Surface 743,                            !- Name
+  TopFloor_Plenum - Floor_u,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {4d77c79d-adfd-4d53-b3b4-88154ee2c76c}, !- Space Name
@@ -13998,7 +13722,7 @@ OS:Surface,
 
 OS:Surface,
   {1b7d4555-6a31-49b2-844c-daafc09e3cab}, !- Handle
-  Surface 744,                            !- Name
+  TopFloor_Plenum - Floor_v,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {4d77c79d-adfd-4d53-b3b4-88154ee2c76c}, !- Space Name
@@ -14015,7 +13739,7 @@ OS:Surface,
 
 OS:Surface,
   {2985451c-1bf5-4110-89c7-ef432c5ed563}, !- Handle
-  Surface 745,                            !- Name
+  TopFloor_Plenum - Floor_k,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {4d77c79d-adfd-4d53-b3b4-88154ee2c76c}, !- Space Name
@@ -14032,7 +13756,7 @@ OS:Surface,
 
 OS:Surface,
   {510324d7-a7ff-4c70-a8f9-4b1553b57b59}, !- Handle
-  Surface 746,                            !- Name
+  TopFloor_Plenum - Floor_j,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {4d77c79d-adfd-4d53-b3b4-88154ee2c76c}, !- Space Name
@@ -14049,7 +13773,7 @@ OS:Surface,
 
 OS:Surface,
   {9ba7dc1f-ce03-42ae-a104-7534a0c67b98}, !- Handle
-  Surface 747,                            !- Name
+  TopFloor_Plenum - Floor_w,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {4d77c79d-adfd-4d53-b3b4-88154ee2c76c}, !- Space Name
@@ -14066,7 +13790,7 @@ OS:Surface,
 
 OS:Surface,
   {841d54b8-1925-426e-9e02-021adaf683a8}, !- Handle
-  Surface 748,                            !- Name
+  TopFloor_Plenum - Floor_c,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {4d77c79d-adfd-4d53-b3b4-88154ee2c76c}, !- Space Name
@@ -14083,7 +13807,7 @@ OS:Surface,
 
 OS:Surface,
   {7dd745e9-65a3-44ad-8ee3-95d9c91d3f78}, !- Handle
-  Surface 749,                            !- Name
+  TopFloor_Plenum - Floor_x,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {4d77c79d-adfd-4d53-b3b4-88154ee2c76c}, !- Space Name
@@ -14100,7 +13824,7 @@ OS:Surface,
 
 OS:Surface,
   {ab742cdf-ce4a-4d8f-b5db-331fba3c6c04}, !- Handle
-  Surface 750,                            !- Name
+  TopFloor_Plenum - Floor_y,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {4d77c79d-adfd-4d53-b3b4-88154ee2c76c}, !- Space Name
@@ -14117,7 +13841,7 @@ OS:Surface,
 
 OS:Surface,
   {ed7119be-7a85-40b4-aff1-860b45c37bbd}, !- Handle
-  Surface 751,                            !- Name
+  TopFloor_Plenum - Floor_a,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {4d77c79d-adfd-4d53-b3b4-88154ee2c76c}, !- Space Name
@@ -14134,7 +13858,7 @@ OS:Surface,
 
 OS:Surface,
   {47fbe994-4076-4400-897b-8dbfee5912c2}, !- Handle
-  Surface 752,                            !- Name
+  TopFloor_Plenum - Floor_f,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {4d77c79d-adfd-4d53-b3b4-88154ee2c76c}, !- Space Name
@@ -14151,7 +13875,7 @@ OS:Surface,
 
 OS:Surface,
   {a4391108-01bc-4e3e-921e-f326cb080871}, !- Handle
-  Surface 753,                            !- Name
+  TopFloor_Plenum - Floor_b,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {4d77c79d-adfd-4d53-b3b4-88154ee2c76c}, !- Space Name
@@ -14168,7 +13892,7 @@ OS:Surface,
 
 OS:Surface,
   {ca17dbea-1cc7-4822-bc7e-9d41d0e0c444}, !- Handle
-  Surface 754,                            !- Name
+  TopFloor_Plenum - Floor_z,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {4d77c79d-adfd-4d53-b3b4-88154ee2c76c}, !- Space Name
@@ -14191,7 +13915,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  1.70960468004467e-016,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   16.769225,                              !- Z Origin {m}
   {c6dc659b-0ea6-49c7-9aee-b48d6c13ab59}, !- Building Story Name
   {fc5af255-4dab-4b97-818b-5e39bbc96d79}, !- Thermal Zone Name
@@ -14200,7 +13924,7 @@ OS:Space,
 
 OS:Surface,
   {f64603f1-383e-4d0a-a6d9-58f04fcef692}, !- Handle
-  Surface 755,                            !- Name
+  Corridor_Top_ZN_1 - Floor_a,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {25c3df23-a990-4261-95ff-261dd8556920}, !- Space Name
@@ -14221,7 +13945,7 @@ OS:Surface,
 
 OS:Surface,
   {f3e7659a-abd0-4b24-9c92-55ce3fba0d63}, !- Handle
-  Surface 756,                            !- Name
+  Corridor_Top_ZN_1 - Wall 000_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {25c3df23-a990-4261-95ff-261dd8556920}, !- Space Name
@@ -14238,7 +13962,7 @@ OS:Surface,
 
 OS:Surface,
   {3a1e8f53-ea36-4b6d-a2c1-54198d351926}, !- Handle
-  Surface 757,                            !- Name
+  Corridor_Top_ZN_1 - Wall 090_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {25c3df23-a990-4261-95ff-261dd8556920}, !- Space Name
@@ -14255,7 +13979,7 @@ OS:Surface,
 
 OS:Surface,
   {2bf8f8ae-8d62-4f27-8ae2-ffb7dc7d991e}, !- Handle
-  Surface 758,                            !- Name
+  Corridor_Top_ZN_1 - Wall 090_b,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {25c3df23-a990-4261-95ff-261dd8556920}, !- Space Name
@@ -14272,7 +13996,7 @@ OS:Surface,
 
 OS:Surface,
   {b8d8a5d5-cc06-4180-94ab-19264c06b090}, !- Handle
-  Surface 759,                            !- Name
+  Corridor_Top_ZN_1 - Wall 180_c,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {25c3df23-a990-4261-95ff-261dd8556920}, !- Space Name
@@ -14289,7 +14013,7 @@ OS:Surface,
 
 OS:Surface,
   {a9dbec1b-3d41-4446-9f67-06bddea6f083}, !- Handle
-  Surface 760,                            !- Name
+  Corridor_Top_ZN_1 - Wall 270_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {25c3df23-a990-4261-95ff-261dd8556920}, !- Space Name
@@ -14306,7 +14030,7 @@ OS:Surface,
 
 OS:Surface,
   {bb420af4-f5f0-4b15-b966-87fadf873ed2}, !- Handle
-  Surface 761,                            !- Name
+  Corridor_Top_ZN_1 - Wall 180_b,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {25c3df23-a990-4261-95ff-261dd8556920}, !- Space Name
@@ -14323,7 +14047,7 @@ OS:Surface,
 
 OS:Surface,
   {cb7f8cac-7fdd-4c19-833c-18ed28ebb045}, !- Handle
-  Surface 762,                            !- Name
+  Corridor_Top_ZN_1 - Wall 090_c,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {25c3df23-a990-4261-95ff-261dd8556920}, !- Space Name
@@ -14340,7 +14064,7 @@ OS:Surface,
 
 OS:Surface,
   {0deac273-d9ff-4175-bf4f-b4ecb76735ba}, !- Handle
-  Surface 763,                            !- Name
+  Corridor_Top_ZN_1 - Wall 000_b,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {25c3df23-a990-4261-95ff-261dd8556920}, !- Space Name
@@ -14357,7 +14081,7 @@ OS:Surface,
 
 OS:Surface,
   {d7b12df6-cb78-4efb-96ad-422e95d5da6f}, !- Handle
-  Surface 764,                            !- Name
+  Corridor_Top_ZN_1 - RoofCeiling_a,      !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {25c3df23-a990-4261-95ff-261dd8556920}, !- Space Name
@@ -14378,7 +14102,7 @@ OS:Surface,
 
 OS:Surface,
   {b91ef553-0b6e-4371-8453-9756fdf23152}, !- Handle
-  Surface 765,                            !- Name
+  Corridor_Top_ZN_1 - Wall 180_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {25c3df23-a990-4261-95ff-261dd8556920}, !- Space Name
@@ -14395,7 +14119,7 @@ OS:Surface,
 
 OS:Surface,
   {a15ac5be-572d-4017-81f6-dbc6da3821a3}, !- Handle
-  Surface 766,                            !- Name
+  Corridor_Top_ZN_1 - Wall 000_c,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {25c3df23-a990-4261-95ff-261dd8556920}, !- Space Name
@@ -14418,7 +14142,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  1.70960468004467e-016,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   16.769225,                              !- Z Origin {m}
   {c6dc659b-0ea6-49c7-9aee-b48d6c13ab59}, !- Building Story Name
   {83aee078-263b-4ad8-b910-2c21c1b29bf9}, !- Thermal Zone Name
@@ -14427,7 +14151,7 @@ OS:Space,
 
 OS:Surface,
   {ea7c2a5d-1422-41dc-b5e5-00a7f58ba0e6}, !- Handle
-  Surface 767,                            !- Name
+  Restroom_Top_ZN - Floor_a,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {7450b33a-3578-4219-b0a8-7835998142b8}, !- Space Name
@@ -14444,7 +14168,7 @@ OS:Surface,
 
 OS:Surface,
   {0a76723f-ea7d-43f6-a40c-95c8d6cb7bb1}, !- Handle
-  Surface 768,                            !- Name
+  Restroom_Top_ZN - Wall 090_a,           !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {7450b33a-3578-4219-b0a8-7835998142b8}, !- Space Name
@@ -14461,7 +14185,7 @@ OS:Surface,
 
 OS:Surface,
   {a669d36f-4851-4363-b8a8-e17d303a9b48}, !- Handle
-  Surface 769,                            !- Name
+  Restroom_Top_ZN - Wall 000_a,           !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {7450b33a-3578-4219-b0a8-7835998142b8}, !- Space Name
@@ -14478,7 +14202,7 @@ OS:Surface,
 
 OS:Surface,
   {efd3cc01-6ab9-4123-9e89-48cb675da354}, !- Handle
-  Surface 770,                            !- Name
+  Restroom_Top_ZN - Wall 270_a,           !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {7450b33a-3578-4219-b0a8-7835998142b8}, !- Space Name
@@ -14495,7 +14219,7 @@ OS:Surface,
 
 OS:Surface,
   {5f93005b-8145-4f86-b250-abcaa48b4f73}, !- Handle
-  Surface 771,                            !- Name
+  Restroom_Top_ZN - RoofCeiling_a,        !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {7450b33a-3578-4219-b0a8-7835998142b8}, !- Space Name
@@ -14512,7 +14236,7 @@ OS:Surface,
 
 OS:Surface,
   {daca7924-9622-40ac-972e-28acb8d6b606}, !- Handle
-  Surface 772,                            !- Name
+  Restroom_Top_ZN - Wall 180_a,           !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {7450b33a-3578-4219-b0a8-7835998142b8}, !- Space Name
@@ -14535,7 +14259,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  1.70960468004467e-016,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   16.769225,                              !- Z Origin {m}
   {c6dc659b-0ea6-49c7-9aee-b48d6c13ab59}, !- Building Story Name
   {129d270a-b446-4ec7-abf7-0cfbb0b9eb06}, !- Thermal Zone Name
@@ -14544,7 +14268,7 @@ OS:Space,
 
 OS:Surface,
   {636f5ace-4da2-4d2d-8df1-86a3d75aa53f}, !- Handle
-  Surface 773,                            !- Name
+  Lobby_Top_ZN - Floor_a,                 !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {df7b5c9e-b3b0-45c2-ab64-4539905de144}, !- Space Name
@@ -14561,7 +14285,7 @@ OS:Surface,
 
 OS:Surface,
   {cba14f26-904b-4588-9dc1-1cfd4249efb9}, !- Handle
-  Surface 774,                            !- Name
+  Lobby_Top_ZN - Wall 270_c,              !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {df7b5c9e-b3b0-45c2-ab64-4539905de144}, !- Space Name
@@ -14578,7 +14302,7 @@ OS:Surface,
 
 OS:Surface,
   {b609c875-72c7-4a9b-928d-7b07e0e25e83}, !- Handle
-  Surface 775,                            !- Name
+  Lobby_Top_ZN - Wall 180_a,              !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {df7b5c9e-b3b0-45c2-ab64-4539905de144}, !- Space Name
@@ -14595,7 +14319,7 @@ OS:Surface,
 
 OS:Surface,
   {e5cf588d-c20c-4600-a3b8-719b9a477f8b}, !- Handle
-  Surface 776,                            !- Name
+  Lobby_Top_ZN - Wall 090_b,              !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {df7b5c9e-b3b0-45c2-ab64-4539905de144}, !- Space Name
@@ -14612,7 +14336,7 @@ OS:Surface,
 
 OS:Surface,
   {2344736a-c07b-4e84-ac95-2b1700f4d776}, !- Handle
-  Surface 777,                            !- Name
+  Lobby_Top_ZN - Wall 000_a,              !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {df7b5c9e-b3b0-45c2-ab64-4539905de144}, !- Space Name
@@ -14629,7 +14353,7 @@ OS:Surface,
 
 OS:Surface,
   {6b527d98-180a-4973-9a61-6b8ef1f4fd29}, !- Handle
-  Surface 778,                            !- Name
+  Lobby_Top_ZN - RoofCeiling_a,           !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {df7b5c9e-b3b0-45c2-ab64-4539905de144}, !- Space Name
@@ -14646,7 +14370,7 @@ OS:Surface,
 
 OS:Surface,
   {535b385b-df8c-458e-83cc-d8d9360005dc}, !- Handle
-  Surface 779,                            !- Name
+  Lobby_Top_ZN - Wall 090_c,              !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {df7b5c9e-b3b0-45c2-ab64-4539905de144}, !- Space Name
@@ -14663,7 +14387,7 @@ OS:Surface,
 
 OS:Surface,
   {7697e7d7-e6db-4347-8d89-19398fa7d96a}, !- Handle
-  Surface 780,                            !- Name
+  Lobby_Top_ZN - Wall 270_d,              !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {df7b5c9e-b3b0-45c2-ab64-4539905de144}, !- Space Name
@@ -14680,7 +14404,7 @@ OS:Surface,
 
 OS:Surface,
   {6db8af1c-168a-4aa2-b95e-dc97b1ab7845}, !- Handle
-  Surface 781,                            !- Name
+  Lobby_Top_ZN - Wall 270_a,              !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {df7b5c9e-b3b0-45c2-ab64-4539905de144}, !- Space Name
@@ -14697,7 +14421,7 @@ OS:Surface,
 
 OS:Surface,
   {066e15c3-b8d1-4dbe-bab4-d0b5204026e7}, !- Handle
-  Surface 782,                            !- Name
+  Lobby_Top_ZN - Wall 090_a,              !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {df7b5c9e-b3b0-45c2-ab64-4539905de144}, !- Space Name
@@ -14714,7 +14438,7 @@ OS:Surface,
 
 OS:Surface,
   {a647fd13-468b-455c-84c5-f6b54342bc3a}, !- Handle
-  Surface 783,                            !- Name
+  Lobby_Top_ZN - Wall 270_e,              !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {df7b5c9e-b3b0-45c2-ab64-4539905de144}, !- Space Name
@@ -14731,7 +14455,7 @@ OS:Surface,
 
 OS:Surface,
   {6091d746-e7fd-4b29-8163-b35c50177985}, !- Handle
-  Surface 784,                            !- Name
+  Lobby_Top_ZN - Wall 090_d,              !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {df7b5c9e-b3b0-45c2-ab64-4539905de144}, !- Space Name
@@ -14748,7 +14472,7 @@ OS:Surface,
 
 OS:Surface,
   {387f2e18-1f54-4fb2-b1e9-ec94ab38e50a}, !- Handle
-  Surface 785,                            !- Name
+  Lobby_Top_ZN - Wall 270_b,              !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {df7b5c9e-b3b0-45c2-ab64-4539905de144}, !- Space Name
@@ -14771,7 +14495,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  1.70960468004467e-016,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   16.769225,                              !- Z Origin {m}
   {c6dc659b-0ea6-49c7-9aee-b48d6c13ab59}, !- Building Story Name
   {0deb7f95-9771-4cf8-ac0b-768c6abbf042}, !- Thermal Zone Name
@@ -14781,7 +14505,7 @@ OS:Space,
 
 OS:Surface,
   {9e2fa9bd-3415-4272-9057-c6a91133d20b}, !- Handle
-  Surface 786,                            !- Name
+  Corridor_Top_ZN_2 - Floor_a,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {c3398bd6-ed63-4a7a-80a0-df068eb486ac}, !- Space Name
@@ -14802,7 +14526,7 @@ OS:Surface,
 
 OS:Surface,
   {4cc21443-7983-401e-9b85-9f180d0056c4}, !- Handle
-  Surface 787,                            !- Name
+  Corridor_Top_ZN_2 - Wall 270_c,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c3398bd6-ed63-4a7a-80a0-df068eb486ac}, !- Space Name
@@ -14819,7 +14543,7 @@ OS:Surface,
 
 OS:Surface,
   {9bb2a76d-ecc4-461e-9f9c-33b615273a69}, !- Handle
-  Surface 788,                            !- Name
+  Corridor_Top_ZN_2 - Wall 180_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c3398bd6-ed63-4a7a-80a0-df068eb486ac}, !- Space Name
@@ -14836,7 +14560,7 @@ OS:Surface,
 
 OS:Surface,
   {aa2b6f9b-9fb6-4661-815d-6a659a356f13}, !- Handle
-  Surface 789,                            !- Name
+  Corridor_Top_ZN_2 - Wall 270_b,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c3398bd6-ed63-4a7a-80a0-df068eb486ac}, !- Space Name
@@ -14853,7 +14577,7 @@ OS:Surface,
 
 OS:Surface,
   {d48179f0-9858-46ea-aa9b-5e3f22c43858}, !- Handle
-  Surface 790,                            !- Name
+  Corridor_Top_ZN_2 - Wall 000_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c3398bd6-ed63-4a7a-80a0-df068eb486ac}, !- Space Name
@@ -14870,7 +14594,7 @@ OS:Surface,
 
 OS:Surface,
   {48ab7dac-6133-4d8c-8ec3-f6dcf0ff20eb}, !- Handle
-  Surface 791,                            !- Name
+  Corridor_Top_ZN_2 - Wall 270_d,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c3398bd6-ed63-4a7a-80a0-df068eb486ac}, !- Space Name
@@ -14887,7 +14611,7 @@ OS:Surface,
 
 OS:Surface,
   {94a163ed-49c1-49b4-afb7-278a67522c95}, !- Handle
-  Surface 792,                            !- Name
+  Corridor_Top_ZN_2 - RoofCeiling_a,      !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {c3398bd6-ed63-4a7a-80a0-df068eb486ac}, !- Space Name
@@ -14908,7 +14632,7 @@ OS:Surface,
 
 OS:Surface,
   {9ec85ba5-7d5f-4bbd-b241-f897d6736578}, !- Handle
-  Surface 793,                            !- Name
+  Corridor_Top_ZN_2 - Wall 180_b,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c3398bd6-ed63-4a7a-80a0-df068eb486ac}, !- Space Name
@@ -14925,7 +14649,7 @@ OS:Surface,
 
 OS:Surface,
   {95209852-ae2d-4071-a8b7-5640c754df60}, !- Handle
-  Surface 794,                            !- Name
+  Corridor_Top_ZN_2 - Wall 000_b,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c3398bd6-ed63-4a7a-80a0-df068eb486ac}, !- Space Name
@@ -14942,7 +14666,7 @@ OS:Surface,
 
 OS:Surface,
   {9254ceeb-5fb3-4821-a148-e9fc3e5e1776}, !- Handle
-  Surface 795,                            !- Name
+  Corridor_Top_ZN_2 - Wall 090_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c3398bd6-ed63-4a7a-80a0-df068eb486ac}, !- Space Name
@@ -14959,7 +14683,7 @@ OS:Surface,
 
 OS:Surface,
   {1a866f7a-cdd1-4461-9d05-420fc1bd2495}, !- Handle
-  Surface 796,                            !- Name
+  Corridor_Top_ZN_2 - Wall 270_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c3398bd6-ed63-4a7a-80a0-df068eb486ac}, !- Space Name
@@ -14976,7 +14700,7 @@ OS:Surface,
 
 OS:Surface,
   {5172c28a-d23d-4a14-a20a-1cac59e498b3}, !- Handle
-  Surface 797,                            !- Name
+  Corridor_Top_ZN_2 - Wall 270_e,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c3398bd6-ed63-4a7a-80a0-df068eb486ac}, !- Space Name
@@ -14999,7 +14723,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  1.70960468004467e-016,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   16.769225,                              !- Z Origin {m}
   {c6dc659b-0ea6-49c7-9aee-b48d6c13ab59}, !- Building Story Name
   {f65ffa6f-f4e1-4977-be97-4187d28ea53d}, !- Thermal Zone Name
@@ -15008,7 +14732,7 @@ OS:Space,
 
 OS:Surface,
   {25701932-e6b8-45d2-95f5-5a6cfc4f7421}, !- Handle
-  Surface 798,                            !- Name
+  Mechanical_Top_ZN_2 - Floor_a,          !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {35c156c5-f4cf-4e63-9c82-b3fbbb417654}, !- Space Name
@@ -15025,7 +14749,7 @@ OS:Surface,
 
 OS:Surface,
   {7c64dc15-2bd8-4058-b99b-f3746ae62d0f}, !- Handle
-  Surface 799,                            !- Name
+  Mechanical_Top_ZN_2 - Wall 090_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {35c156c5-f4cf-4e63-9c82-b3fbbb417654}, !- Space Name
@@ -15042,7 +14766,7 @@ OS:Surface,
 
 OS:Surface,
   {d52a13a0-ce65-427b-8d90-9dbb4e6a8b01}, !- Handle
-  Surface 800,                            !- Name
+  Mechanical_Top_ZN_2 - Wall 000_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {35c156c5-f4cf-4e63-9c82-b3fbbb417654}, !- Space Name
@@ -15059,7 +14783,7 @@ OS:Surface,
 
 OS:Surface,
   {a59b901f-fa94-4d79-8728-0deee336a5fe}, !- Handle
-  Surface 801,                            !- Name
+  Mechanical_Top_ZN_2 - RoofCeiling_a,    !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {35c156c5-f4cf-4e63-9c82-b3fbbb417654}, !- Space Name
@@ -15076,7 +14800,7 @@ OS:Surface,
 
 OS:Surface,
   {fa0555de-43d0-49ed-a79d-c7b3e82494dc}, !- Handle
-  Surface 802,                            !- Name
+  Mechanical_Top_ZN_2 - Wall 270_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {35c156c5-f4cf-4e63-9c82-b3fbbb417654}, !- Space Name
@@ -15093,7 +14817,7 @@ OS:Surface,
 
 OS:Surface,
   {9fc05baf-bd04-47df-aa70-f0393eaab509}, !- Handle
-  Surface 803,                            !- Name
+  Mechanical_Top_ZN_2 - Wall 180_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {35c156c5-f4cf-4e63-9c82-b3fbbb417654}, !- Space Name
@@ -15116,7 +14840,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  1.70960468004467e-016,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   16.769225,                              !- Z Origin {m}
   {c6dc659b-0ea6-49c7-9aee-b48d6c13ab59}, !- Building Story Name
   {73a41701-761f-4764-bdad-29b2504bc7f6}, !- Thermal Zone Name
@@ -15125,7 +14849,7 @@ OS:Space,
 
 OS:Surface,
   {9a3c0bd2-9623-4931-a178-db05ae7e5aab}, !- Handle
-  Surface 804,                            !- Name
+  Stair_Top_ZN_2 - Floor_a,               !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {dcf614f0-b036-415c-a7fb-22018c50bff7}, !- Space Name
@@ -15142,7 +14866,7 @@ OS:Surface,
 
 OS:Surface,
   {57905df4-f702-4653-a3fa-83fbb33f5bd5}, !- Handle
-  Surface 805,                            !- Name
+  Stair_Top_ZN_2 - RoofCeiling_a,         !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {dcf614f0-b036-415c-a7fb-22018c50bff7}, !- Space Name
@@ -15159,7 +14883,7 @@ OS:Surface,
 
 OS:Surface,
   {cc10de09-0f66-45fd-a388-b52b1bc6eea2}, !- Handle
-  Surface 806,                            !- Name
+  Stair_Top_ZN_2 - Wall 090_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {dcf614f0-b036-415c-a7fb-22018c50bff7}, !- Space Name
@@ -15176,7 +14900,7 @@ OS:Surface,
 
 OS:Surface,
   {36e7c217-9930-4303-8379-b80ec5b530ba}, !- Handle
-  Surface 807,                            !- Name
+  Stair_Top_ZN_2 - Wall 270_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {dcf614f0-b036-415c-a7fb-22018c50bff7}, !- Space Name
@@ -15193,7 +14917,7 @@ OS:Surface,
 
 OS:Surface,
   {e3281579-c05a-4d98-967d-b46fd486731d}, !- Handle
-  Surface 808,                            !- Name
+  Stair_Top_ZN_2 - Wall 180_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {dcf614f0-b036-415c-a7fb-22018c50bff7}, !- Space Name
@@ -15210,7 +14934,7 @@ OS:Surface,
 
 OS:Surface,
   {a95776f8-fc08-4fe1-a636-0440d050d3a5}, !- Handle
-  Surface 809,                            !- Name
+  Stair_Top_ZN_2 - Wall 000_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {dcf614f0-b036-415c-a7fb-22018c50bff7}, !- Space Name
@@ -15233,7 +14957,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  1.70960468004467e-016,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   16.769225,                              !- Z Origin {m}
   {c6dc659b-0ea6-49c7-9aee-b48d6c13ab59}, !- Building Story Name
   {8fcfd052-8598-4129-86b1-e6542a3e81a8}, !- Thermal Zone Name
@@ -15243,7 +14967,7 @@ OS:Space,
 
 OS:Surface,
   {e175b4af-e892-4c90-b449-bc4e799ca829}, !- Handle
-  Surface 810,                            !- Name
+  OpenOffice_Top_ZN_2 - Floor_a,          !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {df4fe64a-14fd-40d9-9198-717182283562}, !- Space Name
@@ -15262,7 +14986,7 @@ OS:Surface,
 
 OS:SubSurface,
   {4b1079ed-0dd6-4585-ad8f-2c9051dc7c72}, !- Handle
-  Sub Surface 16,                         !- Name
+  OpenOffice_Top_ZN_2 - Wall 090_b - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {eb3c1ec1-1381-408c-bdae-6f6316205c1b}, !- Surface Name
@@ -15279,7 +15003,7 @@ OS:SubSurface,
 
 OS:Surface,
   {1ca0669a-505a-45a0-83cf-53b68da960aa}, !- Handle
-  Surface 811,                            !- Name
+  OpenOffice_Top_ZN_2 - Wall 090_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {df4fe64a-14fd-40d9-9198-717182283562}, !- Space Name
@@ -15296,7 +15020,7 @@ OS:Surface,
 
 OS:Surface,
   {3160078a-9a7f-4c5a-9d80-a62e9ac3aac3}, !- Handle
-  Surface 812,                            !- Name
+  OpenOffice_Top_ZN_2 - Wall 180_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {df4fe64a-14fd-40d9-9198-717182283562}, !- Space Name
@@ -15313,7 +15037,7 @@ OS:Surface,
 
 OS:Surface,
   {56238296-a130-4b73-810c-49dd252c4831}, !- Handle
-  Surface 813,                            !- Name
+  OpenOffice_Top_ZN_2 - Wall 180_b,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {df4fe64a-14fd-40d9-9198-717182283562}, !- Space Name
@@ -15330,7 +15054,7 @@ OS:Surface,
 
 OS:Surface,
   {aa6b55e4-aac0-4f28-974f-84a9b3c28384}, !- Handle
-  Surface 814,                            !- Name
+  OpenOffice_Top_ZN_2 - RoofCeiling_a,    !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {df4fe64a-14fd-40d9-9198-717182283562}, !- Space Name
@@ -15349,7 +15073,7 @@ OS:Surface,
 
 OS:Surface,
   {8b0e6af0-b99d-4ef8-81c5-7fb786e2cf74}, !- Handle
-  Surface 815,                            !- Name
+  OpenOffice_Top_ZN_2 - Wall 000_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {df4fe64a-14fd-40d9-9198-717182283562}, !- Space Name
@@ -15366,7 +15090,7 @@ OS:Surface,
 
 OS:Surface,
   {15525c30-7f2c-4f0f-97cb-f0aa7d90cb1a}, !- Handle
-  Surface 816,                            !- Name
+  OpenOffice_Top_ZN_2 - Wall 270_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {df4fe64a-14fd-40d9-9198-717182283562}, !- Space Name
@@ -15383,7 +15107,7 @@ OS:Surface,
 
 OS:Surface,
   {f49f22fd-44c6-48d7-aa73-dad23a33c12f}, !- Handle
-  Surface 817,                            !- Name
+  OpenOffice_Top_ZN_2 - Wall 270_b,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {df4fe64a-14fd-40d9-9198-717182283562}, !- Space Name
@@ -15400,7 +15124,7 @@ OS:Surface,
 
 OS:Surface,
   {eb3c1ec1-1381-408c-bdae-6f6316205c1b}, !- Handle
-  Surface 818,                            !- Name
+  OpenOffice_Top_ZN_2 - Wall 090_b,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {df4fe64a-14fd-40d9-9198-717182283562}, !- Space Name
@@ -15423,7 +15147,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  1.70960468004467e-016,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   16.769225,                              !- Z Origin {m}
   {c6dc659b-0ea6-49c7-9aee-b48d6c13ab59}, !- Building Story Name
   {b6317cc5-9cf5-432a-a360-e17072864fa5}, !- Thermal Zone Name
@@ -15432,7 +15156,7 @@ OS:Space,
 
 OS:Surface,
   {f2b20997-1c3b-4aed-abd5-a044c491104c}, !- Handle
-  Surface 819,                            !- Name
+  OpenOffice_Top_ZN_3 - Floor_a,          !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {c7140ad1-3a73-4de8-9788-8604ef70fd48}, !- Space Name
@@ -15451,7 +15175,7 @@ OS:Surface,
 
 OS:Surface,
   {5b31c1dd-1162-4ef0-b208-9d4e4ff3a1de}, !- Handle
-  Surface 820,                            !- Name
+  OpenOffice_Top_ZN_3 - Wall 090_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c7140ad1-3a73-4de8-9788-8604ef70fd48}, !- Space Name
@@ -15468,7 +15192,7 @@ OS:Surface,
 
 OS:Surface,
   {9580fcee-a78b-4600-b1dc-d1f8bd797b17}, !- Handle
-  Surface 821,                            !- Name
+  OpenOffice_Top_ZN_3 - Wall 000_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c7140ad1-3a73-4de8-9788-8604ef70fd48}, !- Space Name
@@ -15485,7 +15209,7 @@ OS:Surface,
 
 OS:Surface,
   {87344eb1-fc85-424e-a32b-38c96a17f526}, !- Handle
-  Surface 822,                            !- Name
+  OpenOffice_Top_ZN_3 - Wall 270_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c7140ad1-3a73-4de8-9788-8604ef70fd48}, !- Space Name
@@ -15502,7 +15226,7 @@ OS:Surface,
 
 OS:Surface,
   {b41d541c-bdf1-4e66-9551-c01a6efdfa90}, !- Handle
-  Surface 823,                            !- Name
+  OpenOffice_Top_ZN_3 - Wall 180_c,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c7140ad1-3a73-4de8-9788-8604ef70fd48}, !- Space Name
@@ -15512,14 +15236,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  15.05712, 36.5458375, 19.5130875000001, !- X,Y,Z Vertex 1 {m}
-  6.096, 36.5458375, 19.5130875,          !- X,Y,Z Vertex 2 {m}
-  6.096, 36.5458375, 16.7683,             !- X,Y,Z Vertex 3 {m}
-  15.05712, 36.5458375, 16.7683;          !- X,Y,Z Vertex 4 {m}
+  6.096, 36.5458375, 19.5130875,          !- X,Y,Z Vertex 1 {m}
+  6.096, 36.5458375, 16.7683,             !- X,Y,Z Vertex 2 {m}
+  15.05712, 36.5458375, 16.7683,          !- X,Y,Z Vertex 3 {m}
+  15.05712, 36.5458375, 19.5130875;       !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {3e5019e6-707f-47b3-931d-b4334b44b33e}, !- Handle
-  Surface 824,                            !- Name
+  OpenOffice_Top_ZN_3 - Wall 090_b,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c7140ad1-3a73-4de8-9788-8604ef70fd48}, !- Space Name
@@ -15536,7 +15260,7 @@ OS:Surface,
 
 OS:SubSurface,
   {d18dee57-8ead-4171-a98a-7ffa863bb30c}, !- Handle
-  Sub Surface 17,                         !- Name
+  OpenOffice_Top_ZN_3 - Wall 000_c - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {887301b8-cd37-4813-8b11-6405d98a5952}, !- Surface Name
@@ -15553,7 +15277,7 @@ OS:SubSurface,
 
 OS:Surface,
   {9eb13795-6028-40b8-84bc-74bf516b6927}, !- Handle
-  Surface 825,                            !- Name
+  OpenOffice_Top_ZN_3 - RoofCeiling_a,    !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {c7140ad1-3a73-4de8-9788-8604ef70fd48}, !- Space Name
@@ -15572,7 +15296,7 @@ OS:Surface,
 
 OS:Surface,
   {abe55579-5f59-4274-8103-f43690d7ba6e}, !- Handle
-  Surface 826,                            !- Name
+  OpenOffice_Top_ZN_3 - Wall 180_d,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c7140ad1-3a73-4de8-9788-8604ef70fd48}, !- Space Name
@@ -15589,7 +15313,7 @@ OS:Surface,
 
 OS:Surface,
   {2c9404e7-c619-4137-8b2a-c6d19a3310d0}, !- Handle
-  Surface 827,                            !- Name
+  OpenOffice_Top_ZN_3 - Wall 000_b,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c7140ad1-3a73-4de8-9788-8604ef70fd48}, !- Space Name
@@ -15606,7 +15330,7 @@ OS:Surface,
 
 OS:Surface,
   {e9d0c528-fa39-4585-9540-48a4153eb97c}, !- Handle
-  Surface 828,                            !- Name
+  OpenOffice_Top_ZN_3 - Wall 180_e,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c7140ad1-3a73-4de8-9788-8604ef70fd48}, !- Space Name
@@ -15616,14 +15340,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  15.05712, 36.5458375, 19.5130875000001, !- X,Y,Z Vertex 1 {m}
+  15.05712, 36.5458375, 19.5130875,       !- X,Y,Z Vertex 1 {m}
   15.05712, 36.5458375, 16.7683,          !- X,Y,Z Vertex 2 {m}
   35.3568, 36.5458375, 16.7683,           !- X,Y,Z Vertex 3 {m}
   35.3568, 36.5458375, 19.5130875;        !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {880a71c0-faeb-4c1b-b4ab-233e30c1921c}, !- Handle
-  Surface 829,                            !- Name
+  OpenOffice_Top_ZN_3 - Wall 180_b,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c7140ad1-3a73-4de8-9788-8604ef70fd48}, !- Space Name
@@ -15640,7 +15364,7 @@ OS:Surface,
 
 OS:Surface,
   {e817ee7a-b8ff-48ab-b886-5422452c1be5}, !- Handle
-  Surface 830,                            !- Name
+  OpenOffice_Top_ZN_3 - Wall 180_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c7140ad1-3a73-4de8-9788-8604ef70fd48}, !- Space Name
@@ -15657,7 +15381,7 @@ OS:Surface,
 
 OS:Surface,
   {887301b8-cd37-4813-8b11-6405d98a5952}, !- Handle
-  Surface 831,                            !- Name
+  OpenOffice_Top_ZN_3 - Wall 000_c,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c7140ad1-3a73-4de8-9788-8604ef70fd48}, !- Space Name
@@ -15680,7 +15404,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  1.70960468004467e-016,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   16.769225,                              !- Z Origin {m}
   {c6dc659b-0ea6-49c7-9aee-b48d6c13ab59}, !- Building Story Name
   {77e08a9c-e4d4-4766-8515-217310511690}, !- Thermal Zone Name
@@ -15689,7 +15413,7 @@ OS:Space,
 
 OS:Surface,
   {4d5263cc-ea81-49db-8685-8b21675b7ffc}, !- Handle
-  Surface 832,                            !- Name
+  OpenOffice_Top_ZN_4 - Floor_a,          !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {dbf48444-bc98-49f6-9706-b2a52b333dee}, !- Space Name
@@ -15708,7 +15432,7 @@ OS:Surface,
 
 OS:Surface,
   {3df6dd25-e8e9-4d97-a908-72b348f8dd90}, !- Handle
-  Surface 833,                            !- Name
+  OpenOffice_Top_ZN_4 - RoofCeiling_a,    !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {dbf48444-bc98-49f6-9706-b2a52b333dee}, !- Space Name
@@ -15718,16 +15442,16 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  15.05712, 6.096, 19.5130875000001,      !- X,Y,Z Vertex 1 {m}
-  15.05712, 36.5458375, 19.5130875000001, !- X,Y,Z Vertex 2 {m}
-  6.096, 36.5458375, 19.5130875000001,    !- X,Y,Z Vertex 3 {m}
-  6.096, 32.8882375, 19.5130875000001,    !- X,Y,Z Vertex 4 {m}
-  0, 32.8882375, 19.5130875000001,        !- X,Y,Z Vertex 5 {m}
-  0, 6.096, 19.5130875000001;             !- X,Y,Z Vertex 6 {m}
+  15.05712, 6.096, 19.5130875,            !- X,Y,Z Vertex 1 {m}
+  15.05712, 36.5458375, 19.5130875,       !- X,Y,Z Vertex 2 {m}
+  6.096, 36.5458375, 19.5130875,          !- X,Y,Z Vertex 3 {m}
+  6.096, 32.8882375, 19.5130875,          !- X,Y,Z Vertex 4 {m}
+  0, 32.8882375, 19.5130875,              !- X,Y,Z Vertex 5 {m}
+  0, 6.096, 19.5130875;                   !- X,Y,Z Vertex 6 {m}
 
 OS:Surface,
   {d2d5e217-de00-4568-a0c6-b655faf08646}, !- Handle
-  Surface 834,                            !- Name
+  OpenOffice_Top_ZN_4 - Wall 000_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {dbf48444-bc98-49f6-9706-b2a52b333dee}, !- Space Name
@@ -15737,14 +15461,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  6.096, 32.8882375, 19.5130875000001,    !- X,Y,Z Vertex 1 {m}
+  6.096, 32.8882375, 19.5130875,          !- X,Y,Z Vertex 1 {m}
   6.096, 32.8882375, 16.7683,             !- X,Y,Z Vertex 2 {m}
   0, 32.8882375, 16.7683,                 !- X,Y,Z Vertex 3 {m}
-  0, 32.8882375, 19.5130875000001;        !- X,Y,Z Vertex 4 {m}
+  0, 32.8882375, 19.5130875;              !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {beefd7bb-791b-40dd-b369-5952a8b7aa64}, !- Handle
-  Surface 835,                            !- Name
+  OpenOffice_Top_ZN_4 - Wall 000_b,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {dbf48444-bc98-49f6-9706-b2a52b333dee}, !- Space Name
@@ -15754,14 +15478,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  15.05712, 36.5458375, 19.5130875000001, !- X,Y,Z Vertex 1 {m}
+  15.05712, 36.5458375, 19.5130875,       !- X,Y,Z Vertex 1 {m}
   15.05712, 36.5458375, 16.7683,          !- X,Y,Z Vertex 2 {m}
   6.096, 36.5458375, 16.7683,             !- X,Y,Z Vertex 3 {m}
-  6.096, 36.5458375, 19.5130875000001;    !- X,Y,Z Vertex 4 {m}
+  6.096, 36.5458375, 19.5130875;          !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {0fd6a79d-16c3-4f0a-802b-a0604a9076ac}, !- Handle
-  Surface 836,                            !- Name
+  OpenOffice_Top_ZN_4 - Wall 180_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {dbf48444-bc98-49f6-9706-b2a52b333dee}, !- Space Name
@@ -15771,14 +15495,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 6.096, 19.5130875000001,             !- X,Y,Z Vertex 1 {m}
+  0, 6.096, 19.5130875,                   !- X,Y,Z Vertex 1 {m}
   0, 6.096, 16.7683,                      !- X,Y,Z Vertex 2 {m}
   15.05712, 6.096, 16.7683,               !- X,Y,Z Vertex 3 {m}
-  15.05712, 6.096, 19.5130875000001;      !- X,Y,Z Vertex 4 {m}
+  15.05712, 6.096, 19.5130875;            !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {4381c20e-b1ef-4a22-8960-ad5698dbec2e}, !- Handle
-  Surface 837,                            !- Name
+  OpenOffice_Top_ZN_4 - Wall 270_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {dbf48444-bc98-49f6-9706-b2a52b333dee}, !- Space Name
@@ -15788,14 +15512,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  6.096, 36.5458375, 19.5130875000001,    !- X,Y,Z Vertex 1 {m}
+  6.096, 36.5458375, 19.5130875,          !- X,Y,Z Vertex 1 {m}
   6.096, 36.5458375, 16.7683,             !- X,Y,Z Vertex 2 {m}
   6.096, 32.8882375, 16.7683,             !- X,Y,Z Vertex 3 {m}
-  6.096, 32.8882375, 19.5130875000001;    !- X,Y,Z Vertex 4 {m}
+  6.096, 32.8882375, 19.5130875;          !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {954323c4-3ac1-482a-912e-b84dbdbc207a}, !- Handle
-  Sub Surface 18,                         !- Name
+  OpenOffice_Top_ZN_4 - Wall 270_b - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {b464b74f-21fc-4bd8-b556-41ddbf302ade}, !- Surface Name
@@ -15812,7 +15536,7 @@ OS:SubSurface,
 
 OS:Surface,
   {11e4fcf1-b0ad-4ab0-9135-895e7c7f55ef}, !- Handle
-  Surface 838,                            !- Name
+  OpenOffice_Top_ZN_4 - Wall 090_b,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {dbf48444-bc98-49f6-9706-b2a52b333dee}, !- Space Name
@@ -15822,14 +15546,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  15.05712, 36.5458375, 19.5130875000001, !- X,Y,Z Vertex 1 {m}
-  15.05712, 12.1618375, 19.5130875,       !- X,Y,Z Vertex 2 {m}
-  15.05712, 12.1618375, 16.7683,          !- X,Y,Z Vertex 3 {m}
-  15.05712, 36.5458375, 16.7683;          !- X,Y,Z Vertex 4 {m}
+  15.05712, 12.1618375, 19.5130875,       !- X,Y,Z Vertex 1 {m}
+  15.05712, 12.1618375, 16.7683,          !- X,Y,Z Vertex 2 {m}
+  15.05712, 36.5458375, 16.7683,          !- X,Y,Z Vertex 3 {m}
+  15.05712, 36.5458375, 19.5130875;       !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {b6e0fd8c-5e54-4829-8e7e-7f42ca61e63c}, !- Handle
-  Surface 839,                            !- Name
+  OpenOffice_Top_ZN_4 - Wall 090_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {dbf48444-bc98-49f6-9706-b2a52b333dee}, !- Space Name
@@ -15839,14 +15563,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  15.05712, 6.096, 19.5130875000001,      !- X,Y,Z Vertex 1 {m}
+  15.05712, 6.096, 19.5130875,            !- X,Y,Z Vertex 1 {m}
   15.05712, 6.096, 16.7683,               !- X,Y,Z Vertex 2 {m}
   15.05712, 12.1618375, 16.7683,          !- X,Y,Z Vertex 3 {m}
   15.05712, 12.1618375, 19.5130875;       !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {b464b74f-21fc-4bd8-b556-41ddbf302ade}, !- Handle
-  Surface 840,                            !- Name
+  OpenOffice_Top_ZN_4 - Wall 270_b,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {dbf48444-bc98-49f6-9706-b2a52b333dee}, !- Space Name
@@ -15856,10 +15580,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 32.8882375, 19.5130875000001,        !- X,Y,Z Vertex 1 {m}
+  0, 32.8882375, 19.5130875,              !- X,Y,Z Vertex 1 {m}
   0, 32.8882375, 16.7683,                 !- X,Y,Z Vertex 2 {m}
   0, 6.096, 16.7683,                      !- X,Y,Z Vertex 3 {m}
-  0, 6.096, 19.5130875000001;             !- X,Y,Z Vertex 4 {m}
+  0, 6.096, 19.5130875;                   !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {c01a040d-a69c-4ac6-a575-a70f57ab2f9c}, !- Handle
@@ -15869,7 +15593,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  1.70960468004467e-016,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   16.769225,                              !- Z Origin {m}
   {c6dc659b-0ea6-49c7-9aee-b48d6c13ab59}, !- Building Story Name
   {cddf7e0f-bb38-454c-9167-0602097b48e7}, !- Thermal Zone Name
@@ -15878,7 +15602,7 @@ OS:Space,
 
 OS:Surface,
   {4c828c1c-424d-4eb9-b109-67a48a6ec26d}, !- Handle
-  Surface 841,                            !- Name
+  OpenOffice_Top_ZN_1 - Wall 180_b,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c01a040d-a69c-4ac6-a575-a70f57ab2f9c}, !- Space Name
@@ -15895,7 +15619,7 @@ OS:Surface,
 
 OS:Surface,
   {fb14554d-54fe-4107-8b5d-2221adf641d1}, !- Handle
-  Surface 842,                            !- Name
+  OpenOffice_Top_ZN_1 - Floor_a,          !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {c01a040d-a69c-4ac6-a575-a70f57ab2f9c}, !- Space Name
@@ -15906,15 +15630,15 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   67.01155, 12.1618375, 16.7683,          !- X,Y,Z Vertex 1 {m}
-  67.01155, -1.70960468004467e-016, 16.7683, !- X,Y,Z Vertex 2 {m}
-  19.32432, 1.89995241761664e-016, 16.7683, !- X,Y,Z Vertex 3 {m}
+  67.01155, 0, 16.7683,                   !- X,Y,Z Vertex 2 {m}
+  19.32432, 0, 16.7683,                   !- X,Y,Z Vertex 3 {m}
   19.32432, 6.096, 16.7683,               !- X,Y,Z Vertex 4 {m}
   15.05712, 6.096, 16.7683,               !- X,Y,Z Vertex 5 {m}
   15.05712, 12.1618375, 16.7683;          !- X,Y,Z Vertex 6 {m}
 
 OS:Surface,
   {fd53317f-9a43-44c0-a46a-6e38d105a9db}, !- Handle
-  Surface 843,                            !- Name
+  OpenOffice_Top_ZN_1 - RoofCeiling_a,    !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {c01a040d-a69c-4ac6-a575-a70f57ab2f9c}, !- Space Name
@@ -15924,16 +15648,16 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  67.01155, -1.70960468004467e-016, 19.5130875, !- X,Y,Z Vertex 1 {m}
+  67.01155, 0, 19.5130875,                !- X,Y,Z Vertex 1 {m}
   67.01155, 12.1618375, 19.5130875,       !- X,Y,Z Vertex 2 {m}
   15.05712, 12.1618375, 19.5130875,       !- X,Y,Z Vertex 3 {m}
   15.05712, 6.096, 19.5130875,            !- X,Y,Z Vertex 4 {m}
   19.32432, 6.096, 19.5130875,            !- X,Y,Z Vertex 5 {m}
-  19.32432, 1.89995241761664e-016, 19.5130875; !- X,Y,Z Vertex 6 {m}
+  19.32432, 0, 19.5130875;                !- X,Y,Z Vertex 6 {m}
 
 OS:Surface,
   {cc9da7c2-2bb3-40d1-b2f5-3f29193e790e}, !- Handle
-  Surface 844,                            !- Name
+  OpenOffice_Top_ZN_1 - Wall 270_b,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c01a040d-a69c-4ac6-a575-a70f57ab2f9c}, !- Space Name
@@ -15945,12 +15669,12 @@ OS:Surface,
   ,                                       !- Number of Vertices
   19.32432, 6.096, 19.5130875,            !- X,Y,Z Vertex 1 {m}
   19.32432, 6.096, 16.7683,               !- X,Y,Z Vertex 2 {m}
-  19.32432, 1.89995241761664e-016, 16.7683, !- X,Y,Z Vertex 3 {m}
-  19.32432, 1.89995241761664e-016, 19.5130875; !- X,Y,Z Vertex 4 {m}
+  19.32432, 0, 16.7683,                   !- X,Y,Z Vertex 3 {m}
+  19.32432, 0, 19.5130875;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {a4379a13-188c-48ea-97f4-a5be00c5b4b7}, !- Handle
-  Surface 845,                            !- Name
+  OpenOffice_Top_ZN_1 - Wall 270_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c01a040d-a69c-4ac6-a575-a70f57ab2f9c}, !- Space Name
@@ -15967,7 +15691,7 @@ OS:Surface,
 
 OS:Surface,
   {70f4e72d-84d3-4a94-9a05-b262d4aff91d}, !- Handle
-  Surface 846,                            !- Name
+  OpenOffice_Top_ZN_1 - Wall 000_c,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c01a040d-a69c-4ac6-a575-a70f57ab2f9c}, !- Space Name
@@ -15984,7 +15708,7 @@ OS:Surface,
 
 OS:Surface,
   {c862d70b-47f6-44c7-9507-e92df402228d}, !- Handle
-  Surface 847,                            !- Name
+  OpenOffice_Top_ZN_1 - Wall 090_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c01a040d-a69c-4ac6-a575-a70f57ab2f9c}, !- Space Name
@@ -15994,14 +15718,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  67.01155, -1.70960468004467e-016, 19.5130875, !- X,Y,Z Vertex 1 {m}
-  67.01155, -1.70960468004467e-016, 16.7683, !- X,Y,Z Vertex 2 {m}
+  67.01155, 0, 19.5130875,                !- X,Y,Z Vertex 1 {m}
+  67.01155, 0, 16.7683,                   !- X,Y,Z Vertex 2 {m}
   67.01155, 12.1618375, 16.7683,          !- X,Y,Z Vertex 3 {m}
   67.01155, 12.1618375, 19.5130875;       !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {3ae45cda-1018-4d07-9715-981d00f7d05d}, !- Handle
-  Surface 848,                            !- Name
+  OpenOffice_Top_ZN_1 - Wall 000_b,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c01a040d-a69c-4ac6-a575-a70f57ab2f9c}, !- Space Name
@@ -16018,7 +15742,7 @@ OS:Surface,
 
 OS:Surface,
   {b2a4713c-faa9-40f9-ae5f-f8b774b5a28b}, !- Handle
-  Surface 849,                            !- Name
+  OpenOffice_Top_ZN_1 - Wall 000_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c01a040d-a69c-4ac6-a575-a70f57ab2f9c}, !- Space Name
@@ -16035,7 +15759,7 @@ OS:Surface,
 
 OS:Surface,
   {9502ee6f-c68c-48c3-980d-6cacd8a0c750}, !- Handle
-  Surface 850,                            !- Name
+  OpenOffice_Top_ZN_1 - Wall 000_d,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c01a040d-a69c-4ac6-a575-a70f57ab2f9c}, !- Space Name
@@ -16052,7 +15776,7 @@ OS:Surface,
 
 OS:Surface,
   {bf7c3648-c75f-47b9-9831-834639881e4c}, !- Handle
-  Surface 851,                            !- Name
+  OpenOffice_Top_ZN_1 - Wall 180_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c01a040d-a69c-4ac6-a575-a70f57ab2f9c}, !- Space Name
@@ -16062,10 +15786,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  19.32432, 1.89995241761664e-016, 19.5130875, !- X,Y,Z Vertex 1 {m}
-  19.32432, 1.89995241761664e-016, 16.7683, !- X,Y,Z Vertex 2 {m}
-  67.01155, -1.70960468004467e-016, 16.7683, !- X,Y,Z Vertex 3 {m}
-  67.01155, -1.70960468004467e-016, 19.5130875; !- X,Y,Z Vertex 4 {m}
+  19.32432, 0, 19.5130875,                !- X,Y,Z Vertex 1 {m}
+  19.32432, 0, 16.7683,                   !- X,Y,Z Vertex 2 {m}
+  67.01155, 0, 16.7683,                   !- X,Y,Z Vertex 3 {m}
+  67.01155, 0, 19.5130875;                !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {fc9d49d6-11d6-4890-a251-357277c53f0b}, !- Handle
@@ -16075,7 +15799,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  1.70960468004467e-016,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   16.769225,                              !- Z Origin {m}
   {c6dc659b-0ea6-49c7-9aee-b48d6c13ab59}, !- Building Story Name
   {71a7da80-b013-427b-a119-e704e1bebb7d}, !- Thermal Zone Name
@@ -16084,7 +15808,7 @@ OS:Space,
 
 OS:Surface,
   {b7a284c0-8e6b-43f4-b857-01eb253b723b}, !- Handle
-  Surface 852,                            !- Name
+  EnclosedOffice_Top_ZN_8 - Floor_a,      !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {fc9d49d6-11d6-4890-a251-357277c53f0b}, !- Space Name
@@ -16101,7 +15825,7 @@ OS:Surface,
 
 OS:Surface,
   {971b502f-d55f-4cb0-b6be-5f3f44d8cdda}, !- Handle
-  Surface 853,                            !- Name
+  EnclosedOffice_Top_ZN_8 - Wall 090_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {fc9d49d6-11d6-4890-a251-357277c53f0b}, !- Space Name
@@ -16118,7 +15842,7 @@ OS:Surface,
 
 OS:Surface,
   {6b11f63d-ed82-4317-ad1a-f5d64d8c8611}, !- Handle
-  Surface 854,                            !- Name
+  EnclosedOffice_Top_ZN_8 - RoofCeiling_a, !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {fc9d49d6-11d6-4890-a251-357277c53f0b}, !- Space Name
@@ -16135,7 +15859,7 @@ OS:Surface,
 
 OS:Surface,
   {a8822683-cad5-410a-983c-e02e481705da}, !- Handle
-  Surface 855,                            !- Name
+  EnclosedOffice_Top_ZN_8 - Wall 180_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {fc9d49d6-11d6-4890-a251-357277c53f0b}, !- Space Name
@@ -16152,7 +15876,7 @@ OS:Surface,
 
 OS:SubSurface,
   {8c224ee4-d80e-4ea5-88e2-397cb9eb8f84}, !- Handle
-  Sub Surface 20,                         !- Name
+  EnclosedOffice_Top_ZN_8 - Wall 270_a - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {710857f8-365b-4f52-8b09-643c7dbc7d82}, !- Surface Name
@@ -16169,7 +15893,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {dd93b347-f8d9-49d7-ae37-9b9c1890c568}, !- Handle
-  Sub Surface 21,                         !- Name
+  EnclosedOffice_Top_ZN_8 - Wall 000_a - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {ce37a7bd-19ee-489e-b547-a66869a75def}, !- Surface Name
@@ -16186,7 +15910,7 @@ OS:SubSurface,
 
 OS:Surface,
   {e6e7d822-5976-4e34-9f45-135dd07ecf8e}, !- Handle
-  Surface 856,                            !- Name
+  EnclosedOffice_Top_ZN_8 - Wall 090_b,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {fc9d49d6-11d6-4890-a251-357277c53f0b}, !- Space Name
@@ -16203,7 +15927,7 @@ OS:Surface,
 
 OS:Surface,
   {710857f8-365b-4f52-8b09-643c7dbc7d82}, !- Handle
-  Surface 857,                            !- Name
+  EnclosedOffice_Top_ZN_8 - Wall 270_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {fc9d49d6-11d6-4890-a251-357277c53f0b}, !- Space Name
@@ -16220,7 +15944,7 @@ OS:Surface,
 
 OS:Surface,
   {ce37a7bd-19ee-489e-b547-a66869a75def}, !- Handle
-  Surface 858,                            !- Name
+  EnclosedOffice_Top_ZN_8 - Wall 000_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {fc9d49d6-11d6-4890-a251-357277c53f0b}, !- Space Name
@@ -16243,7 +15967,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  1.70960468004467e-016,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   16.769225,                              !- Z Origin {m}
   {c6dc659b-0ea6-49c7-9aee-b48d6c13ab59}, !- Building Story Name
   {ec3626a9-76c2-417b-bc9f-c4fabbe46460}, !- Thermal Zone Name
@@ -16252,7 +15976,7 @@ OS:Space,
 
 OS:Surface,
   {48203d27-25de-40e4-a502-13e088c5017e}, !- Handle
-  Surface 859,                            !- Name
+  EnclosedOffice_Top_ZN_4 - Floor_a,      !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {419feea8-adb1-425a-9776-8bc6bb52904a}, !- Space Name
@@ -16269,7 +15993,7 @@ OS:Surface,
 
 OS:Surface,
   {d9e41d55-e6f1-4a3a-a9e3-fe83192289fc}, !- Handle
-  Surface 860,                            !- Name
+  EnclosedOffice_Top_ZN_4 - Wall 000_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {419feea8-adb1-425a-9776-8bc6bb52904a}, !- Space Name
@@ -16286,7 +16010,7 @@ OS:Surface,
 
 OS:Surface,
   {6df9614b-e7f0-41ec-a21a-a696448c723f}, !- Handle
-  Surface 861,                            !- Name
+  EnclosedOffice_Top_ZN_4 - Wall 090_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {419feea8-adb1-425a-9776-8bc6bb52904a}, !- Space Name
@@ -16303,7 +16027,7 @@ OS:Surface,
 
 OS:Surface,
   {21162b4e-0b99-4612-9ea1-609cd33c12f7}, !- Handle
-  Surface 862,                            !- Name
+  EnclosedOffice_Top_ZN_4 - Wall 180_b,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {419feea8-adb1-425a-9776-8bc6bb52904a}, !- Space Name
@@ -16320,7 +16044,7 @@ OS:Surface,
 
 OS:Surface,
   {06aaa599-50f7-42eb-b6fe-cbebc46b15e6}, !- Handle
-  Surface 863,                            !- Name
+  EnclosedOffice_Top_ZN_4 - Wall 270_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {419feea8-adb1-425a-9776-8bc6bb52904a}, !- Space Name
@@ -16337,7 +16061,7 @@ OS:Surface,
 
 OS:Surface,
   {0447eeae-b9c9-4718-aef3-33ffeb6d9b5b}, !- Handle
-  Surface 864,                            !- Name
+  EnclosedOffice_Top_ZN_4 - RoofCeiling_a, !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {419feea8-adb1-425a-9776-8bc6bb52904a}, !- Space Name
@@ -16354,7 +16078,7 @@ OS:Surface,
 
 OS:Surface,
   {87c3a91f-0537-4b96-8909-c5b6f920c388}, !- Handle
-  Surface 865,                            !- Name
+  EnclosedOffice_Top_ZN_4 - Wall 180_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {419feea8-adb1-425a-9776-8bc6bb52904a}, !- Space Name
@@ -16377,7 +16101,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  1.70960468004467e-016,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   16.769225,                              !- Z Origin {m}
   {c6dc659b-0ea6-49c7-9aee-b48d6c13ab59}, !- Building Story Name
   {3644f601-3ca9-422a-a7f2-1b3fd812291f}, !- Thermal Zone Name
@@ -16386,7 +16110,7 @@ OS:Space,
 
 OS:Surface,
   {684d9419-390e-427f-93cf-b3514f5f1c3e}, !- Handle
-  Surface 866,                            !- Name
+  EnclosedOffice_Top_ZN_2 - Floor_a,      !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {513b2db8-ebfa-4e78-ae8a-bddd44ed6462}, !- Space Name
@@ -16403,7 +16127,7 @@ OS:Surface,
 
 OS:Surface,
   {2da984d2-22dd-4d02-871a-85d4407d5756}, !- Handle
-  Surface 867,                            !- Name
+  EnclosedOffice_Top_ZN_2 - RoofCeiling_a, !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {513b2db8-ebfa-4e78-ae8a-bddd44ed6462}, !- Space Name
@@ -16420,7 +16144,7 @@ OS:Surface,
 
 OS:Surface,
   {0b5573ca-79c7-4694-921f-57318018b43b}, !- Handle
-  Surface 868,                            !- Name
+  EnclosedOffice_Top_ZN_2 - Wall 180_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {513b2db8-ebfa-4e78-ae8a-bddd44ed6462}, !- Space Name
@@ -16437,7 +16161,7 @@ OS:Surface,
 
 OS:Surface,
   {b1612dae-2772-41f5-b0f0-0a294accee22}, !- Handle
-  Surface 869,                            !- Name
+  EnclosedOffice_Top_ZN_2 - Wall 000_b,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {513b2db8-ebfa-4e78-ae8a-bddd44ed6462}, !- Space Name
@@ -16454,7 +16178,7 @@ OS:Surface,
 
 OS:Surface,
   {0000138d-35ab-4c45-916d-e67345e9b82a}, !- Handle
-  Surface 870,                            !- Name
+  EnclosedOffice_Top_ZN_2 - Wall 270_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {513b2db8-ebfa-4e78-ae8a-bddd44ed6462}, !- Space Name
@@ -16471,7 +16195,7 @@ OS:Surface,
 
 OS:Surface,
   {6f956f09-a62a-41ea-88a9-26ef1153510e}, !- Handle
-  Surface 871,                            !- Name
+  EnclosedOffice_Top_ZN_2 - Wall 090_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {513b2db8-ebfa-4e78-ae8a-bddd44ed6462}, !- Space Name
@@ -16488,7 +16212,7 @@ OS:Surface,
 
 OS:Surface,
   {c8f84ad0-3fe9-41dd-ad91-ea83789d7300}, !- Handle
-  Surface 872,                            !- Name
+  EnclosedOffice_Top_ZN_2 - Wall 000_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {513b2db8-ebfa-4e78-ae8a-bddd44ed6462}, !- Space Name
@@ -16505,7 +16229,7 @@ OS:Surface,
 
 OS:Surface,
   {229162cd-be9c-4dd1-95b6-b0e6b56a964e}, !- Handle
-  Surface 873,                            !- Name
+  EnclosedOffice_Top_ZN_2 - Wall 000_c,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {513b2db8-ebfa-4e78-ae8a-bddd44ed6462}, !- Space Name
@@ -16528,7 +16252,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  1.70960468004467e-016,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   16.769225,                              !- Z Origin {m}
   {c6dc659b-0ea6-49c7-9aee-b48d6c13ab59}, !- Building Story Name
   {43008630-280f-42b3-ab5d-336c4e8e7b46}, !- Thermal Zone Name
@@ -16538,7 +16262,7 @@ OS:Space,
 
 OS:Surface,
   {32c0099e-398f-4351-85ae-fee7fa9893b3}, !- Handle
-  Surface 874,                            !- Name
+  ConfRoom_Top_ZN_2 - Floor_a,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {2ae60b52-7e62-46b0-9606-f6269e0b2f50}, !- Space Name
@@ -16555,7 +16279,7 @@ OS:Surface,
 
 OS:SubSurface,
   {d24c2213-2104-401a-9767-821d9228bac9}, !- Handle
-  Sub Surface 22,                         !- Name
+  ConfRoom_Top_ZN_2 - Wall 000_a - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {c2c19480-53b0-4ef2-bcab-90d6443d3e40}, !- Surface Name
@@ -16572,7 +16296,7 @@ OS:SubSurface,
 
 OS:Surface,
   {4992cdb8-78f9-47b4-8046-8d3b880878a7}, !- Handle
-  Surface 875,                            !- Name
+  ConfRoom_Top_ZN_2 - Wall 270_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {2ae60b52-7e62-46b0-9606-f6269e0b2f50}, !- Space Name
@@ -16589,7 +16313,7 @@ OS:Surface,
 
 OS:Surface,
   {2dd95df0-6b7e-4bea-89a7-9a5002d0049d}, !- Handle
-  Surface 876,                            !- Name
+  ConfRoom_Top_ZN_2 - Wall 180_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {2ae60b52-7e62-46b0-9606-f6269e0b2f50}, !- Space Name
@@ -16606,7 +16330,7 @@ OS:Surface,
 
 OS:Surface,
   {2bc77dd8-d5f5-4392-87ce-0aa9f2607164}, !- Handle
-  Surface 877,                            !- Name
+  ConfRoom_Top_ZN_2 - Wall 090_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {2ae60b52-7e62-46b0-9606-f6269e0b2f50}, !- Space Name
@@ -16623,7 +16347,7 @@ OS:Surface,
 
 OS:Surface,
   {78c82684-73c1-481b-8ebd-74383bcc3ed3}, !- Handle
-  Surface 878,                            !- Name
+  ConfRoom_Top_ZN_2 - RoofCeiling_a,      !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {2ae60b52-7e62-46b0-9606-f6269e0b2f50}, !- Space Name
@@ -16640,7 +16364,7 @@ OS:Surface,
 
 OS:Surface,
   {c2c19480-53b0-4ef2-bcab-90d6443d3e40}, !- Handle
-  Surface 879,                            !- Name
+  ConfRoom_Top_ZN_2 - Wall 000_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {2ae60b52-7e62-46b0-9606-f6269e0b2f50}, !- Space Name
@@ -16663,7 +16387,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  1.70960468004467e-016,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   16.769225,                              !- Z Origin {m}
   {c6dc659b-0ea6-49c7-9aee-b48d6c13ab59}, !- Building Story Name
   {28f99742-d2fb-4b2e-8f11-e9fe6399f613}, !- Thermal Zone Name
@@ -16672,7 +16396,7 @@ OS:Space,
 
 OS:Surface,
   {35a15b9f-6bf8-4b04-94bd-c0f94cc6d972}, !- Handle
-  Surface 880,                            !- Name
+  EnclosedOffice_Top_ZN_3 - Floor_a,      !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {bc120234-440e-4be2-94af-896d404bb4a4}, !- Space Name
@@ -16689,7 +16413,7 @@ OS:Surface,
 
 OS:Surface,
   {25108ab2-f2df-4deb-8881-6f7dde24edd0}, !- Handle
-  Surface 881,                            !- Name
+  EnclosedOffice_Top_ZN_3 - RoofCeiling_a, !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {bc120234-440e-4be2-94af-896d404bb4a4}, !- Space Name
@@ -16706,7 +16430,7 @@ OS:Surface,
 
 OS:Surface,
   {b6c2b678-d448-4fcb-a56a-5124124153a4}, !- Handle
-  Surface 882,                            !- Name
+  EnclosedOffice_Top_ZN_3 - Wall 180_b,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {bc120234-440e-4be2-94af-896d404bb4a4}, !- Space Name
@@ -16723,7 +16447,7 @@ OS:Surface,
 
 OS:Surface,
   {e957baff-e95f-44e6-bfe1-decf8094358e}, !- Handle
-  Surface 883,                            !- Name
+  EnclosedOffice_Top_ZN_3 - Wall 270_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {bc120234-440e-4be2-94af-896d404bb4a4}, !- Space Name
@@ -16740,7 +16464,7 @@ OS:Surface,
 
 OS:Surface,
   {d56ddad6-cacc-4280-97b7-8a7e74916330}, !- Handle
-  Surface 884,                            !- Name
+  EnclosedOffice_Top_ZN_3 - Wall 000_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {bc120234-440e-4be2-94af-896d404bb4a4}, !- Space Name
@@ -16757,7 +16481,7 @@ OS:Surface,
 
 OS:Surface,
   {e85ed891-0382-4ec1-88ef-c07487e9571f}, !- Handle
-  Surface 885,                            !- Name
+  EnclosedOffice_Top_ZN_3 - Wall 090_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {bc120234-440e-4be2-94af-896d404bb4a4}, !- Space Name
@@ -16774,7 +16498,7 @@ OS:Surface,
 
 OS:Surface,
   {1a315657-092b-47a9-ac7a-95e4165ef813}, !- Handle
-  Surface 886,                            !- Name
+  EnclosedOffice_Top_ZN_3 - Wall 180_c,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {bc120234-440e-4be2-94af-896d404bb4a4}, !- Space Name
@@ -16791,7 +16515,7 @@ OS:Surface,
 
 OS:Surface,
   {d5088cda-9fd2-4277-8f35-f61fa313f2a2}, !- Handle
-  Surface 887,                            !- Name
+  EnclosedOffice_Top_ZN_3 - Wall 180_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {bc120234-440e-4be2-94af-896d404bb4a4}, !- Space Name
@@ -16814,7 +16538,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  1.70960468004467e-016,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   16.769225,                              !- Z Origin {m}
   {c6dc659b-0ea6-49c7-9aee-b48d6c13ab59}, !- Building Story Name
   {6d6153ea-ae94-49ec-99e0-58bc3de9748c}, !- Thermal Zone Name
@@ -16823,7 +16547,7 @@ OS:Space,
 
 OS:Surface,
   {a95148ea-114a-4e9d-930c-3b5b7a9a2cae}, !- Handle
-  Surface 888,                            !- Name
+  EnclosedOffice_Top_ZN_7 - Floor_a,      !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {248f43f3-92d6-4232-8d12-07eb6f755358}, !- Space Name
@@ -16840,7 +16564,7 @@ OS:Surface,
 
 OS:SubSurface,
   {b10a85a0-72d5-41c5-b516-e5463c143431}, !- Handle
-  Sub Surface 23,                         !- Name
+  EnclosedOffice_Top_ZN_7 - Wall 000_a - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {b4f8313c-231d-44d0-a17e-0a8b96964ed6}, !- Surface Name
@@ -16857,7 +16581,7 @@ OS:SubSurface,
 
 OS:Surface,
   {5c311a07-6bc5-4368-a8bc-8a62de8a3f4e}, !- Handle
-  Surface 889,                            !- Name
+  EnclosedOffice_Top_ZN_7 - Wall 180_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {248f43f3-92d6-4232-8d12-07eb6f755358}, !- Space Name
@@ -16874,7 +16598,7 @@ OS:Surface,
 
 OS:Surface,
   {9348ad7e-f35a-4a03-9d8a-ac588ead26df}, !- Handle
-  Surface 890,                            !- Name
+  EnclosedOffice_Top_ZN_7 - Wall 270_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {248f43f3-92d6-4232-8d12-07eb6f755358}, !- Space Name
@@ -16891,7 +16615,7 @@ OS:Surface,
 
 OS:Surface,
   {0df24c94-83f3-4fc0-b5e4-63a5d00bb330}, !- Handle
-  Surface 891,                            !- Name
+  EnclosedOffice_Top_ZN_7 - RoofCeiling_a, !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {248f43f3-92d6-4232-8d12-07eb6f755358}, !- Space Name
@@ -16908,7 +16632,7 @@ OS:Surface,
 
 OS:Surface,
   {b4f8313c-231d-44d0-a17e-0a8b96964ed6}, !- Handle
-  Surface 892,                            !- Name
+  EnclosedOffice_Top_ZN_7 - Wall 000_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {248f43f3-92d6-4232-8d12-07eb6f755358}, !- Space Name
@@ -16925,7 +16649,7 @@ OS:Surface,
 
 OS:Surface,
   {1342dadb-ad4e-4da0-8a6d-204a43acbcd8}, !- Handle
-  Surface 893,                            !- Name
+  EnclosedOffice_Top_ZN_7 - Wall 090_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {248f43f3-92d6-4232-8d12-07eb6f755358}, !- Space Name
@@ -16948,7 +16672,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  1.70960468004467e-016,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   16.769225,                              !- Z Origin {m}
   {c6dc659b-0ea6-49c7-9aee-b48d6c13ab59}, !- Building Story Name
   {3dd55c58-8f5f-44ca-8592-8d27b0c9057f}, !- Thermal Zone Name
@@ -16958,7 +16682,7 @@ OS:Space,
 
 OS:Surface,
   {579476dc-f06c-42bc-adce-cc177cd8adbf}, !- Handle
-  Surface 894,                            !- Name
+  Classroom_Top_ZN - Floor_a,             !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {5f409ca9-e958-47a4-a82d-fc82cb8c9108}, !- Space Name
@@ -16975,7 +16699,7 @@ OS:Surface,
 
 OS:Surface,
   {68e010d3-cc01-476c-898d-9403e89d8f9a}, !- Handle
-  Surface 895,                            !- Name
+  Classroom_Top_ZN - Wall 090_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {5f409ca9-e958-47a4-a82d-fc82cb8c9108}, !- Space Name
@@ -16992,7 +16716,7 @@ OS:Surface,
 
 OS:Surface,
   {f357a765-eb2c-479e-834d-12d3fae25c14}, !- Handle
-  Surface 896,                            !- Name
+  Classroom_Top_ZN - RoofCeiling_a,       !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {5f409ca9-e958-47a4-a82d-fc82cb8c9108}, !- Space Name
@@ -17009,7 +16733,7 @@ OS:Surface,
 
 OS:Surface,
   {2f529e22-3138-419c-ba08-4a692239b8da}, !- Handle
-  Surface 897,                            !- Name
+  Classroom_Top_ZN - Wall 180_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {5f409ca9-e958-47a4-a82d-fc82cb8c9108}, !- Space Name
@@ -17026,7 +16750,7 @@ OS:Surface,
 
 OS:Surface,
   {568ff20d-b8f8-4bc4-9071-eb289f29b385}, !- Handle
-  Surface 898,                            !- Name
+  Classroom_Top_ZN - Wall 270_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {5f409ca9-e958-47a4-a82d-fc82cb8c9108}, !- Space Name
@@ -17043,7 +16767,7 @@ OS:Surface,
 
 OS:Surface,
   {b3ef706d-7f2a-45a5-9400-70a8285636bf}, !- Handle
-  Surface 899,                            !- Name
+  Classroom_Top_ZN - Wall 000_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {5f409ca9-e958-47a4-a82d-fc82cb8c9108}, !- Space Name
@@ -17060,7 +16784,7 @@ OS:Surface,
 
 OS:SubSurface,
   {8916b819-4bd9-464e-b271-aac410451e61}, !- Handle
-  Sub Surface 25,                         !- Name
+  Classroom_Top_ZN - Wall 000_a - Sub:a,  !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {b3ef706d-7f2a-45a5-9400-70a8285636bf}, !- Surface Name
@@ -17083,7 +16807,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  1.70960468004467e-016,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   16.769225,                              !- Z Origin {m}
   {c6dc659b-0ea6-49c7-9aee-b48d6c13ab59}, !- Building Story Name
   {871ea7d7-f61c-420f-bd74-db8a08804423}, !- Thermal Zone Name
@@ -17093,7 +16817,7 @@ OS:Space,
 
 OS:Surface,
   {3c107bde-7c1c-4fc2-a478-e7b93a8932fa}, !- Handle
-  Surface 900,                            !- Name
+  ConfRoom_Top_ZN_1 - Floor_a,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {c9882431-063b-495c-9ecd-cb638afc9db5}, !- Space Name
@@ -17104,13 +16828,13 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   19.32432, 6.096, 16.7683,               !- X,Y,Z Vertex 1 {m}
-  19.32432, 7.13243387670845e-017, 16.7683, !- X,Y,Z Vertex 2 {m}
-  15.05712, 7.13243387670845e-017, 16.7683, !- X,Y,Z Vertex 3 {m}
+  19.32432, 0, 16.7683,                   !- X,Y,Z Vertex 2 {m}
+  15.05712, 0, 16.7683,                   !- X,Y,Z Vertex 3 {m}
   15.05712, 6.096, 16.7683;               !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {d9c9cf0e-17f4-4a09-acb6-2c11b3bbaaec}, !- Handle
-  Surface 901,                            !- Name
+  ConfRoom_Top_ZN_1 - RoofCeiling_a,      !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {c9882431-063b-495c-9ecd-cb638afc9db5}, !- Space Name
@@ -17120,14 +16844,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  19.32432, 7.13243387670845e-017, 19.5130875, !- X,Y,Z Vertex 1 {m}
+  19.32432, 0, 19.5130875,                !- X,Y,Z Vertex 1 {m}
   19.32432, 6.096, 19.5130875,            !- X,Y,Z Vertex 2 {m}
   15.05712, 6.096, 19.5130875,            !- X,Y,Z Vertex 3 {m}
-  15.05712, 7.13243387670845e-017, 19.5130875; !- X,Y,Z Vertex 4 {m}
+  15.05712, 0, 19.5130875;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {00532189-a035-474f-b661-1c52f92f4ced}, !- Handle
-  Surface 902,                            !- Name
+  ConfRoom_Top_ZN_1 - Wall 090_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c9882431-063b-495c-9ecd-cb638afc9db5}, !- Space Name
@@ -17137,14 +16861,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  19.32432, 7.13243387670845e-017, 19.5130875, !- X,Y,Z Vertex 1 {m}
-  19.32432, 7.13243387670845e-017, 16.7683, !- X,Y,Z Vertex 2 {m}
+  19.32432, 0, 19.5130875,                !- X,Y,Z Vertex 1 {m}
+  19.32432, 0, 16.7683,                   !- X,Y,Z Vertex 2 {m}
   19.32432, 6.096, 16.7683,               !- X,Y,Z Vertex 3 {m}
   19.32432, 6.096, 19.5130875;            !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {ea0d08ed-ca3a-4d88-923e-bac141686afa}, !- Handle
-  Surface 903,                            !- Name
+  ConfRoom_Top_ZN_1 - Wall 000_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c9882431-063b-495c-9ecd-cb638afc9db5}, !- Space Name
@@ -17161,7 +16885,7 @@ OS:Surface,
 
 OS:Surface,
   {dbd29631-aed9-458f-ac6a-d9c1b6935093}, !- Handle
-  Surface 904,                            !- Name
+  ConfRoom_Top_ZN_1 - Wall 270_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c9882431-063b-495c-9ecd-cb638afc9db5}, !- Space Name
@@ -17173,12 +16897,12 @@ OS:Surface,
   ,                                       !- Number of Vertices
   15.05712, 6.096, 19.5130875,            !- X,Y,Z Vertex 1 {m}
   15.05712, 6.096, 16.7683,               !- X,Y,Z Vertex 2 {m}
-  15.05712, 7.13243387670845e-017, 16.7683, !- X,Y,Z Vertex 3 {m}
-  15.05712, 7.13243387670845e-017, 19.5130875; !- X,Y,Z Vertex 4 {m}
+  15.05712, 0, 16.7683,                   !- X,Y,Z Vertex 3 {m}
+  15.05712, 0, 19.5130875;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {cc43616a-142d-485f-aa88-cd293f0e6af9}, !- Handle
-  Surface 905,                            !- Name
+  ConfRoom_Top_ZN_1 - Wall 180_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c9882431-063b-495c-9ecd-cb638afc9db5}, !- Space Name
@@ -17188,10 +16912,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  15.05712, 7.13243387670845e-017, 19.5130875, !- X,Y,Z Vertex 1 {m}
-  15.05712, 7.13243387670845e-017, 16.7683, !- X,Y,Z Vertex 2 {m}
-  19.32432, 7.13243387670845e-017, 16.7683, !- X,Y,Z Vertex 3 {m}
-  19.32432, 7.13243387670845e-017, 19.5130875; !- X,Y,Z Vertex 4 {m}
+  15.05712, 0, 19.5130875,                !- X,Y,Z Vertex 1 {m}
+  15.05712, 0, 16.7683,                   !- X,Y,Z Vertex 2 {m}
+  19.32432, 0, 16.7683,                   !- X,Y,Z Vertex 3 {m}
+  19.32432, 0, 19.5130875;                !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {62c92f33-b4a5-4a58-a64f-f7d12632bf50}, !- Handle
@@ -17201,7 +16925,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  1.70960468004467e-016,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   16.769225,                              !- Z Origin {m}
   {c6dc659b-0ea6-49c7-9aee-b48d6c13ab59}, !- Building Story Name
   {3298aba5-c8d2-4d68-a96a-a3669328404b}, !- Thermal Zone Name
@@ -17211,7 +16935,7 @@ OS:Space,
 
 OS:Surface,
   {ec3b26a5-ee81-4c8c-9b4a-c9dca95eda33}, !- Handle
-  Surface 906,                            !- Name
+  EnclosedOffice_Top_ZN_5 - Floor_a,      !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {62c92f33-b4a5-4a58-a64f-f7d12632bf50}, !- Space Name
@@ -17222,13 +16946,13 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   15.05712, 6.096, 16.7683,               !- X,Y,Z Vertex 1 {m}
-  15.05712, -1.70960468004467e-016, 16.7683, !- X,Y,Z Vertex 2 {m}
-  0, -1.70960468004467e-016, 16.7683,     !- X,Y,Z Vertex 3 {m}
+  15.05712, 0, 16.7683,                   !- X,Y,Z Vertex 2 {m}
+  0, 0, 16.7683,                          !- X,Y,Z Vertex 3 {m}
   0, 6.096, 16.7683;                      !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {81a36470-1414-45b0-8cdc-81707bab9f24}, !- Handle
-  Sub Surface 27,                         !- Name
+  EnclosedOffice_Top_ZN_5 - Wall 270_a - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {f3200508-c6b7-41cd-9520-83eeda396974}, !- Surface Name
@@ -17245,7 +16969,7 @@ OS:SubSurface,
 
 OS:Surface,
   {3ce10ebc-7ed9-4607-815b-dfe90fc4510b}, !- Handle
-  Surface 907,                            !- Name
+  EnclosedOffice_Top_ZN_5 - Wall 000_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {62c92f33-b4a5-4a58-a64f-f7d12632bf50}, !- Space Name
@@ -17262,7 +16986,7 @@ OS:Surface,
 
 OS:Surface,
   {39707ed1-7a92-4893-b1cc-b49e1a3c4239}, !- Handle
-  Surface 908,                            !- Name
+  EnclosedOffice_Top_ZN_5 - Wall 090_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {62c92f33-b4a5-4a58-a64f-f7d12632bf50}, !- Space Name
@@ -17272,14 +16996,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  15.05712, -1.70960468004467e-016, 19.5130875, !- X,Y,Z Vertex 1 {m}
-  15.05712, -1.70960468004467e-016, 16.7683, !- X,Y,Z Vertex 2 {m}
+  15.05712, 0, 19.5130875,                !- X,Y,Z Vertex 1 {m}
+  15.05712, 0, 16.7683,                   !- X,Y,Z Vertex 2 {m}
   15.05712, 6.096, 16.7683,               !- X,Y,Z Vertex 3 {m}
   15.05712, 6.096, 19.5130875;            !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {686c9174-6ef2-4a61-aa3f-d4296541c123}, !- Handle
-  Surface 909,                            !- Name
+  EnclosedOffice_Top_ZN_5 - RoofCeiling_a, !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {62c92f33-b4a5-4a58-a64f-f7d12632bf50}, !- Space Name
@@ -17289,14 +17013,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  15.05712, -1.70960468004467e-016, 19.5130875, !- X,Y,Z Vertex 1 {m}
+  15.05712, 0, 19.5130875,                !- X,Y,Z Vertex 1 {m}
   15.05712, 6.096, 19.5130875,            !- X,Y,Z Vertex 2 {m}
   0, 6.096, 19.5130875,                   !- X,Y,Z Vertex 3 {m}
-  0, -1.70960468004467e-016, 19.5130875;  !- X,Y,Z Vertex 4 {m}
+  0, 0, 19.5130875;                       !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {d393e4d1-b8c4-4d74-906d-66594e9c6246}, !- Handle
-  Surface 910,                            !- Name
+  EnclosedOffice_Top_ZN_5 - Wall 180_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {62c92f33-b4a5-4a58-a64f-f7d12632bf50}, !- Space Name
@@ -17306,14 +17030,14 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, -1.70960468004467e-016, 19.5130875,  !- X,Y,Z Vertex 1 {m}
-  0, -1.70960468004467e-016, 16.7683,     !- X,Y,Z Vertex 2 {m}
-  15.05712, -1.70960468004467e-016, 16.7683, !- X,Y,Z Vertex 3 {m}
-  15.05712, -1.70960468004467e-016, 19.5130875; !- X,Y,Z Vertex 4 {m}
+  0, 0, 19.5130875,                       !- X,Y,Z Vertex 1 {m}
+  0, 0, 16.7683,                          !- X,Y,Z Vertex 2 {m}
+  15.05712, 0, 16.7683,                   !- X,Y,Z Vertex 3 {m}
+  15.05712, 0, 19.5130875;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {f3200508-c6b7-41cd-9520-83eeda396974}, !- Handle
-  Surface 911,                            !- Name
+  EnclosedOffice_Top_ZN_5 - Wall 270_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {62c92f33-b4a5-4a58-a64f-f7d12632bf50}, !- Space Name
@@ -17325,12 +17049,12 @@ OS:Surface,
   ,                                       !- Number of Vertices
   0, 6.096, 19.5130875,                   !- X,Y,Z Vertex 1 {m}
   0, 6.096, 16.7683,                      !- X,Y,Z Vertex 2 {m}
-  0, -1.70960468004467e-016, 16.7683,     !- X,Y,Z Vertex 3 {m}
-  0, -1.70960468004467e-016, 19.5130875;  !- X,Y,Z Vertex 4 {m}
+  0, 0, 16.7683,                          !- X,Y,Z Vertex 3 {m}
+  0, 0, 19.5130875;                       !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {221827d7-129b-4be1-9d1c-ae21d444579b}, !- Handle
-  Sub Surface 28,                         !- Name
+  EnclosedOffice_Top_ZN_5 - Wall 180_a - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {d393e4d1-b8c4-4d74-906d-66594e9c6246}, !- Surface Name
@@ -17353,7 +17077,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  1.70960468004467e-016,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   16.769225,                              !- Z Origin {m}
   {c6dc659b-0ea6-49c7-9aee-b48d6c13ab59}, !- Building Story Name
   {af1c755b-2534-4319-9f4d-4eff03eaaab8}, !- Thermal Zone Name
@@ -17362,7 +17086,7 @@ OS:Space,
 
 OS:SubSurface,
   {ccf22548-b296-4591-9f0c-323421868494}, !- Handle
-  Sub Surface 29,                         !- Name
+  EnclosedOffice_Top_ZN_6 - Wall 090_a - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {543fb78d-5a19-44a5-92b2-f01b44a2b8fd}, !- Surface Name
@@ -17379,7 +17103,7 @@ OS:SubSurface,
 
 OS:Surface,
   {685904eb-7cf7-4cab-83dd-47db2a5dc279}, !- Handle
-  Surface 912,                            !- Name
+  EnclosedOffice_Top_ZN_6 - RoofCeiling_a, !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {334d03a1-30c9-4a9c-abba-2260ef6ab24a}, !- Space Name
@@ -17389,14 +17113,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  73.10755, 7.93235758299346e-016, 19.5130875, !- X,Y,Z Vertex 1 {m}
+  73.10755, 0, 19.5130875,                !- X,Y,Z Vertex 1 {m}
   73.10755, 15.8194375, 19.5130875,       !- X,Y,Z Vertex 2 {m}
   67.01155, 15.8194375, 19.5130875,       !- X,Y,Z Vertex 3 {m}
-  67.01155, -9.9636129237382e-017, 19.5130875; !- X,Y,Z Vertex 4 {m}
+  67.01155, 0, 19.5130875;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {b852b2cb-1edd-49f1-be35-eb756aa86293}, !- Handle
-  Surface 913,                            !- Name
+  EnclosedOffice_Top_ZN_6 - Wall 000_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {334d03a1-30c9-4a9c-abba-2260ef6ab24a}, !- Space Name
@@ -17413,7 +17137,7 @@ OS:Surface,
 
 OS:Surface,
   {b041b15d-d581-48f9-8e47-7ea93ed95315}, !- Handle
-  Surface 914,                            !- Name
+  EnclosedOffice_Top_ZN_6 - Wall 270_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {334d03a1-30c9-4a9c-abba-2260ef6ab24a}, !- Space Name
@@ -17430,7 +17154,7 @@ OS:Surface,
 
 OS:Surface,
   {21ada7ba-d07d-4f1d-b371-fb05292cbcd4}, !- Handle
-  Surface 915,                            !- Name
+  EnclosedOffice_Top_ZN_6 - Floor_a,      !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {334d03a1-30c9-4a9c-abba-2260ef6ab24a}, !- Space Name
@@ -17441,13 +17165,13 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   73.10755, 15.8194375, 16.7683,          !- X,Y,Z Vertex 1 {m}
-  73.10755, 7.93235758299346e-016, 16.7683, !- X,Y,Z Vertex 2 {m}
-  67.01155, -9.9636129237382e-017, 16.7683, !- X,Y,Z Vertex 3 {m}
+  73.10755, 0, 16.7683,                   !- X,Y,Z Vertex 2 {m}
+  67.01155, -0, 16.7683,                  !- X,Y,Z Vertex 3 {m}
   67.01155, 15.8194375, 16.7683;          !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {543fb78d-5a19-44a5-92b2-f01b44a2b8fd}, !- Handle
-  Surface 916,                            !- Name
+  EnclosedOffice_Top_ZN_6 - Wall 090_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {334d03a1-30c9-4a9c-abba-2260ef6ab24a}, !- Space Name
@@ -17457,14 +17181,14 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  73.10755, 7.93235758299346e-016, 19.5130875, !- X,Y,Z Vertex 1 {m}
-  73.10755, 7.93235758299346e-016, 16.7683, !- X,Y,Z Vertex 2 {m}
+  73.10755, 0, 19.5130875,                !- X,Y,Z Vertex 1 {m}
+  73.10755, 0, 16.7683,                   !- X,Y,Z Vertex 2 {m}
   73.10755, 15.8194375, 16.7683,          !- X,Y,Z Vertex 3 {m}
   73.10755, 15.8194375, 19.5130875;       !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {f179e472-780d-4f97-ad13-89db5b0d6100}, !- Handle
-  Surface 917,                            !- Name
+  EnclosedOffice_Top_ZN_6 - Wall 270_b,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {334d03a1-30c9-4a9c-abba-2260ef6ab24a}, !- Space Name
@@ -17476,12 +17200,12 @@ OS:Surface,
   ,                                       !- Number of Vertices
   67.01155, 12.1618375, 19.5130875,       !- X,Y,Z Vertex 1 {m}
   67.01155, 12.1618375, 16.7683,          !- X,Y,Z Vertex 2 {m}
-  67.01155, -9.9636129237382e-017, 16.7683, !- X,Y,Z Vertex 3 {m}
-  67.01155, -9.9636129237382e-017, 19.5130875; !- X,Y,Z Vertex 4 {m}
+  67.01155, -0, 16.7683,                  !- X,Y,Z Vertex 3 {m}
+  67.01155, -0, 19.5130875;               !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {77a99b46-4f4c-41c7-bac0-ab890d9bb72b}, !- Handle
-  Surface 918,                            !- Name
+  EnclosedOffice_Top_ZN_6 - Wall 180_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {334d03a1-30c9-4a9c-abba-2260ef6ab24a}, !- Space Name
@@ -17491,10 +17215,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  67.01155, -9.9636129237382e-017, 19.5130875, !- X,Y,Z Vertex 1 {m}
-  67.01155, -9.9636129237382e-017, 16.7683, !- X,Y,Z Vertex 2 {m}
-  73.10755, 7.93235758299346e-016, 16.7683, !- X,Y,Z Vertex 3 {m}
-  73.10755, 7.93235758299346e-016, 19.5130875; !- X,Y,Z Vertex 4 {m}
+  67.01155, 0, 19.5130875,                !- X,Y,Z Vertex 1 {m}
+  67.01155, 0, 16.7683,                   !- X,Y,Z Vertex 2 {m}
+  73.10755, 0, 16.7683,                   !- X,Y,Z Vertex 3 {m}
+  73.10755, 0, 19.5130875;                !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {58801023-d3cf-484c-89ce-4f098ca4fbb5}, !- Handle
@@ -17504,7 +17228,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  1.70960468004467e-016,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   16.769225,                              !- Z Origin {m}
   {c6dc659b-0ea6-49c7-9aee-b48d6c13ab59}, !- Building Story Name
   {aa3beef5-6318-414d-a9d8-070beb26184a}, !- Thermal Zone Name
@@ -17513,7 +17237,7 @@ OS:Space,
 
 OS:Surface,
   {1afadaf2-6af5-4f46-8dc9-8c9eb8bd2911}, !- Handle
-  Surface 919,                            !- Name
+  Dining_Top_ZN - Floor_a,                !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {58801023-d3cf-484c-89ce-4f098ca4fbb5}, !- Space Name
@@ -17530,7 +17254,7 @@ OS:Surface,
 
 OS:Surface,
   {c37161a9-cde3-436a-b4af-ba08d7d26290}, !- Handle
-  Surface 920,                            !- Name
+  Dining_Top_ZN - Wall 090_b,             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {58801023-d3cf-484c-89ce-4f098ca4fbb5}, !- Space Name
@@ -17547,7 +17271,7 @@ OS:Surface,
 
 OS:Surface,
   {246741a3-7b49-4307-b73d-51cf63d05cfe}, !- Handle
-  Surface 921,                            !- Name
+  Dining_Top_ZN - Wall 270_a,             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {58801023-d3cf-484c-89ce-4f098ca4fbb5}, !- Space Name
@@ -17564,7 +17288,7 @@ OS:Surface,
 
 OS:Surface,
   {b1bef9ef-aa60-4487-9504-d1db19b5cd8a}, !- Handle
-  Surface 922,                            !- Name
+  Dining_Top_ZN - RoofCeiling_a,          !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {58801023-d3cf-484c-89ce-4f098ca4fbb5}, !- Space Name
@@ -17581,7 +17305,7 @@ OS:Surface,
 
 OS:Surface,
   {84d70176-5998-422b-b21b-11d3ffa3aeb9}, !- Handle
-  Surface 923,                            !- Name
+  Dining_Top_ZN - Wall 180_a,             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {58801023-d3cf-484c-89ce-4f098ca4fbb5}, !- Space Name
@@ -17598,7 +17322,7 @@ OS:Surface,
 
 OS:Surface,
   {f02ade32-c4a5-4df9-a8aa-bdd5ff4701fd}, !- Handle
-  Surface 924,                            !- Name
+  Dining_Top_ZN - Wall 000_a,             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {58801023-d3cf-484c-89ce-4f098ca4fbb5}, !- Space Name
@@ -17615,7 +17339,7 @@ OS:Surface,
 
 OS:Surface,
   {6c005a68-77c6-490d-84cf-762bf7c7f3a6}, !- Handle
-  Surface 925,                            !- Name
+  Dining_Top_ZN - Wall 090_a,             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {58801023-d3cf-484c-89ce-4f098ca4fbb5}, !- Space Name
@@ -17638,7 +17362,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  1.70960468004467e-016,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   16.769225,                              !- Z Origin {m}
   {c6dc659b-0ea6-49c7-9aee-b48d6c13ab59}, !- Building Story Name
   {f06950cb-d819-4c7b-96bc-e1cc8407e5b2}, !- Thermal Zone Name
@@ -17648,7 +17372,7 @@ OS:Space,
 
 OS:Surface,
   {d1131ddf-fc66-45d1-9fa6-2ba1441b06e6}, !- Handle
-  Surface 926,                            !- Name
+  ActiveStorage_Top_ZN - Floor_a,         !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0937544b-91fd-45a0-8a78-a2e3c8f55883}, !- Space Name
@@ -17665,7 +17389,7 @@ OS:Surface,
 
 OS:Surface,
   {18b49c53-751d-40c1-8f60-fffb17698d04}, !- Handle
-  Surface 927,                            !- Name
+  ActiveStorage_Top_ZN - Wall 270_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {0937544b-91fd-45a0-8a78-a2e3c8f55883}, !- Space Name
@@ -17682,7 +17406,7 @@ OS:Surface,
 
 OS:Surface,
   {6d312cd9-fd6a-4916-917a-556f58862399}, !- Handle
-  Surface 928,                            !- Name
+  ActiveStorage_Top_ZN - RoofCeiling_a,   !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {0937544b-91fd-45a0-8a78-a2e3c8f55883}, !- Space Name
@@ -17699,7 +17423,7 @@ OS:Surface,
 
 OS:Surface,
   {3696502d-91ec-41a1-82a7-27b3864f91f0}, !- Handle
-  Surface 929,                            !- Name
+  ActiveStorage_Top_ZN - Wall 180_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {0937544b-91fd-45a0-8a78-a2e3c8f55883}, !- Space Name
@@ -17716,7 +17440,7 @@ OS:Surface,
 
 OS:Surface,
   {91e3049c-56bf-4e47-ac78-29d3ef6a83d6}, !- Handle
-  Surface 930,                            !- Name
+  ActiveStorage_Top_ZN - Wall 090_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {0937544b-91fd-45a0-8a78-a2e3c8f55883}, !- Space Name
@@ -17733,7 +17457,7 @@ OS:Surface,
 
 OS:Surface,
   {491cea9b-5602-4787-874f-c13087e0254f}, !- Handle
-  Surface 931,                            !- Name
+  ActiveStorage_Top_ZN - Wall 000_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {0937544b-91fd-45a0-8a78-a2e3c8f55883}, !- Space Name
@@ -17756,7 +17480,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  -3.41920936008933e-016,                 !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   16.769225,                              !- Z Origin {m}
   {c6dc659b-0ea6-49c7-9aee-b48d6c13ab59}, !- Building Story Name
   {8bd91944-30a6-4451-97e1-a72292e5c062}, !- Thermal Zone Name
@@ -17766,7 +17490,7 @@ OS:Space,
 
 OS:Surface,
   {eb3450ef-bd72-44fd-91ae-cb4f6b9023ba}, !- Handle
-  Surface 932,                            !- Name
+  Datacenter_Top_ZN - Floor_a,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {68502790-a796-43e0-8fd4-6ca4099e63d3}, !- Space Name
@@ -17783,7 +17507,7 @@ OS:Surface,
 
 OS:Surface,
   {cba2c276-237c-4be6-9947-d0c991b928c7}, !- Handle
-  Surface 933,                            !- Name
+  Datacenter_Top_ZN - Wall 270_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {68502790-a796-43e0-8fd4-6ca4099e63d3}, !- Space Name
@@ -17800,7 +17524,7 @@ OS:Surface,
 
 OS:Surface,
   {7f79a806-5e4c-4c47-bbc3-77947d9f303b}, !- Handle
-  Surface 934,                            !- Name
+  Datacenter_Top_ZN - Wall 000_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {68502790-a796-43e0-8fd4-6ca4099e63d3}, !- Space Name
@@ -17817,7 +17541,7 @@ OS:Surface,
 
 OS:Surface,
   {52dd323f-64bd-4345-b4e3-1e776fa17795}, !- Handle
-  Surface 935,                            !- Name
+  Datacenter_Top_ZN - Wall 180_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {68502790-a796-43e0-8fd4-6ca4099e63d3}, !- Space Name
@@ -17834,7 +17558,7 @@ OS:Surface,
 
 OS:Surface,
   {423651be-2c92-4c3a-b249-602df93d277e}, !- Handle
-  Surface 936,                            !- Name
+  Datacenter_Top_ZN - RoofCeiling_a,      !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {68502790-a796-43e0-8fd4-6ca4099e63d3}, !- Space Name
@@ -17851,7 +17575,7 @@ OS:Surface,
 
 OS:Surface,
   {3469ac3d-f6e4-4808-bdbd-647c3be457bb}, !- Handle
-  Surface 937,                            !- Name
+  Datacenter_Top_ZN - Wall 090_b,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {68502790-a796-43e0-8fd4-6ca4099e63d3}, !- Space Name
@@ -17868,7 +17592,7 @@ OS:Surface,
 
 OS:Surface,
   {e94e71ff-14d0-479d-b67b-2641ff268fd6}, !- Handle
-  Surface 938,                            !- Name
+  Datacenter_Top_ZN - Wall 090_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {68502790-a796-43e0-8fd4-6ca4099e63d3}, !- Space Name
@@ -17885,7 +17609,7 @@ OS:Surface,
 
 OS:Surface,
   {5c83f179-f958-4e51-bcb2-4dca97f1e818}, !- Handle
-  Surface 939,                            !- Name
+  Datacenter_Top_ZN - Wall 090_c,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {68502790-a796-43e0-8fd4-6ca4099e63d3}, !- Space Name
@@ -17908,7 +17632,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  -9.9636129237382e-017,                  !- Y Origin {m}
+  -0,                                     !- Y Origin {m}
   16.769225,                              !- Z Origin {m}
   {c6dc659b-0ea6-49c7-9aee-b48d6c13ab59}, !- Building Story Name
   {ae4ce1c9-f505-4044-85a6-71629c95c50c}, !- Thermal Zone Name
@@ -17917,7 +17641,7 @@ OS:Space,
 
 OS:Surface,
   {2279ebe2-8ef8-41e1-83fb-a5c975fcab55}, !- Handle
-  Surface 940,                            !- Name
+  Mechanical_Top_ZN_1 - Floor_a,          !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {b86c8dee-441d-442b-8049-fbca0fd5505a}, !- Space Name
@@ -17934,7 +17658,7 @@ OS:Surface,
 
 OS:Surface,
   {3133cb1a-ce6d-43b3-9a4a-2392e16a2da3}, !- Handle
-  Surface 941,                            !- Name
+  Mechanical_Top_ZN_1 - Wall 000_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {b86c8dee-441d-442b-8049-fbca0fd5505a}, !- Space Name
@@ -17951,7 +17675,7 @@ OS:Surface,
 
 OS:Surface,
   {0661a1a8-917f-4f01-a12e-6aa9ada9f774}, !- Handle
-  Surface 942,                            !- Name
+  Mechanical_Top_ZN_1 - RoofCeiling_a,    !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {b86c8dee-441d-442b-8049-fbca0fd5505a}, !- Space Name
@@ -17968,7 +17692,7 @@ OS:Surface,
 
 OS:Surface,
   {f4e181bc-c765-4aab-b4e4-58866d60ad26}, !- Handle
-  Surface 943,                            !- Name
+  Mechanical_Top_ZN_1 - Wall 180_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {b86c8dee-441d-442b-8049-fbca0fd5505a}, !- Space Name
@@ -17985,7 +17709,7 @@ OS:Surface,
 
 OS:Surface,
   {8dcd94ab-45db-45c3-82f4-b5f9d25f31fb}, !- Handle
-  Surface 944,                            !- Name
+  Mechanical_Top_ZN_1 - Wall 090_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {b86c8dee-441d-442b-8049-fbca0fd5505a}, !- Space Name
@@ -18002,7 +17726,7 @@ OS:Surface,
 
 OS:Surface,
   {88ccdc95-b95c-4fdf-a6a3-d42368c35085}, !- Handle
-  Surface 945,                            !- Name
+  Mechanical_Top_ZN_1 - Wall 270_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {b86c8dee-441d-442b-8049-fbca0fd5505a}, !- Space Name
@@ -18025,7 +17749,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  -9.9636129237382e-017,                  !- Y Origin {m}
+  -0,                                     !- Y Origin {m}
   16.769225,                              !- Z Origin {m}
   {c6dc659b-0ea6-49c7-9aee-b48d6c13ab59}, !- Building Story Name
   {aad5b3f7-2c97-4662-8fd3-96b5a4759cd6}, !- Thermal Zone Name
@@ -18034,7 +17758,7 @@ OS:Space,
 
 OS:Surface,
   {4a97f490-4fdb-4abd-98e4-a63c1c9a78af}, !- Handle
-  Surface 946,                            !- Name
+  Stair_Top_ZN_1 - Floor_a,               !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {26fdf65e-7eab-4d9a-9d58-edb548dfc152}, !- Space Name
@@ -18051,7 +17775,7 @@ OS:Surface,
 
 OS:Surface,
   {aeabb8b9-65fe-4ed2-b014-df8e8192e38e}, !- Handle
-  Surface 947,                            !- Name
+  Stair_Top_ZN_1 - Wall 000_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {26fdf65e-7eab-4d9a-9d58-edb548dfc152}, !- Space Name
@@ -18068,7 +17792,7 @@ OS:Surface,
 
 OS:Surface,
   {68ebbafa-2676-47a5-a8a8-901a42ae57db}, !- Handle
-  Surface 948,                            !- Name
+  Stair_Top_ZN_1 - Wall 270_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {26fdf65e-7eab-4d9a-9d58-edb548dfc152}, !- Space Name
@@ -18085,7 +17809,7 @@ OS:Surface,
 
 OS:Surface,
   {33e52181-f2a1-4738-983c-ba4ddcaa7e96}, !- Handle
-  Surface 949,                            !- Name
+  Stair_Top_ZN_1 - Wall 180_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {26fdf65e-7eab-4d9a-9d58-edb548dfc152}, !- Space Name
@@ -18102,7 +17826,7 @@ OS:Surface,
 
 OS:Surface,
   {e1b13ecc-3556-470b-bb1b-e21f6800be9d}, !- Handle
-  Surface 950,                            !- Name
+  Stair_Top_ZN_1 - RoofCeiling_a,         !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {26fdf65e-7eab-4d9a-9d58-edb548dfc152}, !- Space Name
@@ -18119,7 +17843,7 @@ OS:Surface,
 
 OS:Surface,
   {635b9b24-c4dc-48a6-b68e-bfc98d285795}, !- Handle
-  Surface 951,                            !- Name
+  Stair_Top_ZN_1 - Wall 090_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {26fdf65e-7eab-4d9a-9d58-edb548dfc152}, !- Space Name
@@ -18142,7 +17866,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  -9.9636129237382e-017,                  !- Y Origin {m}
+  -0,                                     !- Y Origin {m}
   16.769225,                              !- Z Origin {m}
   {c6dc659b-0ea6-49c7-9aee-b48d6c13ab59}, !- Building Story Name
   {4dee8b79-925f-44e9-826b-93192c3b96d5}, !- Thermal Zone Name
@@ -18151,7 +17875,7 @@ OS:Space,
 
 OS:Surface,
   {1e3f898b-28ee-453a-81c9-0f588b19fdb1}, !- Handle
-  Surface 952,                            !- Name
+  EnclosedOffice_Top_ZN_1 - Floor_a,      !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {9d0321fa-b9e2-4aa4-9331-0dae158856a9}, !- Space Name
@@ -18168,7 +17892,7 @@ OS:Surface,
 
 OS:Surface,
   {84e0af34-dc7c-4f62-bdc1-25592f88c1bf}, !- Handle
-  Surface 953,                            !- Name
+  EnclosedOffice_Top_ZN_1 - Wall 000_c,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {9d0321fa-b9e2-4aa4-9331-0dae158856a9}, !- Space Name
@@ -18185,7 +17909,7 @@ OS:Surface,
 
 OS:Surface,
   {ca5246bc-1d6c-4da1-a88a-fd87d9d6ad9e}, !- Handle
-  Surface 954,                            !- Name
+  EnclosedOffice_Top_ZN_1 - Wall 270_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {9d0321fa-b9e2-4aa4-9331-0dae158856a9}, !- Space Name
@@ -18202,7 +17926,7 @@ OS:Surface,
 
 OS:Surface,
   {9168d14d-f6e0-48c8-9cdc-81625f521982}, !- Handle
-  Surface 955,                            !- Name
+  EnclosedOffice_Top_ZN_1 - RoofCeiling_a, !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {9d0321fa-b9e2-4aa4-9331-0dae158856a9}, !- Space Name
@@ -18219,7 +17943,7 @@ OS:Surface,
 
 OS:Surface,
   {26fbd591-3bf6-4971-b12a-9c6ee2e0fdc4}, !- Handle
-  Surface 956,                            !- Name
+  EnclosedOffice_Top_ZN_1 - Wall 090_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {9d0321fa-b9e2-4aa4-9331-0dae158856a9}, !- Space Name
@@ -18236,7 +17960,7 @@ OS:Surface,
 
 OS:Surface,
   {339fa220-da83-4f45-be45-03f1bea1d5f0}, !- Handle
-  Surface 957,                            !- Name
+  EnclosedOffice_Top_ZN_1 - Wall 180_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {9d0321fa-b9e2-4aa4-9331-0dae158856a9}, !- Space Name
@@ -18253,7 +17977,7 @@ OS:Surface,
 
 OS:Surface,
   {54062d24-d299-4c8f-8848-45bc49dd8778}, !- Handle
-  Surface 958,                            !- Name
+  EnclosedOffice_Top_ZN_1 - Wall 000_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {9d0321fa-b9e2-4aa4-9331-0dae158856a9}, !- Space Name
@@ -18270,7 +17994,7 @@ OS:Surface,
 
 OS:Surface,
   {c45b5f08-73f0-4924-82e9-93c0048cb01e}, !- Handle
-  Surface 959,                            !- Name
+  EnclosedOffice_Top_ZN_1 - Wall 000_b,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {9d0321fa-b9e2-4aa4-9331-0dae158856a9}, !- Space Name
@@ -18287,7 +18011,7 @@ OS:Surface,
 
 OS:SubSurface,
   {f6e1ba8a-066d-4456-98b3-14396cf0343c}, !- Handle
-  Sub Surface 32,                         !- Name
+  Lobby_Bot_ZN_1 - Wall 180_a - Sub:a,    !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {dbd9f73a-f822-4cab-9a1b-178006e56952}, !- Surface Name
@@ -18298,13 +18022,13 @@ OS:SubSurface,
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
   15.08252, 0, 2.50031250000002,          !- X,Y,Z Vertex 1 {m}
-  15.08252, 0, 0.914400000000023,         !- X,Y,Z Vertex 2 {m}
-  41.7322, 0, 0.914400000000023,          !- X,Y,Z Vertex 3 {m}
+  15.08252, 0, 0.9144,                    !- X,Y,Z Vertex 2 {m}
+  41.7322, 0, 0.9144,                     !- X,Y,Z Vertex 3 {m}
   41.7322, 0, 2.50031250000002;           !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {54abb189-65e2-470f-bb9c-b056c6e0c231}, !- Handle
-  Sub Surface 34,                         !- Name
+  Lounge_Bot_ZN - Wall 180_a - Sub:a,     !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {ca069a8f-67b7-4d3a-aeb8-c321d5b27330}, !- Surface Name
@@ -18315,13 +18039,13 @@ OS:SubSurface,
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
   56.4134, 0, 2.50031250000002,           !- X,Y,Z Vertex 1 {m}
-  56.4134, 0, 0.914400000000023,          !- X,Y,Z Vertex 2 {m}
-  73.08215, 0, 0.914400000000023,         !- X,Y,Z Vertex 3 {m}
+  56.4134, 0, 0.9144,                     !- X,Y,Z Vertex 2 {m}
+  73.08215, 0, 0.9144,                    !- X,Y,Z Vertex 3 {m}
   73.08215, 0, 2.50031250000002;          !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {83d51c54-1fcf-426a-89f5-10763581dae1}, !- Handle
-  Sub Surface 36,                         !- Name
+  ConfRoom_Bot_ZN_1 - Wall 270_a - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {c1aeea34-8f7a-4322-9f0a-27dff754dd80}, !- Surface Name
@@ -18332,13 +18056,13 @@ OS:SubSurface,
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
   0, 36.5204375, 2.50031250000002,        !- X,Y,Z Vertex 1 {m}
-  0, 36.5204375, 0.914400000000023,       !- X,Y,Z Vertex 2 {m}
-  0, 32.9136375, 0.914400000000023,       !- X,Y,Z Vertex 3 {m}
+  0, 36.5204375, 0.9144,                  !- X,Y,Z Vertex 2 {m}
+  0, 32.9136375, 0.9144,                  !- X,Y,Z Vertex 3 {m}
   0, 32.9136375, 2.50031250000002;        !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {40c2cef9-691a-420c-96ed-403169059f2f}, !- Handle
-  Sub Surface 39,                         !- Name
+  OpenOffice_Bot_ZN_3 - Wall 000_b - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {a2dab8d0-beab-4a33-ba7a-533c04b77bd3}, !- Surface Name
@@ -18349,13 +18073,13 @@ OS:SubSurface,
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
   49.74844, 48.7378375, 2.50031250000002, !- X,Y,Z Vertex 1 {m}
-  49.74844, 48.7378375, 0.914400000000023, !- X,Y,Z Vertex 2 {m}
-  6.1214, 48.7378375, 0.914400000000023,  !- X,Y,Z Vertex 3 {m}
+  49.74844, 48.7378375, 0.9144,           !- X,Y,Z Vertex 2 {m}
+  6.1214, 48.7378375, 0.9144,             !- X,Y,Z Vertex 3 {m}
   6.1214, 48.7378375, 2.50031250000002;   !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {b5dbda81-00d3-42b1-bcad-eaf59476f7ef}, !- Handle
-  Sub Surface 42,                         !- Name
+  EnclosedOffice_Bot_ZN_6 - Wall 000_a - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {98843775-12f5-436b-93c3-b5611b90e8c4}, !- Surface Name
@@ -18366,13 +18090,13 @@ OS:SubSurface,
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
   73.08215, 48.7378375, 2.50031250000002, !- X,Y,Z Vertex 1 {m}
-  73.08215, 48.7378375, 0.914400000000023, !- X,Y,Z Vertex 2 {m}
-  56.4134, 48.7378375, 0.914400000000023, !- X,Y,Z Vertex 3 {m}
+  73.08215, 48.7378375, 0.9144,           !- X,Y,Z Vertex 2 {m}
+  56.4134, 48.7378375, 0.9144,            !- X,Y,Z Vertex 3 {m}
   56.4134, 48.7378375, 2.50031250000002;  !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {58b4f153-6736-4b7e-8be2-8a3d27701490}, !- Handle
-  Sub Surface 43,                         !- Name
+  EnclosedOffice_Bot_ZN_6 - Wall 090_a - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {f5368d3d-8f7a-4065-922a-2b6aeac7ceb6}, !- Surface Name
@@ -18383,13 +18107,13 @@ OS:SubSurface,
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
   73.10755, 42.6672375, 2.50031250000002, !- X,Y,Z Vertex 1 {m}
-  73.10755, 42.6672375, 0.914400000000023, !- X,Y,Z Vertex 2 {m}
-  73.10755, 48.7124375, 0.914400000000023, !- X,Y,Z Vertex 3 {m}
+  73.10755, 42.6672375, 0.9144,           !- X,Y,Z Vertex 2 {m}
+  73.10755, 48.7124375, 0.9144,           !- X,Y,Z Vertex 3 {m}
   73.10755, 48.7124375, 2.50031250000002; !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {10e9b0ce-0510-4f1a-9c15-b16ba530c15f}, !- Handle
-  Sub Surface 44,                         !- Name
+  OpenOffice_Bot_ZN_2 - Wall 090_a - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {1f7b2e72-26f5-4720-9973-a6c0a6a95678}, !- Surface Name
@@ -18400,13 +18124,13 @@ OS:SubSurface,
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
   73.10755, 5.5118, 2.50031250000002,     !- X,Y,Z Vertex 1 {m}
-  73.10755, 5.5118, 0.914400000000023,    !- X,Y,Z Vertex 2 {m}
-  73.10755, 42.6164375, 0.914400000000023, !- X,Y,Z Vertex 3 {m}
+  73.10755, 5.5118, 0.9144,               !- X,Y,Z Vertex 2 {m}
+  73.10755, 42.6164375, 0.9144,           !- X,Y,Z Vertex 3 {m}
   73.10755, 42.6164375, 2.50031250000002; !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {cdc923a3-7d99-4f7c-aa3c-cbf10309b084}, !- Handle
-  Sub Surface 13,                         !- Name
+  EnclosedOffice_Mid_ZN_6 - Wall 090_a - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {cea5a155-7d9a-4904-985e-19ffca5df6a1}, !- Surface Name
@@ -18416,14 +18140,14 @@ OS:SubSurface,
   ,                                       !- Frame and Divider Name
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
-  73.10755, 0.0254000000000004, 19.2686125, !- X,Y,Z Vertex 1 {m}
-  73.10755, 0.0254000000000004, 17.6827,  !- X,Y,Z Vertex 2 {m}
+  73.10755, 0.0254, 19.2686125,           !- X,Y,Z Vertex 1 {m}
+  73.10755, 0.0254, 17.6827,              !- X,Y,Z Vertex 2 {m}
   73.10755, 15.7940375, 17.6827,          !- X,Y,Z Vertex 3 {m}
   73.10755, 15.7940375, 19.2686125;       !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {d04dd4aa-bcc9-48a4-8d7f-ed4accec978c}, !- Handle
-  Surface 433,                            !- Name
+  EnclosedOffice_Mid_ZN_6 - Wall 180_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {229a7bbf-bc1e-4953-9017-a5dc9b8a0efa}, !- Space Name
@@ -18433,14 +18157,14 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  67.01155, -2.82692873330216e-017, 19.5130875, !- X,Y,Z Vertex 1 {m}
-  67.01155, -2.18635900903243e-016, 16.7683, !- X,Y,Z Vertex 2 {m}
-  73.10755, 5.31502302824763e-016, 16.7683, !- X,Y,Z Vertex 3 {m}
-  73.10755, 7.21868916394984e-016, 19.5130875; !- X,Y,Z Vertex 4 {m}
+  67.01155, 0, 19.5130875,                !- X,Y,Z Vertex 1 {m}
+  67.01155, 0, 16.7683,                   !- X,Y,Z Vertex 2 {m}
+  73.10755, 0, 16.7683,                   !- X,Y,Z Vertex 3 {m}
+  73.10755, 0, 19.5130875;                !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {c7a10902-ed8e-448a-b61a-94b13fd56cf7}, !- Handle
-  Sub Surface 48,                         !- Name
+  OpenOffice_Bot_ZN_1 - Wall 180_a - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {eb1ae448-b161-4bf7-8b6c-47f3b024251f}, !- Surface Name
@@ -18451,13 +18175,13 @@ OS:SubSurface,
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
   0.0254, 0, 2.50031250000002,            !- X,Y,Z Vertex 1 {m}
-  0.0254, 0, 0.914400000000023,           !- X,Y,Z Vertex 2 {m}
-  15.03172, 0, 0.914400000000023,         !- X,Y,Z Vertex 3 {m}
+  0.0254, 0, 0.9144,                      !- X,Y,Z Vertex 2 {m}
+  15.03172, 0, 0.9144,                    !- X,Y,Z Vertex 3 {m}
   15.03172, 0, 2.50031250000002;          !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {72a3aeaa-6d0a-4bcb-bc29-18981e6b1902}, !- Handle
-  Sub Surface 49,                         !- Name
+  Atrium_Bot_ZN - Wall 180_a - Sub:a,     !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {bcd19e90-fef5-4106-9baf-fba678065b87}, !- Surface Name
@@ -18468,13 +18192,13 @@ OS:SubSurface,
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
   41.783, 0, 2.50031250000002,            !- X,Y,Z Vertex 1 {m}
-  41.783, 0, 0.914400000000023,           !- X,Y,Z Vertex 2 {m}
-  56.3626, 0, 0.914400000000023,          !- X,Y,Z Vertex 3 {m}
+  41.783, 0, 0.9144,                      !- X,Y,Z Vertex 2 {m}
+  56.3626, 0, 0.9144,                     !- X,Y,Z Vertex 3 {m}
   56.3626, 0, 2.50031250000002;           !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {a4806307-ee1f-4e00-9834-aebc941a93b3}, !- Handle
-  Sub Surface 50,                         !- Name
+  Lounge_Bot_ZN - Wall 090_a - Sub:a,     !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {5253dd60-1db9-4939-a76e-cebe3921b278}, !- Surface Name
@@ -18485,13 +18209,13 @@ OS:SubSurface,
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
   73.10755, 0.0254, 2.50031250000002,     !- X,Y,Z Vertex 1 {m}
-  73.10755, 0.0254, 0.914400000000023,    !- X,Y,Z Vertex 2 {m}
-  73.10755, 5.461, 0.914400000000023,     !- X,Y,Z Vertex 3 {m}
+  73.10755, 0.0254, 0.9144,               !- X,Y,Z Vertex 2 {m}
+  73.10755, 5.461, 0.9144,                !- X,Y,Z Vertex 3 {m}
   73.10755, 5.461, 2.50031250000002;      !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {59e4db2c-d19e-4397-920f-82b9663a592a}, !- Handle
-  Sub Surface 51,                         !- Name
+  ConfRoom_Bot_ZN_2 - Wall 000_a - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {5b6207b8-627f-4638-869e-8972058936e8}, !- Surface Name
@@ -18502,13 +18226,13 @@ OS:SubSurface,
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
   56.3626, 48.7378375, 2.50031250000002,  !- X,Y,Z Vertex 1 {m}
-  56.3626, 48.7378375, 0.914400000000023, !- X,Y,Z Vertex 2 {m}
-  52.1462, 48.7378375, 0.914400000000023, !- X,Y,Z Vertex 3 {m}
+  56.3626, 48.7378375, 0.9144,            !- X,Y,Z Vertex 2 {m}
+  52.1462, 48.7378375, 0.9144,            !- X,Y,Z Vertex 3 {m}
   52.1462, 48.7378375, 2.50031250000002;  !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {10830952-f0d7-4e19-b9cd-ded730b6833f}, !- Handle
-  Sub Surface 52,                         !- Name
+  Classroom_Bot_ZN - Wall 000_a - Sub:a,  !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {e4e696fb-dce4-464b-a600-96814ebd50c0}, !- Surface Name
@@ -18519,13 +18243,13 @@ OS:SubSurface,
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
   52.0954, 48.7378375, 2.50031250000002,  !- X,Y,Z Vertex 1 {m}
-  52.0954, 48.7378375, 0.914400000000023, !- X,Y,Z Vertex 2 {m}
-  49.79924, 48.7378375, 0.914400000000023, !- X,Y,Z Vertex 3 {m}
+  52.0954, 48.7378375, 0.9144,            !- X,Y,Z Vertex 2 {m}
+  49.79924, 48.7378375, 0.9144,           !- X,Y,Z Vertex 3 {m}
   49.79924, 48.7378375, 2.50031250000002; !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {55f8e0f7-5fc4-4089-978f-8dd5216fbcf3}, !- Handle
-  Sub Surface 53,                         !- Name
+  EnclosedOffice_Bot_ZN_5 - Wall 000_a - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {80ed3036-d1a7-419b-b5c7-03b3b61db5a2}, !- Surface Name
@@ -18536,13 +18260,13 @@ OS:SubSurface,
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
   6.0706, 48.7378375, 2.50031250000002,   !- X,Y,Z Vertex 1 {m}
-  6.0706, 48.7378375, 0.914400000000023,  !- X,Y,Z Vertex 2 {m}
-  0.0254, 48.7378375, 0.914400000000023,  !- X,Y,Z Vertex 3 {m}
+  6.0706, 48.7378375, 0.9144,             !- X,Y,Z Vertex 2 {m}
+  0.0254, 48.7378375, 0.9144,             !- X,Y,Z Vertex 3 {m}
   0.0254, 48.7378375, 2.50031250000002;   !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {69cafdc5-22bb-470c-ab8f-1b24c620f598}, !- Handle
-  Sub Surface 54,                         !- Name
+  EnclosedOffice_Bot_ZN_5 - Wall 270_a - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {d122896e-8962-4d48-8239-5e0398939479}, !- Surface Name
@@ -18553,13 +18277,13 @@ OS:SubSurface,
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
   0, 48.7124375, 2.50031250000002,        !- X,Y,Z Vertex 1 {m}
-  0, 48.7124375, 0.914400000000023,       !- X,Y,Z Vertex 2 {m}
-  0, 36.5712375, 0.914400000000023,       !- X,Y,Z Vertex 3 {m}
+  0, 48.7124375, 0.9144,                  !- X,Y,Z Vertex 2 {m}
+  0, 36.5712375, 0.9144,                  !- X,Y,Z Vertex 3 {m}
   0, 36.5712375, 2.50031250000002;        !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {f76c495a-bc78-41bd-9db8-da87553322e1}, !- Handle
-  Sub Surface 55,                         !- Name
+  OpenOffice_Bot_ZN_1 - Wall 270_b - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {01de1208-62b8-463a-ba6a-955a1699ca62}, !- Surface Name
@@ -18570,13 +18294,13 @@ OS:SubSurface,
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
   0, 32.8628375, 2.50031250000002,        !- X,Y,Z Vertex 1 {m}
-  0, 32.8628375, 0.914400000000023,       !- X,Y,Z Vertex 2 {m}
-  0, 0.0253999999999998, 0.914400000000023, !- X,Y,Z Vertex 3 {m}
+  0, 32.8628375, 0.9144,                  !- X,Y,Z Vertex 2 {m}
+  0, 0.0253999999999998, 0.9144,          !- X,Y,Z Vertex 3 {m}
   0, 0.0253999999999998, 2.50031250000002; !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {53727e3d-b387-4eed-ad9c-2ce54bd9a988}, !- Handle
-  Sub Surface 56,                         !- Name
+  ConfRoom_Mid_ZN_1 - Wall 180_a - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {19d6bf15-1d85-44eb-a794-b42fdaa63767}, !- Surface Name
@@ -18593,7 +18317,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {e9117d5d-d623-4396-aedb-c01c697823b6}, !- Handle
-  Sub Surface 57,                         !- Name
+  OpenOffice_Mid_ZN_1 - Wall 180_b - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {24b93784-cce3-4dda-bb6a-04461145c6d4}, !- Surface Name
@@ -18610,7 +18334,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {b4d347ba-849e-4e40-b16a-ad394bf34fd5}, !- Handle
-  Sub Surface 58,                         !- Name
+  EnclosedOffice_Mid_ZN_6 - Wall 180_a - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {d04dd4aa-bcc9-48a4-8d7f-ed4accec978c}, !- Surface Name
@@ -18627,7 +18351,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {f1fda713-020b-4236-9492-e323888896ef}, !- Handle
-  Sub Surface 60,                         !- Name
+  ConfRoom_Top_ZN_1 - Wall 180_a - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {cc43616a-142d-485f-aa88-cd293f0e6af9}, !- Surface Name
@@ -18644,7 +18368,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {21f04a5a-b298-4b76-ab49-e3c8ddde8386}, !- Handle
-  Sub Surface 61,                         !- Name
+  OpenOffice_Top_ZN_1 - Wall 180_a - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {bf7c3648-c75f-47b9-9831-834639881e4c}, !- Surface Name
@@ -18661,7 +18385,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {7d994615-3149-4aaf-b62b-18177a85e1d8}, !- Handle
-  Sub Surface 62,                         !- Name
+  EnclosedOffice_Top_ZN_6 - Wall 180_a - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {77a99b46-4f4c-41c7-bac0-ab890d9bb72b}, !- Surface Name
@@ -18678,7 +18402,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {63a3b69b-f3e9-47b9-98c4-1c62290358f7}, !- Handle
-  Sub Surface 63,                         !- Name
+  EnclosedOffice_Top_ZN_7 - Wall 090_a - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {1342dadb-ad4e-4da0-8a6d-204a43acbcd8}, !- Surface Name
@@ -18695,7 +18419,7 @@ OS:SubSurface,
 
 OS:Surface,
   {cce9ab3d-f9f6-4ee7-a7ae-1d4ef4f205d6}, !- Handle
-  Surface 123,                            !- Name
+  EnclosedOffice_Mid_ZN_8 - Wall 270_a,   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {aceaf852-6a17-4647-a5bc-ffe90e228da1}, !- Space Name
@@ -18712,7 +18436,7 @@ OS:Surface,
 
 OS:SubSurface,
   {9f0c006c-6f8a-485b-9bc6-8bddb7bc6727}, !- Handle
-  Sub Surface 2,                          !- Name
+  EnclosedOffice_Mid_ZN_8 - Wall 270_a - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {cce9ab3d-f9f6-4ee7-a7ae-1d4ef4f205d6}, !- Surface Name
@@ -18729,7 +18453,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {dd58bc69-f957-4d68-aadf-b863c98991c8}, !- Handle
-  Sub Surface 3,                          !- Name
+  EnclosedOffice_Mid_ZN_8 - Wall 000_a - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {28ab6aae-1332-4971-b2f3-06269f3e7b9e}, !- Surface Name
@@ -18741,8 +18465,8 @@ OS:SubSurface,
   ,                                       !- Number of Vertices
   6.0706, 48.7378375, 19.2686125,         !- X,Y,Z Vertex 1 {m}
   6.0706, 48.7378375, 17.6827,            !- X,Y,Z Vertex 2 {m}
-  0.0254000000000007, 48.7378375, 17.6827, !- X,Y,Z Vertex 3 {m}
-  0.0254000000000007, 48.7378375, 19.2686125; !- X,Y,Z Vertex 4 {m}
+  0.0254, 48.7378375, 17.6827,            !- X,Y,Z Vertex 3 {m}
+  0.0254, 48.7378375, 19.2686125;         !- X,Y,Z Vertex 4 {m}
 
 OS:SpaceType,
   {55901ff9-4a1c-46a0-8384-61dd0c18e8fd}, !- Handle
@@ -18751,6 +18475,7 @@ OS:SpaceType,
   ,                                       !- Default Schedule Set Name
   {1387cc37-4d7b-4f7f-86b3-e285075a148e}, !- Group Rendering Name
   ,                                       !- Design Specification Outdoor Air Object Name
+  ,                                       !- Standards Template
   Office,                                 !- Standards Building Type
   OpenOffice;                             !- Standards Space Type
 
@@ -18768,6 +18493,7 @@ OS:SpaceType,
   ,                                       !- Default Schedule Set Name
   {cc772eef-de54-43c2-b85a-a10de18e5b13}, !- Group Rendering Name
   ,                                       !- Design Specification Outdoor Air Object Name
+  ,                                       !- Standards Template
   Office,                                 !- Standards Building Type
   ClosedOffice;                           !- Standards Space Type
 
@@ -18785,6 +18511,7 @@ OS:SpaceType,
   ,                                       !- Default Schedule Set Name
   {f95a3f05-079b-4b27-8005-df87c23246f2}, !- Group Rendering Name
   ,                                       !- Design Specification Outdoor Air Object Name
+  ,                                       !- Standards Template
   Office,                                 !- Standards Building Type
   Elec/MechRoom;                          !- Standards Space Type
 
@@ -18802,6 +18529,7 @@ OS:SpaceType,
   ,                                       !- Default Schedule Set Name
   {4f50db8c-15e9-426f-83d2-9ec9581b4aa8}, !- Group Rendering Name
   ,                                       !- Design Specification Outdoor Air Object Name
+  ,                                       !- Standards Template
   Office,                                 !- Standards Building Type
   Corridor;                               !- Standards Space Type
 
@@ -18819,6 +18547,7 @@ OS:SpaceType,
   ,                                       !- Default Schedule Set Name
   {1708cbe5-533e-4dcd-bdfd-a7905b49eb3f}, !- Group Rendering Name
   ,                                       !- Design Specification Outdoor Air Object Name
+  ,                                       !- Standards Template
   Office,                                 !- Standards Building Type
   Restroom;                               !- Standards Space Type
 
@@ -18836,6 +18565,7 @@ OS:SpaceType,
   ,                                       !- Default Schedule Set Name
   {51d0357b-8dcc-46a8-8147-6e4ae929de2d}, !- Group Rendering Name
   ,                                       !- Design Specification Outdoor Air Object Name
+  ,                                       !- Standards Template
   Office,                                 !- Standards Building Type
   Lobby;                                  !- Standards Space Type
 
@@ -18853,6 +18583,7 @@ OS:SpaceType,
   ,                                       !- Default Schedule Set Name
   {5b4db05a-e3aa-4691-a828-be7c19730c34}, !- Group Rendering Name
   ,                                       !- Design Specification Outdoor Air Object Name
+  ,                                       !- Standards Template
   Office,                                 !- Standards Building Type
   Stair;                                  !- Standards Space Type
 
@@ -18871,6 +18602,7 @@ OS:SpaceType,
   ,                                       !- Default Schedule Set Name
   {81238171-1bb6-49b8-96f6-58b5e3fbf0f8}, !- Group Rendering Name
   ,                                       !- Design Specification Outdoor Air Object Name
+  ,                                       !- Standards Template
   Office,                                 !- Standards Building Type
   Dining;                                 !- Standards Space Type
 
@@ -18888,6 +18620,7 @@ OS:SpaceType,
   ,                                       !- Default Schedule Set Name
   {329a96ca-030a-4aa0-92d7-862dbb62dbda}, !- Group Rendering Name
   ,                                       !- Design Specification Outdoor Air Object Name
+  ,                                       !- Standards Template
   Office,                                 !- Standards Building Type
   Conference;                             !- Standards Space Type
 
@@ -18905,6 +18638,7 @@ OS:SpaceType,
   ,                                       !- Default Schedule Set Name
   {69347753-25b6-4f5c-b66a-2d8ce0fc90d4}, !- Group Rendering Name
   ,                                       !- Design Specification Outdoor Air Object Name
+  ,                                       !- Standards Template
   Office,                                 !- Standards Building Type
   Storage;                                !- Standards Space Type
 
@@ -18922,6 +18656,7 @@ OS:SpaceType,
   ,                                       !- Default Schedule Set Name
   {70112ab4-810d-4a54-933c-8dc9a21f3119}, !- Group Rendering Name
   ,                                       !- Design Specification Outdoor Air Object Name
+  ,                                       !- Standards Template
   Office,                                 !- Standards Building Type
   Classroom;                              !- Standards Space Type
 
@@ -18939,6 +18674,7 @@ OS:SpaceType,
   ,                                       !- Default Schedule Set Name
   {95ccf356-3dd3-40f5-8b41-746c84a8c446}, !- Group Rendering Name
   ,                                       !- Design Specification Outdoor Air Object Name
+  ,                                       !- Standards Template
   Office,                                 !- Standards Building Type
   BreakRoom;                              !- Standards Space Type
 
@@ -18956,6 +18692,7 @@ OS:SpaceType,
   ,                                       !- Default Schedule Set Name
   {dfe7bc47-b47a-465d-8dfe-aac3a9a32494}, !- Group Rendering Name
   ,                                       !- Design Specification Outdoor Air Object Name
+  ,                                       !- Standards Template
   Office,                                 !- Standards Building Type
   OfficeLarge Data Center;                !- Standards Space Type
 
@@ -18973,6 +18710,7 @@ OS:SpaceType,
   ,                                       !- Default Schedule Set Name
   {711e801a-193d-4b81-a8dc-027496c01cd2}, !- Group Rendering Name
   ,                                       !- Design Specification Outdoor Air Object Name
+  ,                                       !- Standards Template
   Office,                                 !- Standards Building Type
   OfficeLarge Main Data Center;           !- Standards Space Type
 
@@ -18996,7 +18734,7 @@ OS:ThermalZone,
   {5a3ed552-3d06-4790-9a61-5beb3e37f1cc}, !- Zone Air Inlet Port List
   {1cee395f-1456-4aa2-b35f-5b52f45ec61f}, !- Zone Air Exhaust Port List
   {94b62e0c-d1d1-4937-8d5b-127a52418d62}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {897d1eec-9040-4e75-81c2-fee2fa34f437}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -19006,6 +18744,12 @@ OS:ThermalZone,
   ,                                       !- Thermostat Name
   No,                                     !- Use Ideal Air Loads
   ;                                       !- Humidistat Name
+
+OS:PortList,
+  {897d1eec-9040-4e75-81c2-fee2fa34f437}, !- Handle
+  Port List 6,                            !- Name
+  {936a55f7-16a1-49ce-8b99-91f0947c37e5}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {93975f5e-d4ff-4de2-820a-bd2e3f72d248}, !- Handle
@@ -19079,7 +18823,7 @@ OS:ThermalZone,
   {469b4470-6a4b-4b46-b61c-c0b59654eefa}, !- Zone Air Inlet Port List
   {96850727-8448-4448-8c09-5a778a20f98f}, !- Zone Air Exhaust Port List
   {f8fd45cb-08e8-4ca2-8278-84b93603dbb3}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {551ea075-67b1-46ce-9714-445728df6f11}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -19088,6 +18832,12 @@ OS:ThermalZone,
   {72eab394-eae8-44dc-b8aa-a0a44aed938d}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {551ea075-67b1-46ce-9714-445728df6f11}, !- Handle
+  Port List 7,                            !- Name
+  {fcf9f4c0-15f2-4969-b91f-da010923ed44}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {3a44e7a2-98fd-4bff-9edf-d6756bf54560}, !- Handle
@@ -19161,7 +18911,7 @@ OS:ThermalZone,
   {6d3f5e12-cee2-4799-b2bc-7765d6bd6d1f}, !- Zone Air Inlet Port List
   {033bbc93-b9fc-4a22-b72b-64a0fd7db0bc}, !- Zone Air Exhaust Port List
   {cbd8e4ec-f490-4c6f-9ba7-c08cf2ae35f3}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {ac7d99ee-4365-42ad-9603-6272a2ee2582}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -19170,6 +18920,12 @@ OS:ThermalZone,
   {5f95bfb7-c1f6-42d1-bf14-890cca131343}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {ac7d99ee-4365-42ad-9603-6272a2ee2582}, !- Handle
+  Port List 8,                            !- Name
+  {bb950b64-26be-42cf-820c-f100acf37277}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {2f5e34c1-2bf3-469d-ba78-c68aec0772a5}, !- Handle
@@ -19243,7 +18999,7 @@ OS:ThermalZone,
   {1840ddac-e6b8-469b-8952-012dd92db478}, !- Zone Air Inlet Port List
   {149e19ca-b057-4b68-9ded-492ddb6efb37}, !- Zone Air Exhaust Port List
   {df9eae9a-514f-4988-8ed7-36201aba80e1}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {aff2b99a-bc77-4d06-a910-120cf1e60a95}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -19253,6 +19009,12 @@ OS:ThermalZone,
   ,                                       !- Thermostat Name
   No,                                     !- Use Ideal Air Loads
   ;                                       !- Humidistat Name
+
+OS:PortList,
+  {aff2b99a-bc77-4d06-a910-120cf1e60a95}, !- Handle
+  Port List 2,                            !- Name
+  {b7e1732c-8f7b-4d17-b493-30105978df29}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {3bb9411d-611e-43b1-bfb2-550c05889491}, !- Handle
@@ -19326,7 +19088,7 @@ OS:ThermalZone,
   {a8408758-5ba4-473f-a7fd-d5b7d806f477}, !- Zone Air Inlet Port List
   {1bbee3e9-a753-452f-b4bb-1a135aefccbb}, !- Zone Air Exhaust Port List
   {404fc315-48f3-4167-a0c5-115ad32eecde}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {3c29110d-5ed8-4c45-99c5-b00c819133d1}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -19336,6 +19098,12 @@ OS:ThermalZone,
   ,                                       !- Thermostat Name
   No,                                     !- Use Ideal Air Loads
   ;                                       !- Humidistat Name
+
+OS:PortList,
+  {3c29110d-5ed8-4c45-99c5-b00c819133d1}, !- Handle
+  Port List 9,                            !- Name
+  {c00c1a55-e8c8-4e94-9afd-c184119f5273}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {e9c2372e-bf2b-4e99-a0af-1c015e309b8a}, !- Handle
@@ -19409,7 +19177,7 @@ OS:ThermalZone,
   {28b68b00-c23c-40f0-93f9-3f0fd2928a32}, !- Zone Air Inlet Port List
   {5e939bdf-deec-4302-8e91-5c558f0fa575}, !- Zone Air Exhaust Port List
   {6875c114-37fc-4d34-810b-878d72884db2}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {df576cf5-483b-4f19-8f89-3575704dd993}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -19418,6 +19186,12 @@ OS:ThermalZone,
   {d91233c1-fb9f-4c90-b851-4c32ea6920e6}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {df576cf5-483b-4f19-8f89-3575704dd993}, !- Handle
+  Port List 10,                           !- Name
+  {ee4cc09b-6e36-4e4f-87e2-0d0c12691c4c}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {af931bd1-4d06-43b3-a203-d5536b98c220}, !- Handle
@@ -19491,7 +19265,7 @@ OS:ThermalZone,
   {00cd96b8-8ad5-48ba-bd69-f68ca42f45fc}, !- Zone Air Inlet Port List
   {9768cc37-5442-4fd1-87af-ed0f9d2d0ddc}, !- Zone Air Exhaust Port List
   {2d4e6576-f856-4418-b12c-4fa61be3a1fb}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {d335de21-f350-4a79-9f13-5402804c4ffe}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -19500,6 +19274,12 @@ OS:ThermalZone,
   {d9a7bcc5-29a0-48fd-821e-697900372523}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {d335de21-f350-4a79-9f13-5402804c4ffe}, !- Handle
+  Port List 11,                           !- Name
+  {2f0fb3d4-ceca-4279-afc1-c6190ec86ec6}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {d405848f-b590-42b9-910f-d7cf5d651b78}, !- Handle
@@ -19573,7 +19353,7 @@ OS:ThermalZone,
   {65a71640-4ea9-4e91-96f6-7571ac64d2ae}, !- Zone Air Inlet Port List
   {65dee913-2738-48cf-99e3-5e631c975aec}, !- Zone Air Exhaust Port List
   {7a20241f-8e32-4461-afd9-a46659696705}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {d124a4a1-b13d-4843-8f9b-27ffc1a30e3f}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -19582,6 +19362,12 @@ OS:ThermalZone,
   {5b6b218e-2587-450d-a4bb-f82d2cc44b5d}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {d124a4a1-b13d-4843-8f9b-27ffc1a30e3f}, !- Handle
+  Port List 12,                           !- Name
+  {f06950cb-d819-4c7b-96bc-e1cc8407e5b2}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {0ae02c95-7723-4067-b8dd-ddf2703ab5a5}, !- Handle
@@ -19655,7 +19441,7 @@ OS:ThermalZone,
   {4126452f-d049-44a5-af50-bc90b4892825}, !- Zone Air Inlet Port List
   {414bcb5a-c23c-47d8-a2d6-7e77bb92005f}, !- Zone Air Exhaust Port List
   {7b5ffeea-d978-4144-8630-748909a38c7b}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {d8941572-aff4-42c9-ac56-8de4068d3d0d}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -19665,6 +19451,12 @@ OS:ThermalZone,
   ,                                       !- Thermostat Name
   No,                                     !- Use Ideal Air Loads
   ;                                       !- Humidistat Name
+
+OS:PortList,
+  {d8941572-aff4-42c9-ac56-8de4068d3d0d}, !- Handle
+  Port List 13,                           !- Name
+  {ec6c973d-c668-4b43-91d9-3d24f85bf2a1}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {4b3fe602-392c-47b6-9e17-33ecb1c77a1e}, !- Handle
@@ -19738,7 +19530,7 @@ OS:ThermalZone,
   {c661e173-3b5a-4e13-9558-fc1b29885192}, !- Zone Air Inlet Port List
   {6a08f873-18e7-417b-b8b6-0ef30429b8b6}, !- Zone Air Exhaust Port List
   {1d8717b9-6f2a-4066-b6a3-a6d3eac742f9}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {00b3ecc8-e1ff-407e-8b91-781a85623f87}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -19747,6 +19539,12 @@ OS:ThermalZone,
   {087b6ba7-bcbc-4ef0-9f05-6fb5f2131b8a}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {00b3ecc8-e1ff-407e-8b91-781a85623f87}, !- Handle
+  Port List 14,                           !- Name
+  {4f1eb317-106d-40ec-a2ea-11206537f0a1}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {a2500992-bff3-41d3-bdc7-d9b54b8c2aad}, !- Handle
@@ -19820,7 +19618,7 @@ OS:ThermalZone,
   {8aa5fc9f-a7cb-4767-a919-75e16eb0247b}, !- Zone Air Inlet Port List
   {1394ba8a-4851-4234-9ea2-040f597a5773}, !- Zone Air Exhaust Port List
   {aae7ca2f-82fc-4457-97db-bc0f4884f140}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {20bfce1d-3459-471b-af5f-4581f36b5234}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -19829,6 +19627,12 @@ OS:ThermalZone,
   {50f0081a-8fdf-4035-9258-aed65bafb380}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {20bfce1d-3459-471b-af5f-4581f36b5234}, !- Handle
+  Port List 15,                           !- Name
+  {d83bf3df-df79-43e4-badc-d44240a87a1e}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {8cebfa5b-0fb4-4b90-8e36-5757b410b3a8}, !- Handle
@@ -19902,7 +19706,7 @@ OS:ThermalZone,
   {73cbeccb-cd84-4c9f-b9c6-02df57688843}, !- Zone Air Inlet Port List
   {6543c861-e367-49ef-80a0-96d3a67dc7dc}, !- Zone Air Exhaust Port List
   {c0cd1856-b1ac-469c-86f9-47689640ddb8}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {9b86221e-3088-4d42-a02b-31665583af39}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -19911,6 +19715,12 @@ OS:ThermalZone,
   {425bfd7f-f5d1-4e08-a0cf-005bd0a9d770}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {9b86221e-3088-4d42-a02b-31665583af39}, !- Handle
+  Port List 16,                           !- Name
+  {fec48942-2cf5-46e1-ae13-1569781a05d8}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {41332f78-ce09-4a55-88ed-1646a9c4aa01}, !- Handle
@@ -19984,7 +19794,7 @@ OS:ThermalZone,
   {a9d7710b-a0c3-48db-9ddf-8694b43c8bed}, !- Zone Air Inlet Port List
   {4fac6b80-7075-4cfb-a56b-b28c33b447a8}, !- Zone Air Exhaust Port List
   {57cd4649-2370-4ab0-8fe3-ef9da2dab8e8}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {cff667a6-f159-4443-825d-86f76f2d78b9}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -19993,6 +19803,12 @@ OS:ThermalZone,
   {7d37287b-7dd4-458d-ba6c-98672345cfe3}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {cff667a6-f159-4443-825d-86f76f2d78b9}, !- Handle
+  Port List 17,                           !- Name
+  {6bdf15c4-10d1-4d09-a69c-1fe467193fcb}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {65c6f6cd-c68a-47d1-b2f2-2fa05993ea22}, !- Handle
@@ -20066,7 +19882,7 @@ OS:ThermalZone,
   {eb5e496e-7282-4e46-9d70-c778b493612f}, !- Zone Air Inlet Port List
   {5a4c4171-f7f8-4d27-8c19-8ff1961e81b5}, !- Zone Air Exhaust Port List
   {65b37f8a-bdae-4f0f-981a-01d1a2ec10a1}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {d7ed45f1-d140-4e52-a8f4-4b6a8ad8c161}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -20076,6 +19892,12 @@ OS:ThermalZone,
   ,                                       !- Thermostat Name
   No,                                     !- Use Ideal Air Loads
   ;                                       !- Humidistat Name
+
+OS:PortList,
+  {d7ed45f1-d140-4e52-a8f4-4b6a8ad8c161}, !- Handle
+  Port List 18,                           !- Name
+  {c7c5710b-5396-45b9-aef3-b4851ec51476}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {f936cae0-9804-496a-8c9b-cc06e5aa14b9}, !- Handle
@@ -20149,7 +19971,7 @@ OS:ThermalZone,
   {b57eaa1b-a675-4f96-bef3-13a3faf35421}, !- Zone Air Inlet Port List
   {cfa4336a-ee01-4fa8-b8cd-a1961778f972}, !- Zone Air Exhaust Port List
   {500cf01e-aac4-4103-a255-2fd8e60f8aea}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {366abf82-ff14-4bc3-adec-c53bf52b6562}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -20159,6 +19981,12 @@ OS:ThermalZone,
   ,                                       !- Thermostat Name
   No,                                     !- Use Ideal Air Loads
   ;                                       !- Humidistat Name
+
+OS:PortList,
+  {366abf82-ff14-4bc3-adec-c53bf52b6562}, !- Handle
+  Port List 19,                           !- Name
+  {0575665a-e229-4d0e-af4a-df83f635d52b}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {8cf2752c-d962-4359-b2f8-b932cc7e87c8}, !- Handle
@@ -20232,7 +20060,7 @@ OS:ThermalZone,
   {f7869815-16e9-4ff0-adcf-fbce36455254}, !- Zone Air Inlet Port List
   {e96d9001-f73a-49f9-959b-28af59bedc71}, !- Zone Air Exhaust Port List
   {89e58d1e-d819-4482-be2a-f59b1ec0d40e}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {29b5ade7-a1be-465b-b9d9-a8fc208388f4}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -20241,6 +20069,12 @@ OS:ThermalZone,
   {007d53ba-7971-4c8e-83c0-fa53b035f00f}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {29b5ade7-a1be-465b-b9d9-a8fc208388f4}, !- Handle
+  Port List 20,                           !- Name
+  {edbf4a78-3b20-49cb-aba5-c49f767c67ad}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {bb6dea3e-c668-42ad-9913-ecea9580bb18}, !- Handle
@@ -20314,7 +20148,7 @@ OS:ThermalZone,
   {c4097d59-45f3-4720-af3c-3d334ba7785b}, !- Zone Air Inlet Port List
   {596049ca-4529-461e-91b2-ef540dbb69c0}, !- Zone Air Exhaust Port List
   {908b0280-6ec0-40da-83e9-c3364f9f3e42}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {1349db05-80e5-402d-ae1f-a713a4ed3284}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -20323,6 +20157,12 @@ OS:ThermalZone,
   {1cfea012-7488-4a35-a1cc-119dea592d07}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {1349db05-80e5-402d-ae1f-a713a4ed3284}, !- Handle
+  Port List 21,                           !- Name
+  {65c7b380-960f-4d59-ab03-cbc64c1cfc05}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {aaa40d11-f6d3-46d3-8759-6dae66d12f81}, !- Handle
@@ -20396,7 +20236,7 @@ OS:ThermalZone,
   {d4488b22-a6c3-4f2a-9e4a-1b82aa258ce7}, !- Zone Air Inlet Port List
   {0fdf4e99-5349-4901-87aa-d4dd9325c79c}, !- Zone Air Exhaust Port List
   {d04e66a8-63c6-4a97-bf81-f2037ec66287}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {eaeb5e51-a02a-4a40-a1ee-11fa9df09ba0}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -20405,6 +20245,12 @@ OS:ThermalZone,
   {746f6abb-aeb8-4672-883c-04162eee6503}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {eaeb5e51-a02a-4a40-a1ee-11fa9df09ba0}, !- Handle
+  Port List 22,                           !- Name
+  {546c6105-c7be-4e52-9688-49a1ea47f4c4}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {146a20c6-4117-4509-9369-768fbb99b00b}, !- Handle
@@ -20478,7 +20324,7 @@ OS:ThermalZone,
   {c4ea59c4-13d7-4d55-bf4a-4324bdb7998c}, !- Zone Air Inlet Port List
   {81d176ab-62d0-463b-8b2b-fbcf9c751620}, !- Zone Air Exhaust Port List
   {4b75c366-b3f5-4a63-8f1c-b423642ca230}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {64092e38-5ba3-42d3-b9cd-a101b5da9af0}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -20487,6 +20333,12 @@ OS:ThermalZone,
   {9bd389c4-c83b-41a1-8e4f-9cc47e5e3c63}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {64092e38-5ba3-42d3-b9cd-a101b5da9af0}, !- Handle
+  Port List 3,                            !- Name
+  {f9243986-e4ac-45e4-b930-282147fe7d69}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {10161140-35a2-4d62-a378-46056d42f25a}, !- Handle
@@ -20560,7 +20412,7 @@ OS:ThermalZone,
   {003af424-cf2a-4d20-a5e2-ed45d977e6fc}, !- Zone Air Inlet Port List
   {6ee0b9dd-3a32-4caf-8402-781bf96a2121}, !- Zone Air Exhaust Port List
   {02d150f4-8061-4863-9dbe-6302e08117ae}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {f72eaf39-f37c-4043-8f33-a522c7d5fd79}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -20569,6 +20421,12 @@ OS:ThermalZone,
   {dc887681-760c-4b3c-a3c4-7ca420a3bab5}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {f72eaf39-f37c-4043-8f33-a522c7d5fd79}, !- Handle
+  Port List 23,                           !- Name
+  {e2fa0a8c-a81c-45c2-9f8f-f3c4898f7cb4}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {cba264ac-28cb-4b37-9e08-bea35b2a8e6a}, !- Handle
@@ -20642,7 +20500,7 @@ OS:ThermalZone,
   {11ea531e-4935-477a-bc17-eccf1eebb76d}, !- Zone Air Inlet Port List
   {9fd685b4-66b4-4707-b407-0611000ec637}, !- Zone Air Exhaust Port List
   {1227889e-e831-4019-b70f-5c94bd4f5c26}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {71d8be5c-90db-4217-91c0-012f966cf90b}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -20651,6 +20509,12 @@ OS:ThermalZone,
   {d41325b4-262b-4138-b041-d98e03b23fe6}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {71d8be5c-90db-4217-91c0-012f966cf90b}, !- Handle
+  Port List 24,                           !- Name
+  {ad9a0ecb-ccbe-4d88-a813-fd0452d413d0}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {8b577b16-f994-4a72-b6eb-88e077f33f59}, !- Handle
@@ -20724,7 +20588,7 @@ OS:ThermalZone,
   {69444987-2780-4cd8-90c7-385fdb17c9e2}, !- Zone Air Inlet Port List
   {3fc05e3d-e24d-4826-af03-05000fbc3990}, !- Zone Air Exhaust Port List
   {856d1046-0b97-43d3-bd39-d1f3884032b8}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {516be012-b946-45ce-89f7-87551d331da4}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -20733,6 +20597,12 @@ OS:ThermalZone,
   {f880eae4-ca05-4c82-8893-5358ddbfb0dd}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {516be012-b946-45ce-89f7-87551d331da4}, !- Handle
+  Port List 25,                           !- Name
+  {4b4a36c9-7e4d-4aba-b6c4-e1ddb1b871bf}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {c9786adc-cc3c-4639-87af-5b7b5636b755}, !- Handle
@@ -20806,7 +20676,7 @@ OS:ThermalZone,
   {63aaaceb-3d5b-47b7-b49d-d88eae80b9d2}, !- Zone Air Inlet Port List
   {b78800d4-753c-4bf1-b047-8ce1646161a2}, !- Zone Air Exhaust Port List
   {fd8ebf58-cf2e-4f21-b8ea-76506d1510c1}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {ce1f6a39-79d4-4207-bbe5-f2b1f9b0d677}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -20816,6 +20686,12 @@ OS:ThermalZone,
   ,                                       !- Thermostat Name
   No,                                     !- Use Ideal Air Loads
   ;                                       !- Humidistat Name
+
+OS:PortList,
+  {ce1f6a39-79d4-4207-bbe5-f2b1f9b0d677}, !- Handle
+  Port List 26,                           !- Name
+  {194fb585-e74b-4317-9963-0bfc9ab085f2}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {623bfda2-f18e-4e01-a702-9bb64c12af62}, !- Handle
@@ -20889,7 +20765,7 @@ OS:ThermalZone,
   {30704a2b-29ec-40ce-a4bc-fb483f8389dc}, !- Zone Air Inlet Port List
   {58966a92-7b92-4be7-9640-adcbcfcde049}, !- Zone Air Exhaust Port List
   {35838e80-9365-4868-93cf-7f11f24f9da1}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {6f9665dd-c6aa-4a9f-b0f8-bf7488758dcd}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -20898,6 +20774,12 @@ OS:ThermalZone,
   {b6a5ed42-e7a7-4b3e-a94b-bcc14b1a4a4e}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {6f9665dd-c6aa-4a9f-b0f8-bf7488758dcd}, !- Handle
+  Port List 27,                           !- Name
+  {c77c16ea-0b1a-45f9-a0c2-5ac6ea24dcd6}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {fd299d39-829f-445d-8103-b96d027f3ccb}, !- Handle
@@ -20971,7 +20853,7 @@ OS:ThermalZone,
   {8abea0f2-c2f5-4cdc-a1c9-1a5ae967f5b8}, !- Zone Air Inlet Port List
   {aa0a548e-9cec-424f-8bb1-5ca86fa9149a}, !- Zone Air Exhaust Port List
   {b80790a2-52cd-4331-92b2-9e4084108abe}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {09dca53e-7855-4936-a725-c471de3efc37}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -20981,6 +20863,12 @@ OS:ThermalZone,
   ,                                       !- Thermostat Name
   No,                                     !- Use Ideal Air Loads
   ;                                       !- Humidistat Name
+
+OS:PortList,
+  {09dca53e-7855-4936-a725-c471de3efc37}, !- Handle
+  Port List 28,                           !- Name
+  {7ca8262d-f153-4ffd-9b7b-3877f5ae6d91}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {c03816d0-4e03-443d-9b91-e8f57c85e76d}, !- Handle
@@ -21054,7 +20942,7 @@ OS:ThermalZone,
   {d5f6a3fa-9ff8-4e25-8f03-22f9ae5ba010}, !- Zone Air Inlet Port List
   {8082eb12-ad81-4768-a7e3-3638e0433180}, !- Zone Air Exhaust Port List
   {9cae7332-24ca-4420-8ba6-5c799c240dd9}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {320d4373-fa16-44d8-bd25-1ac8bcae8f8c}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -21064,6 +20952,12 @@ OS:ThermalZone,
   ,                                       !- Thermostat Name
   No,                                     !- Use Ideal Air Loads
   ;                                       !- Humidistat Name
+
+OS:PortList,
+  {320d4373-fa16-44d8-bd25-1ac8bcae8f8c}, !- Handle
+  Port List 29,                           !- Name
+  {549ea789-7ede-45ee-8e8d-fb85d5233efd}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {6f0a7d84-97d1-4855-be5f-89122c0644ba}, !- Handle
@@ -21137,7 +21031,7 @@ OS:ThermalZone,
   {95af597b-822f-405c-8d6b-4cf2f9a0ab55}, !- Zone Air Inlet Port List
   {470adea1-374c-4c58-a37f-499bd6c404e9}, !- Zone Air Exhaust Port List
   {0f1c2836-7d7e-48c0-8350-05788ee2a5cc}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {6129a66e-42c2-4308-8bf4-e3102b89d72e}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -21146,6 +21040,12 @@ OS:ThermalZone,
   {e35a0533-3c9e-44bf-9e80-2d897d4769b0}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {6129a66e-42c2-4308-8bf4-e3102b89d72e}, !- Handle
+  Port List 30,                           !- Name
+  {2c7f8dae-7af0-4295-9fa3-da3a2d421cdf}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {94f5ad78-39f9-4a63-9030-22dd1540fca7}, !- Handle
@@ -21219,7 +21119,7 @@ OS:ThermalZone,
   {fe01ce38-2c86-42a1-ae93-3730e2588594}, !- Zone Air Inlet Port List
   {f9fed36a-1da9-49db-8beb-826b9477051b}, !- Zone Air Exhaust Port List
   {9bd10b30-afa2-400f-a7d8-d7fe9d53b1a1}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {81507dbf-6503-44d9-949d-94ee765eb1ea}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -21229,6 +21129,12 @@ OS:ThermalZone,
   ,                                       !- Thermostat Name
   No,                                     !- Use Ideal Air Loads
   ;                                       !- Humidistat Name
+
+OS:PortList,
+  {81507dbf-6503-44d9-949d-94ee765eb1ea}, !- Handle
+  Port List 31,                           !- Name
+  {a0083f4e-c7e2-4e71-b0dc-d47245c95b78}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {2badb9a6-57da-4053-b737-bf04d2ef409e}, !- Handle
@@ -21302,7 +21208,7 @@ OS:ThermalZone,
   {2f76792e-f04c-4cf2-b0df-fc6f5f149298}, !- Zone Air Inlet Port List
   {e198459b-6ad0-4047-b4fa-4b8761d9ff7d}, !- Zone Air Exhaust Port List
   {094e4036-6c00-4acc-82d9-8d548465b79a}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {f7720977-ce07-486e-ad0f-781563f738d5}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -21311,6 +21217,12 @@ OS:ThermalZone,
   {2d3648b9-b4b7-45b6-9bb1-7264354fefc6}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {f7720977-ce07-486e-ad0f-781563f738d5}, !- Handle
+  Port List 32,                           !- Name
+  {d1dadafa-f1ef-4c6e-bbd7-6bbe092ddda3}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {bda2cfcb-855c-41e8-a707-3534c4224a1c}, !- Handle
@@ -21384,7 +21296,7 @@ OS:ThermalZone,
   {829e4f06-8be5-4969-b185-1d4ab42dff39}, !- Zone Air Inlet Port List
   {b5b8f048-095f-42c8-96e4-0593fb4ad2cc}, !- Zone Air Exhaust Port List
   {ec652346-3ef2-4049-b00a-430536445ad9}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {84c2e828-7247-4689-84da-ec5be3e6b9b8}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -21393,6 +21305,12 @@ OS:ThermalZone,
   {eb7b5b3a-1aa7-4750-b699-5faac4d6b4af}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {84c2e828-7247-4689-84da-ec5be3e6b9b8}, !- Handle
+  Port List 33,                           !- Name
+  {24692ccd-5552-4cbf-b595-a4c81c10d226}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {8cbdcd02-b202-4fd7-960b-887b9c0f575a}, !- Handle
@@ -21466,7 +21384,7 @@ OS:ThermalZone,
   {8d8f9361-4f1a-48ae-becd-fa4f32b72273}, !- Zone Air Inlet Port List
   {34c84ee9-1266-4924-9846-501ed49f3758}, !- Zone Air Exhaust Port List
   {479401a2-778a-4b98-8b3d-fdea40a23ea5}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {acd0c4f2-8e50-43c0-ac3d-77a22b7bfccd}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -21475,6 +21393,12 @@ OS:ThermalZone,
   {ccc4709b-b97d-45d0-9c93-0dacb956c43c}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {acd0c4f2-8e50-43c0-ac3d-77a22b7bfccd}, !- Handle
+  Port List 34,                           !- Name
+  {5a6f1951-f616-4b87-8a81-4ec5d485061b}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {c97af87b-44c8-4dff-a662-dc6851137ed6}, !- Handle
@@ -21548,7 +21472,7 @@ OS:ThermalZone,
   {e23790d9-9d4c-45c0-9a80-4529cf327b35}, !- Zone Air Inlet Port List
   {75722368-6293-4b42-99a7-c3fb66980b56}, !- Zone Air Exhaust Port List
   {d6e76cb2-bd63-45bd-9b12-0b2711e7ebeb}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {37a652e5-7658-45ef-be26-531675055a7b}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -21557,6 +21481,12 @@ OS:ThermalZone,
   {1db3e6fa-0c97-4946-a101-085aa6e1a5af}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {37a652e5-7658-45ef-be26-531675055a7b}, !- Handle
+  Port List 35,                           !- Name
+  {24c6e98b-7d69-4992-a40c-cea5531906ef}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {8e9a80e5-4096-4b39-8fb1-af0223c81a7c}, !- Handle
@@ -21630,7 +21560,7 @@ OS:ThermalZone,
   {f756b958-f3b7-4458-aaf7-a463f20e4d66}, !- Zone Air Inlet Port List
   {00277df6-fb09-4f93-8a58-b402a139ec25}, !- Zone Air Exhaust Port List
   {8f8897fb-a70d-45b9-8173-56ef106874b1}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {910e7c61-7a0e-4319-bed3-b9c51d5fa18e}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -21639,6 +21569,12 @@ OS:ThermalZone,
   {61d40613-8a57-4146-aea8-ce1838c19a80}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {910e7c61-7a0e-4319-bed3-b9c51d5fa18e}, !- Handle
+  Port List 36,                           !- Name
+  {edaaa869-f170-4cd8-9ec6-82a26cc1076e}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {7355adf7-9de5-4058-8349-aa659f9b4935}, !- Handle
@@ -21712,7 +21648,7 @@ OS:ThermalZone,
   {3f85ca3b-4e30-4653-8fb2-6f5c57ddf57e}, !- Zone Air Inlet Port List
   {3f185e50-812e-4bfc-91b0-f4fdae48e63d}, !- Zone Air Exhaust Port List
   {a3abc07b-2a22-4351-ace5-9edb663d4eb1}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {8761d143-ae5a-404e-bdb2-7c25168bb0db}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -21721,6 +21657,12 @@ OS:ThermalZone,
   {ae48db5f-9b72-4ec0-9575-5c89c24d065a}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {8761d143-ae5a-404e-bdb2-7c25168bb0db}, !- Handle
+  Port List 37,                           !- Name
+  {3ce80d2e-76d0-4859-8926-b77adf25a483}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {f6e73346-4826-4551-b742-6fb05189a848}, !- Handle
@@ -21794,7 +21736,7 @@ OS:ThermalZone,
   {f62d3687-e30c-4107-b668-f18eaaf2b36b}, !- Zone Air Inlet Port List
   {bda9f1f3-8a48-41b0-9ea3-d8c0d2f57e66}, !- Zone Air Exhaust Port List
   {90c145ba-2647-45ad-8322-46c7ce2bf3c9}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {8876fe34-7458-4720-a010-8ab8812bed0e}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -21803,6 +21745,12 @@ OS:ThermalZone,
   {3233e48f-3d98-4eeb-87a5-5d7fe3344dd5}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {8876fe34-7458-4720-a010-8ab8812bed0e}, !- Handle
+  Port List 38,                           !- Name
+  {b62acc88-274c-4612-852e-9fa6a521407b}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {d16de200-7d6b-4b5b-9acd-24db73a4a84c}, !- Handle
@@ -21876,7 +21824,7 @@ OS:ThermalZone,
   {9f0ae0ca-78f2-42d5-8e0b-42f2b1ad2b95}, !- Zone Air Inlet Port List
   {fa151e0f-de0f-4524-9ff2-6da11bb3f8e0}, !- Zone Air Exhaust Port List
   {fadf5366-993f-4e96-aaee-427c3a4ed4aa}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {301fd1e3-200f-453b-b093-481f959050ec}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -21886,6 +21834,12 @@ OS:ThermalZone,
   ,                                       !- Thermostat Name
   No,                                     !- Use Ideal Air Loads
   ;                                       !- Humidistat Name
+
+OS:PortList,
+  {301fd1e3-200f-453b-b093-481f959050ec}, !- Handle
+  Port List 39,                           !- Name
+  {941a09c6-44e2-4638-85dd-3a03927bcce5}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {4a92a09e-ee7e-4703-9c4b-a3cb9ba32d27}, !- Handle
@@ -21959,7 +21913,7 @@ OS:ThermalZone,
   {c22709e6-95f5-4030-bc9f-d9c1a1908a87}, !- Zone Air Inlet Port List
   {55790c10-055c-4fa3-a712-e9e397cf2395}, !- Zone Air Exhaust Port List
   {0845af6b-bd15-40d2-a6ad-d97bcb3ce183}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {994e1ddb-2689-4499-bc58-482d08ee4610}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -21968,6 +21922,12 @@ OS:ThermalZone,
   {f74f64b9-8a62-4a8c-9eae-fdf9c6f27cf4}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {994e1ddb-2689-4499-bc58-482d08ee4610}, !- Handle
+  Port List 40,                           !- Name
+  {0295ea84-a10a-42b4-b473-9bf9b84edf88}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {73e45fb6-bda6-4f64-84fa-35d8dd70f09a}, !- Handle
@@ -22041,7 +22001,7 @@ OS:ThermalZone,
   {d6d9acf4-f12f-4829-bf88-ec8d516b05c1}, !- Zone Air Inlet Port List
   {a3bb893d-e390-4e94-b8c7-f9b899705d7f}, !- Zone Air Exhaust Port List
   {889581c4-82c6-438c-bd86-ae5cddcf0bfe}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {18a4b89c-7f93-4344-a2de-252abd0fe527}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -22050,6 +22010,12 @@ OS:ThermalZone,
   {620fcca6-0d1d-45d4-9d88-b8c0fd8bd2f7}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {18a4b89c-7f93-4344-a2de-252abd0fe527}, !- Handle
+  Port List 41,                           !- Name
+  {99d3a714-8a43-4b6d-af79-9f26a7cf3039}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {46fa49b5-d934-4c4d-89fb-ba537f406757}, !- Handle
@@ -22123,7 +22089,7 @@ OS:ThermalZone,
   {ee07b375-a664-4f94-8a42-8f73d3456d42}, !- Zone Air Inlet Port List
   {365617fb-2b48-49fc-b44b-5cee3f126319}, !- Zone Air Exhaust Port List
   {3ad11180-a944-442a-8c41-1e358e326455}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {1bb2cffd-6eae-4306-82c9-1e727ccc2745}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -22132,6 +22098,12 @@ OS:ThermalZone,
   {5c54cd7b-a2b4-4908-b9db-8c2d649e67e7}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {1bb2cffd-6eae-4306-82c9-1e727ccc2745}, !- Handle
+  Port List 42,                           !- Name
+  {d7b9b1eb-2d2f-4cf4-bd3d-82358c3aa9f9}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {0bdc651b-c9ab-487a-92bd-d1ebc02863d4}, !- Handle
@@ -22205,7 +22177,7 @@ OS:ThermalZone,
   {868dce00-2c32-4e02-8359-94af5db7790b}, !- Zone Air Inlet Port List
   {3db6de1f-77ea-4ed9-a506-aecebce849f6}, !- Zone Air Exhaust Port List
   {9d1978a4-db29-4063-a02d-4f990abadf09}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {7b1db081-c83c-4d3a-b37e-f3309950b682}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -22214,6 +22186,12 @@ OS:ThermalZone,
   {607ec178-5b07-474f-a4bf-e648b26bed06}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {7b1db081-c83c-4d3a-b37e-f3309950b682}, !- Handle
+  Port List 43,                           !- Name
+  {c3672bb6-703b-469c-82ed-0cd78429b563}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {0207eadb-b8e7-41d1-9db2-70ec2aa7fc18}, !- Handle
@@ -22287,7 +22265,7 @@ OS:ThermalZone,
   {614002b7-81d2-4ec4-83c4-409c64e88deb}, !- Zone Air Inlet Port List
   {057eef27-028b-41eb-9319-10cbc93b55b2}, !- Zone Air Exhaust Port List
   {2d112acd-e232-4289-93a5-2efde3b01bcf}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {d73a6b51-9d7c-49d2-81b2-d1fbcf8a907f}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -22296,6 +22274,12 @@ OS:ThermalZone,
   {6f9beb7e-244b-4aa7-ac08-ace6ab54fb38}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {d73a6b51-9d7c-49d2-81b2-d1fbcf8a907f}, !- Handle
+  Port List 44,                           !- Name
+  {68ebc7b1-20b4-4059-9d8e-a12fc6a3ab55}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {d73b44c4-f320-49ac-a5e8-209253540980}, !- Handle
@@ -22369,7 +22353,7 @@ OS:ThermalZone,
   {eaa375aa-f77f-4ab0-8a3e-d0c0659b2a79}, !- Zone Air Inlet Port List
   {e99c558f-039a-41d2-b3d2-52197b6637b3}, !- Zone Air Exhaust Port List
   {ea92301d-cf1f-4e10-b1ac-a7f55d1054a6}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {3da691d3-83f5-443c-9dfe-51b2ea8d737e}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -22379,6 +22363,12 @@ OS:ThermalZone,
   ,                                       !- Thermostat Name
   No,                                     !- Use Ideal Air Loads
   ;                                       !- Humidistat Name
+
+OS:PortList,
+  {3da691d3-83f5-443c-9dfe-51b2ea8d737e}, !- Handle
+  Port List 45,                           !- Name
+  {65410c3e-92e4-4b8f-98ab-8f1f031a8b56}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {b1e9e5bf-2f44-47f6-9278-c94ba156f039}, !- Handle
@@ -22452,7 +22442,7 @@ OS:ThermalZone,
   {5f4eb17c-dd89-47a5-bcc9-ce35f234b2e8}, !- Zone Air Inlet Port List
   {0617e3d2-42aa-4d5a-b34a-edac0c317571}, !- Zone Air Exhaust Port List
   {1ea6cd52-4efd-44e2-be45-0fda7cdb2f12}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {db85c575-f513-474f-9564-5e29d4d48b04}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -22461,6 +22451,12 @@ OS:ThermalZone,
   {c2e94769-8529-4a3f-af4f-0455a4a1004c}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {db85c575-f513-474f-9564-5e29d4d48b04}, !- Handle
+  Port List 46,                           !- Name
+  {d8b3a51e-da18-4473-927d-48ad0b76ec34}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {8a4f6f64-bca1-4e00-8be5-c39e15094ab3}, !- Handle
@@ -22534,7 +22530,7 @@ OS:ThermalZone,
   {328e992c-5b5a-483a-a56e-91bd4a4cc42d}, !- Zone Air Inlet Port List
   {05dd18af-3eb6-4bf0-a697-a691611c8734}, !- Zone Air Exhaust Port List
   {ae13c14e-a081-46e9-a5be-54e983899e7f}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {ad0d83ee-a2b6-4d13-8aa2-3a4f02ced5fe}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -22543,6 +22539,12 @@ OS:ThermalZone,
   {49399887-9cd9-42e5-b8bd-2f907ab8c3d6}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {ad0d83ee-a2b6-4d13-8aa2-3a4f02ced5fe}, !- Handle
+  Port List 47,                           !- Name
+  {4c102e1a-d097-41f1-b771-1efd9f4489de}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {0c4842d5-ef6a-4642-9b31-d9e624ca4165}, !- Handle
@@ -22616,7 +22618,7 @@ OS:ThermalZone,
   {114e0ae8-d492-4364-8cbd-7c0ee43f577b}, !- Zone Air Inlet Port List
   {73d438e5-a9c4-4bed-9817-908c4e15ac84}, !- Zone Air Exhaust Port List
   {ebb15057-567e-435d-9be0-425425a7ffa4}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {1a4d7e42-be86-47e0-9568-66534abc3268}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -22625,6 +22627,12 @@ OS:ThermalZone,
   {7b2049d1-8d32-4cd2-9d61-13eff6d4bf9e}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {1a4d7e42-be86-47e0-9568-66534abc3268}, !- Handle
+  Port List 48,                           !- Name
+  {d7f7ca26-e041-449f-a36b-f2d3937a11cf}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {4af90f28-30f3-4744-9c2d-f3ac7f4bde3c}, !- Handle
@@ -22698,7 +22706,7 @@ OS:ThermalZone,
   {8b17757e-9fb3-44e7-8944-7b5bda76dadf}, !- Zone Air Inlet Port List
   {82f18f07-f83b-46aa-bc10-8dcb5bafec4c}, !- Zone Air Exhaust Port List
   {5f37a8ce-51dd-4f87-9c00-10bed301ea46}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {4c230749-ed69-48cf-907f-434d097433ae}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -22708,6 +22716,12 @@ OS:ThermalZone,
   ,                                       !- Thermostat Name
   No,                                     !- Use Ideal Air Loads
   ;                                       !- Humidistat Name
+
+OS:PortList,
+  {4c230749-ed69-48cf-907f-434d097433ae}, !- Handle
+  Port List 49,                           !- Name
+  {cdda4c5c-bfd6-400d-aa35-f24afcab1d50}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {44b37ba2-975a-4558-835a-91a47f0d5540}, !- Handle
@@ -22781,7 +22795,7 @@ OS:ThermalZone,
   {720120d0-1e3c-43a7-9dd6-3e777f0ef95f}, !- Zone Air Inlet Port List
   {6c1e75ab-5248-46f7-829e-9dd19c254887}, !- Zone Air Exhaust Port List
   {f706e771-9830-4fca-8730-f5b5375145af}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {336cfddd-b71c-4f60-8c02-7681cd11f29d}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -22790,6 +22804,12 @@ OS:ThermalZone,
   {7f420ac0-4b74-43a0-a0c5-8e202bbf74f1}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {336cfddd-b71c-4f60-8c02-7681cd11f29d}, !- Handle
+  Port List 50,                           !- Name
+  {424bc9a1-ef70-4a65-93b9-4f7304e5b038}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {3d74a13e-fc86-43ac-aa91-0c8657d7dafb}, !- Handle
@@ -22863,7 +22883,7 @@ OS:ThermalZone,
   {a3e56296-8af5-4943-8de4-9ecf5d9f5c38}, !- Zone Air Inlet Port List
   {698c3533-5e5c-47ba-a6a4-4617a94a99d9}, !- Zone Air Exhaust Port List
   {5428fc06-5132-4053-b20e-fbeea6196bb3}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {b791ac3f-48e0-4328-a591-95287426b0fb}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -22872,6 +22892,12 @@ OS:ThermalZone,
   {2a10d763-59c4-4d4d-8e7a-3f06d8f101fd}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {b791ac3f-48e0-4328-a591-95287426b0fb}, !- Handle
+  Port List 51,                           !- Name
+  {aa9399c3-209e-4f80-bb79-ca799abc6ebb}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {4268c8bd-0439-47ef-a5df-583c05077929}, !- Handle
@@ -22945,7 +22971,7 @@ OS:ThermalZone,
   {81f3ee78-ea77-47e0-bb03-9aabcb3171a6}, !- Zone Air Inlet Port List
   {1021eb75-ab32-43b4-836a-89d548a3d2c5}, !- Zone Air Exhaust Port List
   {c12eadcb-4766-405b-bd20-af3780df38ae}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {df4ad555-265d-4640-a9d8-7cf5a3f00e41}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -22955,6 +22981,12 @@ OS:ThermalZone,
   ,                                       !- Thermostat Name
   No,                                     !- Use Ideal Air Loads
   ;                                       !- Humidistat Name
+
+OS:PortList,
+  {df4ad555-265d-4640-a9d8-7cf5a3f00e41}, !- Handle
+  Port List 52,                           !- Name
+  {2081e7e1-6d73-4a57-8b17-c9a892cebd15}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {f7c438e7-7063-41ae-9fe8-fecd424ebb7d}, !- Handle
@@ -23028,7 +23060,7 @@ OS:ThermalZone,
   {5d71c584-c40c-4281-a6a5-71c63344f756}, !- Zone Air Inlet Port List
   {46f957fd-3ff3-463b-93a5-dadf54dc912a}, !- Zone Air Exhaust Port List
   {ed385170-7f59-46fb-b2bc-ee95c5c6b3f0}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {02bac3b7-d054-45cf-9671-3f816368597b}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -23037,6 +23069,12 @@ OS:ThermalZone,
   {42066c99-44c4-4427-aea3-1069de3e51f0}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {02bac3b7-d054-45cf-9671-3f816368597b}, !- Handle
+  Port List 53,                           !- Name
+  {6e389102-c296-4fca-9967-ea3fc04b7604}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {19c2f69f-da20-4094-9289-0224bbaf7b18}, !- Handle
@@ -23110,7 +23148,7 @@ OS:ThermalZone,
   {228b69b5-14ab-4808-8bac-f663657d60ae}, !- Zone Air Inlet Port List
   {a8b08bcf-84c6-4b30-84ee-9894a92c865c}, !- Zone Air Exhaust Port List
   {bca2b24d-d34b-4530-a7c6-b3279736c8b4}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {d5cc092a-68cb-42b5-8ab2-1c9c2dcfdb12}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -23119,6 +23157,12 @@ OS:ThermalZone,
   {1d45b949-9dc9-4d78-aeea-2cdbd0fa83fb}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {d5cc092a-68cb-42b5-8ab2-1c9c2dcfdb12}, !- Handle
+  Port List 54,                           !- Name
+  {f1391854-9c9c-47a6-a16c-84bb8f2b670b}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {7d541dad-a2e4-4563-a9f4-a3ce256d1703}, !- Handle
@@ -23192,7 +23236,7 @@ OS:ThermalZone,
   {aea4681c-6fe0-43aa-a71e-e4a2e8cc9ea3}, !- Zone Air Inlet Port List
   {cf914a40-fb89-4e09-86d7-9e443d6f754d}, !- Zone Air Exhaust Port List
   {0dd1dbe4-7227-4dd3-84f4-fddda938eab0}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {ef3d7c72-295e-47d0-8a81-f299a73d7f35}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -23202,6 +23246,12 @@ OS:ThermalZone,
   ,                                       !- Thermostat Name
   No,                                     !- Use Ideal Air Loads
   ;                                       !- Humidistat Name
+
+OS:PortList,
+  {ef3d7c72-295e-47d0-8a81-f299a73d7f35}, !- Handle
+  Port List 55,                           !- Name
+  {1802aa86-c46d-46e6-b4ea-4457bba4c853}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {ee6ee0a7-538c-4702-8007-5e226085f1ec}, !- Handle
@@ -23275,7 +23325,7 @@ OS:ThermalZone,
   {c4ef7eeb-c505-4b7b-92f1-15284438af24}, !- Zone Air Inlet Port List
   {30a1a483-4c8f-414d-b3b4-1d0648f97bca}, !- Zone Air Exhaust Port List
   {12512adf-3aeb-46b5-b7c5-7a8be52779a0}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {b5e74723-40fc-44dd-9114-86040cf4b6aa}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -23285,6 +23335,12 @@ OS:ThermalZone,
   ,                                       !- Thermostat Name
   No,                                     !- Use Ideal Air Loads
   ;                                       !- Humidistat Name
+
+OS:PortList,
+  {b5e74723-40fc-44dd-9114-86040cf4b6aa}, !- Handle
+  Port List 5,                            !- Name
+  {891b7832-0aaa-4acd-84c3-02859cdcd2e8}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {99b812e3-e0af-4b5b-a916-9c5379328477}, !- Handle
@@ -23358,7 +23414,7 @@ OS:ThermalZone,
   {90c3cd4a-7e30-4d61-8caf-8604e3136dc9}, !- Zone Air Inlet Port List
   {dce0537f-1051-4cc0-82ca-ffb422897f4e}, !- Zone Air Exhaust Port List
   {d6a6ac8b-f458-43ff-a987-c0d070f04cfb}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {723f384b-1562-41f6-8069-2b142680962b}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -23367,6 +23423,12 @@ OS:ThermalZone,
   {8d158d75-4df7-4291-abfa-e7a220c150cf}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {723f384b-1562-41f6-8069-2b142680962b}, !- Handle
+  Port List 56,                           !- Name
+  {8d5d7697-b262-4ab7-960c-f0c2e27e12dc}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {887b8905-45ed-47d1-a859-e5bc6505969f}, !- Handle
@@ -23440,7 +23502,7 @@ OS:ThermalZone,
   {086deecc-61b3-4fe9-afbb-1cd40920a89c}, !- Zone Air Inlet Port List
   {8aba1e97-f141-457a-8e88-09807defd83e}, !- Zone Air Exhaust Port List
   {191dc929-4896-4e5f-84b3-2b1ec8bc5f1f}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {33180e78-2910-45fe-9c5a-20fae1084cc4}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -23449,6 +23511,12 @@ OS:ThermalZone,
   {e9e6db7c-dbc6-4ed3-8aaf-c7a95bfa8122}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {33180e78-2910-45fe-9c5a-20fae1084cc4}, !- Handle
+  Port List 57,                           !- Name
+  {c02e50e0-4509-4110-80f1-1402738fc471}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {a508c944-6366-4932-ae92-31f2ac393a60}, !- Handle
@@ -23522,7 +23590,7 @@ OS:ThermalZone,
   {b7e81784-3920-4f54-945c-da8afb999eca}, !- Zone Air Inlet Port List
   {091e068c-48c0-43d8-90c9-af2a15b7d1e6}, !- Zone Air Exhaust Port List
   {f2b2989f-7824-48df-b536-5f9c2bd7432f}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {e8291351-80d8-47b8-87f9-1ff81dfc738a}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -23531,6 +23599,12 @@ OS:ThermalZone,
   {ac163b36-c36c-4cee-862c-d3af6345b03f}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {e8291351-80d8-47b8-87f9-1ff81dfc738a}, !- Handle
+  Port List 58,                           !- Name
+  {d05a5493-b71b-4933-8325-a1878b929030}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {a7605fda-4183-4227-87f5-dab702b76048}, !- Handle
@@ -23604,7 +23678,7 @@ OS:ThermalZone,
   {26ff1be4-ff7b-460c-bb32-3109ce13d0f0}, !- Zone Air Inlet Port List
   {fdce8e29-b191-4705-aa0b-95210e214000}, !- Zone Air Exhaust Port List
   {6f393ae2-3f24-41fd-8181-46af2a9a4bdc}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {746d08fa-297d-478a-9dbb-fdfa8dce4a51}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -23613,6 +23687,12 @@ OS:ThermalZone,
   {b3f9b7ab-d996-4f00-b365-8a4d59fee777}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {746d08fa-297d-478a-9dbb-fdfa8dce4a51}, !- Handle
+  Port List 59,                           !- Name
+  {41d0029b-530c-44b1-81ff-bb402ce459d5}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {cb8f16dc-26ae-402a-9dad-2dc743b92a00}, !- Handle
@@ -23686,7 +23766,7 @@ OS:ThermalZone,
   {31adbbbc-2fa5-4e77-b261-5feea94f0cbd}, !- Zone Air Inlet Port List
   {404fc2d3-7cee-41ef-96fc-afaf738e8753}, !- Zone Air Exhaust Port List
   {c7ce371a-3971-4191-8118-e522b88a7d14}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {3c68d7e2-9df3-4365-b2ef-37c983f16cea}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -23696,6 +23776,12 @@ OS:ThermalZone,
   ,                                       !- Thermostat Name
   No,                                     !- Use Ideal Air Loads
   ;                                       !- Humidistat Name
+
+OS:PortList,
+  {3c68d7e2-9df3-4365-b2ef-37c983f16cea}, !- Handle
+  Port List 60,                           !- Name
+  {804edf1f-dec3-4f20-8602-d6f249cfe881}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {add26e9e-d627-4136-91e4-7d9ca44b30f4}, !- Handle
@@ -23769,7 +23855,7 @@ OS:ThermalZone,
   {84c98865-1ec3-4f5c-a896-3c0e8787668a}, !- Zone Air Inlet Port List
   {b62d8a05-5307-4416-8829-d1f284fcc06d}, !- Zone Air Exhaust Port List
   {7c86e156-c31e-4547-872f-f0719eb65631}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {df298bd6-e23e-4197-a889-5592fed92e63}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -23778,6 +23864,12 @@ OS:ThermalZone,
   {59b0ae51-2287-43c0-910e-7488862471aa}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {df298bd6-e23e-4197-a889-5592fed92e63}, !- Handle
+  Port List 61,                           !- Name
+  {568cf90e-c7f1-497a-9e70-538619154ba5}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {16bed3ff-bd80-49e0-bfc3-7c0bf1e9c9b9}, !- Handle
@@ -23851,7 +23943,7 @@ OS:ThermalZone,
   {faa61121-76dc-41ca-82d3-65b952ac4aad}, !- Zone Air Inlet Port List
   {00fcd5ac-f3fb-40d9-b974-d9eafff5ec1c}, !- Zone Air Exhaust Port List
   {6fdaf9e4-d93b-47d2-bc23-70c4e4a2e257}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {7fdca9b9-1e7d-4389-bb02-6250ce1a6052}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -23860,6 +23952,12 @@ OS:ThermalZone,
   {172cbb0e-804d-44db-82de-bf33251ab28a}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {7fdca9b9-1e7d-4389-bb02-6250ce1a6052}, !- Handle
+  Port List 62,                           !- Name
+  {3f16b9d9-958d-412c-8555-c9731d3a7a8d}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {cff4bbac-dd5d-4bf0-bc5f-956c1cb1802b}, !- Handle
@@ -23933,7 +24031,7 @@ OS:ThermalZone,
   {24c4ebaf-cab5-403a-a5a9-3610fa57df1e}, !- Zone Air Inlet Port List
   {39b32f5b-4dcc-4d1d-9820-c4a58096f423}, !- Zone Air Exhaust Port List
   {36485579-e562-4e5a-9f2d-3f9cc8a7a34e}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {8d6e3efb-593a-4cfb-a748-d7b71d260524}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -23943,6 +24041,12 @@ OS:ThermalZone,
   ,                                       !- Thermostat Name
   No,                                     !- Use Ideal Air Loads
   ;                                       !- Humidistat Name
+
+OS:PortList,
+  {8d6e3efb-593a-4cfb-a748-d7b71d260524}, !- Handle
+  Port List 63,                           !- Name
+  {3a0e0f76-22a1-40fc-8dc8-575feab053f3}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {869c203e-4938-4d74-ab47-b89e71330d7f}, !- Handle
@@ -24016,7 +24120,7 @@ OS:ThermalZone,
   {58de3af4-6ef2-49a3-980c-9b43b4ccac7a}, !- Zone Air Inlet Port List
   {97f5925f-b743-4a77-a6b0-4ffba720a783}, !- Zone Air Exhaust Port List
   {09c45d74-5b52-445e-bf85-8f7d9dcf2783}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {cc6993b6-fd77-479e-a03a-cc79ac074853}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -24025,6 +24129,12 @@ OS:ThermalZone,
   {f41f5bf3-6a5c-47a2-ad25-36daade378ec}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {cc6993b6-fd77-479e-a03a-cc79ac074853}, !- Handle
+  Port List 64,                           !- Name
+  {4ce98111-f677-467d-aa00-25a8adc3bd7d}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {7b806eeb-f2a0-4f5e-b3bf-b37531c892d4}, !- Handle
@@ -24098,7 +24208,7 @@ OS:ThermalZone,
   {c0824e72-65ab-46df-b2d5-7c06eeecb14d}, !- Zone Air Inlet Port List
   {8c4e0d87-747c-4801-9a5c-685dd2049df6}, !- Zone Air Exhaust Port List
   {428ef86a-8c5c-4bba-8082-5668af07a4ce}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {7bb7168b-4a95-408e-a93d-92ccb46bedf1}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -24107,6 +24217,12 @@ OS:ThermalZone,
   {046c5583-18d4-41be-99b4-c723b6dfaf6a}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {7bb7168b-4a95-408e-a93d-92ccb46bedf1}, !- Handle
+  Port List 65,                           !- Name
+  {d3248960-ceca-431c-b9a3-62a5a70e26b8}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {7c041f7d-3ada-420d-b57d-f5f63627e7e1}, !- Handle
@@ -24180,7 +24296,7 @@ OS:ThermalZone,
   {1f2e722d-719e-4cd4-864c-ca35a7c083d1}, !- Zone Air Inlet Port List
   {eec2b7da-eca3-44cd-b40c-301aaaa9b598}, !- Zone Air Exhaust Port List
   {f3bdd005-b165-4e9f-8172-172440644c0b}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {7442d2c5-05e6-4f29-b7f2-9d29daa3632e}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -24190,6 +24306,12 @@ OS:ThermalZone,
   ,                                       !- Thermostat Name
   No,                                     !- Use Ideal Air Loads
   ;                                       !- Humidistat Name
+
+OS:PortList,
+  {7442d2c5-05e6-4f29-b7f2-9d29daa3632e}, !- Handle
+  Port List 66,                           !- Name
+  {5bb83625-d5c0-43e8-8305-bb70beb1ffdd}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {5eb20b5e-f3a4-4767-96cc-93ea8d52f702}, !- Handle
@@ -24263,7 +24385,7 @@ OS:ThermalZone,
   {52fa6b91-35bb-4b32-9118-e55d1bf440b8}, !- Zone Air Inlet Port List
   {768dd75a-8191-40f3-a515-58bdf475d435}, !- Zone Air Exhaust Port List
   {678c9f58-3a21-4b76-8cfe-531718cc7031}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {513d580f-cf5a-4839-bb03-9bc48e6c6ea4}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -24273,6 +24395,12 @@ OS:ThermalZone,
   ,                                       !- Thermostat Name
   No,                                     !- Use Ideal Air Loads
   ;                                       !- Humidistat Name
+
+OS:PortList,
+  {513d580f-cf5a-4839-bb03-9bc48e6c6ea4}, !- Handle
+  Port List 67,                           !- Name
+  {10f9fd89-8360-4455-aea7-dc0dce9b9d40}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {c45c28c3-5663-4528-a717-2d28737591bd}, !- Handle
@@ -24346,7 +24474,7 @@ OS:ThermalZone,
   {5ff53e34-5c2c-40b7-8aa8-64b5889b6deb}, !- Zone Air Inlet Port List
   {885407bd-e4fc-4c50-b9b0-2de8ff68c43f}, !- Zone Air Exhaust Port List
   {654b9e6f-ad3d-49fb-aecc-a527be828aee}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {45ec073c-07c5-4d32-9bc7-5eb422e2e825}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -24356,6 +24484,12 @@ OS:ThermalZone,
   ,                                       !- Thermostat Name
   No,                                     !- Use Ideal Air Loads
   ;                                       !- Humidistat Name
+
+OS:PortList,
+  {45ec073c-07c5-4d32-9bc7-5eb422e2e825}, !- Handle
+  Port List 68,                           !- Name
+  {3bb39094-57ff-4e7d-a64b-a39f1374aff0}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {fc0e248d-4fe6-4eeb-93c3-6360da8ddbc6}, !- Handle
@@ -24429,7 +24563,7 @@ OS:ThermalZone,
   {80adac6c-3b5f-4575-81d7-8a2c0695d10c}, !- Zone Air Inlet Port List
   {021223f0-9621-442f-a091-3dabdc1f59a8}, !- Zone Air Exhaust Port List
   {d6c5e3ba-53a7-4cae-848a-8fa88e483940}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {116576d4-b046-4a67-a21c-144469f20d11}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -24439,6 +24573,12 @@ OS:ThermalZone,
   ,                                       !- Thermostat Name
   No,                                     !- Use Ideal Air Loads
   ;                                       !- Humidistat Name
+
+OS:PortList,
+  {116576d4-b046-4a67-a21c-144469f20d11}, !- Handle
+  Port List 69,                           !- Name
+  {85c37285-4cbd-4d3a-b7c1-5f8d9ec7a39e}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {0f468aeb-b544-4b1e-9871-77f6738478db}, !- Handle
@@ -24512,7 +24652,7 @@ OS:ThermalZone,
   {a6add13f-5172-416b-8c1f-f8228f8d44b2}, !- Zone Air Inlet Port List
   {7233f677-c81d-4b01-8c2e-39b0f3276148}, !- Zone Air Exhaust Port List
   {a4385ef9-7d49-4a28-a311-aabb25ac9e06}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {f0c99152-a093-4c07-8569-b70ced9aedfb}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -24522,6 +24662,12 @@ OS:ThermalZone,
   ,                                       !- Thermostat Name
   No,                                     !- Use Ideal Air Loads
   ;                                       !- Humidistat Name
+
+OS:PortList,
+  {f0c99152-a093-4c07-8569-b70ced9aedfb}, !- Handle
+  Port List 70,                           !- Name
+  {6c2e50cd-662c-4795-866c-0aa0e38b1a47}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {f5dc2fc6-c57b-4e25-857f-d47818fa7a14}, !- Handle
@@ -24595,7 +24741,7 @@ OS:ThermalZone,
   {8114a77e-0137-4ca0-af7d-102a0ba632a8}, !- Zone Air Inlet Port List
   {87e69798-b84d-498a-9173-10701787a10a}, !- Zone Air Exhaust Port List
   {e8aba9bf-e9f5-4796-ad5b-b9fea2374620}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {50162edc-d56b-48cc-9336-ca3b194a4be0}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -24605,6 +24751,12 @@ OS:ThermalZone,
   ,                                       !- Thermostat Name
   No,                                     !- Use Ideal Air Loads
   ;                                       !- Humidistat Name
+
+OS:PortList,
+  {50162edc-d56b-48cc-9336-ca3b194a4be0}, !- Handle
+  Port List 71,                           !- Name
+  {974cee9e-d85a-4263-ac03-1347234a56f9}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {08053fc1-7222-450b-a09c-71295043970f}, !- Handle
@@ -24678,7 +24830,7 @@ OS:ThermalZone,
   {71518ce3-98e4-4664-bd7e-8138af8c8a77}, !- Zone Air Inlet Port List
   {2f840a07-3075-4939-93f0-d7c7c3069756}, !- Zone Air Exhaust Port List
   {39c8ad3d-0cf6-483a-a6f7-a374ba90c68d}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {44f13c8e-7e93-424b-bae0-d778a8f8a747}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -24688,6 +24840,12 @@ OS:ThermalZone,
   ,                                       !- Thermostat Name
   No,                                     !- Use Ideal Air Loads
   ;                                       !- Humidistat Name
+
+OS:PortList,
+  {44f13c8e-7e93-424b-bae0-d778a8f8a747}, !- Handle
+  Port List 72,                           !- Name
+  {2b842f84-562d-4c0f-9af7-69cee978cdb9}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {c0c309b5-73b1-416b-a23f-43616f97a7dc}, !- Handle
@@ -24761,7 +24919,7 @@ OS:ThermalZone,
   {720c2db6-bf8e-445d-97bf-c9dd4a5a8dce}, !- Zone Air Inlet Port List
   {e5736696-f0be-488a-8a01-3ad7d2ee4f9e}, !- Zone Air Exhaust Port List
   {5047eae8-a361-47f5-99b2-da5317103297}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {f76faa0b-7f3f-446a-8847-e60164b23018}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -24771,6 +24929,12 @@ OS:ThermalZone,
   ,                                       !- Thermostat Name
   No,                                     !- Use Ideal Air Loads
   ;                                       !- Humidistat Name
+
+OS:PortList,
+  {f76faa0b-7f3f-446a-8847-e60164b23018}, !- Handle
+  Port List 1,                            !- Name
+  {0495627f-0734-4036-b2ca-1fcaa67fe801}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {92e39d96-1180-4ffb-8bab-dd8c8955905b}, !- Handle
@@ -24844,7 +25008,7 @@ OS:ThermalZone,
   {02b26988-0315-42bf-9573-8ca36e95f5cf}, !- Zone Air Inlet Port List
   {52761440-5e2a-4e77-878b-d4ad6c910dec}, !- Zone Air Exhaust Port List
   {ae83fd31-df36-4325-aad0-d00a25166e90}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {8722908c-eae8-4765-8295-d95fe53ec659}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -24854,6 +25018,12 @@ OS:ThermalZone,
   ,                                       !- Thermostat Name
   No,                                     !- Use Ideal Air Loads
   ;                                       !- Humidistat Name
+
+OS:PortList,
+  {8722908c-eae8-4765-8295-d95fe53ec659}, !- Handle
+  Port List 73,                           !- Name
+  {0ad96d5c-fdc1-45fb-9d99-6a8328408ca2}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {d811616f-ac29-4173-af23-d59e213896c5}, !- Handle
@@ -24927,7 +25097,7 @@ OS:ThermalZone,
   {f3625196-8821-44ff-bc4d-ea3e20955773}, !- Zone Air Inlet Port List
   {aefc8424-eeb0-4b5c-9f51-de27bace3ca9}, !- Zone Air Exhaust Port List
   {972a5578-c030-499c-8007-d4b8c834de1e}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {9eeea059-431e-421a-ab2f-702a137866dd}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -24937,6 +25107,12 @@ OS:ThermalZone,
   ,                                       !- Thermostat Name
   No,                                     !- Use Ideal Air Loads
   ;                                       !- Humidistat Name
+
+OS:PortList,
+  {9eeea059-431e-421a-ab2f-702a137866dd}, !- Handle
+  Port List 74,                           !- Name
+  {52788c4b-3ae7-47ee-969b-e7036e401a0f}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {f8fea869-45a1-4e5d-99a5-1e4427276456}, !- Handle
@@ -25010,7 +25186,7 @@ OS:ThermalZone,
   {2333adda-60d5-4545-a5ea-8e35bf005981}, !- Zone Air Inlet Port List
   {251ce43e-5384-4560-aca1-ef33a75aaa02}, !- Zone Air Exhaust Port List
   {aaf6f045-6f95-479e-9b35-527bb443c2d7}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {70e843e5-d69e-4b0e-907e-9b6ffe4861f1}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -25020,6 +25196,12 @@ OS:ThermalZone,
   ,                                       !- Thermostat Name
   No,                                     !- Use Ideal Air Loads
   ;                                       !- Humidistat Name
+
+OS:PortList,
+  {70e843e5-d69e-4b0e-907e-9b6ffe4861f1}, !- Handle
+  Port List 75,                           !- Name
+  {dd651187-a70a-4292-8d7d-4edb1153137c}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {168bc705-3325-4036-b7f6-1568be81068b}, !- Handle
@@ -25093,7 +25275,7 @@ OS:ThermalZone,
   {8027ebdf-ac62-41c2-b9fc-ebe6711e7ef7}, !- Zone Air Inlet Port List
   {7f6063dc-9200-4145-bc82-ac507e77d022}, !- Zone Air Exhaust Port List
   {f92df0ff-59e1-4d41-b90b-ff3750dad466}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {740ce830-4cc7-4d95-89ea-3b8cefc1e5d8}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -25103,6 +25285,12 @@ OS:ThermalZone,
   ,                                       !- Thermostat Name
   No,                                     !- Use Ideal Air Loads
   ;                                       !- Humidistat Name
+
+OS:PortList,
+  {740ce830-4cc7-4d95-89ea-3b8cefc1e5d8}, !- Handle
+  Port List 76,                           !- Name
+  {37f4b4df-4f90-4579-b048-9de2bec29218}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {4ab5938f-9332-4335-a939-553005df387d}, !- Handle
@@ -25176,7 +25364,7 @@ OS:ThermalZone,
   {842aadfe-eb7f-4849-aab2-523383ee093c}, !- Zone Air Inlet Port List
   {2747ddd4-ba40-4bbd-bc3c-4d74135527db}, !- Zone Air Exhaust Port List
   {8ced7c1b-2266-40fd-b6b5-11abb58eba2e}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {a1588436-52e6-4886-975e-f4ff4568b96b}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -25186,6 +25374,12 @@ OS:ThermalZone,
   ,                                       !- Thermostat Name
   No,                                     !- Use Ideal Air Loads
   ;                                       !- Humidistat Name
+
+OS:PortList,
+  {a1588436-52e6-4886-975e-f4ff4568b96b}, !- Handle
+  Port List 77,                           !- Name
+  {ff689a62-e983-41e2-acef-45e3a396488e}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {0370febe-2c0c-4925-86ac-ad240b5a7a6e}, !- Handle
@@ -25259,7 +25453,7 @@ OS:ThermalZone,
   {3f72ec0b-427b-4577-9898-9b3676c7183f}, !- Zone Air Inlet Port List
   {a6e8d6dc-825e-424a-86a5-124ef1acf3e5}, !- Zone Air Exhaust Port List
   {821da8f5-7596-401c-8200-c5f7ae2fb5df}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {787e7835-d24a-4daf-aaa9-8a4e36f19656}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -25269,6 +25463,12 @@ OS:ThermalZone,
   ,                                       !- Thermostat Name
   No,                                     !- Use Ideal Air Loads
   ;                                       !- Humidistat Name
+
+OS:PortList,
+  {787e7835-d24a-4daf-aaa9-8a4e36f19656}, !- Handle
+  Port List 78,                           !- Name
+  {7785db66-96c9-412e-b289-fecb6aabead7}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {8f76a792-e8df-4670-8b62-8d8d19f6bb00}, !- Handle
@@ -25342,7 +25542,7 @@ OS:ThermalZone,
   {8bcee025-4395-4909-af83-f54382d13579}, !- Zone Air Inlet Port List
   {4a9aa5a1-b277-470b-a988-3eb3e70a305c}, !- Zone Air Exhaust Port List
   {7006c29c-f812-488e-9da2-c5924ae0c448}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {84259fe8-8fda-4cc3-bf9c-312ec738c0b8}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -25351,6 +25551,12 @@ OS:ThermalZone,
   {0495601a-6b0d-4333-b1e4-61c51d336c66}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {84259fe8-8fda-4cc3-bf9c-312ec738c0b8}, !- Handle
+  Port List 79,                           !- Name
+  {ad12b5c8-865a-4507-a9f3-377d3070acf9}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {cf9e6ec1-5666-42b4-80f3-262a1edac362}, !- Handle
@@ -25424,7 +25630,7 @@ OS:ThermalZone,
   {55a7659a-45bb-48fc-8890-c634dd4d2fa8}, !- Zone Air Inlet Port List
   {4872f072-e73d-4c7e-a078-5146d79dc59e}, !- Zone Air Exhaust Port List
   {834928d4-0d51-405f-a713-df9e3a19a34b}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {ee50e1b9-053b-4870-aecb-de8747be7c75}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -25433,6 +25639,12 @@ OS:ThermalZone,
   {5da0dc45-c272-41ba-910c-910698bf4ed5}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {ee50e1b9-053b-4870-aecb-de8747be7c75}, !- Handle
+  Port List 80,                           !- Name
+  {fc5af255-4dab-4b97-818b-5e39bbc96d79}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {afe7089f-f733-4bae-882b-198f34380782}, !- Handle
@@ -25506,7 +25718,7 @@ OS:ThermalZone,
   {6e975568-dbd8-461b-ab97-c6be3cf5896d}, !- Zone Air Inlet Port List
   {ff8a558b-c9e5-4214-a919-5ee3c70c5ec1}, !- Zone Air Exhaust Port List
   {f04a7a13-296b-440c-91f0-c59514d80e93}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {049a3451-4c1e-49d1-9157-a6ac99f9621d}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -25515,6 +25727,12 @@ OS:ThermalZone,
   {41e67c01-3d52-442b-8449-e86d4ae53c19}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {049a3451-4c1e-49d1-9157-a6ac99f9621d}, !- Handle
+  Port List 81,                           !- Name
+  {83aee078-263b-4ad8-b910-2c21c1b29bf9}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {b6b25f6a-3a96-40ec-b09e-66ad9db230a4}, !- Handle
@@ -25588,7 +25806,7 @@ OS:ThermalZone,
   {ee757be7-06ab-437a-9321-ae88e3e52ea0}, !- Zone Air Inlet Port List
   {803c3615-8c30-4b0d-82c6-e5da863b75ab}, !- Zone Air Exhaust Port List
   {09aee1e7-bd81-4dcd-a3cb-1e3e7671f279}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {36859e58-effe-419a-b98a-621214345a2d}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -25598,6 +25816,12 @@ OS:ThermalZone,
   ,                                       !- Thermostat Name
   No,                                     !- Use Ideal Air Loads
   ;                                       !- Humidistat Name
+
+OS:PortList,
+  {36859e58-effe-419a-b98a-621214345a2d}, !- Handle
+  Port List 82,                           !- Name
+  {129d270a-b446-4ec7-abf7-0cfbb0b9eb06}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {285dfcf4-fef0-4051-93ba-9157d82cc562}, !- Handle
@@ -25671,7 +25895,7 @@ OS:ThermalZone,
   {48cc0a89-e390-4bd1-a573-bd3d60039cff}, !- Zone Air Inlet Port List
   {22885b83-c120-4b53-89a4-87da50067f8c}, !- Zone Air Exhaust Port List
   {beea2cef-e915-48c9-8ed6-95e8679327a5}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {43fc4a67-dea4-4490-af40-3dddc4538d63}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -25680,6 +25904,12 @@ OS:ThermalZone,
   {da5e4a0b-40f3-470f-b2d1-4a2dbbe7bf79}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {43fc4a67-dea4-4490-af40-3dddc4538d63}, !- Handle
+  Port List 83,                           !- Name
+  {0deb7f95-9771-4cf8-ac0b-768c6abbf042}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {613a496e-4b7f-44be-8bac-fd15ee7fe8fa}, !- Handle
@@ -25753,7 +25983,7 @@ OS:ThermalZone,
   {1593bc0a-e733-43de-8f79-d7776aab1cf1}, !- Zone Air Inlet Port List
   {d09c22ea-1dea-4b34-afaa-152c8b91bf07}, !- Zone Air Exhaust Port List
   {d6a072bb-d87d-4a1c-ac3d-8d89a970e755}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {148710bf-062c-4acb-8aa9-8ac0c7fda40b}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -25762,6 +25992,12 @@ OS:ThermalZone,
   {ef9c2a0e-755e-41fa-8d33-27f608d7e5cf}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {148710bf-062c-4acb-8aa9-8ac0c7fda40b}, !- Handle
+  Port List 84,                           !- Name
+  {f65ffa6f-f4e1-4977-be97-4187d28ea53d}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {949be03f-3ff1-4405-890d-87ac0b1f9e77}, !- Handle
@@ -25835,7 +26071,7 @@ OS:ThermalZone,
   {cd53ea0d-11d3-40ed-9aec-21d46a715f25}, !- Zone Air Inlet Port List
   {00ff4ed6-67a3-4c41-b03c-b4ae196c560f}, !- Zone Air Exhaust Port List
   {25598eea-fa49-48e6-a5d5-d4db3512b094}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {e9b8cf61-3ae1-4ae8-8c3f-21fe876f2858}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -25844,6 +26080,12 @@ OS:ThermalZone,
   {ed7d3f7d-0cf1-4214-a9d4-e65fc9e022a4}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {e9b8cf61-3ae1-4ae8-8c3f-21fe876f2858}, !- Handle
+  Port List 85,                           !- Name
+  {73a41701-761f-4764-bdad-29b2504bc7f6}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {1c7c00d0-1de0-438d-b553-77e36b364878}, !- Handle
@@ -25917,7 +26159,7 @@ OS:ThermalZone,
   {62e17143-a5cb-4491-a79f-deb6656d9d9c}, !- Zone Air Inlet Port List
   {3c9a007d-8059-4409-a23f-33d509f4f514}, !- Zone Air Exhaust Port List
   {458af43a-4873-4080-8c2d-52ac8b852e21}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {484fdf2d-eb2c-4ece-8d88-1817303f36d0}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -25926,6 +26168,12 @@ OS:ThermalZone,
   {b03d87d8-c161-42ca-88ef-d2bea2b2426e}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {484fdf2d-eb2c-4ece-8d88-1817303f36d0}, !- Handle
+  Port List 86,                           !- Name
+  {28f99742-d2fb-4b2e-8f11-e9fe6399f613}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {5752bc2d-1dab-49ad-919e-e633773c5593}, !- Handle
@@ -25999,7 +26247,7 @@ OS:ThermalZone,
   {cbe4bdb5-53c8-4bb1-888a-16d2d85797b9}, !- Zone Air Inlet Port List
   {4a10da05-dba4-4df3-930e-6d8de0386837}, !- Zone Air Exhaust Port List
   {0c67b289-b29e-417e-969e-9584822d5667}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {b20754e3-e6cc-4786-b5d6-8b0a906a53b1}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -26008,6 +26256,12 @@ OS:ThermalZone,
   {8f6c2b2e-6372-4bf4-a733-be3e99a94fb9}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {b20754e3-e6cc-4786-b5d6-8b0a906a53b1}, !- Handle
+  Port List 87,                           !- Name
+  {8fcfd052-8598-4129-86b1-e6542a3e81a8}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {4f1f6ce2-2fe4-4bf0-b9d6-d3428cdf978c}, !- Handle
@@ -26081,7 +26335,7 @@ OS:ThermalZone,
   {9d6740c6-bd9b-4c68-977a-4e5e7ec49624}, !- Zone Air Inlet Port List
   {d6fa2191-c595-45f9-8e4a-e67b62b1de77}, !- Zone Air Exhaust Port List
   {f3cae8b5-22ae-4b93-9d40-d79aaf9003b9}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {382c9f98-8944-4005-be24-d5635788e7e3}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -26090,6 +26344,12 @@ OS:ThermalZone,
   {d5abbf39-cb88-4ce3-b147-5aaaabbe670b}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {382c9f98-8944-4005-be24-d5635788e7e3}, !- Handle
+  Port List 88,                           !- Name
+  {b6317cc5-9cf5-432a-a360-e17072864fa5}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {3058da27-db33-47dc-9e90-941df38a70d8}, !- Handle
@@ -26163,7 +26423,7 @@ OS:ThermalZone,
   {b86aaa22-8f02-4dfb-95cb-7a89e2f2fe8e}, !- Zone Air Inlet Port List
   {dadf0b8c-c922-47d9-b284-436ab67d5b89}, !- Zone Air Exhaust Port List
   {6667b668-2daa-412f-98d5-7714cd87e2fa}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {a2708186-bd57-4636-9349-61bb1a820833}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -26172,6 +26432,12 @@ OS:ThermalZone,
   {c7be7daa-afa8-4c8a-ba96-d01a2c8de256}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {a2708186-bd57-4636-9349-61bb1a820833}, !- Handle
+  Port List 89,                           !- Name
+  {77e08a9c-e4d4-4766-8515-217310511690}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {bb404966-305e-4ec8-8d20-76a80639fdf8}, !- Handle
@@ -26245,7 +26511,7 @@ OS:ThermalZone,
   {531d7594-31b5-4613-9f4d-503de1e36230}, !- Zone Air Inlet Port List
   {8c08d2d9-f8c7-4882-af3c-7aff5c0101d3}, !- Zone Air Exhaust Port List
   {ce5d5c8b-d37c-40cb-b7ea-65b2d3b09a45}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {9e5df88c-fe47-4d33-a972-b57e385f0a39}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -26255,6 +26521,12 @@ OS:ThermalZone,
   ,                                       !- Thermostat Name
   No,                                     !- Use Ideal Air Loads
   ;                                       !- Humidistat Name
+
+OS:PortList,
+  {9e5df88c-fe47-4d33-a972-b57e385f0a39}, !- Handle
+  Port List 90,                           !- Name
+  {cddf7e0f-bb38-454c-9167-0602097b48e7}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {f79a74ba-d47d-4adc-a9dc-f915842dd94d}, !- Handle
@@ -26328,7 +26600,7 @@ OS:ThermalZone,
   {be29e257-83eb-4a1f-bcf9-5bc8231abbf7}, !- Zone Air Inlet Port List
   {79efbc2e-1527-4470-bc90-9ec0bfb0e579}, !- Zone Air Exhaust Port List
   {93f0753d-fd36-4bf4-8bc6-6a7b8c97315a}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {93236fbf-cfb0-4c54-94e9-5c6878fd1343}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -26337,6 +26609,12 @@ OS:ThermalZone,
   {d1ff2773-9b6f-49ef-87e2-e60991cea6e3}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {93236fbf-cfb0-4c54-94e9-5c6878fd1343}, !- Handle
+  Port List 91,                           !- Name
+  {71a7da80-b013-427b-a119-e704e1bebb7d}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {b7bb1ad8-6e96-40b1-bc34-c78207553fb2}, !- Handle
@@ -26410,7 +26688,7 @@ OS:ThermalZone,
   {73d941fc-72c7-4e0f-a310-125951a66d63}, !- Zone Air Inlet Port List
   {91ae9e34-927d-4b8f-895a-d8a761b88407}, !- Zone Air Exhaust Port List
   {3ee90ab5-a695-4310-81c4-cc664ad11b36}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {69723c92-e575-48e5-b288-f28db502cce1}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -26419,6 +26697,12 @@ OS:ThermalZone,
   {2ecf87a0-c9ae-4ccd-b42a-f4c20d208334}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {69723c92-e575-48e5-b288-f28db502cce1}, !- Handle
+  Port List 92,                           !- Name
+  {ec3626a9-76c2-417b-bc9f-c4fabbe46460}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {038d8b25-dc62-4f5d-a351-a2fcac29e1a5}, !- Handle
@@ -26492,7 +26776,7 @@ OS:ThermalZone,
   {eeb4e2ba-492a-4474-bbed-8654dc9aedaf}, !- Zone Air Inlet Port List
   {383c2752-495e-4a59-846e-bae1c29fd287}, !- Zone Air Exhaust Port List
   {8ef00aae-9f0d-469e-b199-1b041a0a145b}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {9f72a37b-60b1-4071-ba6b-a84731d026bf}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -26501,6 +26785,12 @@ OS:ThermalZone,
   {15da4208-cd1f-4eba-b773-2675a59c838a}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {9f72a37b-60b1-4071-ba6b-a84731d026bf}, !- Handle
+  Port List 93,                           !- Name
+  {3644f601-3ca9-422a-a7f2-1b3fd812291f}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {4f0fdbca-04a7-4531-a861-56a7cac2d20c}, !- Handle
@@ -26574,7 +26864,7 @@ OS:ThermalZone,
   {1693a014-6d06-415c-b4f9-e4abe56dac00}, !- Zone Air Inlet Port List
   {be4ebc10-154d-4474-b6fb-86fb2dca2dd5}, !- Zone Air Exhaust Port List
   {f636f486-a2f3-4ef0-b6e2-6368fe36235a}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {a6d2ea59-d199-449f-ab87-4611e21b41cf}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -26583,6 +26873,12 @@ OS:ThermalZone,
   {e4c3c7ff-2058-4a03-9aab-7e826bf473d6}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {a6d2ea59-d199-449f-ab87-4611e21b41cf}, !- Handle
+  Port List 94,                           !- Name
+  {43008630-280f-42b3-ab5d-336c4e8e7b46}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {7766906d-ff43-401a-8f3d-225e1376e4b6}, !- Handle
@@ -26656,7 +26952,7 @@ OS:ThermalZone,
   {7c1c1f61-6abc-4003-8f04-eccb33686aac}, !- Zone Air Inlet Port List
   {7488e27c-f760-4094-808b-90dc2378f601}, !- Zone Air Exhaust Port List
   {e4fb88d0-72f4-420b-881e-3641e00a0a59}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {725d8feb-4dc8-4cb4-8dd6-a683526a8a87}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -26665,6 +26961,12 @@ OS:ThermalZone,
   {5e4d1f6d-e7d3-4402-8d57-04c6f45915f2}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {725d8feb-4dc8-4cb4-8dd6-a683526a8a87}, !- Handle
+  Port List 95,                           !- Name
+  {6d6153ea-ae94-49ec-99e0-58bc3de9748c}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {8f083fe6-04c5-42c3-8fbd-1810581b5b79}, !- Handle
@@ -26738,7 +27040,7 @@ OS:ThermalZone,
   {840d11ab-fc25-45ed-bcf5-a46e86693f18}, !- Zone Air Inlet Port List
   {31212820-1bef-4b26-b70c-ffd26cc9862b}, !- Zone Air Exhaust Port List
   {96d4a851-07b9-4a0f-b917-c6332860867b}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {26902c0a-2bb0-464f-b23e-ae3b3f1e8d46}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -26747,6 +27049,12 @@ OS:ThermalZone,
   {090fc408-edfc-40d4-b5da-90ba55e74a88}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {26902c0a-2bb0-464f-b23e-ae3b3f1e8d46}, !- Handle
+  Port List 96,                           !- Name
+  {3dd55c58-8f5f-44ca-8592-8d27b0c9057f}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {9b9f408c-f617-40c2-b196-39e4ea48dd79}, !- Handle
@@ -26820,7 +27128,7 @@ OS:ThermalZone,
   {25789561-ab92-418d-9a68-39803b2877d1}, !- Zone Air Inlet Port List
   {85045acc-794b-40c7-ba2f-8677f647bba2}, !- Zone Air Exhaust Port List
   {472348d2-29fd-4c23-b5d8-24d0a6d3aad9}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {216b44d8-a55f-4967-8cae-36a8984573b4}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -26830,6 +27138,12 @@ OS:ThermalZone,
   ,                                       !- Thermostat Name
   No,                                     !- Use Ideal Air Loads
   ;                                       !- Humidistat Name
+
+OS:PortList,
+  {216b44d8-a55f-4967-8cae-36a8984573b4}, !- Handle
+  Port List 97,                           !- Name
+  {871ea7d7-f61c-420f-bd74-db8a08804423}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {136809f2-2aa1-4e88-8377-cf70bada0af5}, !- Handle
@@ -26903,7 +27217,7 @@ OS:ThermalZone,
   {bf8e998a-89a9-4db3-bde2-024d3684284a}, !- Zone Air Inlet Port List
   {d98ee98c-f407-41b7-b82c-d0b43e1b37c1}, !- Zone Air Exhaust Port List
   {aa183501-4987-4590-a950-c9a255d99968}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {a21b0db9-51b8-4100-9847-304cb495e4c9}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -26912,6 +27226,12 @@ OS:ThermalZone,
   {34a6efb7-928f-4e58-8d10-a3ba1fc65c55}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {a21b0db9-51b8-4100-9847-304cb495e4c9}, !- Handle
+  Port List 98,                           !- Name
+  {3298aba5-c8d2-4d68-a96a-a3669328404b}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {603cee71-69b6-4da6-a418-0c3d0608eadd}, !- Handle
@@ -26985,7 +27305,7 @@ OS:ThermalZone,
   {ce09d6b5-986c-4267-a253-9561fb206bad}, !- Zone Air Inlet Port List
   {14402b09-2412-4660-bf40-2957b1373e47}, !- Zone Air Exhaust Port List
   {6ef64b08-d77a-4d2a-85e7-4190216696d2}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {611acec2-a076-45a8-83b7-41bf0d2cd046}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -26994,6 +27314,12 @@ OS:ThermalZone,
   {d760c161-1799-42de-a3b5-4ca7edf1ccad}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {611acec2-a076-45a8-83b7-41bf0d2cd046}, !- Handle
+  Port List 99,                           !- Name
+  {af1c755b-2534-4319-9f4d-4eff03eaaab8}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {51ee4cce-3f1c-4c7f-969e-bdb666da9233}, !- Handle
@@ -27067,7 +27393,7 @@ OS:ThermalZone,
   {c383e336-01d9-43fc-b668-3a3c96d406e3}, !- Zone Air Inlet Port List
   {008d7bfa-9799-4cf6-9d03-de91f9213c50}, !- Zone Air Exhaust Port List
   {6328d0e7-02f1-4196-b500-9958ff1dd116}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {5672ac89-1255-4973-b804-a0e39033658d}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -27076,6 +27402,12 @@ OS:ThermalZone,
   {fa857472-4706-4d3a-9797-9afafec3286f}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {5672ac89-1255-4973-b804-a0e39033658d}, !- Handle
+  Port List 100,                          !- Name
+  {aa3beef5-6318-414d-a9d8-070beb26184a}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {d8803e54-be68-459d-a663-aa3d853adf8b}, !- Handle
@@ -27149,7 +27481,7 @@ OS:ThermalZone,
   {a0e37221-1be0-4380-81c2-6c8a624b9730}, !- Zone Air Inlet Port List
   {3812ec3c-0277-4954-85d3-eaea663d533d}, !- Zone Air Exhaust Port List
   {e4d2a3e7-bb65-402e-8a33-1b7471d61a0f}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {643a2e0c-0de1-45de-a337-b480f554acf8}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -27158,6 +27490,12 @@ OS:ThermalZone,
   {87ce9972-60d1-467a-bc90-e7368a0daa7c}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {643a2e0c-0de1-45de-a337-b480f554acf8}, !- Handle
+  Port List 101,                          !- Name
+  {8bd91944-30a6-4451-97e1-a72292e5c062}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {2c171a24-5ab4-4484-a098-7cfb968ce58c}, !- Handle
@@ -27231,7 +27569,7 @@ OS:ThermalZone,
   {edee0687-33a2-4057-9c17-e03d74a7a2dc}, !- Zone Air Inlet Port List
   {5efc7c5b-8b49-4b9d-93dc-11fedcfe99ab}, !- Zone Air Exhaust Port List
   {28a6a8d7-b118-4fcf-a582-3e7c6d5557d9}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {1015fe2b-e85c-4e90-99c9-1d7c8826efaf}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -27241,6 +27579,12 @@ OS:ThermalZone,
   ,                                       !- Thermostat Name
   No,                                     !- Use Ideal Air Loads
   ;                                       !- Humidistat Name
+
+OS:PortList,
+  {1015fe2b-e85c-4e90-99c9-1d7c8826efaf}, !- Handle
+  Port List 102,                          !- Name
+  {ae4ce1c9-f505-4044-85a6-71629c95c50c}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {433d3573-2503-485a-8c33-60c565cb564c}, !- Handle
@@ -27314,7 +27658,7 @@ OS:ThermalZone,
   {6782aef9-0189-4841-899d-0322e5a7d479}, !- Zone Air Inlet Port List
   {9cdad7aa-8705-4a6f-9553-e431df7f3fd9}, !- Zone Air Exhaust Port List
   {54c589ae-4b66-4c5e-a71e-45737f7efa65}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {c31e7b2a-4c7d-4122-9599-a2142db46f2e}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -27323,6 +27667,12 @@ OS:ThermalZone,
   {0b8b9c59-b6e0-456e-8584-046ae23b635e}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {c31e7b2a-4c7d-4122-9599-a2142db46f2e}, !- Handle
+  Port List 103,                          !- Name
+  {aad5b3f7-2c97-4662-8fd3-96b5a4759cd6}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {a5c159de-9e0e-4ace-bc6e-30aaa2d7a2b3}, !- Handle
@@ -27396,7 +27746,7 @@ OS:ThermalZone,
   {11d8fd5a-e287-4c1f-9aa4-92b78c873622}, !- Zone Air Inlet Port List
   {9a2debf1-82e1-4732-8ab2-a7b8c25fdfff}, !- Zone Air Exhaust Port List
   {33f89894-e20b-4d82-bb7c-1bfd8a80c441}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {8f698843-093b-4ec0-a6d1-9b25dd415afd}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -27406,6 +27756,12 @@ OS:ThermalZone,
   ,                                       !- Thermostat Name
   No,                                     !- Use Ideal Air Loads
   ;                                       !- Humidistat Name
+
+OS:PortList,
+  {8f698843-093b-4ec0-a6d1-9b25dd415afd}, !- Handle
+  Port List 4,                            !- Name
+  {4dee8b79-925f-44e9-826b-93192c3b96d5}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {598b2e2e-3be1-4320-839e-2e0d97f6ecec}, !- Handle
@@ -28259,4 +28615,21 @@ OS:Rendering:Color,
   127,                                    !- Rendering Red Value
   255,                                    !- Rendering Green Value
   212;                                    !- Rendering Blue Value
+
+OS:Surface,
+  {629c4fc1-92d2-4230-aba3-6c2d402832a0}, !- Handle
+  EnclosedOffice_Bot_ZN_3 - Wall 000_a,   !- Name
+  Wall,                                   !- Surface Type
+  ,                                       !- Construction Name
+  {23bb7aaa-6a7c-4d7a-826f-f4ffe1c733a5}, !- Space Name
+  Surface,                                !- Outside Boundary Condition
+  {6f368ef3-25e3-488f-9074-552a5e205dec}, !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  35.3568, 35.0218375, 2.7447875,         !- X,Y,Z Vertex 1 {m}
+  35.3568, 35.0218375, 0,                 !- X,Y,Z Vertex 2 {m}
+  18.288, 35.0218375, 0,                  !- X,Y,Z Vertex 3 {m}
+  18.288, 35.0218375, 2.7447875;          !- X,Y,Z Vertex 4 {m}
 

--- a/data/geometry/ASHRAEMediumOfficeDetailed.osm
+++ b/data/geometry/ASHRAEMediumOfficeDetailed.osm
@@ -1,7 +1,7 @@
 
 OS:Version,
-  {27ab0958-a306-456b-8ced-d6a42410ac31}, !- Handle
-  2.3.0;                                  !- Version Identifier
+  {377f15b4-9d78-46e2-bb3b-6648d679e245}, !- Handle
+  2.7.1;                                  !- Version Identifier
 
 OS:Space,
   {dead6e0b-93b8-47d9-be64-14bafc65d3ed}, !- Handle
@@ -11,7 +11,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  -7.21911419532262e-016,                 !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {6ae3b0c2-4c48-48f5-899c-4535e4abda9b}, !- Building Story Name
   {3a7886cf-2a83-410c-b706-a9101db3432f}, !- Thermal Zone Name
@@ -21,7 +21,7 @@ OS:Space,
 
 OS:Surface,
   {4f6ce9ef-b8a0-47b3-9969-91dba85f795f}, !- Handle
-  Surface 1,                              !- Name
+  ConfRoom_Bot_1 - Floor_a,               !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {dead6e0b-93b8-47d9-be64-14bafc65d3ed}, !- Space Name
@@ -38,7 +38,7 @@ OS:Surface,
 
 OS:Surface,
   {ee216b85-e4fa-45dc-adf5-783ca88f1a36}, !- Handle
-  Surface 2,                              !- Name
+  ConfRoom_Bot_1 - Wall 180_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {dead6e0b-93b8-47d9-be64-14bafc65d3ed}, !- Space Name
@@ -55,7 +55,7 @@ OS:Surface,
 
 OS:Surface,
   {cbd6def7-e055-4b6a-88bf-bbe3cb1b13da}, !- Handle
-  Surface 3,                              !- Name
+  ConfRoom_Bot_1 - Wall 270_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {dead6e0b-93b8-47d9-be64-14bafc65d3ed}, !- Space Name
@@ -72,7 +72,7 @@ OS:Surface,
 
 OS:Surface,
   {dc55e7e1-f28e-4c44-9c0c-ae5c75980c3a}, !- Handle
-  Surface 4,                              !- Name
+  ConfRoom_Bot_1 - Wall 090_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {dead6e0b-93b8-47d9-be64-14bafc65d3ed}, !- Space Name
@@ -89,7 +89,7 @@ OS:Surface,
 
 OS:Surface,
   {d0520f38-85f4-4064-8058-2959a439f858}, !- Handle
-  Surface 5,                              !- Name
+  ConfRoom_Bot_1 - RoofCeiling_a,         !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {dead6e0b-93b8-47d9-be64-14bafc65d3ed}, !- Space Name
@@ -106,7 +106,7 @@ OS:Surface,
 
 OS:Surface,
   {8692d635-5bfc-4d4a-ab16-6d36862bfb62}, !- Handle
-  Surface 6,                              !- Name
+  ConfRoom_Bot_1 - Wall 000_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {dead6e0b-93b8-47d9-be64-14bafc65d3ed}, !- Space Name
@@ -129,7 +129,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {6ae3b0c2-4c48-48f5-899c-4535e4abda9b}, !- Building Story Name
   {50f269fe-e2e6-4649-9146-723f691a44fb}, !- Thermal Zone Name
@@ -139,7 +139,7 @@ OS:Space,
 
 OS:Surface,
   {06281163-a7c3-4bb2-8dfd-b2b1e724e646}, !- Handle
-  Surface 7,                              !- Name
+  EnclosedOffice_Bot_3 - Floor_a,         !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {3722a907-8e46-4db9-958e-74273550d93b}, !- Space Name
@@ -156,7 +156,7 @@ OS:Surface,
 
 OS:Surface,
   {14810237-4695-4b22-a6db-37edca1b81cb}, !- Handle
-  Surface 8,                              !- Name
+  EnclosedOffice_Bot_3 - Wall 090_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3722a907-8e46-4db9-958e-74273550d93b}, !- Space Name
@@ -173,7 +173,7 @@ OS:Surface,
 
 OS:Surface,
   {f08cc2cf-59e9-4ab3-9f31-736d2720d8ba}, !- Handle
-  Surface 9,                              !- Name
+  EnclosedOffice_Bot_3 - RoofCeiling_a,   !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {3722a907-8e46-4db9-958e-74273550d93b}, !- Space Name
@@ -190,7 +190,7 @@ OS:Surface,
 
 OS:Surface,
   {5c0cd1fa-0554-48ed-b89c-e2f023ca9f57}, !- Handle
-  Surface 10,                             !- Name
+  EnclosedOffice_Bot_3 - Wall 000_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3722a907-8e46-4db9-958e-74273550d93b}, !- Space Name
@@ -207,7 +207,7 @@ OS:Surface,
 
 OS:Surface,
   {461fd235-e5a3-4976-a758-86cdaae6c00b}, !- Handle
-  Surface 11,                             !- Name
+  EnclosedOffice_Bot_3 - Wall 180_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3722a907-8e46-4db9-958e-74273550d93b}, !- Space Name
@@ -224,7 +224,7 @@ OS:Surface,
 
 OS:Surface,
   {cf00a667-0aef-4d0e-931f-a1e797d33f2f}, !- Handle
-  Surface 12,                             !- Name
+  EnclosedOffice_Bot_3 - Wall 270_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3722a907-8e46-4db9-958e-74273550d93b}, !- Space Name
@@ -247,7 +247,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {6ae3b0c2-4c48-48f5-899c-4535e4abda9b}, !- Building Story Name
   {6ace123f-abf3-430c-a767-2511c188ec0c}, !- Thermal Zone Name
@@ -257,7 +257,7 @@ OS:Space,
 
 OS:Surface,
   {654c4941-8477-4724-af24-46237acf2edc}, !- Handle
-  Surface 13,                             !- Name
+  Lounge_Bot - Floor_a,                   !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {234ac46c-ffc3-4573-99a3-a40a78cb0ee7}, !- Space Name
@@ -274,7 +274,7 @@ OS:Surface,
 
 OS:Surface,
   {83f0b611-5859-48ed-9c67-7c6698f68579}, !- Handle
-  Surface 14,                             !- Name
+  Lounge_Bot - Wall 000_a,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {234ac46c-ffc3-4573-99a3-a40a78cb0ee7}, !- Space Name
@@ -291,7 +291,7 @@ OS:Surface,
 
 OS:Surface,
   {53730ee6-f809-471a-b8b7-bb05f9bb7849}, !- Handle
-  Surface 15,                             !- Name
+  Lounge_Bot - RoofCeiling_a,             !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {234ac46c-ffc3-4573-99a3-a40a78cb0ee7}, !- Space Name
@@ -308,7 +308,7 @@ OS:Surface,
 
 OS:Surface,
   {df65ba66-691a-4bc7-ab66-a62103c480e9}, !- Handle
-  Surface 16,                             !- Name
+  Lounge_Bot - Wall 270_a,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {234ac46c-ffc3-4573-99a3-a40a78cb0ee7}, !- Space Name
@@ -325,7 +325,7 @@ OS:Surface,
 
 OS:Surface,
   {9750e3db-ab55-4cb3-93f8-807563459cf0}, !- Handle
-  Surface 17,                             !- Name
+  Lounge_Bot - Wall 090_a,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {234ac46c-ffc3-4573-99a3-a40a78cb0ee7}, !- Space Name
@@ -342,7 +342,7 @@ OS:Surface,
 
 OS:Surface,
   {cc4872fe-0abd-4224-bdcd-434ba9df8fa0}, !- Handle
-  Surface 18,                             !- Name
+  Lounge_Bot - Wall 180_a,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {234ac46c-ffc3-4573-99a3-a40a78cb0ee7}, !- Space Name
@@ -365,7 +365,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {6ae3b0c2-4c48-48f5-899c-4535e4abda9b}, !- Building Story Name
   {dd8f204f-43c7-488b-aced-b516b7634775}, !- Thermal Zone Name
@@ -375,7 +375,7 @@ OS:Space,
 
 OS:Surface,
   {92e0bc99-320e-4c25-b0d7-2947c3d2731b}, !- Handle
-  Surface 19,                             !- Name
+  EnclosedOffice_Bot_4 - Floor_a,         !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {01b8e746-81ac-4927-8f78-0abadefcbe48}, !- Space Name
@@ -392,7 +392,7 @@ OS:Surface,
 
 OS:Surface,
   {5444054f-3e70-427a-8c65-6e1f92bef721}, !- Handle
-  Surface 20,                             !- Name
+  EnclosedOffice_Bot_4 - Wall 000_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {01b8e746-81ac-4927-8f78-0abadefcbe48}, !- Space Name
@@ -409,7 +409,7 @@ OS:Surface,
 
 OS:Surface,
   {90084885-6457-42a1-be13-9cb390c97b73}, !- Handle
-  Surface 21,                             !- Name
+  EnclosedOffice_Bot_4 - Wall 270_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {01b8e746-81ac-4927-8f78-0abadefcbe48}, !- Space Name
@@ -426,7 +426,7 @@ OS:Surface,
 
 OS:Surface,
   {7903bab5-19a0-47e1-93fa-88a1831c144e}, !- Handle
-  Surface 22,                             !- Name
+  EnclosedOffice_Bot_4 - Wall 090_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {01b8e746-81ac-4927-8f78-0abadefcbe48}, !- Space Name
@@ -443,7 +443,7 @@ OS:Surface,
 
 OS:Surface,
   {f3a3e826-998e-414f-b44e-d0d1c74c33ea}, !- Handle
-  Surface 23,                             !- Name
+  EnclosedOffice_Bot_4 - Wall 180_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {01b8e746-81ac-4927-8f78-0abadefcbe48}, !- Space Name
@@ -460,7 +460,7 @@ OS:Surface,
 
 OS:Surface,
   {165569b2-f724-479f-beb0-59ac81daf096}, !- Handle
-  Surface 24,                             !- Name
+  EnclosedOffice_Bot_4 - RoofCeiling_a,   !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {01b8e746-81ac-4927-8f78-0abadefcbe48}, !- Space Name
@@ -483,7 +483,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {6ae3b0c2-4c48-48f5-899c-4535e4abda9b}, !- Building Story Name
   {d7559f81-feff-4e7d-90a9-3719a14d60ee}, !- Thermal Zone Name
@@ -493,7 +493,7 @@ OS:Space,
 
 OS:Surface,
   {9e6124db-9389-46ec-a29e-99e5a93b8902}, !- Handle
-  Surface 25,                             !- Name
+  ConfRoom_Bot_2 - Floor_a,               !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {5c3f4599-a380-4a4b-9c7b-8ddf191cfd3c}, !- Space Name
@@ -510,7 +510,7 @@ OS:Surface,
 
 OS:Surface,
   {35b9daf8-42ba-4f2a-8154-7c9bea01af2a}, !- Handle
-  Surface 26,                             !- Name
+  ConfRoom_Bot_2 - RoofCeiling_a,         !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {5c3f4599-a380-4a4b-9c7b-8ddf191cfd3c}, !- Space Name
@@ -527,7 +527,7 @@ OS:Surface,
 
 OS:Surface,
   {483def8c-a833-4c12-82f0-d5efaf2c8d77}, !- Handle
-  Surface 27,                             !- Name
+  ConfRoom_Bot_2 - Wall 270_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {5c3f4599-a380-4a4b-9c7b-8ddf191cfd3c}, !- Space Name
@@ -544,7 +544,7 @@ OS:Surface,
 
 OS:Surface,
   {e951ea82-4724-418a-9414-4abe1b5613cc}, !- Handle
-  Surface 28,                             !- Name
+  ConfRoom_Bot_2 - Wall 180_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {5c3f4599-a380-4a4b-9c7b-8ddf191cfd3c}, !- Space Name
@@ -561,7 +561,7 @@ OS:Surface,
 
 OS:Surface,
   {3675566c-d679-4694-942d-baaa29068541}, !- Handle
-  Surface 29,                             !- Name
+  ConfRoom_Bot_2 - Wall 000_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {5c3f4599-a380-4a4b-9c7b-8ddf191cfd3c}, !- Space Name
@@ -578,7 +578,7 @@ OS:Surface,
 
 OS:Surface,
   {1c501ce7-9cbd-482b-9b37-9bdee8fb66d6}, !- Handle
-  Surface 30,                             !- Name
+  ConfRoom_Bot_2 - Wall 090_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {5c3f4599-a380-4a4b-9c7b-8ddf191cfd3c}, !- Space Name
@@ -601,7 +601,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {6ae3b0c2-4c48-48f5-899c-4535e4abda9b}, !- Building Story Name
   {fed42c3c-cef1-4c79-9b92-13675d5c52ae}, !- Thermal Zone Name
@@ -611,7 +611,7 @@ OS:Space,
 
 OS:Surface,
   {7d85d010-a6c5-4100-b914-5148f6051a07}, !- Handle
-  Surface 31,                             !- Name
+  EnclosedOffice_Bot_1 - Floor_a,         !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {fde173d0-3216-4c8c-81aa-f97765d7e07b}, !- Space Name
@@ -628,7 +628,7 @@ OS:Surface,
 
 OS:Surface,
   {71ca0ab1-a2ce-4b84-9cde-00e947add9c6}, !- Handle
-  Surface 32,                             !- Name
+  EnclosedOffice_Bot_1 - Wall 180_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {fde173d0-3216-4c8c-81aa-f97765d7e07b}, !- Space Name
@@ -645,7 +645,7 @@ OS:Surface,
 
 OS:Surface,
   {0d6d4e30-d5d6-4763-9ace-49b99d1fac51}, !- Handle
-  Surface 33,                             !- Name
+  EnclosedOffice_Bot_1 - Wall 090_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {fde173d0-3216-4c8c-81aa-f97765d7e07b}, !- Space Name
@@ -662,7 +662,7 @@ OS:Surface,
 
 OS:Surface,
   {f1f26603-9b76-4c89-8bd4-e59d6987d3c2}, !- Handle
-  Surface 34,                             !- Name
+  EnclosedOffice_Bot_1 - Wall 000_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {fde173d0-3216-4c8c-81aa-f97765d7e07b}, !- Space Name
@@ -679,7 +679,7 @@ OS:Surface,
 
 OS:Surface,
   {b04a2501-431a-4745-a51d-64230f66347d}, !- Handle
-  Surface 35,                             !- Name
+  EnclosedOffice_Bot_1 - Wall 270_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {fde173d0-3216-4c8c-81aa-f97765d7e07b}, !- Space Name
@@ -696,7 +696,7 @@ OS:Surface,
 
 OS:Surface,
   {74e9feca-a5b1-43ac-8cf4-70d0a10f0bb7}, !- Handle
-  Surface 36,                             !- Name
+  EnclosedOffice_Bot_1 - RoofCeiling_a,   !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {fde173d0-3216-4c8c-81aa-f97765d7e07b}, !- Space Name
@@ -719,7 +719,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {6ae3b0c2-4c48-48f5-899c-4535e4abda9b}, !- Building Story Name
   {8c0b6af5-fb91-4b2d-a4f7-84b0129c6bac}, !- Thermal Zone Name
@@ -729,7 +729,7 @@ OS:Space,
 
 OS:Surface,
   {73ed7be2-800f-4d4c-8eae-5fae5129d965}, !- Handle
-  Surface 37,                             !- Name
+  Corridor_Bot_1 - Floor_a,               !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {3582db20-b034-4500-9c2e-ddf83e8c51fb}, !- Space Name
@@ -750,7 +750,7 @@ OS:Surface,
 
 OS:Surface,
   {febc77dd-cf16-4297-afb5-7ff0ec153126}, !- Handle
-  Surface 38,                             !- Name
+  Corridor_Bot_1 - Wall 090_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3582db20-b034-4500-9c2e-ddf83e8c51fb}, !- Space Name
@@ -767,7 +767,7 @@ OS:Surface,
 
 OS:Surface,
   {15cc338b-8594-47e0-9990-08a1456cd676}, !- Handle
-  Surface 39,                             !- Name
+  Corridor_Bot_1 - RoofCeiling_a,         !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {3582db20-b034-4500-9c2e-ddf83e8c51fb}, !- Space Name
@@ -788,7 +788,7 @@ OS:Surface,
 
 OS:Surface,
   {aa703743-3fc8-46a8-9bac-9d5715a44ffc}, !- Handle
-  Surface 40,                             !- Name
+  Corridor_Bot_1 - Wall 000_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3582db20-b034-4500-9c2e-ddf83e8c51fb}, !- Space Name
@@ -805,7 +805,7 @@ OS:Surface,
 
 OS:Surface,
   {bd6e007f-ca8b-49e7-88b9-0422b18cbb55}, !- Handle
-  Surface 41,                             !- Name
+  Corridor_Bot_1 - Wall 000_c,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3582db20-b034-4500-9c2e-ddf83e8c51fb}, !- Space Name
@@ -822,7 +822,7 @@ OS:Surface,
 
 OS:Surface,
   {14ac1ab4-752d-45e9-afda-47d432cd3aa0}, !- Handle
-  Surface 42,                             !- Name
+  Corridor_Bot_1 - Wall 270_b,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3582db20-b034-4500-9c2e-ddf83e8c51fb}, !- Space Name
@@ -839,7 +839,7 @@ OS:Surface,
 
 OS:Surface,
   {eebe45c5-82e8-4b65-a1d3-4c10988bb014}, !- Handle
-  Surface 43,                             !- Name
+  Corridor_Bot_1 - Wall 000_b,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3582db20-b034-4500-9c2e-ddf83e8c51fb}, !- Space Name
@@ -856,7 +856,7 @@ OS:Surface,
 
 OS:Surface,
   {a4b3cc85-a4e4-40ff-a6da-f765063873ed}, !- Handle
-  Surface 44,                             !- Name
+  Corridor_Bot_1 - Wall 090_b,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3582db20-b034-4500-9c2e-ddf83e8c51fb}, !- Space Name
@@ -873,7 +873,7 @@ OS:Surface,
 
 OS:Surface,
   {14f75553-0faa-4095-adfa-11cde0946c50}, !- Handle
-  Surface 45,                             !- Name
+  Corridor_Bot_1 - Wall 180_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3582db20-b034-4500-9c2e-ddf83e8c51fb}, !- Space Name
@@ -890,7 +890,7 @@ OS:Surface,
 
 OS:Surface,
   {8dfddb87-bf60-4486-b9dd-549bf77ef6b8}, !- Handle
-  Surface 46,                             !- Name
+  Corridor_Bot_1 - Wall 270_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3582db20-b034-4500-9c2e-ddf83e8c51fb}, !- Space Name
@@ -913,7 +913,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {6ae3b0c2-4c48-48f5-899c-4535e4abda9b}, !- Building Story Name
   {40974fb9-e93b-44c4-a16d-088b59a37fa6}, !- Thermal Zone Name
@@ -923,7 +923,7 @@ OS:Space,
 
 OS:Surface,
   {588398bf-e4d7-4973-a353-4d05e8d28d64}, !- Handle
-  Surface 47,                             !- Name
+  OpenOffice_Bot_2 - Floor_a,             !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {71627c3d-b8bb-4822-94c6-e191f607c7c3}, !- Space Name
@@ -940,7 +940,7 @@ OS:Surface,
 
 OS:Surface,
   {77d4713f-bbef-48af-a4d5-15ac61e977d0}, !- Handle
-  Surface 48,                             !- Name
+  OpenOffice_Bot_2 - RoofCeiling_a,       !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {71627c3d-b8bb-4822-94c6-e191f607c7c3}, !- Space Name
@@ -957,7 +957,7 @@ OS:Surface,
 
 OS:Surface,
   {9cd7ae6a-0ffc-4f15-91c4-e5035c1a18ea}, !- Handle
-  Surface 49,                             !- Name
+  OpenOffice_Bot_2 - Wall 180_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {71627c3d-b8bb-4822-94c6-e191f607c7c3}, !- Space Name
@@ -974,7 +974,7 @@ OS:Surface,
 
 OS:Surface,
   {013ecd01-5927-4ede-b8b9-ba85a5d1762a}, !- Handle
-  Surface 50,                             !- Name
+  OpenOffice_Bot_2 - Wall 090_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {71627c3d-b8bb-4822-94c6-e191f607c7c3}, !- Space Name
@@ -991,7 +991,7 @@ OS:Surface,
 
 OS:Surface,
   {7622965e-11df-4604-83fd-d17ca1ed335e}, !- Handle
-  Surface 51,                             !- Name
+  OpenOffice_Bot_2 - Wall 270_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {71627c3d-b8bb-4822-94c6-e191f607c7c3}, !- Space Name
@@ -1008,7 +1008,7 @@ OS:Surface,
 
 OS:Surface,
   {d3fa7153-5c3d-4ae6-a4f0-cb8a271ca465}, !- Handle
-  Surface 52,                             !- Name
+  OpenOffice_Bot_2 - Wall 000_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {71627c3d-b8bb-4822-94c6-e191f607c7c3}, !- Space Name
@@ -1031,7 +1031,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {6ae3b0c2-4c48-48f5-899c-4535e4abda9b}, !- Building Story Name
   {b77be4f7-7476-403e-ba6b-617ed7b714c5}, !- Thermal Zone Name
@@ -1041,7 +1041,7 @@ OS:Space,
 
 OS:Surface,
   {49be1aab-20f6-4210-98f9-253d9e3a2401}, !- Handle
-  Surface 53,                             !- Name
+  ActiveStorage_Bot_2 - Floor_a,          !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {73402641-4d57-419b-a232-ecaadb97f818}, !- Space Name
@@ -1058,7 +1058,7 @@ OS:Surface,
 
 OS:Surface,
   {4708090f-a1ff-426d-a2c8-d392b07e4e1a}, !- Handle
-  Surface 54,                             !- Name
+  ActiveStorage_Bot_2 - RoofCeiling_a,    !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {73402641-4d57-419b-a232-ecaadb97f818}, !- Space Name
@@ -1075,7 +1075,7 @@ OS:Surface,
 
 OS:Surface,
   {ed16a6ba-6424-4d7b-a891-06738d6446ef}, !- Handle
-  Surface 55,                             !- Name
+  ActiveStorage_Bot_2 - Wall 270_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {73402641-4d57-419b-a232-ecaadb97f818}, !- Space Name
@@ -1092,7 +1092,7 @@ OS:Surface,
 
 OS:Surface,
   {51e3ae5c-95d7-4b3f-806e-082b4d366841}, !- Handle
-  Surface 56,                             !- Name
+  ActiveStorage_Bot_2 - Wall 180_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {73402641-4d57-419b-a232-ecaadb97f818}, !- Space Name
@@ -1109,7 +1109,7 @@ OS:Surface,
 
 OS:Surface,
   {802c6346-0180-4c32-981d-e7ad44ce080b}, !- Handle
-  Surface 57,                             !- Name
+  ActiveStorage_Bot_2 - Wall 000_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {73402641-4d57-419b-a232-ecaadb97f818}, !- Space Name
@@ -1126,7 +1126,7 @@ OS:Surface,
 
 OS:Surface,
   {4b769701-9cae-41e4-89ff-5c643f1f3026}, !- Handle
-  Surface 58,                             !- Name
+  ActiveStorage_Bot_2 - Wall 090_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {73402641-4d57-419b-a232-ecaadb97f818}, !- Space Name
@@ -1149,7 +1149,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {6ae3b0c2-4c48-48f5-899c-4535e4abda9b}, !- Building Story Name
   {1bd749a4-6837-49ff-a664-93c3d1862eff}, !- Thermal Zone Name
@@ -1159,7 +1159,7 @@ OS:Space,
 
 OS:Surface,
   {9995b598-8ee8-44b3-9b33-97412fe17105}, !- Handle
-  Surface 59,                             !- Name
+  Stair_Bot_2 - Floor_a,                  !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {476eb5f5-f393-4d58-86b4-d6124e4ec4ea}, !- Space Name
@@ -1176,7 +1176,7 @@ OS:Surface,
 
 OS:Surface,
   {7d4514f8-65bd-4ba1-b8ca-b9e532f9fbce}, !- Handle
-  Surface 60,                             !- Name
+  Stair_Bot_2 - Wall 180_a,               !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {476eb5f5-f393-4d58-86b4-d6124e4ec4ea}, !- Space Name
@@ -1193,7 +1193,7 @@ OS:Surface,
 
 OS:Surface,
   {e56244ef-2a13-4649-a4a3-16e4707bc2ca}, !- Handle
-  Surface 61,                             !- Name
+  Stair_Bot_2 - RoofCeiling_a,            !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {476eb5f5-f393-4d58-86b4-d6124e4ec4ea}, !- Space Name
@@ -1210,7 +1210,7 @@ OS:Surface,
 
 OS:Surface,
   {ed93d9e6-605e-40b1-a94f-eb477639ff74}, !- Handle
-  Surface 62,                             !- Name
+  Stair_Bot_2 - Wall 270_a,               !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {476eb5f5-f393-4d58-86b4-d6124e4ec4ea}, !- Space Name
@@ -1227,7 +1227,7 @@ OS:Surface,
 
 OS:Surface,
   {509ea674-504a-4cca-8040-0bfbc403e525}, !- Handle
-  Surface 63,                             !- Name
+  Stair_Bot_2 - Wall 000_a,               !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {476eb5f5-f393-4d58-86b4-d6124e4ec4ea}, !- Space Name
@@ -1244,7 +1244,7 @@ OS:Surface,
 
 OS:Surface,
   {654f8d9c-a95d-4e37-b0e1-551015914fa4}, !- Handle
-  Surface 64,                             !- Name
+  Stair_Bot_2 - Wall 090_a,               !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {476eb5f5-f393-4d58-86b4-d6124e4ec4ea}, !- Space Name
@@ -1267,7 +1267,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {6ae3b0c2-4c48-48f5-899c-4535e4abda9b}, !- Building Story Name
   {7590f5b7-76ad-4e98-bbf5-6f2ef605fba6}, !- Thermal Zone Name
@@ -1277,7 +1277,7 @@ OS:Space,
 
 OS:Surface,
   {99367583-ac99-45c4-9fcb-e9038c9913b4}, !- Handle
-  Surface 65,                             !- Name
+  ActiveStorage_Bot_3 - Floor_a,          !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {c79dfd8e-0c5f-468d-a862-3d8cfa5ecc3d}, !- Space Name
@@ -1294,7 +1294,7 @@ OS:Surface,
 
 OS:Surface,
   {17b7ddb2-ebc0-4b36-ac1f-ec3c69033fc4}, !- Handle
-  Surface 66,                             !- Name
+  ActiveStorage_Bot_3 - Wall 180_b,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c79dfd8e-0c5f-468d-a862-3d8cfa5ecc3d}, !- Space Name
@@ -1311,7 +1311,7 @@ OS:Surface,
 
 OS:Surface,
   {dcbac142-ed99-4b5e-bf65-ee4297cbbeed}, !- Handle
-  Surface 67,                             !- Name
+  ActiveStorage_Bot_3 - Wall 270_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c79dfd8e-0c5f-468d-a862-3d8cfa5ecc3d}, !- Space Name
@@ -1328,7 +1328,7 @@ OS:Surface,
 
 OS:Surface,
   {5da10b39-672b-4d24-81f6-e31368cfab69}, !- Handle
-  Surface 68,                             !- Name
+  ActiveStorage_Bot_3 - RoofCeiling_a,    !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {c79dfd8e-0c5f-468d-a862-3d8cfa5ecc3d}, !- Space Name
@@ -1345,7 +1345,7 @@ OS:Surface,
 
 OS:Surface,
   {d6cacc75-9c02-4976-87c1-1e383dffe58e}, !- Handle
-  Surface 69,                             !- Name
+  ActiveStorage_Bot_3 - Wall 000_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c79dfd8e-0c5f-468d-a862-3d8cfa5ecc3d}, !- Space Name
@@ -1362,7 +1362,7 @@ OS:Surface,
 
 OS:Surface,
   {792a0e12-4da8-4c2d-ba11-4f80114168ae}, !- Handle
-  Surface 70,                             !- Name
+  ActiveStorage_Bot_3 - Wall 090_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c79dfd8e-0c5f-468d-a862-3d8cfa5ecc3d}, !- Space Name
@@ -1385,7 +1385,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {6ae3b0c2-4c48-48f5-899c-4535e4abda9b}, !- Building Story Name
   {9235bed7-49c4-4f8c-a0f5-249682f43044}, !- Thermal Zone Name
@@ -1395,7 +1395,7 @@ OS:Space,
 
 OS:Surface,
   {25375090-3f83-4936-8246-a2158b75276d}, !- Handle
-  Surface 71,                             !- Name
+  Mechanical_Bot - Floor_a,               !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {a851ef72-3731-451e-8776-1a4d556b3063}, !- Space Name
@@ -1412,7 +1412,7 @@ OS:Surface,
 
 OS:Surface,
   {ac099415-a724-44f3-891c-858e0be1ec5d}, !- Handle
-  Surface 72,                             !- Name
+  Mechanical_Bot - Wall 000_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {a851ef72-3731-451e-8776-1a4d556b3063}, !- Space Name
@@ -1429,7 +1429,7 @@ OS:Surface,
 
 OS:Surface,
   {072d529f-7271-4293-adbe-e2920b701774}, !- Handle
-  Surface 73,                             !- Name
+  Mechanical_Bot - RoofCeiling_a,         !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {a851ef72-3731-451e-8776-1a4d556b3063}, !- Space Name
@@ -1446,7 +1446,7 @@ OS:Surface,
 
 OS:Surface,
   {8d889c50-6136-4cb2-9334-ecfcba868f24}, !- Handle
-  Surface 74,                             !- Name
+  Mechanical_Bot - Wall 090_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {a851ef72-3731-451e-8776-1a4d556b3063}, !- Space Name
@@ -1463,7 +1463,7 @@ OS:Surface,
 
 OS:Surface,
   {9c086a86-160c-46d9-bd97-1db0afb8a00e}, !- Handle
-  Surface 75,                             !- Name
+  Mechanical_Bot - Wall 180_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {a851ef72-3731-451e-8776-1a4d556b3063}, !- Space Name
@@ -1480,7 +1480,7 @@ OS:Surface,
 
 OS:Surface,
   {6f49b4a6-cb62-4462-b009-425c24c27f6b}, !- Handle
-  Surface 76,                             !- Name
+  Mechanical_Bot - Wall 270_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {a851ef72-3731-451e-8776-1a4d556b3063}, !- Space Name
@@ -1503,7 +1503,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {6ae3b0c2-4c48-48f5-899c-4535e4abda9b}, !- Building Story Name
   {2586f405-4f2a-4830-968b-a9e77efc1629}, !- Thermal Zone Name
@@ -1513,7 +1513,7 @@ OS:Space,
 
 OS:Surface,
   {5d140d5a-9fdc-43df-89d1-fcfcb147dd98}, !- Handle
-  Surface 77,                             !- Name
+  Lobby_Bot - Floor_a,                    !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {79e07745-0c54-4000-bd7b-056875fc02b7}, !- Space Name
@@ -1530,7 +1530,7 @@ OS:Surface,
 
 OS:Surface,
   {5bd425c0-21e4-4367-8706-52806aef9610}, !- Handle
-  Surface 78,                             !- Name
+  Lobby_Bot - RoofCeiling_a,              !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {79e07745-0c54-4000-bd7b-056875fc02b7}, !- Space Name
@@ -1540,14 +1540,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  26.4795, 6.5611375, 2.74319999999999,   !- X,Y,Z Vertex 1 {m}
-  26.4795, 26.71445, 2.74319999999999,    !- X,Y,Z Vertex 2 {m}
-  23.4315, 26.71445, 2.74319999999999,    !- X,Y,Z Vertex 3 {m}
-  23.4315, 6.5611375, 2.74319999999999;   !- X,Y,Z Vertex 4 {m}
+  26.4795, 6.5611375, 2.7432,             !- X,Y,Z Vertex 1 {m}
+  26.4795, 26.71445, 2.7432,              !- X,Y,Z Vertex 2 {m}
+  23.4315, 26.71445, 2.7432,              !- X,Y,Z Vertex 3 {m}
+  23.4315, 6.5611375, 2.7432;             !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {076aa603-edf3-48ac-b887-cd25c90c30f9}, !- Handle
-  Surface 79,                             !- Name
+  Lobby_Bot - Wall 180_a,                 !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {79e07745-0c54-4000-bd7b-056875fc02b7}, !- Space Name
@@ -1557,14 +1557,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 6.5611375, 2.74319999999999,   !- X,Y,Z Vertex 1 {m}
+  23.4315, 6.5611375, 2.7432,             !- X,Y,Z Vertex 1 {m}
   23.4315, 6.5611375, 0,                  !- X,Y,Z Vertex 2 {m}
   26.4795, 6.5611375, 0,                  !- X,Y,Z Vertex 3 {m}
-  26.4795, 6.5611375, 2.74319999999999;   !- X,Y,Z Vertex 4 {m}
+  26.4795, 6.5611375, 2.7432;             !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {1b7eae37-e019-4cb4-9309-a3080abb3831}, !- Handle
-  Surface 80,                             !- Name
+  Lobby_Bot - Wall 270_a,                 !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {79e07745-0c54-4000-bd7b-056875fc02b7}, !- Space Name
@@ -1574,14 +1574,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 26.71445, 2.74319999999999,    !- X,Y,Z Vertex 1 {m}
+  23.4315, 26.71445, 2.7432,              !- X,Y,Z Vertex 1 {m}
   23.4315, 26.71445, 0,                   !- X,Y,Z Vertex 2 {m}
   23.4315, 22.234525, 0,                  !- X,Y,Z Vertex 3 {m}
-  23.4315, 22.234525, 2.74319999999999;   !- X,Y,Z Vertex 4 {m}
+  23.4315, 22.234525, 2.7432;             !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {49b154bd-608a-4706-8da3-327d7901cd2e}, !- Handle
-  Surface 81,                             !- Name
+  Lobby_Bot - Wall 000_a,                 !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {79e07745-0c54-4000-bd7b-056875fc02b7}, !- Space Name
@@ -1591,14 +1591,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  26.4795, 26.71445, 2.74319999999999,    !- X,Y,Z Vertex 1 {m}
+  26.4795, 26.71445, 2.7432,              !- X,Y,Z Vertex 1 {m}
   26.4795, 26.71445, 0,                   !- X,Y,Z Vertex 2 {m}
   23.4315, 26.71445, 0,                   !- X,Y,Z Vertex 3 {m}
-  23.4315, 26.71445, 2.74319999999999;    !- X,Y,Z Vertex 4 {m}
+  23.4315, 26.71445, 2.7432;              !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {3d14bc77-292a-406d-a12c-e778fde62235}, !- Handle
-  Surface 82,                             !- Name
+  Lobby_Bot - Wall 090_a,                 !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {79e07745-0c54-4000-bd7b-056875fc02b7}, !- Space Name
@@ -1608,10 +1608,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  26.4795, 22.234525, 2.74319999999999,   !- X,Y,Z Vertex 1 {m}
+  26.4795, 22.234525, 2.7432,             !- X,Y,Z Vertex 1 {m}
   26.4795, 22.234525, 0,                  !- X,Y,Z Vertex 2 {m}
   26.4795, 26.71445, 0,                   !- X,Y,Z Vertex 3 {m}
-  26.4795, 26.71445, 2.74319999999999;    !- X,Y,Z Vertex 4 {m}
+  26.4795, 26.71445, 2.7432;              !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {e33b76f2-d31e-486a-ba0e-68c11e5dc618}, !- Handle
@@ -1621,7 +1621,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {6ae3b0c2-4c48-48f5-899c-4535e4abda9b}, !- Building Story Name
   {565b61f6-2e86-41f6-aae0-b9a531aa9bb0}, !- Thermal Zone Name
@@ -1631,7 +1631,7 @@ OS:Space,
 
 OS:Surface,
   {1488437a-b050-4d6d-9277-a84894338986}, !- Handle
-  Surface 83,                             !- Name
+  Dining_Bot - Floor_a,                   !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {e33b76f2-d31e-486a-ba0e-68c11e5dc618}, !- Space Name
@@ -1648,7 +1648,7 @@ OS:Surface,
 
 OS:Surface,
   {e2873024-97eb-4378-9a70-b58a7b7f8085}, !- Handle
-  Surface 84,                             !- Name
+  Dining_Bot - RoofCeiling_a,             !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {e33b76f2-d31e-486a-ba0e-68c11e5dc618}, !- Space Name
@@ -1658,14 +1658,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 22.234525, 2.74319999999999,   !- X,Y,Z Vertex 1 {m}
-  23.4315, 26.71445, 2.74319999999999,    !- X,Y,Z Vertex 2 {m}
-  18.310225, 26.71445, 2.74319999999999,  !- X,Y,Z Vertex 3 {m}
-  18.310225, 22.234525, 2.74319999999999; !- X,Y,Z Vertex 4 {m}
+  23.4315, 22.234525, 2.7432,             !- X,Y,Z Vertex 1 {m}
+  23.4315, 26.71445, 2.7432,              !- X,Y,Z Vertex 2 {m}
+  18.310225, 26.71445, 2.7432,            !- X,Y,Z Vertex 3 {m}
+  18.310225, 22.234525, 2.7432;           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {c74c42f8-8302-4e5a-8062-c08008b71f4f}, !- Handle
-  Surface 85,                             !- Name
+  Dining_Bot - Wall 000_a,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e33b76f2-d31e-486a-ba0e-68c11e5dc618}, !- Space Name
@@ -1675,14 +1675,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 26.71445, 2.74319999999999,    !- X,Y,Z Vertex 1 {m}
+  23.4315, 26.71445, 2.7432,              !- X,Y,Z Vertex 1 {m}
   23.4315, 26.71445, 0,                   !- X,Y,Z Vertex 2 {m}
   18.310225, 26.71445, 0,                 !- X,Y,Z Vertex 3 {m}
-  18.310225, 26.71445, 2.74319999999999;  !- X,Y,Z Vertex 4 {m}
+  18.310225, 26.71445, 2.7432;            !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {eb302358-b2f9-4755-9d45-0cf972252a64}, !- Handle
-  Surface 86,                             !- Name
+  Dining_Bot - Wall 270_a,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e33b76f2-d31e-486a-ba0e-68c11e5dc618}, !- Space Name
@@ -1692,14 +1692,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  18.310225, 26.71445, 2.74319999999999,  !- X,Y,Z Vertex 1 {m}
+  18.310225, 26.71445, 2.7432,            !- X,Y,Z Vertex 1 {m}
   18.310225, 26.71445, 0,                 !- X,Y,Z Vertex 2 {m}
   18.310225, 22.234525, 0,                !- X,Y,Z Vertex 3 {m}
-  18.310225, 22.234525, 2.74319999999999; !- X,Y,Z Vertex 4 {m}
+  18.310225, 22.234525, 2.7432;           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {3a220190-f1ff-4821-a3c8-56876712aad2}, !- Handle
-  Surface 87,                             !- Name
+  Dining_Bot - Wall 180_a,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e33b76f2-d31e-486a-ba0e-68c11e5dc618}, !- Space Name
@@ -1709,14 +1709,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  18.310225, 22.234525, 2.74319999999999, !- X,Y,Z Vertex 1 {m}
+  18.310225, 22.234525, 2.7432,           !- X,Y,Z Vertex 1 {m}
   18.310225, 22.234525, 0,                !- X,Y,Z Vertex 2 {m}
   23.4315, 22.234525, 0,                  !- X,Y,Z Vertex 3 {m}
-  23.4315, 22.234525, 2.74319999999999;   !- X,Y,Z Vertex 4 {m}
+  23.4315, 22.234525, 2.7432;             !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {3d96e6d7-792e-47b0-93dd-9f8666b893ac}, !- Handle
-  Surface 88,                             !- Name
+  Dining_Bot - Wall 090_a,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e33b76f2-d31e-486a-ba0e-68c11e5dc618}, !- Space Name
@@ -1726,10 +1726,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 22.234525, 2.74319999999999,   !- X,Y,Z Vertex 1 {m}
+  23.4315, 22.234525, 2.7432,             !- X,Y,Z Vertex 1 {m}
   23.4315, 22.234525, 0,                  !- X,Y,Z Vertex 2 {m}
   23.4315, 26.71445, 0,                   !- X,Y,Z Vertex 3 {m}
-  23.4315, 26.71445, 2.74319999999999;    !- X,Y,Z Vertex 4 {m}
+  23.4315, 26.71445, 2.7432;              !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {3eecb187-413f-4cee-a5c8-613f53ea8a9a}, !- Handle
@@ -1739,7 +1739,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {6ae3b0c2-4c48-48f5-899c-4535e4abda9b}, !- Building Story Name
   {bd69f731-f897-40c0-9bbc-da49b08fa43c}, !- Thermal Zone Name
@@ -1749,7 +1749,7 @@ OS:Space,
 
 OS:Surface,
   {b81c3311-59da-4fc4-96d5-3b6c17aa4a8c}, !- Handle
-  Surface 89,                             !- Name
+  Restroom_Bot - Floor_a,                 !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {3eecb187-413f-4cee-a5c8-613f53ea8a9a}, !- Space Name
@@ -1766,7 +1766,7 @@ OS:Surface,
 
 OS:Surface,
   {1c8bce2d-a1c4-41e4-aa39-657179bc9a71}, !- Handle
-  Surface 90,                             !- Name
+  Restroom_Bot - Wall 090_a,              !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3eecb187-413f-4cee-a5c8-613f53ea8a9a}, !- Space Name
@@ -1776,14 +1776,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 11.0410625, 2.74319999999999,  !- X,Y,Z Vertex 1 {m}
+  23.4315, 11.0410625, 2.7432,            !- X,Y,Z Vertex 1 {m}
   23.4315, 11.0410625, 0,                 !- X,Y,Z Vertex 2 {m}
   23.4315, 22.234525, 0,                  !- X,Y,Z Vertex 3 {m}
-  23.4315, 22.234525, 2.74319999999999;   !- X,Y,Z Vertex 4 {m}
+  23.4315, 22.234525, 2.7432;             !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {453ad57b-d5ea-40bb-ae09-27b1ae3681b5}, !- Handle
-  Surface 91,                             !- Name
+  Restroom_Bot - RoofCeiling_a,           !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {3eecb187-413f-4cee-a5c8-613f53ea8a9a}, !- Space Name
@@ -1793,14 +1793,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 11.0410625, 2.74319999999999,  !- X,Y,Z Vertex 1 {m}
-  23.4315, 22.234525, 2.74319999999999,   !- X,Y,Z Vertex 2 {m}
-  18.0975, 22.234525, 2.74319999999999,   !- X,Y,Z Vertex 3 {m}
-  18.0975, 11.0410625, 2.74319999999999;  !- X,Y,Z Vertex 4 {m}
+  23.4315, 11.0410625, 2.7432,            !- X,Y,Z Vertex 1 {m}
+  23.4315, 22.234525, 2.7432,             !- X,Y,Z Vertex 2 {m}
+  18.0975, 22.234525, 2.7432,             !- X,Y,Z Vertex 3 {m}
+  18.0975, 11.0410625, 2.7432;            !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {70b62726-059e-471f-8242-9a9e4257729f}, !- Handle
-  Surface 92,                             !- Name
+  Restroom_Bot - Wall 180_a,              !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3eecb187-413f-4cee-a5c8-613f53ea8a9a}, !- Space Name
@@ -1810,14 +1810,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  18.0975, 11.0410625, 2.74319999999999,  !- X,Y,Z Vertex 1 {m}
+  18.0975, 11.0410625, 2.7432,            !- X,Y,Z Vertex 1 {m}
   18.0975, 11.0410625, 0,                 !- X,Y,Z Vertex 2 {m}
   23.4315, 11.0410625, 0,                 !- X,Y,Z Vertex 3 {m}
-  23.4315, 11.0410625, 2.74319999999999;  !- X,Y,Z Vertex 4 {m}
+  23.4315, 11.0410625, 2.7432;            !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {75170074-3fc4-45a9-bae3-e29713f9b795}, !- Handle
-  Surface 93,                             !- Name
+  Restroom_Bot - Wall 000_a,              !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3eecb187-413f-4cee-a5c8-613f53ea8a9a}, !- Space Name
@@ -1827,14 +1827,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  18.310225, 22.234525, 2.74319999999999, !- X,Y,Z Vertex 1 {m}
+  18.310225, 22.234525, 2.7432,           !- X,Y,Z Vertex 1 {m}
   18.310225, 22.234525, 0,                !- X,Y,Z Vertex 2 {m}
   18.0975, 22.234525, 0,                  !- X,Y,Z Vertex 3 {m}
-  18.0975, 22.234525, 2.74319999999999;   !- X,Y,Z Vertex 4 {m}
+  18.0975, 22.234525, 2.7432;             !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {53d29c93-45bb-4f3a-b401-f644d26cc010}, !- Handle
-  Surface 94,                             !- Name
+  Restroom_Bot - Wall 270_a,              !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3eecb187-413f-4cee-a5c8-613f53ea8a9a}, !- Space Name
@@ -1844,10 +1844,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  18.0975, 22.234525, 2.74319999999999,   !- X,Y,Z Vertex 1 {m}
+  18.0975, 22.234525, 2.7432,             !- X,Y,Z Vertex 1 {m}
   18.0975, 22.234525, 0,                  !- X,Y,Z Vertex 2 {m}
   18.0975, 11.0410625, 0,                 !- X,Y,Z Vertex 3 {m}
-  18.0975, 11.0410625, 2.74319999999999;  !- X,Y,Z Vertex 4 {m}
+  18.0975, 11.0410625, 2.7432;            !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {8bfa1513-dde5-445d-b5af-69b547f9fed4}, !- Handle
@@ -1857,7 +1857,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {6ae3b0c2-4c48-48f5-899c-4535e4abda9b}, !- Building Story Name
   {aefed899-7bbf-40b3-83e8-48f3aa1ab1f4}, !- Thermal Zone Name
@@ -1867,7 +1867,7 @@ OS:Space,
 
 OS:Surface,
   {85efcb0c-ec74-4c7d-bba7-8b656f565c19}, !- Handle
-  Surface 95,                             !- Name
+  ActiveStorage_Bot_1 - Floor_a,          !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {8bfa1513-dde5-445d-b5af-69b547f9fed4}, !- Space Name
@@ -1884,7 +1884,7 @@ OS:Surface,
 
 OS:Surface,
   {d81fd8a9-dfc6-4c0b-a0b6-b3ed13527483}, !- Handle
-  Surface 96,                             !- Name
+  ActiveStorage_Bot_1 - Wall 270_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {8bfa1513-dde5-445d-b5af-69b547f9fed4}, !- Space Name
@@ -1901,7 +1901,7 @@ OS:Surface,
 
 OS:Surface,
   {b5e22fab-2aba-4231-a9dd-cefc89f8f25a}, !- Handle
-  Surface 97,                             !- Name
+  ActiveStorage_Bot_1 - Wall 180_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {8bfa1513-dde5-445d-b5af-69b547f9fed4}, !- Space Name
@@ -1918,7 +1918,7 @@ OS:Surface,
 
 OS:Surface,
   {f2ed0a02-aaa0-431b-8d10-7f9de6c57b18}, !- Handle
-  Surface 98,                             !- Name
+  ActiveStorage_Bot_1 - Wall 090_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {8bfa1513-dde5-445d-b5af-69b547f9fed4}, !- Space Name
@@ -1935,7 +1935,7 @@ OS:Surface,
 
 OS:Surface,
   {1e5f03c6-7168-43c2-a56a-808bf06f3087}, !- Handle
-  Surface 99,                             !- Name
+  ActiveStorage_Bot_1 - RoofCeiling_a,    !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {8bfa1513-dde5-445d-b5af-69b547f9fed4}, !- Space Name
@@ -1952,7 +1952,7 @@ OS:Surface,
 
 OS:Surface,
   {2a921ed2-6fd3-400c-89dc-984d881a7eb4}, !- Handle
-  Surface 100,                            !- Name
+  ActiveStorage_Bot_1 - Wall 000_b,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {8bfa1513-dde5-445d-b5af-69b547f9fed4}, !- Space Name
@@ -1975,7 +1975,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {6ae3b0c2-4c48-48f5-899c-4535e4abda9b}, !- Building Story Name
   {8b6a66f3-1dc1-484b-82fc-1495af27d153}, !- Thermal Zone Name
@@ -1985,7 +1985,7 @@ OS:Space,
 
 OS:Surface,
   {e7844b0a-a6d2-42c2-b978-524e916b9d90}, !- Handle
-  Surface 101,                            !- Name
+  Stair_Bot_1 - Floor_a,                  !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {34daa9fc-c3a7-4661-b303-855b08b13084}, !- Space Name
@@ -2002,7 +2002,7 @@ OS:Surface,
 
 OS:Surface,
   {1e973de6-74f1-49bc-b560-9e384fc3105e}, !- Handle
-  Surface 102,                            !- Name
+  Stair_Bot_1 - RoofCeiling_a,            !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {34daa9fc-c3a7-4661-b303-855b08b13084}, !- Space Name
@@ -2019,7 +2019,7 @@ OS:Surface,
 
 OS:Surface,
   {221b9d25-9dcb-4e48-bd17-0b216fa5c729}, !- Handle
-  Surface 103,                            !- Name
+  Stair_Bot_1 - Wall 180_a,               !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {34daa9fc-c3a7-4661-b303-855b08b13084}, !- Space Name
@@ -2036,7 +2036,7 @@ OS:Surface,
 
 OS:Surface,
   {bce80bcb-f0fa-4fb9-bb74-449f6680dad8}, !- Handle
-  Surface 104,                            !- Name
+  Stair_Bot_1 - Wall 270_a,               !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {34daa9fc-c3a7-4661-b303-855b08b13084}, !- Space Name
@@ -2053,7 +2053,7 @@ OS:Surface,
 
 OS:Surface,
   {04829833-a2f0-4323-a72d-bb6d5bda080b}, !- Handle
-  Surface 105,                            !- Name
+  Stair_Bot_1 - Wall 090_a,               !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {34daa9fc-c3a7-4661-b303-855b08b13084}, !- Space Name
@@ -2070,7 +2070,7 @@ OS:Surface,
 
 OS:Surface,
   {47e7ecc0-5fa9-4c6d-952f-eb438815279a}, !- Handle
-  Surface 106,                            !- Name
+  Stair_Bot_1 - Wall 000_a,               !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {34daa9fc-c3a7-4661-b303-855b08b13084}, !- Space Name
@@ -2093,7 +2093,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {6ae3b0c2-4c48-48f5-899c-4535e4abda9b}, !- Building Story Name
   {4d141c4e-7af4-412e-910f-e17d39945991}, !- Thermal Zone Name
@@ -2103,7 +2103,7 @@ OS:Space,
 
 OS:Surface,
   {187d46d4-05af-427f-ba69-597a58d547fb}, !- Handle
-  Surface 107,                            !- Name
+  ActiveStorage_Bot_4 - Floor_a,          !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {28928794-2be1-4844-8cbb-7e9a5135b712}, !- Space Name
@@ -2120,7 +2120,7 @@ OS:Surface,
 
 OS:Surface,
   {f663f55e-9b08-472b-91e3-c6c85938e1fb}, !- Handle
-  Surface 108,                            !- Name
+  ActiveStorage_Bot_4 - Wall 090_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {28928794-2be1-4844-8cbb-7e9a5135b712}, !- Space Name
@@ -2137,7 +2137,7 @@ OS:Surface,
 
 OS:Surface,
   {db07646d-b36a-402c-96bd-1709bc8834c8}, !- Handle
-  Surface 109,                            !- Name
+  ActiveStorage_Bot_4 - Wall 180_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {28928794-2be1-4844-8cbb-7e9a5135b712}, !- Space Name
@@ -2154,7 +2154,7 @@ OS:Surface,
 
 OS:Surface,
   {075d7a7e-4365-47e7-8017-23c153e4fb3f}, !- Handle
-  Surface 110,                            !- Name
+  ActiveStorage_Bot_4 - Wall 270_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {28928794-2be1-4844-8cbb-7e9a5135b712}, !- Space Name
@@ -2171,7 +2171,7 @@ OS:Surface,
 
 OS:Surface,
   {3e8a3608-12a8-4bb3-aead-edbb574fd2a9}, !- Handle
-  Surface 111,                            !- Name
+  ActiveStorage_Bot_4 - Wall 000_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {28928794-2be1-4844-8cbb-7e9a5135b712}, !- Space Name
@@ -2188,7 +2188,7 @@ OS:Surface,
 
 OS:Surface,
   {0ef91d51-8b82-4f1c-902a-0defd7cbbb33}, !- Handle
-  Surface 112,                            !- Name
+  ActiveStorage_Bot_4 - RoofCeiling_a,    !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {28928794-2be1-4844-8cbb-7e9a5135b712}, !- Space Name
@@ -2211,7 +2211,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {6ae3b0c2-4c48-48f5-899c-4535e4abda9b}, !- Building Story Name
   {189c8ddc-f078-4a70-b892-259857f77f05}, !- Thermal Zone Name
@@ -2221,7 +2221,7 @@ OS:Space,
 
 OS:Surface,
   {9711055e-3c8d-4812-8733-72cd6af27c51}, !- Handle
-  Surface 113,                            !- Name
+  Corridor_Bot_2 - Floor_a,               !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {93f9b288-ab23-4aeb-92d3-0f31119c425c}, !- Space Name
@@ -2242,7 +2242,7 @@ OS:Surface,
 
 OS:Surface,
   {5cb714c5-2e2c-4364-8a0a-21d356853357}, !- Handle
-  Surface 114,                            !- Name
+  Corridor_Bot_2 - RoofCeiling_a,         !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {93f9b288-ab23-4aeb-92d3-0f31119c425c}, !- Space Name
@@ -2263,7 +2263,7 @@ OS:Surface,
 
 OS:Surface,
   {5a43a854-4864-4560-aeca-489600726240}, !- Handle
-  Surface 115,                            !- Name
+  Corridor_Bot_2 - Wall 270_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {93f9b288-ab23-4aeb-92d3-0f31119c425c}, !- Space Name
@@ -2280,7 +2280,7 @@ OS:Surface,
 
 OS:Surface,
   {5eefd0f8-d729-4be9-9aa9-2283754fe331}, !- Handle
-  Surface 116,                            !- Name
+  Corridor_Bot_2 - Wall 180_b,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {93f9b288-ab23-4aeb-92d3-0f31119c425c}, !- Space Name
@@ -2297,7 +2297,7 @@ OS:Surface,
 
 OS:Surface,
   {34d50455-c1b6-4277-8864-758169de4a92}, !- Handle
-  Surface 117,                            !- Name
+  Corridor_Bot_2 - Wall 000_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {93f9b288-ab23-4aeb-92d3-0f31119c425c}, !- Space Name
@@ -2314,7 +2314,7 @@ OS:Surface,
 
 OS:Surface,
   {c3feea21-e6c9-48a7-8d76-6d0d26f7e766}, !- Handle
-  Surface 118,                            !- Name
+  Corridor_Bot_2 - Wall 090_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {93f9b288-ab23-4aeb-92d3-0f31119c425c}, !- Space Name
@@ -2331,7 +2331,7 @@ OS:Surface,
 
 OS:Surface,
   {60dd1cca-e70f-4c26-bca8-050e22b29e94}, !- Handle
-  Surface 119,                            !- Name
+  Corridor_Bot_2 - Wall 180_c,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {93f9b288-ab23-4aeb-92d3-0f31119c425c}, !- Space Name
@@ -2348,7 +2348,7 @@ OS:Surface,
 
 OS:Surface,
   {2f9fc9b0-685f-4949-9d4b-21f5bea04783}, !- Handle
-  Surface 120,                            !- Name
+  Corridor_Bot_2 - Wall 270_b,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {93f9b288-ab23-4aeb-92d3-0f31119c425c}, !- Space Name
@@ -2365,7 +2365,7 @@ OS:Surface,
 
 OS:Surface,
   {9bfadcf8-9419-4535-b8c7-fbc1ac3d565d}, !- Handle
-  Surface 121,                            !- Name
+  Corridor_Bot_2 - Wall 180_d,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {93f9b288-ab23-4aeb-92d3-0f31119c425c}, !- Space Name
@@ -2382,7 +2382,7 @@ OS:Surface,
 
 OS:Surface,
   {0798a52b-4bd7-4318-8d42-23a7090f3717}, !- Handle
-  Surface 122,                            !- Name
+  Corridor_Bot_2 - Wall 090_b,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {93f9b288-ab23-4aeb-92d3-0f31119c425c}, !- Space Name
@@ -2399,7 +2399,7 @@ OS:Surface,
 
 OS:Surface,
   {969c55ce-31cc-44b0-bc85-89b3787945a2}, !- Handle
-  Surface 123,                            !- Name
+  Corridor_Bot_2 - Wall 180_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {93f9b288-ab23-4aeb-92d3-0f31119c425c}, !- Space Name
@@ -2422,7 +2422,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {6ae3b0c2-4c48-48f5-899c-4535e4abda9b}, !- Building Story Name
   {41cd6239-97fc-4edf-9fb2-e6e6b420e09f}, !- Thermal Zone Name
@@ -2432,7 +2432,7 @@ OS:Space,
 
 OS:Surface,
   {a1ddf0a1-79b1-4403-97fc-be7bc4505e13}, !- Handle
-  Surface 124,                            !- Name
+  OpenOffice_Bot_1 - Floor_a,             !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {d3b80d82-0387-4e18-a970-84ace3573794}, !- Space Name
@@ -2449,7 +2449,7 @@ OS:Surface,
 
 OS:Surface,
   {80072c6c-b7d4-438b-940d-29b5a7ad3904}, !- Handle
-  Surface 125,                            !- Name
+  OpenOffice_Bot_1 - Wall 270_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d3b80d82-0387-4e18-a970-84ace3573794}, !- Space Name
@@ -2466,7 +2466,7 @@ OS:Surface,
 
 OS:Surface,
   {ec36b517-d3c1-48e5-8fb4-a83048db001c}, !- Handle
-  Surface 126,                            !- Name
+  OpenOffice_Bot_1 - RoofCeiling_a,       !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {d3b80d82-0387-4e18-a970-84ace3573794}, !- Space Name
@@ -2483,7 +2483,7 @@ OS:Surface,
 
 OS:Surface,
   {4b25dd2b-e073-49c1-ae34-a3f18f50ff99}, !- Handle
-  Surface 127,                            !- Name
+  OpenOffice_Bot_1 - Wall 180_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d3b80d82-0387-4e18-a970-84ace3573794}, !- Space Name
@@ -2500,7 +2500,7 @@ OS:Surface,
 
 OS:Surface,
   {d609d0cf-5da6-4ff3-a4c1-c66bd2dadae4}, !- Handle
-  Surface 128,                            !- Name
+  OpenOffice_Bot_1 - Wall 000_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d3b80d82-0387-4e18-a970-84ace3573794}, !- Space Name
@@ -2517,7 +2517,7 @@ OS:Surface,
 
 OS:Surface,
   {8c3ecf28-33e4-4349-be96-476895d0c9cb}, !- Handle
-  Surface 129,                            !- Name
+  OpenOffice_Bot_1 - Wall 090_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d3b80d82-0387-4e18-a970-84ace3573794}, !- Space Name
@@ -2540,7 +2540,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {6ae3b0c2-4c48-48f5-899c-4535e4abda9b}, !- Building Story Name
   {4db7eee2-73e2-4fff-9953-3af33d6ba40d}, !- Thermal Zone Name
@@ -2550,7 +2550,7 @@ OS:Space,
 
 OS:Surface,
   {e53a1f42-6949-45c8-a194-35e9e38bed23}, !- Handle
-  Surface 130,                            !- Name
+  ClassRoom_Bot - Floor_a,                !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {20a72fcc-8f53-4254-a663-0a1e83c54121}, !- Space Name
@@ -2567,7 +2567,7 @@ OS:Surface,
 
 OS:Surface,
   {26c38f2f-9f85-4386-95da-8a6f2e81785f}, !- Handle
-  Surface 131,                            !- Name
+  ClassRoom_Bot - RoofCeiling_a,          !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {20a72fcc-8f53-4254-a663-0a1e83c54121}, !- Space Name
@@ -2584,7 +2584,7 @@ OS:Surface,
 
 OS:Surface,
   {511f210f-bd8d-4fb6-88f0-a6e5a2146ac5}, !- Handle
-  Surface 132,                            !- Name
+  ClassRoom_Bot - Wall 270_a,             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {20a72fcc-8f53-4254-a663-0a1e83c54121}, !- Space Name
@@ -2601,7 +2601,7 @@ OS:Surface,
 
 OS:Surface,
   {4a2ecd01-d744-4305-bad1-f5777e64dbaf}, !- Handle
-  Surface 133,                            !- Name
+  ClassRoom_Bot - Wall 180_a,             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {20a72fcc-8f53-4254-a663-0a1e83c54121}, !- Space Name
@@ -2618,7 +2618,7 @@ OS:Surface,
 
 OS:Surface,
   {49438c66-0fae-4b1f-8971-6c704cbb323e}, !- Handle
-  Surface 134,                            !- Name
+  ClassRoom_Bot - Wall 000_a,             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {20a72fcc-8f53-4254-a663-0a1e83c54121}, !- Space Name
@@ -2635,7 +2635,7 @@ OS:Surface,
 
 OS:Surface,
   {29ce2893-6048-4640-a5b0-5129f75e9048}, !- Handle
-  Surface 135,                            !- Name
+  ClassRoom_Bot - Wall 090_a,             !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {20a72fcc-8f53-4254-a663-0a1e83c54121}, !- Space Name
@@ -2658,7 +2658,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {6ae3b0c2-4c48-48f5-899c-4535e4abda9b}, !- Building Story Name
   {af46f94b-979f-4baf-a003-e6a733d39a41}, !- Thermal Zone Name
@@ -2668,7 +2668,7 @@ OS:Space,
 
 OS:Surface,
   {d804fcb2-bdc1-435a-b560-283411697fdc}, !- Handle
-  Surface 136,                            !- Name
+  OpenOffice_Bot_3 - Floor_a,             !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {22813b20-9643-4e5e-ac1b-ca71f74c398b}, !- Space Name
@@ -2685,7 +2685,7 @@ OS:Surface,
 
 OS:Surface,
   {a322ede9-16bb-4afe-8521-28a263651911}, !- Handle
-  Surface 137,                            !- Name
+  OpenOffice_Bot_3 - RoofCeiling_a,       !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {22813b20-9643-4e5e-ac1b-ca71f74c398b}, !- Space Name
@@ -2702,7 +2702,7 @@ OS:Surface,
 
 OS:Surface,
   {4a3411b7-f72e-459d-8f8c-d7f59440853b}, !- Handle
-  Surface 138,                            !- Name
+  OpenOffice_Bot_3 - Wall 180_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {22813b20-9643-4e5e-ac1b-ca71f74c398b}, !- Space Name
@@ -2719,7 +2719,7 @@ OS:Surface,
 
 OS:Surface,
   {760b961f-fda9-4e5c-b46e-e95c97659ac9}, !- Handle
-  Surface 139,                            !- Name
+  OpenOffice_Bot_3 - Wall 000_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {22813b20-9643-4e5e-ac1b-ca71f74c398b}, !- Space Name
@@ -2736,7 +2736,7 @@ OS:Surface,
 
 OS:Surface,
   {6879ed9a-2909-4bcf-a5d3-4ec2733b6363}, !- Handle
-  Surface 140,                            !- Name
+  OpenOffice_Bot_3 - Wall 090_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {22813b20-9643-4e5e-ac1b-ca71f74c398b}, !- Space Name
@@ -2753,7 +2753,7 @@ OS:Surface,
 
 OS:Surface,
   {5fce64b2-aedc-4858-aa95-fc6191a831ad}, !- Handle
-  Surface 141,                            !- Name
+  OpenOffice_Bot_3 - Wall 270_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {22813b20-9643-4e5e-ac1b-ca71f74c398b}, !- Space Name
@@ -2776,7 +2776,7 @@ OS:Space,
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
   0,                                      !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {6ae3b0c2-4c48-48f5-899c-4535e4abda9b}, !- Building Story Name
   {e45c6c6a-d922-4d61-a121-4f32dbc6de11}, !- Thermal Zone Name
@@ -2786,7 +2786,7 @@ OS:Space,
 
 OS:Surface,
   {c919cb30-b4a9-4371-9cf8-044cecc8541b}, !- Handle
-  Surface 142,                            !- Name
+  EnclosedOffice_Bot_2 - Floor_a,         !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {597c73f0-ba11-4097-8b84-21dbfe0e3af0}, !- Space Name
@@ -2803,7 +2803,7 @@ OS:Surface,
 
 OS:Surface,
   {85cefc1a-7279-4ed5-8774-e414b076b756}, !- Handle
-  Surface 143,                            !- Name
+  EnclosedOffice_Bot_2 - Wall 000_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {597c73f0-ba11-4097-8b84-21dbfe0e3af0}, !- Space Name
@@ -2820,7 +2820,7 @@ OS:Surface,
 
 OS:Surface,
   {18e89e67-920b-451e-84a3-b7057863b1de}, !- Handle
-  Surface 144,                            !- Name
+  EnclosedOffice_Bot_2 - RoofCeiling_a,   !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {597c73f0-ba11-4097-8b84-21dbfe0e3af0}, !- Space Name
@@ -2837,7 +2837,7 @@ OS:Surface,
 
 OS:Surface,
   {b9ded477-a976-45fb-b9b9-9cb6c12d56b8}, !- Handle
-  Surface 145,                            !- Name
+  EnclosedOffice_Bot_2 - Wall 090_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {597c73f0-ba11-4097-8b84-21dbfe0e3af0}, !- Space Name
@@ -2854,7 +2854,7 @@ OS:Surface,
 
 OS:Surface,
   {d393b4bd-4068-401e-a094-d335fef45f68}, !- Handle
-  Surface 146,                            !- Name
+  EnclosedOffice_Bot_2 - Wall 270_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {597c73f0-ba11-4097-8b84-21dbfe0e3af0}, !- Space Name
@@ -2871,7 +2871,7 @@ OS:Surface,
 
 OS:Surface,
   {fbfa89a6-8cc7-41c6-909c-b506dfab37ed}, !- Handle
-  Surface 147,                            !- Name
+  EnclosedOffice_Bot_2 - Wall 180_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {597c73f0-ba11-4097-8b84-21dbfe0e3af0}, !- Space Name
@@ -2888,7 +2888,7 @@ OS:Surface,
 
 OS:Surface,
   {0f29dc6c-1e78-4fe1-8347-733f37238828}, !- Handle
-  Surface 148,                            !- Name
+  ConfRoom_Bot_1 - Wall 000_b,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {dead6e0b-93b8-47d9-be64-14bafc65d3ed}, !- Space Name
@@ -2905,7 +2905,7 @@ OS:Surface,
 
 OS:Surface,
   {f99fee31-b37a-4880-a9cc-b1184ce941ea}, !- Handle
-  Surface 149,                            !- Name
+  ConfRoom_Bot_2 - Wall 000_b,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {5c3f4599-a380-4a4b-9c7b-8ddf191cfd3c}, !- Space Name
@@ -2922,7 +2922,7 @@ OS:Surface,
 
 OS:Surface,
   {5e3d753e-73d2-4e28-a19c-0bec1b46b68d}, !- Handle
-  Surface 150,                            !- Name
+  EnclosedOffice_Bot_1 - Wall 090_b,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {fde173d0-3216-4c8c-81aa-f97765d7e07b}, !- Space Name
@@ -2939,7 +2939,7 @@ OS:Surface,
 
 OS:Surface,
   {6dd6f4f2-071f-446b-a5f3-d745d459a45c}, !- Handle
-  Surface 151,                            !- Name
+  EnclosedOffice_Bot_1 - Wall 090_c,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {fde173d0-3216-4c8c-81aa-f97765d7e07b}, !- Space Name
@@ -2956,7 +2956,7 @@ OS:Surface,
 
 OS:Surface,
   {ed4ddc6c-52d3-498c-a203-218fbd2d8f0a}, !- Handle
-  Surface 152,                            !- Name
+  Corridor_Bot_1 - Wall 000_d,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3582db20-b034-4500-9c2e-ddf83e8c51fb}, !- Space Name
@@ -2973,7 +2973,7 @@ OS:Surface,
 
 OS:Surface,
   {e620d739-762c-42d0-b7ff-4c42b717dc9b}, !- Handle
-  Surface 153,                            !- Name
+  Corridor_Bot_1 - Wall 180_b,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3582db20-b034-4500-9c2e-ddf83e8c51fb}, !- Space Name
@@ -2990,7 +2990,7 @@ OS:Surface,
 
 OS:Surface,
   {15e54436-e188-4b13-bfb4-25843701c8c5}, !- Handle
-  Surface 154,                            !- Name
+  Corridor_Bot_1 - Wall 180_c,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3582db20-b034-4500-9c2e-ddf83e8c51fb}, !- Space Name
@@ -3007,7 +3007,7 @@ OS:Surface,
 
 OS:Surface,
   {66b8f5d0-5b92-4f75-af67-dbb349e16c44}, !- Handle
-  Surface 155,                            !- Name
+  Corridor_Bot_1 - Wall 000_e,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3582db20-b034-4500-9c2e-ddf83e8c51fb}, !- Space Name
@@ -3024,7 +3024,7 @@ OS:Surface,
 
 OS:Surface,
   {7af40f9c-3e7b-49b6-8759-017df8520c2a}, !- Handle
-  Surface 156,                            !- Name
+  Corridor_Bot_1 - Wall 180_d,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3582db20-b034-4500-9c2e-ddf83e8c51fb}, !- Space Name
@@ -3041,7 +3041,7 @@ OS:Surface,
 
 OS:Surface,
   {7feaf36c-d0f7-4046-8c04-f701bba82db8}, !- Handle
-  Surface 157,                            !- Name
+  Corridor_Bot_1 - Wall 000_f,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3582db20-b034-4500-9c2e-ddf83e8c51fb}, !- Space Name
@@ -3058,7 +3058,7 @@ OS:Surface,
 
 OS:Surface,
   {e4658aac-febd-4032-82bf-10873b28c77b}, !- Handle
-  Surface 158,                            !- Name
+  Corridor_Bot_1 - Wall 180_e,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3582db20-b034-4500-9c2e-ddf83e8c51fb}, !- Space Name
@@ -3075,7 +3075,7 @@ OS:Surface,
 
 OS:Surface,
   {3d7066bd-332f-4bbc-b414-3f6ee840c5b7}, !- Handle
-  Surface 159,                            !- Name
+  Corridor_Bot_1 - Wall 000_g,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3582db20-b034-4500-9c2e-ddf83e8c51fb}, !- Space Name
@@ -3092,7 +3092,7 @@ OS:Surface,
 
 OS:Surface,
   {43521a05-d481-489d-aff6-804ff3908cdd}, !- Handle
-  Surface 160,                            !- Name
+  OpenOffice_Bot_2 - Wall 270_c,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {71627c3d-b8bb-4822-94c6-e191f607c7c3}, !- Space Name
@@ -3109,7 +3109,7 @@ OS:Surface,
 
 OS:Surface,
   {10b686bb-2b2e-4a28-9a7a-6b754bfdd7f5}, !- Handle
-  Surface 161,                            !- Name
+  OpenOffice_Bot_2 - Wall 270_b,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {71627c3d-b8bb-4822-94c6-e191f607c7c3}, !- Space Name
@@ -3126,7 +3126,7 @@ OS:Surface,
 
 OS:Surface,
   {ccc59777-a50e-4801-9093-588ea8dcf3fe}, !- Handle
-  Surface 162,                            !- Name
+  OpenOffice_Bot_2 - Wall 090_b,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {71627c3d-b8bb-4822-94c6-e191f607c7c3}, !- Space Name
@@ -3143,7 +3143,7 @@ OS:Surface,
 
 OS:Surface,
   {4bd90679-9151-4eb9-ba79-07676983aa8a}, !- Handle
-  Surface 163,                            !- Name
+  ActiveStorage_Bot_2 - Wall 000_b,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {73402641-4d57-419b-a232-ecaadb97f818}, !- Space Name
@@ -3160,7 +3160,7 @@ OS:Surface,
 
 OS:Surface,
   {13541e31-cd53-4fbf-8fa0-d3efd83d43fd}, !- Handle
-  Surface 164,                            !- Name
+  ActiveStorage_Bot_3 - Wall 180_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c79dfd8e-0c5f-468d-a862-3d8cfa5ecc3d}, !- Space Name
@@ -3177,7 +3177,7 @@ OS:Surface,
 
 OS:Surface,
   {d2c27731-6e08-4d3c-80c0-ad71536d5ae2}, !- Handle
-  Surface 165,                            !- Name
+  Lobby_Bot - Wall 270_b,                 !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {79e07745-0c54-4000-bd7b-056875fc02b7}, !- Space Name
@@ -3187,14 +3187,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 11.0410625, 2.74319999999999,  !- X,Y,Z Vertex 1 {m}
+  23.4315, 11.0410625, 2.7432,            !- X,Y,Z Vertex 1 {m}
   23.4315, 11.0410625, 0,                 !- X,Y,Z Vertex 2 {m}
   23.4315, 6.5611375, 0,                  !- X,Y,Z Vertex 3 {m}
-  23.4315, 6.5611375, 2.74319999999999;   !- X,Y,Z Vertex 4 {m}
+  23.4315, 6.5611375, 2.7432;             !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {30b1412a-8a60-4a48-b84a-ead36555eb5c}, !- Handle
-  Surface 166,                            !- Name
+  Lobby_Bot - Wall 090_b,                 !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {79e07745-0c54-4000-bd7b-056875fc02b7}, !- Space Name
@@ -3204,14 +3204,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  26.4795, 11.0410625, 2.74319999999999,  !- X,Y,Z Vertex 1 {m}
+  26.4795, 11.0410625, 2.7432,            !- X,Y,Z Vertex 1 {m}
   26.4795, 11.0410625, 0,                 !- X,Y,Z Vertex 2 {m}
   26.4795, 22.234525, 0,                  !- X,Y,Z Vertex 3 {m}
-  26.4795, 22.234525, 2.74319999999999;   !- X,Y,Z Vertex 4 {m}
+  26.4795, 22.234525, 2.7432;             !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {4a2df7dc-e4c6-4a5f-b43b-b1c0dd382a04}, !- Handle
-  Surface 167,                            !- Name
+  Lobby_Bot - Wall 090_c,                 !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {79e07745-0c54-4000-bd7b-056875fc02b7}, !- Space Name
@@ -3221,14 +3221,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  26.4795, 6.5611375, 2.74319999999999,   !- X,Y,Z Vertex 1 {m}
+  26.4795, 6.5611375, 2.7432,             !- X,Y,Z Vertex 1 {m}
   26.4795, 6.5611375, 0,                  !- X,Y,Z Vertex 2 {m}
   26.4795, 11.0410625, 0,                 !- X,Y,Z Vertex 3 {m}
-  26.4795, 11.0410625, 2.74319999999999;  !- X,Y,Z Vertex 4 {m}
+  26.4795, 11.0410625, 2.7432;            !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {cf806425-bd04-413c-b002-77865c749901}, !- Handle
-  Surface 168,                            !- Name
+  Lobby_Bot - Wall 270_c,                 !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {79e07745-0c54-4000-bd7b-056875fc02b7}, !- Space Name
@@ -3238,14 +3238,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 22.234525, 2.74319999999999,   !- X,Y,Z Vertex 1 {m}
+  23.4315, 22.234525, 2.7432,             !- X,Y,Z Vertex 1 {m}
   23.4315, 22.234525, 0,                  !- X,Y,Z Vertex 2 {m}
   23.4315, 11.0410625, 0,                 !- X,Y,Z Vertex 3 {m}
-  23.4315, 11.0410625, 2.74319999999999;  !- X,Y,Z Vertex 4 {m}
+  23.4315, 11.0410625, 2.7432;            !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {6cd6b3d6-34d2-4fb0-a649-a5a224843367}, !- Handle
-  Surface 169,                            !- Name
+  Restroom_Bot - Wall 000_b,              !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3eecb187-413f-4cee-a5c8-613f53ea8a9a}, !- Space Name
@@ -3255,14 +3255,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 22.234525, 2.74319999999999,   !- X,Y,Z Vertex 1 {m}
+  23.4315, 22.234525, 2.7432,             !- X,Y,Z Vertex 1 {m}
   23.4315, 22.234525, 0,                  !- X,Y,Z Vertex 2 {m}
   18.310225, 22.234525, 0,                !- X,Y,Z Vertex 3 {m}
-  18.310225, 22.234525, 2.74319999999999; !- X,Y,Z Vertex 4 {m}
+  18.310225, 22.234525, 2.7432;           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {6da7c73a-cf17-4901-855b-14f71cc18f51}, !- Handle
-  Surface 170,                            !- Name
+  ActiveStorage_Bot_1 - Wall 000_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {8bfa1513-dde5-445d-b5af-69b547f9fed4}, !- Space Name
@@ -3279,7 +3279,7 @@ OS:Surface,
 
 OS:Surface,
   {e8058ef7-9442-4ab9-b937-d7a786a5c489}, !- Handle
-  Surface 171,                            !- Name
+  ActiveStorage_Bot_4 - Wall 180_b,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {28928794-2be1-4844-8cbb-7e9a5135b712}, !- Space Name
@@ -3296,7 +3296,7 @@ OS:Surface,
 
 OS:Surface,
   {ac1a0acc-0ecd-494f-b1ca-a9c9de0ee8ae}, !- Handle
-  Surface 172,                            !- Name
+  Corridor_Bot_2 - Wall 180_e,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {93f9b288-ab23-4aeb-92d3-0f31119c425c}, !- Space Name
@@ -3313,7 +3313,7 @@ OS:Surface,
 
 OS:Surface,
   {613ea5db-8d1a-408b-91a6-956b34d6d724}, !- Handle
-  Surface 173,                            !- Name
+  Corridor_Bot_2 - Wall 000_b,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {93f9b288-ab23-4aeb-92d3-0f31119c425c}, !- Space Name
@@ -3330,7 +3330,7 @@ OS:Surface,
 
 OS:Surface,
   {065c988d-7355-4efc-81a9-234d7e16bd44}, !- Handle
-  Surface 174,                            !- Name
+  Corridor_Bot_2 - Wall 180_f,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {93f9b288-ab23-4aeb-92d3-0f31119c425c}, !- Space Name
@@ -3347,7 +3347,7 @@ OS:Surface,
 
 OS:Surface,
   {d22b320f-7852-4141-a449-e0735ee09e66}, !- Handle
-  Surface 175,                            !- Name
+  Corridor_Bot_2 - Wall 180_g,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {93f9b288-ab23-4aeb-92d3-0f31119c425c}, !- Space Name
@@ -3364,7 +3364,7 @@ OS:Surface,
 
 OS:Surface,
   {f131bfc5-286e-4230-b5b6-e2fbb3bc9d76}, !- Handle
-  Surface 176,                            !- Name
+  Corridor_Bot_2 - Wall 180_h,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {93f9b288-ab23-4aeb-92d3-0f31119c425c}, !- Space Name
@@ -3381,7 +3381,7 @@ OS:Surface,
 
 OS:Surface,
   {0c30e32c-3adb-46ab-b9da-524f3eed2df0}, !- Handle
-  Surface 177,                            !- Name
+  OpenOffice_Bot_1 - Wall 090_b,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d3b80d82-0387-4e18-a970-84ace3573794}, !- Space Name
@@ -3398,7 +3398,7 @@ OS:Surface,
 
 OS:Surface,
   {94a4c742-1f30-4c48-8dff-45d9dcf9d881}, !- Handle
-  Surface 178,                            !- Name
+  OpenOffice_Bot_1 - Wall 270_b,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d3b80d82-0387-4e18-a970-84ace3573794}, !- Space Name
@@ -3415,7 +3415,7 @@ OS:Surface,
 
 OS:Surface,
   {528cd941-26ec-4eda-9155-b422f0900bc0}, !- Handle
-  Surface 179,                            !- Name
+  OpenOffice_Bot_1 - Wall 090_c,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d3b80d82-0387-4e18-a970-84ace3573794}, !- Space Name
@@ -3432,7 +3432,7 @@ OS:Surface,
 
 OS:Surface,
   {b955f122-db70-48f9-bd32-e5a77470c474}, !- Handle
-  Surface 180,                            !- Name
+  EnclosedOffice_Bot_2 - Wall 270_b,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {597c73f0-ba11-4097-8b84-21dbfe0e3af0}, !- Space Name
@@ -3449,7 +3449,7 @@ OS:Surface,
 
 OS:Surface,
   {14ab2a28-5129-49d9-a67d-528a02b18f14}, !- Handle
-  Surface 181,                            !- Name
+  EnclosedOffice_Bot_2 - Wall 270_c,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {597c73f0-ba11-4097-8b84-21dbfe0e3af0}, !- Space Name
@@ -3471,7 +3471,7 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
+  0,                                      !- X Origin {m}
   0,                                      !- Y Origin {m}
   2.7432,                                 !- Z Origin {m}
   {6ae3b0c2-4c48-48f5-899c-4535e4abda9b}, !- Building Story Name
@@ -3482,7 +3482,7 @@ OS:Space,
 
 OS:Surface,
   {5f67475b-8b60-42e5-8eb1-cc631dca0676}, !- Handle
-  Surface 182,                            !- Name
+  FirstFloor_Plenum - Floor_g,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -3499,7 +3499,7 @@ OS:Surface,
 
 OS:Surface,
   {863e08ab-9859-4c60-8698-9c9411286b27}, !- Handle
-  Surface 183,                            !- Name
+  FirstFloor_Plenum - Wall 090_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -3516,7 +3516,7 @@ OS:Surface,
 
 OS:Surface,
   {1d490495-37fa-4ce2-9a2f-8112fdf702e7}, !- Handle
-  Surface 184,                            !- Name
+  FirstFloor_Plenum - RoofCeiling_d,      !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -3533,7 +3533,7 @@ OS:Surface,
 
 OS:Surface,
   {21b1990d-04db-4cf5-8ba5-2d8bb4604caa}, !- Handle
-  Surface 185,                            !- Name
+  FirstFloor_Plenum - Wall 000_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -3550,7 +3550,7 @@ OS:Surface,
 
 OS:Surface,
   {84df663a-62ce-4246-82fc-b560895943f7}, !- Handle
-  Surface 186,                            !- Name
+  FirstFloor_Plenum - Wall 270_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -3567,7 +3567,7 @@ OS:Surface,
 
 OS:Surface,
   {300f01f2-ed5d-4904-a70d-d16296d79acc}, !- Handle
-  Surface 187,                            !- Name
+  FirstFloor_Plenum - Wall 180_a,         !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -3584,7 +3584,7 @@ OS:Surface,
 
 OS:Surface,
   {e17c644a-21f7-494c-a40f-2899a4152ed3}, !- Handle
-  Surface 188,                            !- Name
+  FirstFloor_Plenum - Floor_h,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -3594,14 +3594,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  33.6724625, 11.0410625, 1.80477854883065e-015, !- X,Y,Z Vertex 1 {m}
-  33.6724625, 6.5611375, -3.60955709766142e-016, !- X,Y,Z Vertex 2 {m}
-  26.4795, 6.5611375, -3.97051280742745e-015, !- X,Y,Z Vertex 3 {m}
-  26.4795, 11.0410625, -1.80477854883066e-015; !- X,Y,Z Vertex 4 {m}
+  33.6724625, 11.0410625, 0,              !- X,Y,Z Vertex 1 {m}
+  33.6724625, 6.5611375, 0,               !- X,Y,Z Vertex 2 {m}
+  26.4795, 6.5611375, 0,                  !- X,Y,Z Vertex 3 {m}
+  26.4795, 11.0410625, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {8d25bb95-10d8-41e8-96d4-014ffa639085}, !- Handle
-  Surface 189,                            !- Name
+  FirstFloor_Plenum - Floor_b,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -3618,7 +3618,7 @@ OS:Surface,
 
 OS:Surface,
   {b942a384-68c6-4508-a059-35eb642dd1e4}, !- Handle
-  Surface 190,                            !- Name
+  FirstFloor_Plenum - Floor_j,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -3628,14 +3628,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  18.310225, 26.71445, 7.21911419532262e-016, !- X,Y,Z Vertex 1 {m}
-  18.310225, 22.234525, -7.21911419532262e-016, !- X,Y,Z Vertex 2 {m}
-  15.3543, 22.234525, -7.21911419532262e-016, !- X,Y,Z Vertex 3 {m}
-  15.3543, 26.71445, 7.21911419532262e-016; !- X,Y,Z Vertex 4 {m}
+  18.310225, 26.71445, 0,                 !- X,Y,Z Vertex 1 {m}
+  18.310225, 22.234525, 0,                !- X,Y,Z Vertex 2 {m}
+  15.3543, 22.234525, 0,                  !- X,Y,Z Vertex 3 {m}
+  15.3543, 26.71445, 0;                   !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {f67f3364-0404-4268-9dec-5e566497e972}, !- Handle
-  Surface 191,                            !- Name
+  FirstFloor_Plenum - Floor_k,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -3652,7 +3652,7 @@ OS:Surface,
 
 OS:Surface,
   {229790ec-45aa-4146-82ba-a93c85581061}, !- Handle
-  Surface 192,                            !- Name
+  FirstFloor_Plenum - Floor_l,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -3662,14 +3662,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  18.0975, 22.234525, -7.21911419532262e-016, !- X,Y,Z Vertex 1 {m}
-  18.0975, 11.0410625, 7.21911419532262e-016, !- X,Y,Z Vertex 2 {m}
-  15.3543, 11.0410625, 7.21911419532262e-016, !- X,Y,Z Vertex 3 {m}
-  15.3543, 22.234525, -7.21911419532262e-016; !- X,Y,Z Vertex 4 {m}
+  18.0975, 22.234525, 0,                  !- X,Y,Z Vertex 1 {m}
+  18.0975, 11.0410625, 0,                 !- X,Y,Z Vertex 2 {m}
+  15.3543, 11.0410625, 0,                 !- X,Y,Z Vertex 3 {m}
+  15.3543, 22.234525, 0;                  !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {5f64776d-9382-4f3c-b7b7-601dca746ea6}, !- Handle
-  Surface 193,                            !- Name
+  FirstFloor_Plenum - Floor_f,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -3686,7 +3686,7 @@ OS:Surface,
 
 OS:Surface,
   {9316e7eb-b921-4ac3-ac25-d329788eb285}, !- Handle
-  Surface 194,                            !- Name
+  FirstFloor_Plenum - Floor_m,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -3707,7 +3707,7 @@ OS:Surface,
 
 OS:Surface,
   {8c5e2a86-41ec-4af7-befe-d5190c827a9c}, !- Handle
-  Surface 195,                            !- Name
+  FirstFloor_Plenum - Floor_n,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -3717,14 +3717,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 26.71445, -7.21911419532262e-016, !- X,Y,Z Vertex 1 {m}
-  23.4315, 22.234525, -2.16573425859679e-015, !- X,Y,Z Vertex 2 {m}
-  18.310225, 22.234525, -7.21911419532262e-016, !- X,Y,Z Vertex 3 {m}
-  18.310225, 26.71445, 7.21911419532265e-016; !- X,Y,Z Vertex 4 {m}
+  23.4315, 26.71445, 0,                   !- X,Y,Z Vertex 1 {m}
+  23.4315, 22.234525, 0,                  !- X,Y,Z Vertex 2 {m}
+  18.310225, 22.234525, 0,                !- X,Y,Z Vertex 3 {m}
+  18.310225, 26.71445, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {f4c4bbe1-25cb-45da-9cc8-b86db24f396f}, !- Handle
-  Surface 196,                            !- Name
+  FirstFloor_Plenum - Floor_o,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -3741,7 +3741,7 @@ OS:Surface,
 
 OS:Surface,
   {f7df5124-9fae-4704-8532-1aded0d593be}, !- Handle
-  Surface 197,                            !- Name
+  FirstFloor_Plenum - Floor_q,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -3762,7 +3762,7 @@ OS:Surface,
 
 OS:Surface,
   {ff0a2cb5-59da-4ddb-84e8-cc8080749976}, !- Handle
-  Surface 198,                            !- Name
+  FirstFloor_Plenum - Floor_s,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -3772,14 +3772,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  30.9292625, 22.234525, 8.12150346973795e-016, !- X,Y,Z Vertex 1 {m}
-  30.9292625, 11.0410625, -8.12150346973793e-016, !- X,Y,Z Vertex 2 {m}
-  26.4795, 11.0410625, -1.71453962138912e-015, !- X,Y,Z Vertex 3 {m}
-  26.4795, 22.234525, -9.02389274415328e-017; !- X,Y,Z Vertex 4 {m}
+  30.9292625, 22.234525, 0,               !- X,Y,Z Vertex 1 {m}
+  30.9292625, 11.0410625, 0,              !- X,Y,Z Vertex 2 {m}
+  26.4795, 11.0410625, 0,                 !- X,Y,Z Vertex 3 {m}
+  26.4795, 22.234525, 0;                  !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {588ab4e2-6191-42c7-91ea-77eea532f014}, !- Handle
-  Surface 199,                            !- Name
+  FirstFloor_Plenum - Floor_c,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -3789,14 +3789,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  26.4795, 26.71445, -2.70716782324596e-016, !- X,Y,Z Vertex 1 {m}
-  26.4795, 6.5611375, -3.69979602510284e-015, !- X,Y,Z Vertex 2 {m}
-  23.4315, 6.5611375, -3.88027387998591e-015, !- X,Y,Z Vertex 3 {m}
-  23.4315, 26.71445, -4.51194637207666e-016; !- X,Y,Z Vertex 4 {m}
+  26.4795, 26.71445, 0,                   !- X,Y,Z Vertex 1 {m}
+  26.4795, 6.5611375, 0,                  !- X,Y,Z Vertex 2 {m}
+  23.4315, 6.5611375, 0,                  !- X,Y,Z Vertex 3 {m}
+  23.4315, 26.71445, 0;                   !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {e4b4dc62-f283-414a-ac0b-adb41b720f80}, !- Handle
-  Surface 200,                            !- Name
+  FirstFloor_Plenum - Floor_t,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -3813,7 +3813,7 @@ OS:Surface,
 
 OS:Surface,
   {05d3820d-212c-4fe8-bc6b-61ab09afe9da}, !- Handle
-  Surface 201,                            !- Name
+  FirstFloor_Plenum - Floor_p,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -3830,7 +3830,7 @@ OS:Surface,
 
 OS:Surface,
   {ce6e2852-c3ac-4029-84ef-f5ca1af2265b}, !- Handle
-  Surface 202,                            !- Name
+  FirstFloor_Plenum - Floor_e,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -3840,14 +3840,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 22.234525, -2.25597318603832e-015, !- X,Y,Z Vertex 1 {m}
-  23.4315, 11.0410625, -9.9262820185686e-016, !- X,Y,Z Vertex 2 {m}
-  18.0975, 11.0410625, 6.31672492090729e-016, !- X,Y,Z Vertex 3 {m}
-  18.0975, 22.234525, -6.31672492090731e-016; !- X,Y,Z Vertex 4 {m}
+  23.4315, 22.234525, 0,                  !- X,Y,Z Vertex 1 {m}
+  23.4315, 11.0410625, 0,                 !- X,Y,Z Vertex 2 {m}
+  18.0975, 11.0410625, 0,                 !- X,Y,Z Vertex 3 {m}
+  18.0975, 22.234525, 0;                  !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {42ef1f73-58bf-4ce2-bbcd-4fbd18c866a7}, !- Handle
-  Surface 203,                            !- Name
+  FirstFloor_Plenum - Floor_u,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -3864,7 +3864,7 @@ OS:Surface,
 
 OS:Surface,
   {a888b100-622d-42f4-9371-e8c3ace13ccd}, !- Handle
-  Surface 204,                            !- Name
+  FirstFloor_Plenum - Floor_v,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -3874,14 +3874,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 11.0410625, -1.44382283906452e-015, !- X,Y,Z Vertex 1 {m}
-  23.4315, 6.5611375, -3.24860138789518e-015, !- X,Y,Z Vertex 2 {m}
-  15.3543, 6.5611375, -7.21911419532266e-016, !- X,Y,Z Vertex 3 {m}
-  15.3543, 11.0410625, 1.08286712929839e-015; !- X,Y,Z Vertex 4 {m}
+  23.4315, 11.0410625, 0,                 !- X,Y,Z Vertex 1 {m}
+  23.4315, 6.5611375, 0,                  !- X,Y,Z Vertex 2 {m}
+  15.3543, 6.5611375, 0,                  !- X,Y,Z Vertex 3 {m}
+  15.3543, 11.0410625, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {6c01a919-bb8e-43b9-bae4-85061210bdb2}, !- Handle
-  Surface 205,                            !- Name
+  FirstFloor_Plenum - Floor_a,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -3891,14 +3891,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  33.6724625, 22.234525, 8.12150346973791e-016, !- X,Y,Z Vertex 1 {m}
-  33.6724625, 11.0410625, 9.92628201856854e-016, !- X,Y,Z Vertex 2 {m}
-  30.9292625, 11.0410625, 9.02389274415274e-017, !- X,Y,Z Vertex 3 {m}
-  30.9292625, 22.234525, -9.02389274415352e-017; !- X,Y,Z Vertex 4 {m}
+  33.6724625, 22.234525, 0,               !- X,Y,Z Vertex 1 {m}
+  33.6724625, 11.0410625, 0,              !- X,Y,Z Vertex 2 {m}
+  30.9292625, 11.0410625, 0,              !- X,Y,Z Vertex 3 {m}
+  30.9292625, 22.234525, 0;               !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {6c67b581-3bea-4e54-b675-851ec03efb32}, !- Handle
-  Surface 206,                            !- Name
+  FirstFloor_Plenum - Floor_w,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -3915,7 +3915,7 @@ OS:Surface,
 
 OS:Surface,
   {cd30b8b8-78fe-434e-8ff8-bb0bbbf23844}, !- Handle
-  Surface 207,                            !- Name
+  FirstFloor_Plenum - Floor_r,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -3925,14 +3925,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  44.1880625, 26.71445, 9.02389274415329e-017, !- X,Y,Z Vertex 1 {m}
-  44.1880625, 6.5611375, -9.02389274415325e-017, !- X,Y,Z Vertex 2 {m}
-  33.6724625, 6.5611375, -2.70716782324598e-016, !- X,Y,Z Vertex 3 {m}
-  33.6724625, 26.71445, -9.02389274415324e-017; !- X,Y,Z Vertex 4 {m}
+  44.1880625, 26.71445, 0,                !- X,Y,Z Vertex 1 {m}
+  44.1880625, 6.5611375, 0,               !- X,Y,Z Vertex 2 {m}
+  33.6724625, 6.5611375, 0,               !- X,Y,Z Vertex 3 {m}
+  33.6724625, 26.71445, 0;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {43049827-cd30-496b-8983-cc7a97635ffc}, !- Handle
-  Surface 208,                            !- Name
+  FirstFloor_Plenum - Floor_d,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -3949,7 +3949,7 @@ OS:Surface,
 
 OS:Surface,
   {20becf71-cbfe-4124-b276-afcc76bb4c4e}, !- Handle
-  Surface 209,                            !- Name
+  FirstFloor_Plenum - Floor_i,            !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -3959,10 +3959,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  15.3543, 26.71445, 4.51194637207664e-016, !- X,Y,Z Vertex 1 {m}
-  15.3543, 6.5611375, -9.02389274415324e-017, !- X,Y,Z Vertex 2 {m}
-  5.7229375, 6.5611375, -2.70716782324598e-016, !- X,Y,Z Vertex 3 {m}
-  5.7229375, 26.71445, 2.70716782324598e-016; !- X,Y,Z Vertex 4 {m}
+  15.3543, 26.71445, 0,                   !- X,Y,Z Vertex 1 {m}
+  15.3543, 6.5611375, 0,                  !- X,Y,Z Vertex 2 {m}
+  5.7229375, 6.5611375, 0,                !- X,Y,Z Vertex 3 {m}
+  5.7229375, 26.71445, 0;                 !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {4e389877-72d6-482c-9f41-78c8947f9391}, !- Handle
@@ -3971,8 +3971,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   3.9624,                                 !- Z Origin {m}
   {78fc9da4-4d1f-40ea-abef-42e2fc17fcf7}, !- Building Story Name
   {4e496989-a555-48b1-8271-e070772f4120}, !- Thermal Zone Name
@@ -3982,7 +3982,7 @@ OS:Space,
 
 OS:Surface,
   {8d13ee4b-c100-480f-9795-eefebcfda61f}, !- Handle
-  Surface 216,                            !- Name
+  ActiveStorage_Mid_1 - Wall 000_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {4e389877-72d6-482c-9f41-78c8947f9391}, !- Space Name
@@ -3999,7 +3999,7 @@ OS:Surface,
 
 OS:Surface,
   {4b0fe52c-111e-4135-9180-48d3dad025ce}, !- Handle
-  Surface 217,                            !- Name
+  ActiveStorage_Mid_1 - Floor_a,          !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {4e389877-72d6-482c-9f41-78c8947f9391}, !- Space Name
@@ -4016,7 +4016,7 @@ OS:Surface,
 
 OS:Surface,
   {def672f3-e468-4bce-af0f-71a20b744087}, !- Handle
-  Surface 218,                            !- Name
+  ActiveStorage_Mid_1 - Wall 270_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {4e389877-72d6-482c-9f41-78c8947f9391}, !- Space Name
@@ -4033,7 +4033,7 @@ OS:Surface,
 
 OS:Surface,
   {accd6328-53f0-4421-8f5f-ddcb02867660}, !- Handle
-  Surface 219,                            !- Name
+  ActiveStorage_Mid_1 - Wall 180_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {4e389877-72d6-482c-9f41-78c8947f9391}, !- Space Name
@@ -4050,7 +4050,7 @@ OS:Surface,
 
 OS:Surface,
   {3bb21499-2f8d-4777-8c31-37d03d385d0e}, !- Handle
-  Surface 220,                            !- Name
+  ActiveStorage_Mid_1 - Wall 090_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {4e389877-72d6-482c-9f41-78c8947f9391}, !- Space Name
@@ -4067,7 +4067,7 @@ OS:Surface,
 
 OS:Surface,
   {b628aeb5-10b3-48d1-b5f2-95a05a364441}, !- Handle
-  Surface 221,                            !- Name
+  ActiveStorage_Mid_1 - RoofCeiling_a,    !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {4e389877-72d6-482c-9f41-78c8947f9391}, !- Space Name
@@ -4084,7 +4084,7 @@ OS:Surface,
 
 OS:Surface,
   {77646783-bfec-4b8e-a55f-c342a113e86c}, !- Handle
-  Surface 222,                            !- Name
+  ActiveStorage_Mid_1 - Wall 000_b,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {4e389877-72d6-482c-9f41-78c8947f9391}, !- Space Name
@@ -4106,8 +4106,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   3.9624,                                 !- Z Origin {m}
   {78fc9da4-4d1f-40ea-abef-42e2fc17fcf7}, !- Building Story Name
   {f5662b78-3bfa-482a-a1b9-0364a539e96a}, !- Thermal Zone Name
@@ -4117,7 +4117,7 @@ OS:Space,
 
 OS:Surface,
   {a0e62f09-a39d-4d6b-b04c-8065ab8b7dec}, !- Handle
-  Surface 223,                            !- Name
+  EnclosedOffice_Mid_1 - Wall 090_b,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f0a6c979-b679-4887-8c3e-fd2959a4c252}, !- Space Name
@@ -4134,7 +4134,7 @@ OS:Surface,
 
 OS:Surface,
   {24172482-44be-482d-9a3f-e126d32437f8}, !- Handle
-  Surface 224,                            !- Name
+  EnclosedOffice_Mid_1 - Wall 090_c,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f0a6c979-b679-4887-8c3e-fd2959a4c252}, !- Space Name
@@ -4151,7 +4151,7 @@ OS:Surface,
 
 OS:Surface,
   {a15b0901-00ad-4d3a-9e7c-692e8d8aa338}, !- Handle
-  Surface 225,                            !- Name
+  EnclosedOffice_Mid_1 - Floor_a,         !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {f0a6c979-b679-4887-8c3e-fd2959a4c252}, !- Space Name
@@ -4168,7 +4168,7 @@ OS:Surface,
 
 OS:Surface,
   {8c3445de-922a-4f65-879f-0c59700b0920}, !- Handle
-  Surface 226,                            !- Name
+  EnclosedOffice_Mid_1 - Wall 180_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f0a6c979-b679-4887-8c3e-fd2959a4c252}, !- Space Name
@@ -4185,7 +4185,7 @@ OS:Surface,
 
 OS:Surface,
   {800ceafa-f348-4a91-86ec-673a59177c6e}, !- Handle
-  Surface 227,                            !- Name
+  EnclosedOffice_Mid_1 - Wall 090_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f0a6c979-b679-4887-8c3e-fd2959a4c252}, !- Space Name
@@ -4202,7 +4202,7 @@ OS:Surface,
 
 OS:Surface,
   {aa741c95-947f-4828-a165-c636e6a497b8}, !- Handle
-  Surface 228,                            !- Name
+  EnclosedOffice_Mid_1 - Wall 000_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f0a6c979-b679-4887-8c3e-fd2959a4c252}, !- Space Name
@@ -4219,7 +4219,7 @@ OS:Surface,
 
 OS:Surface,
   {1d081beb-e1b0-4f68-ae07-bf494d782507}, !- Handle
-  Surface 229,                            !- Name
+  EnclosedOffice_Mid_1 - Wall 270_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f0a6c979-b679-4887-8c3e-fd2959a4c252}, !- Space Name
@@ -4236,7 +4236,7 @@ OS:Surface,
 
 OS:Surface,
   {d5103abf-63e7-43c1-8162-10544d341158}, !- Handle
-  Surface 230,                            !- Name
+  EnclosedOffice_Mid_1 - RoofCeiling_a,   !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {f0a6c979-b679-4887-8c3e-fd2959a4c252}, !- Space Name
@@ -4258,8 +4258,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   3.9624,                                 !- Z Origin {m}
   {78fc9da4-4d1f-40ea-abef-42e2fc17fcf7}, !- Building Story Name
   {a9e78f84-bbf7-4eb0-b4f0-996f80cefed9}, !- Thermal Zone Name
@@ -4269,7 +4269,7 @@ OS:Space,
 
 OS:Surface,
   {a3f51059-5f63-49a9-bec7-3a2c80ba30c1}, !- Handle
-  Surface 231,                            !- Name
+  Corridor_Mid_1 - Wall 000_d,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {78b6dd7f-2610-4461-8eef-6df2e285809a}, !- Space Name
@@ -4286,7 +4286,7 @@ OS:Surface,
 
 OS:Surface,
   {fbaa7c4a-a9d4-4fa3-963d-d92f5d0cf7ad}, !- Handle
-  Surface 232,                            !- Name
+  Corridor_Mid_1 - Wall 180_c,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {78b6dd7f-2610-4461-8eef-6df2e285809a}, !- Space Name
@@ -4303,7 +4303,7 @@ OS:Surface,
 
 OS:Surface,
   {2bcc89bd-5502-4dd2-bc4f-8f725af4041e}, !- Handle
-  Surface 233,                            !- Name
+  Corridor_Mid_1 - Wall 000_b,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {78b6dd7f-2610-4461-8eef-6df2e285809a}, !- Space Name
@@ -4320,7 +4320,7 @@ OS:Surface,
 
 OS:Surface,
   {1bedf937-ce18-414d-ad99-190acc93546c}, !- Handle
-  Surface 234,                            !- Name
+  Corridor_Mid_1 - Wall 180_b,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {78b6dd7f-2610-4461-8eef-6df2e285809a}, !- Space Name
@@ -4337,7 +4337,7 @@ OS:Surface,
 
 OS:Surface,
   {5059baaf-debe-4369-bc22-f4a680ea0e26}, !- Handle
-  Surface 235,                            !- Name
+  Corridor_Mid_1 - Wall 000_c,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {78b6dd7f-2610-4461-8eef-6df2e285809a}, !- Space Name
@@ -4354,7 +4354,7 @@ OS:Surface,
 
 OS:Surface,
   {1aa3a40e-8249-482a-881d-60812e0fcfa6}, !- Handle
-  Surface 236,                            !- Name
+  Corridor_Mid_1 - Wall 180_d,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {78b6dd7f-2610-4461-8eef-6df2e285809a}, !- Space Name
@@ -4371,7 +4371,7 @@ OS:Surface,
 
 OS:Surface,
   {705b9311-5fbb-47f3-8ea8-085c0c435838}, !- Handle
-  Surface 237,                            !- Name
+  Corridor_Mid_1 - Wall 180_e,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {78b6dd7f-2610-4461-8eef-6df2e285809a}, !- Space Name
@@ -4388,7 +4388,7 @@ OS:Surface,
 
 OS:Surface,
   {45766433-1385-44cc-b385-308b69cca913}, !- Handle
-  Surface 238,                            !- Name
+  Corridor_Mid_1 - Wall 000_e,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {78b6dd7f-2610-4461-8eef-6df2e285809a}, !- Space Name
@@ -4405,7 +4405,7 @@ OS:Surface,
 
 OS:Surface,
   {523b3e51-8238-4f2f-8392-f38cea440ed6}, !- Handle
-  Surface 239,                            !- Name
+  Corridor_Mid_1 - Floor_a,               !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {78b6dd7f-2610-4461-8eef-6df2e285809a}, !- Space Name
@@ -4426,7 +4426,7 @@ OS:Surface,
 
 OS:Surface,
   {ca6afb79-69de-40dc-8b26-ab995b28e91e}, !- Handle
-  Surface 240,                            !- Name
+  Corridor_Mid_1 - Wall 090_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {78b6dd7f-2610-4461-8eef-6df2e285809a}, !- Space Name
@@ -4443,7 +4443,7 @@ OS:Surface,
 
 OS:Surface,
   {b613aea9-ea0d-4e86-9597-8fc0b00a1603}, !- Handle
-  Surface 241,                            !- Name
+  Corridor_Mid_1 - RoofCeiling_a,         !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {78b6dd7f-2610-4461-8eef-6df2e285809a}, !- Space Name
@@ -4464,7 +4464,7 @@ OS:Surface,
 
 OS:Surface,
   {e905fcac-06d1-4338-a605-88ce10d060f9}, !- Handle
-  Surface 242,                            !- Name
+  Corridor_Mid_1 - Wall 000_f,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {78b6dd7f-2610-4461-8eef-6df2e285809a}, !- Space Name
@@ -4481,7 +4481,7 @@ OS:Surface,
 
 OS:Surface,
   {2a493c40-c251-4d6d-8265-975585970da5}, !- Handle
-  Surface 243,                            !- Name
+  Corridor_Mid_1 - Wall 000_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {78b6dd7f-2610-4461-8eef-6df2e285809a}, !- Space Name
@@ -4498,7 +4498,7 @@ OS:Surface,
 
 OS:Surface,
   {94ac5bf5-ef64-4e5a-8458-3452615f0554}, !- Handle
-  Surface 244,                            !- Name
+  Corridor_Mid_1 - Wall 270_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {78b6dd7f-2610-4461-8eef-6df2e285809a}, !- Space Name
@@ -4515,7 +4515,7 @@ OS:Surface,
 
 OS:Surface,
   {dda6f93d-19e4-45d8-bcec-a2f4d8b34680}, !- Handle
-  Surface 245,                            !- Name
+  Corridor_Mid_1 - Wall 000_g,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {78b6dd7f-2610-4461-8eef-6df2e285809a}, !- Space Name
@@ -4532,7 +4532,7 @@ OS:Surface,
 
 OS:Surface,
   {06c0ab92-4595-4f04-8a03-4e86186dddce}, !- Handle
-  Surface 246,                            !- Name
+  Corridor_Mid_1 - Wall 090_b,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {78b6dd7f-2610-4461-8eef-6df2e285809a}, !- Space Name
@@ -4549,7 +4549,7 @@ OS:Surface,
 
 OS:Surface,
   {843950c9-3da7-4b61-ab23-aa079ee7cb04}, !- Handle
-  Surface 247,                            !- Name
+  Corridor_Mid_1 - Wall 180_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {78b6dd7f-2610-4461-8eef-6df2e285809a}, !- Space Name
@@ -4566,7 +4566,7 @@ OS:Surface,
 
 OS:Surface,
   {c44eb5b8-095f-4706-9e27-82b0692b5120}, !- Handle
-  Surface 248,                            !- Name
+  Corridor_Mid_1 - Wall 270_b,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {78b6dd7f-2610-4461-8eef-6df2e285809a}, !- Space Name
@@ -4588,8 +4588,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   3.9624,                                 !- Z Origin {m}
   {78fc9da4-4d1f-40ea-abef-42e2fc17fcf7}, !- Building Story Name
   {21213f5c-925d-448d-b9a4-22723892e069}, !- Thermal Zone Name
@@ -4599,7 +4599,7 @@ OS:Space,
 
 OS:Surface,
   {b7eae8ae-8192-4ae4-9fca-bc06b0f771ea}, !- Handle
-  Surface 249,                            !- Name
+  OpenOffice_Mid_2 - Wall 090_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {df413531-d117-43e3-9eff-bc366114d051}, !- Space Name
@@ -4616,7 +4616,7 @@ OS:Surface,
 
 OS:Surface,
   {7ce93590-cf07-4b57-b3d4-cd1d6209ac31}, !- Handle
-  Surface 250,                            !- Name
+  OpenOffice_Mid_2 - Wall 270_b,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {df413531-d117-43e3-9eff-bc366114d051}, !- Space Name
@@ -4633,7 +4633,7 @@ OS:Surface,
 
 OS:Surface,
   {ed2b5fd9-38e9-47a6-8f05-0194724702c7}, !- Handle
-  Surface 251,                            !- Name
+  OpenOffice_Mid_2 - Wall 270_c,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {df413531-d117-43e3-9eff-bc366114d051}, !- Space Name
@@ -4650,7 +4650,7 @@ OS:Surface,
 
 OS:Surface,
   {ef24add5-7eb8-4f50-988f-153d04b09403}, !- Handle
-  Surface 252,                            !- Name
+  OpenOffice_Mid_2 - Floor_a,             !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {df413531-d117-43e3-9eff-bc366114d051}, !- Space Name
@@ -4667,7 +4667,7 @@ OS:Surface,
 
 OS:Surface,
   {ab9884d1-1fb8-43d4-867c-edb22710260f}, !- Handle
-  Surface 253,                            !- Name
+  OpenOffice_Mid_2 - RoofCeiling_a,       !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {df413531-d117-43e3-9eff-bc366114d051}, !- Space Name
@@ -4684,7 +4684,7 @@ OS:Surface,
 
 OS:Surface,
   {f9d282dd-b3de-4fe6-ae2a-72bc19b5ef09}, !- Handle
-  Surface 254,                            !- Name
+  OpenOffice_Mid_2 - Wall 180_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {df413531-d117-43e3-9eff-bc366114d051}, !- Space Name
@@ -4701,7 +4701,7 @@ OS:Surface,
 
 OS:Surface,
   {5af875f0-e630-45ce-876c-8b7163d16ec6}, !- Handle
-  Surface 255,                            !- Name
+  OpenOffice_Mid_2 - Wall 090_b,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {df413531-d117-43e3-9eff-bc366114d051}, !- Space Name
@@ -4718,7 +4718,7 @@ OS:Surface,
 
 OS:Surface,
   {0e975ad3-a19a-4fc6-bf73-c8f81177ef02}, !- Handle
-  Surface 256,                            !- Name
+  OpenOffice_Mid_2 - Wall 270_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {df413531-d117-43e3-9eff-bc366114d051}, !- Space Name
@@ -4735,7 +4735,7 @@ OS:Surface,
 
 OS:Surface,
   {88bf7f70-d7f3-4a3c-9d3a-5990ff43ae38}, !- Handle
-  Surface 257,                            !- Name
+  OpenOffice_Mid_2 - Wall 000_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {df413531-d117-43e3-9eff-bc366114d051}, !- Space Name
@@ -4757,8 +4757,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   3.9624,                                 !- Z Origin {m}
   {78fc9da4-4d1f-40ea-abef-42e2fc17fcf7}, !- Building Story Name
   {3f26caba-10b2-48c4-a6e2-5f74653bbc44}, !- Thermal Zone Name
@@ -4768,7 +4768,7 @@ OS:Space,
 
 OS:Surface,
   {73c49e8b-31d4-46c7-87db-6e2462c7c9ea}, !- Handle
-  Surface 258,                            !- Name
+  ActiveStorage_Mid_2 - Wall 000_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {9e41e3d2-92f3-42bd-89c8-6609dddb08bc}, !- Space Name
@@ -4785,7 +4785,7 @@ OS:Surface,
 
 OS:Surface,
   {a329fab7-97e7-47d2-bdea-a72a6fde1768}, !- Handle
-  Surface 259,                            !- Name
+  ActiveStorage_Mid_2 - Floor_a,          !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {9e41e3d2-92f3-42bd-89c8-6609dddb08bc}, !- Space Name
@@ -4802,7 +4802,7 @@ OS:Surface,
 
 OS:Surface,
   {d8661755-9584-4833-9c6e-1498f38e34b1}, !- Handle
-  Surface 260,                            !- Name
+  ActiveStorage_Mid_2 - RoofCeiling_a,    !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {9e41e3d2-92f3-42bd-89c8-6609dddb08bc}, !- Space Name
@@ -4819,7 +4819,7 @@ OS:Surface,
 
 OS:Surface,
   {698cfe51-b3b6-48e5-8d47-7306d3f4d140}, !- Handle
-  Surface 261,                            !- Name
+  ActiveStorage_Mid_2 - Wall 270_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {9e41e3d2-92f3-42bd-89c8-6609dddb08bc}, !- Space Name
@@ -4836,7 +4836,7 @@ OS:Surface,
 
 OS:Surface,
   {3a5587c4-d1f9-47f4-b4f3-162fd88625e1}, !- Handle
-  Surface 262,                            !- Name
+  ActiveStorage_Mid_2 - Wall 180_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {9e41e3d2-92f3-42bd-89c8-6609dddb08bc}, !- Space Name
@@ -4853,7 +4853,7 @@ OS:Surface,
 
 OS:Surface,
   {82e5a564-2465-4fea-9077-ee69c2f2d524}, !- Handle
-  Surface 263,                            !- Name
+  ActiveStorage_Mid_2 - Wall 000_b,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {9e41e3d2-92f3-42bd-89c8-6609dddb08bc}, !- Space Name
@@ -4870,7 +4870,7 @@ OS:Surface,
 
 OS:Surface,
   {b3476387-e36b-4c1f-948f-c6bda46bfd3e}, !- Handle
-  Surface 264,                            !- Name
+  ActiveStorage_Mid_2 - Wall 090_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {9e41e3d2-92f3-42bd-89c8-6609dddb08bc}, !- Space Name
@@ -4892,8 +4892,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   3.9624,                                 !- Z Origin {m}
   {78fc9da4-4d1f-40ea-abef-42e2fc17fcf7}, !- Building Story Name
   {34e2116a-bc2e-4145-914c-ee5402691877}, !- Thermal Zone Name
@@ -4903,7 +4903,7 @@ OS:Space,
 
 OS:Surface,
   {27843e1f-58bb-4a51-8234-a22b44da797b}, !- Handle
-  Surface 265,                            !- Name
+  Stair_Mid_2 - Floor_a,                  !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {043c1bed-f3c5-4d34-8a90-734e65850131}, !- Space Name
@@ -4920,7 +4920,7 @@ OS:Surface,
 
 OS:Surface,
   {2b764aa9-840e-47d9-b238-d2076bda30f6}, !- Handle
-  Surface 266,                            !- Name
+  Stair_Mid_2 - Wall 180_a,               !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {043c1bed-f3c5-4d34-8a90-734e65850131}, !- Space Name
@@ -4937,7 +4937,7 @@ OS:Surface,
 
 OS:Surface,
   {c62814a8-1612-4a53-af5f-72c4a9ce824c}, !- Handle
-  Surface 267,                            !- Name
+  Stair_Mid_2 - RoofCeiling_a,            !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {043c1bed-f3c5-4d34-8a90-734e65850131}, !- Space Name
@@ -4954,7 +4954,7 @@ OS:Surface,
 
 OS:Surface,
   {c3d0e0cf-3ca6-4fd6-b9a4-7a3efcafb954}, !- Handle
-  Surface 268,                            !- Name
+  Stair_Mid_2 - Wall 270_a,               !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {043c1bed-f3c5-4d34-8a90-734e65850131}, !- Space Name
@@ -4971,7 +4971,7 @@ OS:Surface,
 
 OS:Surface,
   {9fe1679a-e740-418f-91a0-157116a3225a}, !- Handle
-  Surface 269,                            !- Name
+  Stair_Mid_2 - Wall 000_a,               !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {043c1bed-f3c5-4d34-8a90-734e65850131}, !- Space Name
@@ -4988,7 +4988,7 @@ OS:Surface,
 
 OS:Surface,
   {b18de3ee-fa7a-4a2b-8203-0dc9a8c01be2}, !- Handle
-  Surface 270,                            !- Name
+  Stair_Mid_2 - Wall 090_a,               !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {043c1bed-f3c5-4d34-8a90-734e65850131}, !- Space Name
@@ -5010,8 +5010,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   3.9624,                                 !- Z Origin {m}
   {78fc9da4-4d1f-40ea-abef-42e2fc17fcf7}, !- Building Story Name
   {05d36b9e-f449-426c-b8eb-b5032321d155}, !- Thermal Zone Name
@@ -5021,7 +5021,7 @@ OS:Space,
 
 OS:Surface,
   {901a3483-3b8c-4be0-9d90-115bfc46dc69}, !- Handle
-  Surface 271,                            !- Name
+  ActiveStorage_Mid_3 - Wall 180_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {07c2c681-44df-453e-824e-dbf9410b3f66}, !- Space Name
@@ -5038,7 +5038,7 @@ OS:Surface,
 
 OS:Surface,
   {2ef10164-9b1d-4cdd-a29a-9a8871307619}, !- Handle
-  Surface 272,                            !- Name
+  ActiveStorage_Mid_3 - Floor_a,          !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {07c2c681-44df-453e-824e-dbf9410b3f66}, !- Space Name
@@ -5055,7 +5055,7 @@ OS:Surface,
 
 OS:Surface,
   {39261352-34a7-43f9-b109-8991058e0535}, !- Handle
-  Surface 273,                            !- Name
+  ActiveStorage_Mid_3 - Wall 180_b,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {07c2c681-44df-453e-824e-dbf9410b3f66}, !- Space Name
@@ -5072,7 +5072,7 @@ OS:Surface,
 
 OS:Surface,
   {27852ba4-4913-4686-84e7-f5e0eab1145a}, !- Handle
-  Surface 274,                            !- Name
+  ActiveStorage_Mid_3 - Wall 270_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {07c2c681-44df-453e-824e-dbf9410b3f66}, !- Space Name
@@ -5089,7 +5089,7 @@ OS:Surface,
 
 OS:Surface,
   {7d06b329-226b-4dd9-a519-f0cbc70ea2a9}, !- Handle
-  Surface 275,                            !- Name
+  ActiveStorage_Mid_3 - RoofCeiling_a,    !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {07c2c681-44df-453e-824e-dbf9410b3f66}, !- Space Name
@@ -5106,7 +5106,7 @@ OS:Surface,
 
 OS:Surface,
   {4dffcf8b-1c09-4685-abb2-7bfa22ef3377}, !- Handle
-  Surface 276,                            !- Name
+  ActiveStorage_Mid_3 - Wall 000_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {07c2c681-44df-453e-824e-dbf9410b3f66}, !- Space Name
@@ -5123,7 +5123,7 @@ OS:Surface,
 
 OS:Surface,
   {58e57424-20ac-4e08-9d92-8a1da509248b}, !- Handle
-  Surface 277,                            !- Name
+  ActiveStorage_Mid_3 - Wall 090_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {07c2c681-44df-453e-824e-dbf9410b3f66}, !- Space Name
@@ -5145,8 +5145,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   3.9624,                                 !- Z Origin {m}
   {78fc9da4-4d1f-40ea-abef-42e2fc17fcf7}, !- Building Story Name
   {774bfcef-ec77-49e6-8be7-6fdfdd560d07}, !- Thermal Zone Name
@@ -5156,7 +5156,7 @@ OS:Space,
 
 OS:Surface,
   {d38f5f06-3cbf-4d6e-b704-5045b8d943db}, !- Handle
-  Surface 278,                            !- Name
+  Lobby_Mid - Wall 270_b,                 !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {99514813-db6d-4470-adca-b6b0ff5d6f50}, !- Space Name
@@ -5166,14 +5166,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 22.234525, 2.74319999999999,   !- X,Y,Z Vertex 1 {m}
+  23.4315, 22.234525, 2.7432,             !- X,Y,Z Vertex 1 {m}
   23.4315, 22.234525, 0,                  !- X,Y,Z Vertex 2 {m}
   23.4315, 11.0410625, 0,                 !- X,Y,Z Vertex 3 {m}
-  23.4315, 11.0410625, 2.74319999999999;  !- X,Y,Z Vertex 4 {m}
+  23.4315, 11.0410625, 2.7432;            !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {e9fc9f96-121e-4f6e-a68c-afe05459db9a}, !- Handle
-  Surface 279,                            !- Name
+  Lobby_Mid - Wall 090_b,                 !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {99514813-db6d-4470-adca-b6b0ff5d6f50}, !- Space Name
@@ -5183,14 +5183,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  26.4795, 6.5611375, 2.74319999999999,   !- X,Y,Z Vertex 1 {m}
+  26.4795, 6.5611375, 2.7432,             !- X,Y,Z Vertex 1 {m}
   26.4795, 6.5611375, 0,                  !- X,Y,Z Vertex 2 {m}
   26.4795, 11.0410625, 0,                 !- X,Y,Z Vertex 3 {m}
-  26.4795, 11.0410625, 2.74319999999999;  !- X,Y,Z Vertex 4 {m}
+  26.4795, 11.0410625, 2.7432;            !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {1886a733-b872-4701-b5f9-b99184c05f2a}, !- Handle
-  Surface 280,                            !- Name
+  Lobby_Mid - Wall 090_a,                 !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {99514813-db6d-4470-adca-b6b0ff5d6f50}, !- Space Name
@@ -5200,14 +5200,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  26.4795, 11.0410625, 2.74319999999999,  !- X,Y,Z Vertex 1 {m}
+  26.4795, 11.0410625, 2.7432,            !- X,Y,Z Vertex 1 {m}
   26.4795, 11.0410625, 0,                 !- X,Y,Z Vertex 2 {m}
   26.4795, 22.234525, 0,                  !- X,Y,Z Vertex 3 {m}
-  26.4795, 22.234525, 2.74319999999999;   !- X,Y,Z Vertex 4 {m}
+  26.4795, 22.234525, 2.7432;             !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {989ea5b9-3f1f-4851-bb8f-858c98aca08c}, !- Handle
-  Surface 281,                            !- Name
+  Lobby_Mid - Floor_a,                    !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {99514813-db6d-4470-adca-b6b0ff5d6f50}, !- Space Name
@@ -5224,7 +5224,7 @@ OS:Surface,
 
 OS:Surface,
   {e6f3e681-40b0-442d-bfec-535ad7aae1e7}, !- Handle
-  Surface 282,                            !- Name
+  Lobby_Mid - RoofCeiling_a,              !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {99514813-db6d-4470-adca-b6b0ff5d6f50}, !- Space Name
@@ -5234,14 +5234,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  26.4795, 6.5611375, 2.74319999999999,   !- X,Y,Z Vertex 1 {m}
-  26.4795, 26.71445, 2.74319999999999,    !- X,Y,Z Vertex 2 {m}
-  23.4315, 26.71445, 2.74319999999999,    !- X,Y,Z Vertex 3 {m}
-  23.4315, 6.5611375, 2.74319999999999;   !- X,Y,Z Vertex 4 {m}
+  26.4795, 6.5611375, 2.7432,             !- X,Y,Z Vertex 1 {m}
+  26.4795, 26.71445, 2.7432,              !- X,Y,Z Vertex 2 {m}
+  23.4315, 26.71445, 2.7432,              !- X,Y,Z Vertex 3 {m}
+  23.4315, 6.5611375, 2.7432;             !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {04ebcefc-e70c-48f7-ae01-1ec7a17ab4ac}, !- Handle
-  Surface 283,                            !- Name
+  Lobby_Mid - Wall 180_a,                 !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {99514813-db6d-4470-adca-b6b0ff5d6f50}, !- Space Name
@@ -5251,14 +5251,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 6.5611375, 2.74319999999999,   !- X,Y,Z Vertex 1 {m}
+  23.4315, 6.5611375, 2.7432,             !- X,Y,Z Vertex 1 {m}
   23.4315, 6.5611375, 0,                  !- X,Y,Z Vertex 2 {m}
   26.4795, 6.5611375, 0,                  !- X,Y,Z Vertex 3 {m}
-  26.4795, 6.5611375, 2.74319999999999;   !- X,Y,Z Vertex 4 {m}
+  26.4795, 6.5611375, 2.7432;             !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {12d642bb-1ebb-4cce-9bed-fce43fcd8cd3}, !- Handle
-  Surface 284,                            !- Name
+  Lobby_Mid - Wall 270_a,                 !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {99514813-db6d-4470-adca-b6b0ff5d6f50}, !- Space Name
@@ -5268,14 +5268,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 26.71445, 2.74319999999999,    !- X,Y,Z Vertex 1 {m}
+  23.4315, 26.71445, 2.7432,              !- X,Y,Z Vertex 1 {m}
   23.4315, 26.71445, 0,                   !- X,Y,Z Vertex 2 {m}
   23.4315, 22.234525, 0,                  !- X,Y,Z Vertex 3 {m}
-  23.4315, 22.234525, 2.74319999999999;   !- X,Y,Z Vertex 4 {m}
+  23.4315, 22.234525, 2.7432;             !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {e94cee82-a89c-412c-b80b-347b891cf935}, !- Handle
-  Surface 285,                            !- Name
+  Lobby_Mid - Wall 000_a,                 !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {99514813-db6d-4470-adca-b6b0ff5d6f50}, !- Space Name
@@ -5285,14 +5285,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  26.4795, 26.71445, 2.74319999999999,    !- X,Y,Z Vertex 1 {m}
+  26.4795, 26.71445, 2.7432,              !- X,Y,Z Vertex 1 {m}
   26.4795, 26.71445, 0,                   !- X,Y,Z Vertex 2 {m}
   23.4315, 26.71445, 0,                   !- X,Y,Z Vertex 3 {m}
-  23.4315, 26.71445, 2.74319999999999;    !- X,Y,Z Vertex 4 {m}
+  23.4315, 26.71445, 2.7432;              !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {30c514f8-de4e-40b6-8b6f-d7e7a14c6fdd}, !- Handle
-  Surface 286,                            !- Name
+  Lobby_Mid - Wall 090_c,                 !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {99514813-db6d-4470-adca-b6b0ff5d6f50}, !- Space Name
@@ -5302,14 +5302,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  26.4795, 22.234525, 2.74319999999999,   !- X,Y,Z Vertex 1 {m}
+  26.4795, 22.234525, 2.7432,             !- X,Y,Z Vertex 1 {m}
   26.4795, 22.234525, 0,                  !- X,Y,Z Vertex 2 {m}
   26.4795, 26.71445, 0,                   !- X,Y,Z Vertex 3 {m}
-  26.4795, 26.71445, 2.74319999999999;    !- X,Y,Z Vertex 4 {m}
+  26.4795, 26.71445, 2.7432;              !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {d859326b-58b9-4680-b56b-946909729f67}, !- Handle
-  Surface 287,                            !- Name
+  Lobby_Mid - Wall 270_c,                 !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {99514813-db6d-4470-adca-b6b0ff5d6f50}, !- Space Name
@@ -5319,10 +5319,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 11.0410625, 2.74319999999999,  !- X,Y,Z Vertex 1 {m}
+  23.4315, 11.0410625, 2.7432,            !- X,Y,Z Vertex 1 {m}
   23.4315, 11.0410625, 0,                 !- X,Y,Z Vertex 2 {m}
   23.4315, 6.5611375, 0,                  !- X,Y,Z Vertex 3 {m}
-  23.4315, 6.5611375, 2.74319999999999;   !- X,Y,Z Vertex 4 {m}
+  23.4315, 6.5611375, 2.7432;             !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {57f3f5b2-5b72-4b03-a755-cfb36254100f}, !- Handle
@@ -5331,8 +5331,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   3.9624,                                 !- Z Origin {m}
   {34c2b3a4-b93e-443b-9867-ce24d7c61c21}, !- Building Story Name
   {80a3580d-b968-449c-a5cc-d3b35a0abc8f}, !- Thermal Zone Name
@@ -5342,7 +5342,7 @@ OS:Space,
 
 OS:Surface,
   {ba9d2fce-bc21-4b7b-b29e-3d02ed301468}, !- Handle
-  Surface 288,                            !- Name
+  Dining_Mid - Floor_a,                   !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {57f3f5b2-5b72-4b03-a755-cfb36254100f}, !- Space Name
@@ -5359,7 +5359,7 @@ OS:Surface,
 
 OS:Surface,
   {60a7d649-cd8d-4d88-9112-3c857dcb83cb}, !- Handle
-  Surface 289,                            !- Name
+  Dining_Mid - RoofCeiling_a,             !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {57f3f5b2-5b72-4b03-a755-cfb36254100f}, !- Space Name
@@ -5369,14 +5369,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 22.234525, 2.74319999999999,   !- X,Y,Z Vertex 1 {m}
-  23.4315, 26.71445, 2.74319999999999,    !- X,Y,Z Vertex 2 {m}
-  18.310225, 26.71445, 2.74319999999999,  !- X,Y,Z Vertex 3 {m}
-  18.310225, 22.234525, 2.74319999999999; !- X,Y,Z Vertex 4 {m}
+  23.4315, 22.234525, 2.7432,             !- X,Y,Z Vertex 1 {m}
+  23.4315, 26.71445, 2.7432,              !- X,Y,Z Vertex 2 {m}
+  18.310225, 26.71445, 2.7432,            !- X,Y,Z Vertex 3 {m}
+  18.310225, 22.234525, 2.7432;           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {75fb4cf4-660b-455a-ad02-52f2de5ecb09}, !- Handle
-  Surface 290,                            !- Name
+  Dining_Mid - Wall 000_a,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {57f3f5b2-5b72-4b03-a755-cfb36254100f}, !- Space Name
@@ -5386,14 +5386,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 26.71445, 2.74319999999999,    !- X,Y,Z Vertex 1 {m}
+  23.4315, 26.71445, 2.7432,              !- X,Y,Z Vertex 1 {m}
   23.4315, 26.71445, 0,                   !- X,Y,Z Vertex 2 {m}
   18.310225, 26.71445, 0,                 !- X,Y,Z Vertex 3 {m}
-  18.310225, 26.71445, 2.74319999999999;  !- X,Y,Z Vertex 4 {m}
+  18.310225, 26.71445, 2.7432;            !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {6cef89df-7578-40ad-a5e8-a5bcb07c96b1}, !- Handle
-  Surface 291,                            !- Name
+  Dining_Mid - Wall 270_a,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {57f3f5b2-5b72-4b03-a755-cfb36254100f}, !- Space Name
@@ -5403,14 +5403,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  18.310225, 26.71445, 2.74319999999999,  !- X,Y,Z Vertex 1 {m}
+  18.310225, 26.71445, 2.7432,            !- X,Y,Z Vertex 1 {m}
   18.310225, 26.71445, 0,                 !- X,Y,Z Vertex 2 {m}
   18.310225, 22.234525, 0,                !- X,Y,Z Vertex 3 {m}
-  18.310225, 22.234525, 2.74319999999999; !- X,Y,Z Vertex 4 {m}
+  18.310225, 22.234525, 2.7432;           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {40d3059e-13a8-4a46-96bc-706f4deb52ad}, !- Handle
-  Surface 292,                            !- Name
+  Dining_Mid - Wall 180_a,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {57f3f5b2-5b72-4b03-a755-cfb36254100f}, !- Space Name
@@ -5420,14 +5420,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  18.310225, 22.234525, 2.74319999999999, !- X,Y,Z Vertex 1 {m}
+  18.310225, 22.234525, 2.7432,           !- X,Y,Z Vertex 1 {m}
   18.310225, 22.234525, 0,                !- X,Y,Z Vertex 2 {m}
   23.4315, 22.234525, 0,                  !- X,Y,Z Vertex 3 {m}
-  23.4315, 22.234525, 2.74319999999999;   !- X,Y,Z Vertex 4 {m}
+  23.4315, 22.234525, 2.7432;             !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {a12a8bc2-80b7-488c-a112-0fc5c29a9eda}, !- Handle
-  Surface 293,                            !- Name
+  Dining_Mid - Wall 090_a,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {57f3f5b2-5b72-4b03-a755-cfb36254100f}, !- Space Name
@@ -5437,10 +5437,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 22.234525, 2.74319999999999,   !- X,Y,Z Vertex 1 {m}
+  23.4315, 22.234525, 2.7432,             !- X,Y,Z Vertex 1 {m}
   23.4315, 22.234525, 0,                  !- X,Y,Z Vertex 2 {m}
   23.4315, 26.71445, 0,                   !- X,Y,Z Vertex 3 {m}
-  23.4315, 26.71445, 2.74319999999999;    !- X,Y,Z Vertex 4 {m}
+  23.4315, 26.71445, 2.7432;              !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {97d239e3-2f93-4f66-88a2-7167dc152e5a}, !- Handle
@@ -5449,8 +5449,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   3.9624,                                 !- Z Origin {m}
   {78fc9da4-4d1f-40ea-abef-42e2fc17fcf7}, !- Building Story Name
   {02b55a4a-a5ec-4d4b-9841-96aad4cca002}, !- Thermal Zone Name
@@ -5460,7 +5460,7 @@ OS:Space,
 
 OS:Surface,
   {1630725c-f163-4ca4-91cc-88950cd4f164}, !- Handle
-  Surface 294,                            !- Name
+  ConfRoom_Mid_2 - Wall 000_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {97d239e3-2f93-4f66-88a2-7167dc152e5a}, !- Space Name
@@ -5477,7 +5477,7 @@ OS:Surface,
 
 OS:Surface,
   {ed1b2bc4-1d2a-4327-97df-49b494b81ae3}, !- Handle
-  Surface 295,                            !- Name
+  ConfRoom_Mid_2 - Floor_a,               !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {97d239e3-2f93-4f66-88a2-7167dc152e5a}, !- Space Name
@@ -5494,7 +5494,7 @@ OS:Surface,
 
 OS:Surface,
   {29c142b6-4f3b-4f13-8075-52d74812945b}, !- Handle
-  Surface 296,                            !- Name
+  ConfRoom_Mid_2 - RoofCeiling_a,         !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {97d239e3-2f93-4f66-88a2-7167dc152e5a}, !- Space Name
@@ -5511,7 +5511,7 @@ OS:Surface,
 
 OS:Surface,
   {848d376d-f805-4000-8d39-88e68ff22991}, !- Handle
-  Surface 297,                            !- Name
+  ConfRoom_Mid_2 - Wall 270_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {97d239e3-2f93-4f66-88a2-7167dc152e5a}, !- Space Name
@@ -5528,7 +5528,7 @@ OS:Surface,
 
 OS:Surface,
   {0876207b-490b-4e82-8079-196239528827}, !- Handle
-  Surface 299,                            !- Name
+  ConfRoom_Mid_2 - Wall 000_b,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {97d239e3-2f93-4f66-88a2-7167dc152e5a}, !- Space Name
@@ -5550,8 +5550,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   3.9624,                                 !- Z Origin {m}
   {78fc9da4-4d1f-40ea-abef-42e2fc17fcf7}, !- Building Story Name
   {ecd7832e-2da2-481c-8cda-24c6441f4211}, !- Thermal Zone Name
@@ -5561,7 +5561,7 @@ OS:Space,
 
 OS:Surface,
   {4b0e967e-42d1-449a-9932-5a25e3d3fe9f}, !- Handle
-  Surface 301,                            !- Name
+  Restroom_Mid - Wall 000_a,              !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {7c677a4d-94d0-45a0-ba23-55916435b088}, !- Space Name
@@ -5571,14 +5571,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 22.234525, 2.74319999999999,   !- X,Y,Z Vertex 1 {m}
+  23.4315, 22.234525, 2.7432,             !- X,Y,Z Vertex 1 {m}
   23.4315, 22.234525, 0,                  !- X,Y,Z Vertex 2 {m}
   18.310225, 22.234525, 0,                !- X,Y,Z Vertex 3 {m}
-  18.310225, 22.234525, 2.74319999999999; !- X,Y,Z Vertex 4 {m}
+  18.310225, 22.234525, 2.7432;           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {af19bd74-c144-4dad-b003-5fed5c156bed}, !- Handle
-  Surface 302,                            !- Name
+  Restroom_Mid - Floor_a,                 !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {7c677a4d-94d0-45a0-ba23-55916435b088}, !- Space Name
@@ -5595,7 +5595,7 @@ OS:Surface,
 
 OS:Surface,
   {97a882d3-b5b6-4276-9d3d-b3879b3a92a3}, !- Handle
-  Surface 303,                            !- Name
+  Restroom_Mid - Wall 090_a,              !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {7c677a4d-94d0-45a0-ba23-55916435b088}, !- Space Name
@@ -5605,14 +5605,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 11.0410625, 2.74319999999999,  !- X,Y,Z Vertex 1 {m}
+  23.4315, 11.0410625, 2.7432,            !- X,Y,Z Vertex 1 {m}
   23.4315, 11.0410625, 0,                 !- X,Y,Z Vertex 2 {m}
   23.4315, 22.234525, 0,                  !- X,Y,Z Vertex 3 {m}
-  23.4315, 22.234525, 2.74319999999999;   !- X,Y,Z Vertex 4 {m}
+  23.4315, 22.234525, 2.7432;             !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {846c3b96-38db-4725-8c05-5205575c7a28}, !- Handle
-  Surface 304,                            !- Name
+  Restroom_Mid - RoofCeiling_a,           !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {7c677a4d-94d0-45a0-ba23-55916435b088}, !- Space Name
@@ -5622,14 +5622,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 11.0410625, 2.74319999999999,  !- X,Y,Z Vertex 1 {m}
-  23.4315, 22.234525, 2.74319999999999,   !- X,Y,Z Vertex 2 {m}
-  18.0975, 22.234525, 2.74319999999999,   !- X,Y,Z Vertex 3 {m}
-  18.0975, 11.0410625, 2.74319999999999;  !- X,Y,Z Vertex 4 {m}
+  23.4315, 11.0410625, 2.7432,            !- X,Y,Z Vertex 1 {m}
+  23.4315, 22.234525, 2.7432,             !- X,Y,Z Vertex 2 {m}
+  18.0975, 22.234525, 2.7432,             !- X,Y,Z Vertex 3 {m}
+  18.0975, 11.0410625, 2.7432;            !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {558337d1-5505-4060-84cf-f57857601d4e}, !- Handle
-  Surface 305,                            !- Name
+  Restroom_Mid - Wall 180_a,              !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {7c677a4d-94d0-45a0-ba23-55916435b088}, !- Space Name
@@ -5639,14 +5639,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  18.0975, 11.0410625, 2.74319999999999,  !- X,Y,Z Vertex 1 {m}
+  18.0975, 11.0410625, 2.7432,            !- X,Y,Z Vertex 1 {m}
   18.0975, 11.0410625, 0,                 !- X,Y,Z Vertex 2 {m}
   23.4315, 11.0410625, 0,                 !- X,Y,Z Vertex 3 {m}
-  23.4315, 11.0410625, 2.74319999999999;  !- X,Y,Z Vertex 4 {m}
+  23.4315, 11.0410625, 2.7432;            !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {0acc55b6-f15a-4089-8cec-2a12b9445323}, !- Handle
-  Surface 306,                            !- Name
+  Restroom_Mid - Wall 000_b,              !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {7c677a4d-94d0-45a0-ba23-55916435b088}, !- Space Name
@@ -5656,14 +5656,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  18.310225, 22.234525, 2.74319999999999, !- X,Y,Z Vertex 1 {m}
+  18.310225, 22.234525, 2.7432,           !- X,Y,Z Vertex 1 {m}
   18.310225, 22.234525, 0,                !- X,Y,Z Vertex 2 {m}
   18.0975, 22.234525, 0,                  !- X,Y,Z Vertex 3 {m}
-  18.0975, 22.234525, 2.74319999999999;   !- X,Y,Z Vertex 4 {m}
+  18.0975, 22.234525, 2.7432;             !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {287b2b64-fd66-4077-b7b7-66157987ac6d}, !- Handle
-  Surface 307,                            !- Name
+  Restroom_Mid - Wall 270_a,              !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {7c677a4d-94d0-45a0-ba23-55916435b088}, !- Space Name
@@ -5673,10 +5673,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  18.0975, 22.234525, 2.74319999999999,   !- X,Y,Z Vertex 1 {m}
+  18.0975, 22.234525, 2.7432,             !- X,Y,Z Vertex 1 {m}
   18.0975, 22.234525, 0,                  !- X,Y,Z Vertex 2 {m}
   18.0975, 11.0410625, 0,                 !- X,Y,Z Vertex 3 {m}
-  18.0975, 11.0410625, 2.74319999999999;  !- X,Y,Z Vertex 4 {m}
+  18.0975, 11.0410625, 2.7432;            !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {ac3c829e-9b67-4edf-bc90-a35d87f91269}, !- Handle
@@ -5685,8 +5685,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   3.9624,                                 !- Z Origin {m}
   {78fc9da4-4d1f-40ea-abef-42e2fc17fcf7}, !- Building Story Name
   {def599db-7c71-497c-8a7e-0f727c3b6089}, !- Thermal Zone Name
@@ -5696,7 +5696,7 @@ OS:Space,
 
 OS:Surface,
   {f75a439e-f365-49ac-93c0-08091e3027c6}, !- Handle
-  Surface 308,                            !- Name
+  Mechanical_Mid - Wall 180_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {ac3c829e-9b67-4edf-bc90-a35d87f91269}, !- Space Name
@@ -5713,7 +5713,7 @@ OS:Surface,
 
 OS:Surface,
   {6fc0e25a-ef94-4068-b916-81f09e02966b}, !- Handle
-  Surface 309,                            !- Name
+  Mechanical_Mid - Floor_a,               !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {ac3c829e-9b67-4edf-bc90-a35d87f91269}, !- Space Name
@@ -5730,7 +5730,7 @@ OS:Surface,
 
 OS:Surface,
   {f75e26e1-6525-45f1-aa85-654c3e06c1af}, !- Handle
-  Surface 310,                            !- Name
+  Mechanical_Mid - Wall 000_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {ac3c829e-9b67-4edf-bc90-a35d87f91269}, !- Space Name
@@ -5747,7 +5747,7 @@ OS:Surface,
 
 OS:Surface,
   {d7911a43-5fad-4144-9f0b-6b1160ff1052}, !- Handle
-  Surface 311,                            !- Name
+  Mechanical_Mid - RoofCeiling_a,         !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {ac3c829e-9b67-4edf-bc90-a35d87f91269}, !- Space Name
@@ -5764,7 +5764,7 @@ OS:Surface,
 
 OS:Surface,
   {a89ee92d-e90a-421d-b3e8-aae7428da66e}, !- Handle
-  Surface 312,                            !- Name
+  Mechanical_Mid - Wall 090_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {ac3c829e-9b67-4edf-bc90-a35d87f91269}, !- Space Name
@@ -5781,7 +5781,7 @@ OS:Surface,
 
 OS:Surface,
   {4612af34-b536-4825-817c-28bdc45c4386}, !- Handle
-  Surface 313,                            !- Name
+  Mechanical_Mid - Wall 270_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {ac3c829e-9b67-4edf-bc90-a35d87f91269}, !- Space Name
@@ -5803,8 +5803,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   3.9624,                                 !- Z Origin {m}
   {78fc9da4-4d1f-40ea-abef-42e2fc17fcf7}, !- Building Story Name
   {67ed0980-f2da-40fd-994a-63fb55b9c564}, !- Thermal Zone Name
@@ -5814,7 +5814,7 @@ OS:Space,
 
 OS:Surface,
   {bc39b1de-10d5-4f0c-8067-2d845e960f0b}, !- Handle
-  Surface 326,                            !- Name
+  ConfRoom_Mid_1 - Wall 000_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {a2f42132-0f39-42fb-a9bc-1b029ba5c56d}, !- Space Name
@@ -5831,7 +5831,7 @@ OS:Surface,
 
 OS:Surface,
   {45cf57e1-806c-4a6c-9d4c-3976c988291f}, !- Handle
-  Surface 327,                            !- Name
+  ConfRoom_Mid_1 - Floor_a,               !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {a2f42132-0f39-42fb-a9bc-1b029ba5c56d}, !- Space Name
@@ -5848,7 +5848,7 @@ OS:Surface,
 
 OS:Surface,
   {0a981bab-79b7-4a02-a06a-97a9181484e6}, !- Handle
-  Surface 328,                            !- Name
+  ConfRoom_Mid_1 - Wall 180_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {a2f42132-0f39-42fb-a9bc-1b029ba5c56d}, !- Space Name
@@ -5865,7 +5865,7 @@ OS:Surface,
 
 OS:Surface,
   {f2c323f4-4141-4d95-8e8f-7f7e7c1ae483}, !- Handle
-  Surface 330,                            !- Name
+  ConfRoom_Mid_1 - Wall 090_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {a2f42132-0f39-42fb-a9bc-1b029ba5c56d}, !- Space Name
@@ -5882,7 +5882,7 @@ OS:Surface,
 
 OS:Surface,
   {3f2c6949-9aac-4135-913c-476046b89010}, !- Handle
-  Surface 331,                            !- Name
+  ConfRoom_Mid_1 - RoofCeiling_a,         !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {a2f42132-0f39-42fb-a9bc-1b029ba5c56d}, !- Space Name
@@ -5899,7 +5899,7 @@ OS:Surface,
 
 OS:Surface,
   {aaef4127-649b-44d5-b0a5-793c1c5d1aa1}, !- Handle
-  Surface 332,                            !- Name
+  ConfRoom_Mid_1 - Wall 000_b,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {a2f42132-0f39-42fb-a9bc-1b029ba5c56d}, !- Space Name
@@ -5921,8 +5921,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   3.9624,                                 !- Z Origin {m}
   {78fc9da4-4d1f-40ea-abef-42e2fc17fcf7}, !- Building Story Name
   {67de5769-0be9-4996-820e-fffc469a52b0}, !- Thermal Zone Name
@@ -5932,7 +5932,7 @@ OS:Space,
 
 OS:Surface,
   {d2516ba5-9e30-472f-83fa-418e4f893746}, !- Handle
-  Surface 333,                            !- Name
+  ActiveStorage_Mid_4 - Wall 180_b,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f1c0bfcc-53e0-4195-b145-b5e99dda47cc}, !- Space Name
@@ -5949,7 +5949,7 @@ OS:Surface,
 
 OS:Surface,
   {86167355-730b-48ca-bc8d-a9c53bc6a59b}, !- Handle
-  Surface 334,                            !- Name
+  ActiveStorage_Mid_4 - RoofCeiling_a,    !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {f1c0bfcc-53e0-4195-b145-b5e99dda47cc}, !- Space Name
@@ -5966,7 +5966,7 @@ OS:Surface,
 
 OS:Surface,
   {e0016b53-40e9-426f-9d3e-a4fd16c2db40}, !- Handle
-  Surface 335,                            !- Name
+  ActiveStorage_Mid_4 - Wall 000_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f1c0bfcc-53e0-4195-b145-b5e99dda47cc}, !- Space Name
@@ -5983,7 +5983,7 @@ OS:Surface,
 
 OS:Surface,
   {93d17fe3-fa33-482a-94a2-5e7ebd2ba822}, !- Handle
-  Surface 336,                            !- Name
+  ActiveStorage_Mid_4 - Wall 270_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f1c0bfcc-53e0-4195-b145-b5e99dda47cc}, !- Space Name
@@ -6000,7 +6000,7 @@ OS:Surface,
 
 OS:Surface,
   {4c7d66d1-69ad-4dc5-8b69-8a1aa2c5765f}, !- Handle
-  Surface 337,                            !- Name
+  ActiveStorage_Mid_4 - Wall 180_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f1c0bfcc-53e0-4195-b145-b5e99dda47cc}, !- Space Name
@@ -6017,7 +6017,7 @@ OS:Surface,
 
 OS:Surface,
   {20a6cb7e-5687-4e6f-b3f3-75ddfd63d76e}, !- Handle
-  Surface 338,                            !- Name
+  ActiveStorage_Mid_4 - Wall 090_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f1c0bfcc-53e0-4195-b145-b5e99dda47cc}, !- Space Name
@@ -6034,7 +6034,7 @@ OS:Surface,
 
 OS:Surface,
   {b76dd97c-30bc-4841-b0f9-b618afb5d09a}, !- Handle
-  Surface 339,                            !- Name
+  ActiveStorage_Mid_4 - Floor_a,          !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {f1c0bfcc-53e0-4195-b145-b5e99dda47cc}, !- Space Name
@@ -6056,8 +6056,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   3.9624,                                 !- Z Origin {m}
   {78fc9da4-4d1f-40ea-abef-42e2fc17fcf7}, !- Building Story Name
   {cfe70983-ff7f-498a-a553-eae07d8e721f}, !- Thermal Zone Name
@@ -6067,7 +6067,7 @@ OS:Space,
 
 OS:Surface,
   {64feb8c7-2285-4cca-b262-38ad3a23fd32}, !- Handle
-  Surface 340,                            !- Name
+  Corridor_Mid_2 - Wall 180_c,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {8ac827fd-9254-438e-a8da-229b190abbc7}, !- Space Name
@@ -6084,7 +6084,7 @@ OS:Surface,
 
 OS:Surface,
   {82f77e2e-e8b4-470f-8c62-ccf8552895b7}, !- Handle
-  Surface 341,                            !- Name
+  Corridor_Mid_2 - Wall 180_d,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {8ac827fd-9254-438e-a8da-229b190abbc7}, !- Space Name
@@ -6101,7 +6101,7 @@ OS:Surface,
 
 OS:Surface,
   {92449a80-8cd7-4752-88a2-94e96552ba66}, !- Handle
-  Surface 342,                            !- Name
+  Corridor_Mid_2 - Wall 180_e,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {8ac827fd-9254-438e-a8da-229b190abbc7}, !- Space Name
@@ -6118,7 +6118,7 @@ OS:Surface,
 
 OS:Surface,
   {11043709-e96a-452b-a042-8e5d13fe02c1}, !- Handle
-  Surface 343,                            !- Name
+  Corridor_Mid_2 - Wall 000_b,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {8ac827fd-9254-438e-a8da-229b190abbc7}, !- Space Name
@@ -6135,7 +6135,7 @@ OS:Surface,
 
 OS:Surface,
   {20e57d23-32ff-4d8c-8439-eaba6e14e3fb}, !- Handle
-  Surface 344,                            !- Name
+  Corridor_Mid_2 - Wall 180_f,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {8ac827fd-9254-438e-a8da-229b190abbc7}, !- Space Name
@@ -6152,7 +6152,7 @@ OS:Surface,
 
 OS:Surface,
   {e48385e2-8dc3-4e3b-8c2c-dfe1783347b6}, !- Handle
-  Surface 345,                            !- Name
+  Corridor_Mid_2 - Wall 180_g,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {8ac827fd-9254-438e-a8da-229b190abbc7}, !- Space Name
@@ -6169,7 +6169,7 @@ OS:Surface,
 
 OS:Surface,
   {bcf46479-380f-48ac-be00-e4463d070607}, !- Handle
-  Surface 346,                            !- Name
+  Corridor_Mid_2 - Wall 090_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {8ac827fd-9254-438e-a8da-229b190abbc7}, !- Space Name
@@ -6186,7 +6186,7 @@ OS:Surface,
 
 OS:Surface,
   {6bc5e52c-cb94-4912-bc55-3f5d0a4fbabe}, !- Handle
-  Surface 347,                            !- Name
+  Corridor_Mid_2 - Wall 180_h,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {8ac827fd-9254-438e-a8da-229b190abbc7}, !- Space Name
@@ -6203,7 +6203,7 @@ OS:Surface,
 
 OS:Surface,
   {a6f96998-7832-4e9a-89bd-a1d58b5a7974}, !- Handle
-  Surface 348,                            !- Name
+  Corridor_Mid_2 - Wall 270_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {8ac827fd-9254-438e-a8da-229b190abbc7}, !- Space Name
@@ -6220,7 +6220,7 @@ OS:Surface,
 
 OS:Surface,
   {39076209-d29d-47aa-acc4-2606d40da458}, !- Handle
-  Surface 349,                            !- Name
+  Corridor_Mid_2 - Wall 180_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {8ac827fd-9254-438e-a8da-229b190abbc7}, !- Space Name
@@ -6237,7 +6237,7 @@ OS:Surface,
 
 OS:Surface,
   {2e32b126-9001-49df-80ab-abdc42060f5f}, !- Handle
-  Surface 350,                            !- Name
+  Corridor_Mid_2 - Wall 090_b,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {8ac827fd-9254-438e-a8da-229b190abbc7}, !- Space Name
@@ -6254,7 +6254,7 @@ OS:Surface,
 
 OS:Surface,
   {aa9db808-2608-4d3c-8c49-0aeaaabaf7d8}, !- Handle
-  Surface 351,                            !- Name
+  Corridor_Mid_2 - Wall 000_c,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {8ac827fd-9254-438e-a8da-229b190abbc7}, !- Space Name
@@ -6271,7 +6271,7 @@ OS:Surface,
 
 OS:Surface,
   {68df71c4-fab6-4ed9-868d-b41696a3e858}, !- Handle
-  Surface 352,                            !- Name
+  Corridor_Mid_2 - Wall 180_b,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {8ac827fd-9254-438e-a8da-229b190abbc7}, !- Space Name
@@ -6288,7 +6288,7 @@ OS:Surface,
 
 OS:Surface,
   {ad71dc82-f192-4084-bada-281603cacb2d}, !- Handle
-  Surface 353,                            !- Name
+  Corridor_Mid_2 - Wall 270_b,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {8ac827fd-9254-438e-a8da-229b190abbc7}, !- Space Name
@@ -6305,7 +6305,7 @@ OS:Surface,
 
 OS:Surface,
   {79588968-d14a-4890-bd51-a99f7e05f9e2}, !- Handle
-  Surface 354,                            !- Name
+  Corridor_Mid_2 - RoofCeiling_a,         !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {8ac827fd-9254-438e-a8da-229b190abbc7}, !- Space Name
@@ -6326,7 +6326,7 @@ OS:Surface,
 
 OS:Surface,
   {e053199b-3a0f-4dae-ba0f-6041de0d5e81}, !- Handle
-  Surface 355,                            !- Name
+  Corridor_Mid_2 - Floor_a,               !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {8ac827fd-9254-438e-a8da-229b190abbc7}, !- Space Name
@@ -6352,8 +6352,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   3.9624,                                 !- Z Origin {m}
   {78fc9da4-4d1f-40ea-abef-42e2fc17fcf7}, !- Building Story Name
   {58a6dd06-bc3c-43f1-9705-cfcdd57e5995}, !- Thermal Zone Name
@@ -6363,7 +6363,7 @@ OS:Space,
 
 OS:Surface,
   {169b1485-f15c-44a3-a432-a41881f3d912}, !- Handle
-  Surface 356,                            !- Name
+  OpenOffice_Mid_1 - Wall 090_c,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {cbc7e64c-309f-482e-b2a4-75d926545811}, !- Space Name
@@ -6380,7 +6380,7 @@ OS:Surface,
 
 OS:Surface,
   {42cfdc94-b424-468f-ab82-493b4e10e945}, !- Handle
-  Surface 357,                            !- Name
+  OpenOffice_Mid_1 - Wall 270_b,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {cbc7e64c-309f-482e-b2a4-75d926545811}, !- Space Name
@@ -6397,7 +6397,7 @@ OS:Surface,
 
 OS:Surface,
   {75959681-4c59-4316-b375-67b08b75b5d8}, !- Handle
-  Surface 358,                            !- Name
+  OpenOffice_Mid_1 - Wall 090_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {cbc7e64c-309f-482e-b2a4-75d926545811}, !- Space Name
@@ -6414,7 +6414,7 @@ OS:Surface,
 
 OS:Surface,
   {1b1c91a3-f2fe-4359-88b5-350640779612}, !- Handle
-  Surface 359,                            !- Name
+  OpenOffice_Mid_1 - Wall 090_b,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {cbc7e64c-309f-482e-b2a4-75d926545811}, !- Space Name
@@ -6431,7 +6431,7 @@ OS:Surface,
 
 OS:Surface,
   {1f64b26a-60f0-4032-a55d-6bda158007e8}, !- Handle
-  Surface 360,                            !- Name
+  OpenOffice_Mid_1 - Wall 000_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {cbc7e64c-309f-482e-b2a4-75d926545811}, !- Space Name
@@ -6448,7 +6448,7 @@ OS:Surface,
 
 OS:Surface,
   {bef73890-8ae9-48a2-8413-33d455c241f4}, !- Handle
-  Surface 361,                            !- Name
+  OpenOffice_Mid_1 - Wall 180_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {cbc7e64c-309f-482e-b2a4-75d926545811}, !- Space Name
@@ -6465,7 +6465,7 @@ OS:Surface,
 
 OS:Surface,
   {f05d8223-eb62-40a0-aa98-80b72c86a6b5}, !- Handle
-  Surface 362,                            !- Name
+  OpenOffice_Mid_1 - RoofCeiling_a,       !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {cbc7e64c-309f-482e-b2a4-75d926545811}, !- Space Name
@@ -6482,7 +6482,7 @@ OS:Surface,
 
 OS:Surface,
   {c4cfc101-3250-4c42-bb23-c62e55f3fe58}, !- Handle
-  Surface 363,                            !- Name
+  OpenOffice_Mid_1 - Wall 270_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {cbc7e64c-309f-482e-b2a4-75d926545811}, !- Space Name
@@ -6499,7 +6499,7 @@ OS:Surface,
 
 OS:Surface,
   {c69a87ab-14f2-43fd-9ff6-1c6ab002ad97}, !- Handle
-  Surface 364,                            !- Name
+  OpenOffice_Mid_1 - Floor_a,             !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {cbc7e64c-309f-482e-b2a4-75d926545811}, !- Space Name
@@ -6521,8 +6521,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   3.9624,                                 !- Z Origin {m}
   {78fc9da4-4d1f-40ea-abef-42e2fc17fcf7}, !- Building Story Name
   {3f5d3178-72bf-4636-a11d-c5edb98cbc19}, !- Thermal Zone Name
@@ -6532,7 +6532,7 @@ OS:Space,
 
 OS:Surface,
   {0b1bff4b-2638-419e-be51-c2d1d09537ae}, !- Handle
-  Surface 365,                            !- Name
+  EnclosedOffice_Mid_3 - Wall 090_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {33539362-7b43-49a3-9a0d-5f008832b087}, !- Space Name
@@ -6549,7 +6549,7 @@ OS:Surface,
 
 OS:Surface,
   {cd903760-09fd-4136-8816-159cdd837f3e}, !- Handle
-  Surface 366,                            !- Name
+  EnclosedOffice_Mid_3 - Wall 000_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {33539362-7b43-49a3-9a0d-5f008832b087}, !- Space Name
@@ -6566,7 +6566,7 @@ OS:Surface,
 
 OS:Surface,
   {0b9f3a3b-32a9-414a-b967-6ec87524d695}, !- Handle
-  Surface 367,                            !- Name
+  EnclosedOffice_Mid_3 - Wall 180_b,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {33539362-7b43-49a3-9a0d-5f008832b087}, !- Space Name
@@ -6583,7 +6583,7 @@ OS:Surface,
 
 OS:Surface,
   {62a29ade-333a-4f56-9607-ecb1cf4881ed}, !- Handle
-  Surface 368,                            !- Name
+  EnclosedOffice_Mid_3 - Wall 270_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {33539362-7b43-49a3-9a0d-5f008832b087}, !- Space Name
@@ -6600,7 +6600,7 @@ OS:Surface,
 
 OS:Surface,
   {706dd5ba-ce1c-46e8-92f5-07d4c69efc29}, !- Handle
-  Surface 369,                            !- Name
+  EnclosedOffice_Mid_3 - RoofCeiling_a,   !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {33539362-7b43-49a3-9a0d-5f008832b087}, !- Space Name
@@ -6617,7 +6617,7 @@ OS:Surface,
 
 OS:Surface,
   {f7d77da6-88c0-46db-92f1-2f81104dd262}, !- Handle
-  Surface 370,                            !- Name
+  EnclosedOffice_Mid_3 - Floor_a,         !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {33539362-7b43-49a3-9a0d-5f008832b087}, !- Space Name
@@ -6639,8 +6639,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   3.9624,                                 !- Z Origin {m}
   {78fc9da4-4d1f-40ea-abef-42e2fc17fcf7}, !- Building Story Name
   {e57a208a-d0a0-483c-834b-83f1b15670ba}, !- Thermal Zone Name
@@ -6650,7 +6650,7 @@ OS:Space,
 
 OS:Surface,
   {0ec9bb12-1220-4140-88c5-07a0bff1e85f}, !- Handle
-  Surface 371,                            !- Name
+  OpenOffice_Mid_3 - Wall 270_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {52646ffd-e7f7-4b4f-9543-312ced0a6bae}, !- Space Name
@@ -6667,7 +6667,7 @@ OS:Surface,
 
 OS:Surface,
   {44da1640-8d93-4a46-9955-0ca786e6ac43}, !- Handle
-  Surface 372,                            !- Name
+  OpenOffice_Mid_3 - Wall 090_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {52646ffd-e7f7-4b4f-9543-312ced0a6bae}, !- Space Name
@@ -6684,7 +6684,7 @@ OS:Surface,
 
 OS:Surface,
   {83ea213b-fb53-4b2a-96d3-537b60825b58}, !- Handle
-  Surface 373,                            !- Name
+  OpenOffice_Mid_3 - Wall 000_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {52646ffd-e7f7-4b4f-9543-312ced0a6bae}, !- Space Name
@@ -6701,7 +6701,7 @@ OS:Surface,
 
 OS:Surface,
   {c7ba3eb2-f20e-42b7-9a08-e7b02403dabc}, !- Handle
-  Surface 374,                            !- Name
+  OpenOffice_Mid_3 - Wall 180_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {52646ffd-e7f7-4b4f-9543-312ced0a6bae}, !- Space Name
@@ -6718,7 +6718,7 @@ OS:Surface,
 
 OS:Surface,
   {088b56ae-6db9-40d6-b8f3-797dcd0b6a52}, !- Handle
-  Surface 375,                            !- Name
+  OpenOffice_Mid_3 - RoofCeiling_a,       !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {52646ffd-e7f7-4b4f-9543-312ced0a6bae}, !- Space Name
@@ -6735,7 +6735,7 @@ OS:Surface,
 
 OS:Surface,
   {a04fe17f-54d2-46bc-b58e-9dc20320e537}, !- Handle
-  Surface 376,                            !- Name
+  OpenOffice_Mid_3 - Floor_a,             !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {52646ffd-e7f7-4b4f-9543-312ced0a6bae}, !- Space Name
@@ -6757,8 +6757,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   3.9624,                                 !- Z Origin {m}
   {78fc9da4-4d1f-40ea-abef-42e2fc17fcf7}, !- Building Story Name
   {c1a15444-a578-4521-8793-433c820bcd9c}, !- Thermal Zone Name
@@ -6768,7 +6768,7 @@ OS:Space,
 
 OS:Surface,
   {7b533b22-edd8-411f-980f-bc1c69fb42c8}, !- Handle
-  Surface 377,                            !- Name
+  EnclosedOffice_Mid_2 - Wall 270_c,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {5ce85006-2881-44f2-8075-2f399d15ba10}, !- Space Name
@@ -6785,7 +6785,7 @@ OS:Surface,
 
 OS:Surface,
   {8563e8ee-b726-4194-90dd-0671d42018f8}, !- Handle
-  Surface 378,                            !- Name
+  EnclosedOffice_Mid_2 - Wall 270_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {5ce85006-2881-44f2-8075-2f399d15ba10}, !- Space Name
@@ -6802,7 +6802,7 @@ OS:Surface,
 
 OS:Surface,
   {2e39909e-81d0-4ad2-9668-d2b99f6be80b}, !- Handle
-  Surface 379,                            !- Name
+  EnclosedOffice_Mid_2 - Wall 180_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {5ce85006-2881-44f2-8075-2f399d15ba10}, !- Space Name
@@ -6819,7 +6819,7 @@ OS:Surface,
 
 OS:Surface,
   {253b5007-e611-4a79-a17e-6b1ebad0ae35}, !- Handle
-  Surface 380,                            !- Name
+  EnclosedOffice_Mid_2 - Wall 270_b,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {5ce85006-2881-44f2-8075-2f399d15ba10}, !- Space Name
@@ -6836,7 +6836,7 @@ OS:Surface,
 
 OS:Surface,
   {ddacbdb9-4067-4b7c-8554-a393595dbeb8}, !- Handle
-  Surface 382,                            !- Name
+  EnclosedOffice_Mid_2 - RoofCeiling_a,   !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {5ce85006-2881-44f2-8075-2f399d15ba10}, !- Space Name
@@ -6853,7 +6853,7 @@ OS:Surface,
 
 OS:Surface,
   {5e554606-98a6-4c91-99fc-fd673f4051f1}, !- Handle
-  Surface 384,                            !- Name
+  EnclosedOffice_Mid_2 - Floor_a,         !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {5ce85006-2881-44f2-8075-2f399d15ba10}, !- Space Name
@@ -6875,8 +6875,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   3.9624,                                 !- Z Origin {m}
   {78fc9da4-4d1f-40ea-abef-42e2fc17fcf7}, !- Building Story Name
   {5f9749b4-9adf-40cf-baf8-218be7eb55e4}, !- Thermal Zone Name
@@ -6886,7 +6886,7 @@ OS:Space,
 
 OS:Surface,
   {5343b9f5-5af0-4d72-b421-a0de7a8ebcb7}, !- Handle
-  Surface 385,                            !- Name
+  Stair_Mid_1 - Wall 000_a,               !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f90cece3-70e9-447e-b482-e9cbe5a23e4d}, !- Space Name
@@ -6903,7 +6903,7 @@ OS:Surface,
 
 OS:Surface,
   {24a042d3-60fe-439e-adcd-9a93b63530f4}, !- Handle
-  Surface 386,                            !- Name
+  Stair_Mid_1 - Wall 090_a,               !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f90cece3-70e9-447e-b482-e9cbe5a23e4d}, !- Space Name
@@ -6920,7 +6920,7 @@ OS:Surface,
 
 OS:Surface,
   {728613d7-e5ae-4831-a849-da4e9c128fd1}, !- Handle
-  Surface 387,                            !- Name
+  Stair_Mid_1 - Wall 270_a,               !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f90cece3-70e9-447e-b482-e9cbe5a23e4d}, !- Space Name
@@ -6937,7 +6937,7 @@ OS:Surface,
 
 OS:Surface,
   {c1aaf4a8-4a33-4831-a5d6-2b4b33a557e6}, !- Handle
-  Surface 388,                            !- Name
+  Stair_Mid_1 - Wall 180_a,               !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f90cece3-70e9-447e-b482-e9cbe5a23e4d}, !- Space Name
@@ -6954,7 +6954,7 @@ OS:Surface,
 
 OS:Surface,
   {306030c9-ac82-44ba-81ca-a8948e8a283f}, !- Handle
-  Surface 389,                            !- Name
+  Stair_Mid_1 - RoofCeiling_a,            !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {f90cece3-70e9-447e-b482-e9cbe5a23e4d}, !- Space Name
@@ -6971,7 +6971,7 @@ OS:Surface,
 
 OS:Surface,
   {80135390-5964-49e2-a981-e3fe80ffac11}, !- Handle
-  Surface 390,                            !- Name
+  Stair_Mid_1 - Floor_a,                  !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {f90cece3-70e9-447e-b482-e9cbe5a23e4d}, !- Space Name
@@ -6993,8 +6993,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  -1.6029653594091e-031,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   3.9624,                                 !- Z Origin {m}
   {78fc9da4-4d1f-40ea-abef-42e2fc17fcf7}, !- Building Story Name
   {61acd950-16f4-4c9f-9bf5-f6ac94f01c7c}, !- Thermal Zone Name
@@ -7004,7 +7004,7 @@ OS:Space,
 
 OS:Surface,
   {f2ae63c5-d9ad-4b5c-8bc6-8bfd3c517e86}, !- Handle
-  Surface 210,                            !- Name
+  OpenOffice_Mid_4 - Floor_a,             !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {d760da4e-d075-4ad8-8f56-c8f324e1c9c9}, !- Space Name
@@ -7014,14 +7014,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  41.8417375, 5.34193749999998, 0,        !- X,Y,Z Vertex 1 {m}
+  41.8417375, 5.3419375, 0,               !- X,Y,Z Vertex 1 {m}
   41.8417375, 0, 0,                       !- X,Y,Z Vertex 2 {m}
   8.0692625, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  8.0692625, 5.34193749999998, 0;         !- X,Y,Z Vertex 4 {m}
+  8.0692625, 5.3419375, 0;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {b1949ba7-1aa6-4c3e-a8b4-7c2006e9d2af}, !- Handle
-  Surface 211,                            !- Name
+  OpenOffice_Mid_4 - Wall 270_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d760da4e-d075-4ad8-8f56-c8f324e1c9c9}, !- Space Name
@@ -7031,14 +7031,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  8.0692625, 5.34193749999998, 2.7432,    !- X,Y,Z Vertex 1 {m}
-  8.0692625, 5.34193749999998, 0,         !- X,Y,Z Vertex 2 {m}
+  8.0692625, 5.3419375, 2.7432,           !- X,Y,Z Vertex 1 {m}
+  8.0692625, 5.3419375, 0,                !- X,Y,Z Vertex 2 {m}
   8.0692625, 0, 0,                        !- X,Y,Z Vertex 3 {m}
   8.0692625, 0, 2.7432;                   !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {b2b77bd1-cc2c-49a8-ad61-796c147d3e7d}, !- Handle
-  Surface 212,                            !- Name
+  OpenOffice_Mid_4 - Wall 090_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d760da4e-d075-4ad8-8f56-c8f324e1c9c9}, !- Space Name
@@ -7050,12 +7050,12 @@ OS:Surface,
   ,                                       !- Number of Vertices
   41.8417375, 0, 2.7432,                  !- X,Y,Z Vertex 1 {m}
   41.8417375, 0, 0,                       !- X,Y,Z Vertex 2 {m}
-  41.8417375, 5.34193749999998, 0,        !- X,Y,Z Vertex 3 {m}
-  41.8417375, 5.34193749999998, 2.7432;   !- X,Y,Z Vertex 4 {m}
+  41.8417375, 5.3419375, 0,               !- X,Y,Z Vertex 3 {m}
+  41.8417375, 5.3419375, 2.7432;          !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {d1927d2b-4630-48f8-8e2b-d3d427798232}, !- Handle
-  Surface 213,                            !- Name
+  OpenOffice_Mid_4 - Wall 180_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d760da4e-d075-4ad8-8f56-c8f324e1c9c9}, !- Space Name
@@ -7072,7 +7072,7 @@ OS:Surface,
 
 OS:Surface,
   {63eb00cc-72d6-4f9b-88bd-c8a31ea3acae}, !- Handle
-  Surface 214,                            !- Name
+  OpenOffice_Mid_4 - RoofCeiling_a,       !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {d760da4e-d075-4ad8-8f56-c8f324e1c9c9}, !- Space Name
@@ -7083,13 +7083,13 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   41.8417375, 0, 2.7432,                  !- X,Y,Z Vertex 1 {m}
-  41.8417375, 5.34193749999998, 2.7432,   !- X,Y,Z Vertex 2 {m}
-  8.0692625, 5.34193749999998, 2.7432,    !- X,Y,Z Vertex 3 {m}
+  41.8417375, 5.3419375, 2.7432,          !- X,Y,Z Vertex 2 {m}
+  8.0692625, 5.3419375, 2.7432,           !- X,Y,Z Vertex 3 {m}
   8.0692625, 0, 2.7432;                   !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {589fcc57-d278-4770-b9de-cd499fe4712a}, !- Handle
-  Surface 215,                            !- Name
+  OpenOffice_Mid_4 - Wall 0_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d760da4e-d075-4ad8-8f56-c8f324e1c9c9}, !- Space Name
@@ -7101,8 +7101,8 @@ OS:Surface,
   ,                                       !- Number of Vertices
   16.5735, 5.3419375, 2.7432,             !- X,Y,Z Vertex 1 {m}
   16.5735, 5.3419375, 0,                  !- X,Y,Z Vertex 2 {m}
-  8.0692625, 5.34193749999998, 0,         !- X,Y,Z Vertex 3 {m}
-  8.0692625, 5.34193749999998, 2.7432;    !- X,Y,Z Vertex 4 {m}
+  8.0692625, 5.3419375, 0,                !- X,Y,Z Vertex 3 {m}
+  8.0692625, 5.3419375, 2.7432;           !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Handle
@@ -7111,8 +7111,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  7.21911419532262e-016,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   3.9624,                                 !- Z Origin {m}
   {78fc9da4-4d1f-40ea-abef-42e2fc17fcf7}, !- Building Story Name
   {0d120da8-0d40-4a9f-92e4-6351ebfc47c1}, !- Thermal Zone Name
@@ -7122,7 +7122,7 @@ OS:Space,
 
 OS:Surface,
   {933f2ec8-bbaf-4f85-9621-15ae4df08a1b}, !- Handle
-  Surface 314,                            !- Name
+  MidFloor_Plenum - Floor_c,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -7139,7 +7139,7 @@ OS:Surface,
 
 OS:Surface,
   {e78b7c4f-8e89-4a1a-ad89-b823eb533cd5}, !- Handle
-  Surface 315,                            !- Name
+  MidFloor_Plenum - Wall 000_a,           !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -7156,7 +7156,7 @@ OS:Surface,
 
 OS:Surface,
   {e74d1bbc-92e9-4eb2-902d-21a98566c0ef}, !- Handle
-  Surface 316,                            !- Name
+  MidFloor_Plenum - Wall 180_a,           !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -7173,7 +7173,7 @@ OS:Surface,
 
 OS:Surface,
   {e56f7b18-4662-4dfa-ba78-158c92f5e944}, !- Handle
-  Surface 317,                            !- Name
+  MidFloor_Plenum - RoofCeiling_i,        !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -7190,7 +7190,7 @@ OS:Surface,
 
 OS:Surface,
   {1789f81f-6b62-4a95-9fa6-7967d092e9c2}, !- Handle
-  Surface 318,                            !- Name
+  MidFloor_Plenum - Wall 270_a,           !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -7207,7 +7207,7 @@ OS:Surface,
 
 OS:Surface,
   {f3f5add7-f5e4-44b6-9f2e-7198f53ed153}, !- Handle
-  Surface 319,                            !- Name
+  MidFloor_Plenum - Wall 090_a,           !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -7224,7 +7224,7 @@ OS:Surface,
 
 OS:Surface,
   {2d913b5d-b8d4-463b-928f-e28c6965bf87}, !- Handle
-  Surface 391,                            !- Name
+  Corridor_Mid_2 - Wall 000_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {8ac827fd-9254-438e-a8da-229b190abbc7}, !- Space Name
@@ -7241,7 +7241,7 @@ OS:Surface,
 
 OS:Surface,
   {eb72b64b-20a2-4417-8313-1dfeecbb4dd4}, !- Handle
-  Surface 392,                            !- Name
+  EnclosedOffice_Mid_3 - Wall 180_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {33539362-7b43-49a3-9a0d-5f008832b087}, !- Space Name
@@ -7258,7 +7258,7 @@ OS:Surface,
 
 OS:Surface,
   {af24cb05-6f1d-428d-aede-40185d08fac8}, !- Handle
-  Surface 393,                            !- Name
+  OpenOffice_Mid_4 - Wall 000_b,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d760da4e-d075-4ad8-8f56-c8f324e1c9c9}, !- Space Name
@@ -7268,14 +7268,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  41.8417375, 5.34193749999998, 2.7432,   !- X,Y,Z Vertex 1 {m}
-  41.8417375, 5.34193749999998, 0,        !- X,Y,Z Vertex 2 {m}
+  41.8417375, 5.3419375, 2.7432,          !- X,Y,Z Vertex 1 {m}
+  41.8417375, 5.3419375, 0,               !- X,Y,Z Vertex 2 {m}
   33.3375, 5.3419375, 0,                  !- X,Y,Z Vertex 3 {m}
   33.3375, 5.3419375, 2.7432;             !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {75335b96-f655-460b-86ea-55a62bf15741}, !- Handle
-  Surface 394,                            !- Name
+  OpenOffice_Mid_4 - Wall 000_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d760da4e-d075-4ad8-8f56-c8f324e1c9c9}, !- Space Name
@@ -7292,7 +7292,7 @@ OS:Surface,
 
 OS:Surface,
   {f32190ad-852c-45b6-a84e-3eb1775bfe2b}, !- Handle
-  Surface 395,                            !- Name
+  MidFloor_Plenum - Floor_n,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -7302,14 +7302,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 11.0410625, 2.74319999999999,  !- X,Y,Z Vertex 1 {m}
-  23.4315, 6.5611375, 2.74319999999999,   !- X,Y,Z Vertex 2 {m}
+  23.4315, 11.0410625, 2.7432,            !- X,Y,Z Vertex 1 {m}
+  23.4315, 6.5611375, 2.7432,             !- X,Y,Z Vertex 2 {m}
   15.3543, 6.5611375, 2.7432,             !- X,Y,Z Vertex 3 {m}
   15.3543, 11.0410625, 2.7432;            !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {7366e4e4-c72d-4015-bd7a-d717dbf72933}, !- Handle
-  Surface 396,                            !- Name
+  MidFloor_Plenum - Floor_o,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -7326,7 +7326,7 @@ OS:Surface,
 
 OS:Surface,
   {d5f2ffd2-4889-4af4-ba52-caaf2fa1e9d6}, !- Handle
-  Surface 397,                            !- Name
+  MidFloor_Plenum - Floor_k,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -7343,7 +7343,7 @@ OS:Surface,
 
 OS:Surface,
   {46f64adc-d065-44bf-84f3-be5ed6132aa3}, !- Handle
-  Surface 398,                            !- Name
+  MidFloor_Plenum - Floor_a,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -7360,7 +7360,7 @@ OS:Surface,
 
 OS:Surface,
   {f44c1b70-4843-46d5-95b1-50196dc10696}, !- Handle
-  Surface 399,                            !- Name
+  MidFloor_Plenum - Floor_l,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -7377,7 +7377,7 @@ OS:Surface,
 
 OS:Surface,
   {e4194949-7da1-4491-b979-d49ac4867c61}, !- Handle
-  Surface 400,                            !- Name
+  MidFloor_Plenum - Floor_g,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -7394,7 +7394,7 @@ OS:Surface,
 
 OS:Surface,
   {9b4f91d6-a39c-496e-a4f8-35a8a435d8f1}, !- Handle
-  Surface 401,                            !- Name
+  MidFloor_Plenum - Floor_m,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -7415,7 +7415,7 @@ OS:Surface,
 
 OS:Surface,
   {790b6dec-5689-4302-9f97-dc8d199f86dd}, !- Handle
-  Surface 402,                            !- Name
+  MidFloor_Plenum - Floor_p,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -7426,13 +7426,13 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   23.4315, 26.71445, 2.7432,              !- X,Y,Z Vertex 1 {m}
-  23.4315, 22.234525, 2.74319999999999,   !- X,Y,Z Vertex 2 {m}
+  23.4315, 22.234525, 2.7432,             !- X,Y,Z Vertex 2 {m}
   18.310225, 22.234525, 2.7432,           !- X,Y,Z Vertex 3 {m}
   18.310225, 26.71445, 2.7432;            !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {b2c53ae3-ce4a-4cc4-a4d9-60eb50aed1f3}, !- Handle
-  Surface 403,                            !- Name
+  MidFloor_Plenum - Floor_q,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -7449,7 +7449,7 @@ OS:Surface,
 
 OS:Surface,
   {3faf1d14-7c37-4d1a-985f-1ca512bb978e}, !- Handle
-  Surface 404,                            !- Name
+  MidFloor_Plenum - Floor_e,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -7466,7 +7466,7 @@ OS:Surface,
 
 OS:Surface,
   {ef393780-2d03-4035-b320-480c92c51cee}, !- Handle
-  Surface 405,                            !- Name
+  MidFloor_Plenum - Floor_r,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -7483,7 +7483,7 @@ OS:Surface,
 
 OS:Surface,
   {ecdffcb6-d21c-4547-ad70-21be89552cbf}, !- Handle
-  Surface 406,                            !- Name
+  MidFloor_Plenum - Floor_i,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -7500,7 +7500,7 @@ OS:Surface,
 
 OS:Surface,
   {a88c72aa-845e-44bc-a065-15c1405f2803}, !- Handle
-  Surface 407,                            !- Name
+  MidFloor_Plenum - Floor_f,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -7521,7 +7521,7 @@ OS:Surface,
 
 OS:Surface,
   {65738bd1-1a90-42dc-9fb4-c9fa58baf804}, !- Handle
-  Surface 408,                            !- Name
+  MidFloor_Plenum - Floor_s,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -7531,14 +7531,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 22.234525, 2.74319999999999,   !- X,Y,Z Vertex 1 {m}
-  23.4315, 11.0410625, 2.74319999999999,  !- X,Y,Z Vertex 2 {m}
+  23.4315, 22.234525, 2.7432,             !- X,Y,Z Vertex 1 {m}
+  23.4315, 11.0410625, 2.7432,            !- X,Y,Z Vertex 2 {m}
   18.0975, 11.0410625, 2.7432,            !- X,Y,Z Vertex 3 {m}
   18.0975, 22.234525, 2.7432;             !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {0dcd1069-c8bd-4939-92ca-b08a43745c14}, !- Handle
-  Surface 409,                            !- Name
+  MidFloor_Plenum - Floor_h,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -7555,7 +7555,7 @@ OS:Surface,
 
 OS:Surface,
   {bfe9b452-d0e1-4256-8fa3-731a89643d37}, !- Handle
-  Surface 410,                            !- Name
+  MidFloor_Plenum - Floor_j,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -7572,7 +7572,7 @@ OS:Surface,
 
 OS:Surface,
   {abcfd959-fb40-4b6c-8e22-dd187f6aad6b}, !- Handle
-  Surface 411,                            !- Name
+  MidFloor_Plenum - Floor_b,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -7583,13 +7583,13 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   26.4795, 26.71445, 2.7432,              !- X,Y,Z Vertex 1 {m}
-  26.4795, 6.5611375, 2.74319999999999,   !- X,Y,Z Vertex 2 {m}
-  23.4315, 6.5611375, 2.74319999999999,   !- X,Y,Z Vertex 3 {m}
+  26.4795, 6.5611375, 2.7432,             !- X,Y,Z Vertex 2 {m}
+  23.4315, 6.5611375, 2.7432,             !- X,Y,Z Vertex 3 {m}
   23.4315, 26.71445, 2.7432;              !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {ab9582bc-d893-4ada-899a-2ad4acd8eced}, !- Handle
-  Surface 412,                            !- Name
+  MidFloor_Plenum - Floor_d,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -7606,7 +7606,7 @@ OS:Surface,
 
 OS:Surface,
   {9ac3a9d2-c928-4ee0-b7d0-940fc071a8e2}, !- Handle
-  Surface 413,                            !- Name
+  MidFloor_Plenum - Floor_t,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -7618,12 +7618,12 @@ OS:Surface,
   ,                                       !- Number of Vertices
   33.6724625, 11.0410625, 2.7432,         !- X,Y,Z Vertex 1 {m}
   33.6724625, 6.5611375, 2.7432,          !- X,Y,Z Vertex 2 {m}
-  26.4795, 6.5611375, 2.74319999999999,   !- X,Y,Z Vertex 3 {m}
+  26.4795, 6.5611375, 2.7432,             !- X,Y,Z Vertex 3 {m}
   26.4795, 11.0410625, 2.7432;            !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {a4c3c222-3d22-4a45-b2c5-421b2686d0f0}, !- Handle
-  Surface 414,                            !- Name
+  MidFloor_Plenum - Floor_u,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -7645,8 +7645,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  7.21911419532262e-016,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   7.9248,                                 !- Z Origin {m}
   {34c2b3a4-b93e-443b-9867-ce24d7c61c21}, !- Building Story Name
   {c6b78f1d-6990-419f-accd-c9dcaa76d920}, !- Thermal Zone Name
@@ -7656,7 +7656,7 @@ OS:Space,
 
 OS:Surface,
   {34443c0b-326e-4913-bcc5-e091e59f28ec}, !- Handle
-  Surface 419,                            !- Name
+  Corridor_Top_2 - Floor_a,               !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {684d765c-071b-490a-b181-4f80e0572fd5}, !- Space Name
@@ -7677,7 +7677,7 @@ OS:Surface,
 
 OS:Surface,
   {025468d1-0b2c-4c3a-928b-0dda2a075c3a}, !- Handle
-  Surface 420,                            !- Name
+  Corridor_Top_2 - RoofCeiling_a,         !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {684d765c-071b-490a-b181-4f80e0572fd5}, !- Space Name
@@ -7698,7 +7698,7 @@ OS:Surface,
 
 OS:Surface,
   {58a77044-64b8-41e3-8255-08e9e6b811f5}, !- Handle
-  Surface 421,                            !- Name
+  Corridor_Top_2 - Wall 270_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {684d765c-071b-490a-b181-4f80e0572fd5}, !- Space Name
@@ -7715,7 +7715,7 @@ OS:Surface,
 
 OS:Surface,
   {daf90dda-bf36-4193-98b5-ad6666a02bc7}, !- Handle
-  Surface 422,                            !- Name
+  Corridor_Top_2 - Wall 180_f,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {684d765c-071b-490a-b181-4f80e0572fd5}, !- Space Name
@@ -7732,7 +7732,7 @@ OS:Surface,
 
 OS:Surface,
   {ed96633c-1096-4b8d-b0fe-054f163b127d}, !- Handle
-  Surface 423,                            !- Name
+  Corridor_Top_2 - Wall 000_b,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {684d765c-071b-490a-b181-4f80e0572fd5}, !- Space Name
@@ -7749,7 +7749,7 @@ OS:Surface,
 
 OS:Surface,
   {e91faf45-846e-4226-8ed8-3c0354c451ec}, !- Handle
-  Surface 424,                            !- Name
+  Corridor_Top_2 - Wall 090_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {684d765c-071b-490a-b181-4f80e0572fd5}, !- Space Name
@@ -7766,7 +7766,7 @@ OS:Surface,
 
 OS:Surface,
   {c1fbc202-5aac-4014-81d6-80f1ffad47cb}, !- Handle
-  Surface 425,                            !- Name
+  Corridor_Top_2 - Wall 180_g,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {684d765c-071b-490a-b181-4f80e0572fd5}, !- Space Name
@@ -7783,7 +7783,7 @@ OS:Surface,
 
 OS:Surface,
   {e24fc624-0095-423b-b0a0-6b8a56d56e48}, !- Handle
-  Surface 426,                            !- Name
+  Corridor_Top_2 - Wall 270_b,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {684d765c-071b-490a-b181-4f80e0572fd5}, !- Space Name
@@ -7800,7 +7800,7 @@ OS:Surface,
 
 OS:Surface,
   {82f4421e-560e-4a77-969a-4e8b68d449ce}, !- Handle
-  Surface 427,                            !- Name
+  Corridor_Top_2 - Wall 180_e,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {684d765c-071b-490a-b181-4f80e0572fd5}, !- Space Name
@@ -7817,7 +7817,7 @@ OS:Surface,
 
 OS:Surface,
   {1ea2566d-d8ea-4dcb-a262-0e2a2ac28d46}, !- Handle
-  Surface 428,                            !- Name
+  Corridor_Top_2 - Wall 090_b,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {684d765c-071b-490a-b181-4f80e0572fd5}, !- Space Name
@@ -7834,7 +7834,7 @@ OS:Surface,
 
 OS:Surface,
   {7965761c-ebcf-4ded-aaf6-a86734b1ad81}, !- Handle
-  Surface 429,                            !- Name
+  Corridor_Top_2 - Wall 180_h,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {684d765c-071b-490a-b181-4f80e0572fd5}, !- Space Name
@@ -7851,7 +7851,7 @@ OS:Surface,
 
 OS:Surface,
   {cf01e91f-c43a-4320-ac0b-108bd73d8083}, !- Handle
-  Surface 430,                            !- Name
+  Corridor_Top_2 - Wall 180_b,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {684d765c-071b-490a-b181-4f80e0572fd5}, !- Space Name
@@ -7868,7 +7868,7 @@ OS:Surface,
 
 OS:Surface,
   {123e7a62-eb04-4448-a9bd-b13405432bed}, !- Handle
-  Surface 431,                            !- Name
+  Corridor_Top_2 - Wall 000_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {684d765c-071b-490a-b181-4f80e0572fd5}, !- Space Name
@@ -7885,7 +7885,7 @@ OS:Surface,
 
 OS:Surface,
   {c9024bcd-01cf-4af4-abcb-fddb3cfd0672}, !- Handle
-  Surface 432,                            !- Name
+  Corridor_Top_2 - Wall 180_c,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {684d765c-071b-490a-b181-4f80e0572fd5}, !- Space Name
@@ -7902,7 +7902,7 @@ OS:Surface,
 
 OS:Surface,
   {05a21aa6-4400-4970-b98e-2dc807617027}, !- Handle
-  Surface 433,                            !- Name
+  Corridor_Top_2 - Wall 180_d,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {684d765c-071b-490a-b181-4f80e0572fd5}, !- Space Name
@@ -7919,7 +7919,7 @@ OS:Surface,
 
 OS:Surface,
   {aa14458e-4ff1-4910-87a7-a3edb26d9748}, !- Handle
-  Surface 434,                            !- Name
+  Corridor_Top_2 - Wall 180_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {684d765c-071b-490a-b181-4f80e0572fd5}, !- Space Name
@@ -7936,7 +7936,7 @@ OS:Surface,
 
 OS:Surface,
   {f9d2a1ee-3ed4-444f-b4e4-f35644adfdbf}, !- Handle
-  Surface 435,                            !- Name
+  Corridor_Top_2 - Wall 000_c,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {684d765c-071b-490a-b181-4f80e0572fd5}, !- Space Name
@@ -7958,8 +7958,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  7.21911419532262e-016,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   7.9248,                                 !- Z Origin {m}
   {34c2b3a4-b93e-443b-9867-ce24d7c61c21}, !- Building Story Name
   {355e4c73-cb17-4378-ba21-8644519dfb5a}, !- Thermal Zone Name
@@ -7969,7 +7969,7 @@ OS:Space,
 
 OS:Surface,
   {26446060-329b-4523-9658-4e127a0bdcea}, !- Handle
-  Surface 462,                            !- Name
+  OpenOffice_Top_1 - Floor_a,             !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {012df538-0e9f-408a-b54c-c013737bb521}, !- Space Name
@@ -7986,7 +7986,7 @@ OS:Surface,
 
 OS:Surface,
   {e69bca5d-d4b1-4be7-83e2-445725daf1e8}, !- Handle
-  Surface 463,                            !- Name
+  OpenOffice_Top_1 - Wall 270_b,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {012df538-0e9f-408a-b54c-c013737bb521}, !- Space Name
@@ -8003,7 +8003,7 @@ OS:Surface,
 
 OS:Surface,
   {fbd39b0f-d023-4894-baf3-33a0db34e045}, !- Handle
-  Surface 464,                            !- Name
+  OpenOffice_Top_1 - RoofCeiling_a,       !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {012df538-0e9f-408a-b54c-c013737bb521}, !- Space Name
@@ -8020,7 +8020,7 @@ OS:Surface,
 
 OS:Surface,
   {6ffc3269-e2a2-45b5-b969-f9a2f0634c15}, !- Handle
-  Surface 465,                            !- Name
+  OpenOffice_Top_1 - Wall 180_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {012df538-0e9f-408a-b54c-c013737bb521}, !- Space Name
@@ -8037,7 +8037,7 @@ OS:Surface,
 
 OS:Surface,
   {d17a96e2-eac9-4f77-82df-0b5144efd671}, !- Handle
-  Surface 466,                            !- Name
+  OpenOffice_Top_1 - Wall 000_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {012df538-0e9f-408a-b54c-c013737bb521}, !- Space Name
@@ -8054,7 +8054,7 @@ OS:Surface,
 
 OS:Surface,
   {a966c9e4-3978-457e-aec2-0b83b6ff3686}, !- Handle
-  Surface 467,                            !- Name
+  OpenOffice_Top_1 - Wall 090_b,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {012df538-0e9f-408a-b54c-c013737bb521}, !- Space Name
@@ -8071,7 +8071,7 @@ OS:Surface,
 
 OS:Surface,
   {f7d3fca9-0a73-4e26-a243-91fa67e0717e}, !- Handle
-  Surface 468,                            !- Name
+  OpenOffice_Top_1 - Wall 090_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {012df538-0e9f-408a-b54c-c013737bb521}, !- Space Name
@@ -8088,7 +8088,7 @@ OS:Surface,
 
 OS:Surface,
   {07626e3b-b4c6-4a86-ae2c-77fae2d38eb4}, !- Handle
-  Surface 469,                            !- Name
+  OpenOffice_Top_1 - Wall 270_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {012df538-0e9f-408a-b54c-c013737bb521}, !- Space Name
@@ -8105,7 +8105,7 @@ OS:Surface,
 
 OS:Surface,
   {0ead78fb-558d-4a7c-91e2-9f11f9fab7e9}, !- Handle
-  Surface 470,                            !- Name
+  OpenOffice_Top_1 - Wall 090_c,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {012df538-0e9f-408a-b54c-c013737bb521}, !- Space Name
@@ -8127,8 +8127,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  7.21911419532262e-016,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   7.9248,                                 !- Z Origin {m}
   {34c2b3a4-b93e-443b-9867-ce24d7c61c21}, !- Building Story Name
   {eb3fcf73-8d14-45e9-ad6e-a3a1445d6895}, !- Thermal Zone Name
@@ -8138,7 +8138,7 @@ OS:Space,
 
 OS:Surface,
   {21ba42ce-e881-499e-88e6-2ba41f0b436d}, !- Handle
-  Surface 471,                            !- Name
+  EnclosedOffice_Top_3 - Floor_a,         !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {088fff13-3245-46c2-bd01-90dce95d2d32}, !- Space Name
@@ -8155,7 +8155,7 @@ OS:Surface,
 
 OS:Surface,
   {627d1435-67c5-400e-aacc-ea0892a1edd7}, !- Handle
-  Surface 472,                            !- Name
+  EnclosedOffice_Top_3 - RoofCeiling_a,   !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {088fff13-3245-46c2-bd01-90dce95d2d32}, !- Space Name
@@ -8172,7 +8172,7 @@ OS:Surface,
 
 OS:Surface,
   {3157b624-dcb4-4363-93bb-2269cc2e0a61}, !- Handle
-  Surface 473,                            !- Name
+  EnclosedOffice_Top_3 - Wall 270_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {088fff13-3245-46c2-bd01-90dce95d2d32}, !- Space Name
@@ -8189,7 +8189,7 @@ OS:Surface,
 
 OS:Surface,
   {56c286b1-05b5-4857-8497-2a7d50a3a4dd}, !- Handle
-  Surface 475,                            !- Name
+  EnclosedOffice_Top_3 - Wall 090_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {088fff13-3245-46c2-bd01-90dce95d2d32}, !- Space Name
@@ -8206,7 +8206,7 @@ OS:Surface,
 
 OS:Surface,
   {88631b6b-9c10-4571-b461-718c45f97d42}, !- Handle
-  Surface 476,                            !- Name
+  EnclosedOffice_Top_3 - Wall 180_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {088fff13-3245-46c2-bd01-90dce95d2d32}, !- Space Name
@@ -8223,7 +8223,7 @@ OS:Surface,
 
 OS:Surface,
   {28c05385-483a-411a-8faf-d42d3ea90852}, !- Handle
-  Surface 477,                            !- Name
+  EnclosedOffice_Top_3 - Wall 180_b,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {088fff13-3245-46c2-bd01-90dce95d2d32}, !- Space Name
@@ -8245,8 +8245,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  7.21911419532262e-016,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   7.9248,                                 !- Z Origin {m}
   {34c2b3a4-b93e-443b-9867-ce24d7c61c21}, !- Building Story Name
   {26a377b7-4408-48d2-bf23-ba3ca649317e}, !- Thermal Zone Name
@@ -8256,7 +8256,7 @@ OS:Space,
 
 OS:Surface,
   {610a922f-0df1-41ce-a85d-9f7ca6402772}, !- Handle
-  Surface 478,                            !- Name
+  OpenOffice_Top_3 - Floor_a,             !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {cd57e5c2-5023-4058-b2a8-752285324e5c}, !- Space Name
@@ -8273,7 +8273,7 @@ OS:Surface,
 
 OS:Surface,
   {d513d23b-d820-418d-b4ad-3007315a4207}, !- Handle
-  Surface 479,                            !- Name
+  OpenOffice_Top_3 - RoofCeiling_a,       !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {cd57e5c2-5023-4058-b2a8-752285324e5c}, !- Space Name
@@ -8290,7 +8290,7 @@ OS:Surface,
 
 OS:Surface,
   {ae3a5181-efed-41ff-a750-7572cc4f12f4}, !- Handle
-  Surface 480,                            !- Name
+  OpenOffice_Top_3 - Wall 180_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {cd57e5c2-5023-4058-b2a8-752285324e5c}, !- Space Name
@@ -8307,7 +8307,7 @@ OS:Surface,
 
 OS:Surface,
   {31aaa649-a714-467a-ad54-52a464a4091d}, !- Handle
-  Surface 481,                            !- Name
+  OpenOffice_Top_3 - Wall 000_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {cd57e5c2-5023-4058-b2a8-752285324e5c}, !- Space Name
@@ -8324,7 +8324,7 @@ OS:Surface,
 
 OS:Surface,
   {cb789a33-3145-473e-ad3a-7255de79addb}, !- Handle
-  Surface 482,                            !- Name
+  OpenOffice_Top_3 - Wall 090_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {cd57e5c2-5023-4058-b2a8-752285324e5c}, !- Space Name
@@ -8341,7 +8341,7 @@ OS:Surface,
 
 OS:Surface,
   {c2a4007c-804b-40c7-b5ea-800f3c5f11ce}, !- Handle
-  Surface 483,                            !- Name
+  OpenOffice_Top_3 - Wall 270_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {cd57e5c2-5023-4058-b2a8-752285324e5c}, !- Space Name
@@ -8363,8 +8363,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  7.21911419532262e-016,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   7.9248,                                 !- Z Origin {m}
   {34c2b3a4-b93e-443b-9867-ce24d7c61c21}, !- Building Story Name
   {1ce45898-8a87-4247-875d-8b2234ad4cd1}, !- Thermal Zone Name
@@ -8374,7 +8374,7 @@ OS:Space,
 
 OS:Surface,
   {a4a8ef25-0d55-4b9d-a5a6-4411a3d07617}, !- Handle
-  Surface 484,                            !- Name
+  EnclosedOffice_Top_2 - Floor_a,         !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {9a8fdf16-17b3-4e90-9f33-f4e710f4b4af}, !- Space Name
@@ -8391,7 +8391,7 @@ OS:Surface,
 
 OS:Surface,
   {b077d97e-9c8a-4261-9da8-c1a47d93f40a}, !- Handle
-  Surface 485,                            !- Name
+  EnclosedOffice_Top_2 - Wall 000_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {9a8fdf16-17b3-4e90-9f33-f4e710f4b4af}, !- Space Name
@@ -8408,7 +8408,7 @@ OS:Surface,
 
 OS:Surface,
   {f4044ebb-ceff-4513-b7b8-b00275cf59e0}, !- Handle
-  Surface 486,                            !- Name
+  EnclosedOffice_Top_2 - RoofCeiling_a,   !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {9a8fdf16-17b3-4e90-9f33-f4e710f4b4af}, !- Space Name
@@ -8425,7 +8425,7 @@ OS:Surface,
 
 OS:Surface,
   {92bd749b-a0f8-4c85-9dd8-2a3845c85a89}, !- Handle
-  Surface 487,                            !- Name
+  EnclosedOffice_Top_2 - Wall 090_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {9a8fdf16-17b3-4e90-9f33-f4e710f4b4af}, !- Space Name
@@ -8442,7 +8442,7 @@ OS:Surface,
 
 OS:Surface,
   {d82e57dc-fa0c-419c-b046-51f8e23fee27}, !- Handle
-  Surface 488,                            !- Name
+  EnclosedOffice_Top_2 - Wall 270_b,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {9a8fdf16-17b3-4e90-9f33-f4e710f4b4af}, !- Space Name
@@ -8459,7 +8459,7 @@ OS:Surface,
 
 OS:Surface,
   {d32a2fbc-0fac-4bb4-a6a4-8e894d9097a5}, !- Handle
-  Surface 489,                            !- Name
+  EnclosedOffice_Top_2 - Wall 180_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {9a8fdf16-17b3-4e90-9f33-f4e710f4b4af}, !- Space Name
@@ -8476,7 +8476,7 @@ OS:Surface,
 
 OS:Surface,
   {5e54d1de-060c-4e8c-949e-4dbb88ce2cd5}, !- Handle
-  Surface 490,                            !- Name
+  EnclosedOffice_Top_2 - Wall 270_c,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {9a8fdf16-17b3-4e90-9f33-f4e710f4b4af}, !- Space Name
@@ -8493,7 +8493,7 @@ OS:Surface,
 
 OS:Surface,
   {d0e7d1e0-3e4d-4660-bb2f-f2d6b349b183}, !- Handle
-  Surface 491,                            !- Name
+  EnclosedOffice_Top_2 - Wall 270_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {9a8fdf16-17b3-4e90-9f33-f4e710f4b4af}, !- Space Name
@@ -8515,8 +8515,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  7.21911419532262e-016,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   7.9248,                                 !- Z Origin {m}
   {34c2b3a4-b93e-443b-9867-ce24d7c61c21}, !- Building Story Name
   {a1add966-6ea6-4014-95f8-f7eea197b91c}, !- Thermal Zone Name
@@ -8526,7 +8526,7 @@ OS:Space,
 
 OS:Surface,
   {c4234dbd-9126-4443-8a52-0694d7547d60}, !- Handle
-  Surface 492,                            !- Name
+  Stair_Top_1 - Floor_a,                  !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {f30b4347-26f3-4bab-9859-c9e3ec113927}, !- Space Name
@@ -8543,7 +8543,7 @@ OS:Surface,
 
 OS:Surface,
   {8026faba-7f82-4141-9fee-7969c64fe35f}, !- Handle
-  Surface 493,                            !- Name
+  Stair_Top_1 - RoofCeiling_a,            !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {f30b4347-26f3-4bab-9859-c9e3ec113927}, !- Space Name
@@ -8560,7 +8560,7 @@ OS:Surface,
 
 OS:Surface,
   {1869b770-8ade-4539-8dc3-5f37d7ce1189}, !- Handle
-  Surface 494,                            !- Name
+  Stair_Top_1 - Wall 180_a,               !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f30b4347-26f3-4bab-9859-c9e3ec113927}, !- Space Name
@@ -8577,7 +8577,7 @@ OS:Surface,
 
 OS:Surface,
   {7907f205-f202-4271-bc71-c988cc039c35}, !- Handle
-  Surface 495,                            !- Name
+  Stair_Top_1 - Wall 270_a,               !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f30b4347-26f3-4bab-9859-c9e3ec113927}, !- Space Name
@@ -8594,7 +8594,7 @@ OS:Surface,
 
 OS:Surface,
   {de2adcf9-01e2-41bd-9f3f-5616e147bc92}, !- Handle
-  Surface 496,                            !- Name
+  Stair_Top_1 - Wall 090_a,               !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f30b4347-26f3-4bab-9859-c9e3ec113927}, !- Space Name
@@ -8611,7 +8611,7 @@ OS:Surface,
 
 OS:Surface,
   {f32893e1-e9ef-4f04-99e0-4fc5f739c979}, !- Handle
-  Surface 497,                            !- Name
+  Stair_Top_1 - Wall 000_a,               !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {f30b4347-26f3-4bab-9859-c9e3ec113927}, !- Space Name
@@ -8633,8 +8633,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  7.21911419532262e-016,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   7.9248,                                 !- Z Origin {m}
   {34c2b3a4-b93e-443b-9867-ce24d7c61c21}, !- Building Story Name
   {8ead2b82-5479-452a-ae97-540bbed210f8}, !- Thermal Zone Name
@@ -8644,7 +8644,7 @@ OS:Space,
 
 OS:Surface,
   {28e01bac-bd7b-4f2c-935e-94fc93aa20f5}, !- Handle
-  Surface 498,                            !- Name
+  OpenOffice_Top_4 - Wall 270_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {2c570dca-0fd4-41ad-8bd7-f645979bf614}, !- Space Name
@@ -8654,14 +8654,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  8.0692625, 5.34193749999998, 2.7432,    !- X,Y,Z Vertex 1 {m}
-  8.0692625, 5.34193749999998, 0,         !- X,Y,Z Vertex 2 {m}
+  8.0692625, 5.3419375, 2.7432,           !- X,Y,Z Vertex 1 {m}
+  8.0692625, 5.3419375, 0,                !- X,Y,Z Vertex 2 {m}
   8.0692625, 0, 0,                        !- X,Y,Z Vertex 3 {m}
   8.0692625, 0, 2.7432;                   !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {4be46ab5-a4d5-4786-ab71-d82d8578bd7f}, !- Handle
-  Surface 499,                            !- Name
+  OpenOffice_Top_4 - Wall 090_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {2c570dca-0fd4-41ad-8bd7-f645979bf614}, !- Space Name
@@ -8673,12 +8673,12 @@ OS:Surface,
   ,                                       !- Number of Vertices
   41.8417375, 0, 2.7432,                  !- X,Y,Z Vertex 1 {m}
   41.8417375, 0, 0,                       !- X,Y,Z Vertex 2 {m}
-  41.8417375, 5.34193749999998, 0,        !- X,Y,Z Vertex 3 {m}
-  41.8417375, 5.34193749999998, 2.7432;   !- X,Y,Z Vertex 4 {m}
+  41.8417375, 5.3419375, 0,               !- X,Y,Z Vertex 3 {m}
+  41.8417375, 5.3419375, 2.7432;          !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {201a37ea-f8ed-42fb-9b65-f07245801d17}, !- Handle
-  Surface 500,                            !- Name
+  OpenOffice_Top_4 - Wall 180_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {2c570dca-0fd4-41ad-8bd7-f645979bf614}, !- Space Name
@@ -8695,7 +8695,7 @@ OS:Surface,
 
 OS:Surface,
   {e8fec8d9-a74a-4177-a1c2-a3c97d67bf03}, !- Handle
-  Surface 501,                            !- Name
+  OpenOffice_Top_4 - RoofCeiling_a,       !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {2c570dca-0fd4-41ad-8bd7-f645979bf614}, !- Space Name
@@ -8706,13 +8706,13 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   41.8417375, 0, 2.7432,                  !- X,Y,Z Vertex 1 {m}
-  41.8417375, 5.34193749999998, 2.7432,   !- X,Y,Z Vertex 2 {m}
-  8.0692625, 5.34193749999998, 2.7432,    !- X,Y,Z Vertex 3 {m}
+  41.8417375, 5.3419375, 2.7432,          !- X,Y,Z Vertex 2 {m}
+  8.0692625, 5.3419375, 2.7432,           !- X,Y,Z Vertex 3 {m}
   8.0692625, 0, 2.7432;                   !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {52e9d5da-0644-4492-b567-69362441a487}, !- Handle
-  Surface 502,                            !- Name
+  OpenOffice_Top_4 - Wall 0_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {2c570dca-0fd4-41ad-8bd7-f645979bf614}, !- Space Name
@@ -8724,12 +8724,12 @@ OS:Surface,
   ,                                       !- Number of Vertices
   16.5735, 5.3419375, 2.7432,             !- X,Y,Z Vertex 1 {m}
   16.5735, 5.3419375, 0,                  !- X,Y,Z Vertex 2 {m}
-  8.0692625, 5.34193749999998, 0,         !- X,Y,Z Vertex 3 {m}
-  8.0692625, 5.34193749999998, 2.7432;    !- X,Y,Z Vertex 4 {m}
+  8.0692625, 5.3419375, 0,                !- X,Y,Z Vertex 3 {m}
+  8.0692625, 5.3419375, 2.7432;           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {af6c7172-6e84-4c02-bec5-561668aae843}, !- Handle
-  Surface 503,                            !- Name
+  OpenOffice_Top_4 - Wall 000_b,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {2c570dca-0fd4-41ad-8bd7-f645979bf614}, !- Space Name
@@ -8739,14 +8739,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  41.8417375, 5.34193749999998, 2.7432,   !- X,Y,Z Vertex 1 {m}
-  41.8417375, 5.34193749999998, 0,        !- X,Y,Z Vertex 2 {m}
+  41.8417375, 5.3419375, 2.7432,          !- X,Y,Z Vertex 1 {m}
+  41.8417375, 5.3419375, 0,               !- X,Y,Z Vertex 2 {m}
   33.3375, 5.3419375, 0,                  !- X,Y,Z Vertex 3 {m}
   33.3375, 5.3419375, 2.7432;             !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {fac9b4c0-ef0d-44f6-b2d1-6badd33c9ff9}, !- Handle
-  Surface 504,                            !- Name
+  OpenOffice_Top_4 - Wall 000_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {2c570dca-0fd4-41ad-8bd7-f645979bf614}, !- Space Name
@@ -8763,7 +8763,7 @@ OS:Surface,
 
 OS:Surface,
   {4c8fd388-921d-4d35-a1f2-7c3caeb5cd57}, !- Handle
-  Surface 505,                            !- Name
+  OpenOffice_Top_4 - Floor_a,             !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {2c570dca-0fd4-41ad-8bd7-f645979bf614}, !- Space Name
@@ -8773,10 +8773,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  41.8417375, 5.34193749999998, 0,        !- X,Y,Z Vertex 1 {m}
+  41.8417375, 5.3419375, 0,               !- X,Y,Z Vertex 1 {m}
   41.8417375, 0, 0,                       !- X,Y,Z Vertex 2 {m}
   8.0692625, 0, 0,                        !- X,Y,Z Vertex 3 {m}
-  8.0692625, 5.34193749999998, 0;         !- X,Y,Z Vertex 4 {m}
+  8.0692625, 5.3419375, 0;                !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {d259cafd-e505-4a7c-9fd3-92dde1140f3b}, !- Handle
@@ -8785,8 +8785,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  7.21911419532262e-016,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   7.9248,                                 !- Z Origin {m}
   {34c2b3a4-b93e-443b-9867-ce24d7c61c21}, !- Building Story Name
   {a752b066-febb-43d6-8ce7-a33016318c0b}, !- Thermal Zone Name
@@ -8796,7 +8796,7 @@ OS:Space,
 
 OS:Surface,
   {372c7b69-f3b6-4d62-9eed-f72c3840d150}, !- Handle
-  Surface 506,                            !- Name
+  Mechanical_Top - Wall 270_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d259cafd-e505-4a7c-9fd3-92dde1140f3b}, !- Space Name
@@ -8813,7 +8813,7 @@ OS:Surface,
 
 OS:Surface,
   {9342cbfb-0ca3-42dc-ac2e-24bbfbbe706f}, !- Handle
-  Surface 507,                            !- Name
+  Mechanical_Top - Wall 090_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d259cafd-e505-4a7c-9fd3-92dde1140f3b}, !- Space Name
@@ -8830,7 +8830,7 @@ OS:Surface,
 
 OS:Surface,
   {26d961ec-4398-480d-81d5-31fd87c80c75}, !- Handle
-  Surface 508,                            !- Name
+  Mechanical_Top - Wall 180_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d259cafd-e505-4a7c-9fd3-92dde1140f3b}, !- Space Name
@@ -8847,7 +8847,7 @@ OS:Surface,
 
 OS:Surface,
   {3ae9a62b-b68c-433b-ab05-19521fab75c6}, !- Handle
-  Surface 509,                            !- Name
+  Mechanical_Top - Floor_a,               !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {d259cafd-e505-4a7c-9fd3-92dde1140f3b}, !- Space Name
@@ -8864,7 +8864,7 @@ OS:Surface,
 
 OS:Surface,
   {fe4632ff-93bd-4f26-8c63-acec482cec5c}, !- Handle
-  Surface 510,                            !- Name
+  Mechanical_Top - Wall 000_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {d259cafd-e505-4a7c-9fd3-92dde1140f3b}, !- Space Name
@@ -8881,7 +8881,7 @@ OS:Surface,
 
 OS:Surface,
   {90cf54a6-2b82-4d57-b088-32a2d1bdc7cd}, !- Handle
-  Surface 511,                            !- Name
+  Mechanical_Top - RoofCeiling_a,         !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {d259cafd-e505-4a7c-9fd3-92dde1140f3b}, !- Space Name
@@ -8903,8 +8903,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  7.21911419532262e-016,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   7.9248,                                 !- Z Origin {m}
   {34c2b3a4-b93e-443b-9867-ce24d7c61c21}, !- Building Story Name
   {5d45a573-f58e-4d13-be4b-0a4f4540251e}, !- Thermal Zone Name
@@ -8914,7 +8914,7 @@ OS:Space,
 
 OS:Surface,
   {9553c862-a57e-458a-be6f-f7a5c098dc65}, !- Handle
-  Surface 512,                            !- Name
+  ActiveStorage_Top_4 - Floor_a,          !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {e5b9b64e-a463-490d-aace-ded47cbf2d97}, !- Space Name
@@ -8931,7 +8931,7 @@ OS:Surface,
 
 OS:Surface,
   {e5ab432b-8d38-44e4-82f6-6f29ad2b7e3e}, !- Handle
-  Surface 513,                            !- Name
+  ActiveStorage_Top_4 - Wall 090_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e5b9b64e-a463-490d-aace-ded47cbf2d97}, !- Space Name
@@ -8948,7 +8948,7 @@ OS:Surface,
 
 OS:Surface,
   {662f91e2-d8d2-4ff8-8171-91f0dc84a77a}, !- Handle
-  Surface 514,                            !- Name
+  ActiveStorage_Top_4 - Wall 180_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e5b9b64e-a463-490d-aace-ded47cbf2d97}, !- Space Name
@@ -8965,7 +8965,7 @@ OS:Surface,
 
 OS:Surface,
   {ed3d7ef5-f621-4188-aad5-659f7c2169a5}, !- Handle
-  Surface 515,                            !- Name
+  ActiveStorage_Top_4 - Wall 270_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e5b9b64e-a463-490d-aace-ded47cbf2d97}, !- Space Name
@@ -8982,7 +8982,7 @@ OS:Surface,
 
 OS:Surface,
   {f83eaf56-1007-4d3a-87da-f5bd1a6ea6c7}, !- Handle
-  Surface 516,                            !- Name
+  ActiveStorage_Top_4 - Wall 000_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e5b9b64e-a463-490d-aace-ded47cbf2d97}, !- Space Name
@@ -8999,7 +8999,7 @@ OS:Surface,
 
 OS:Surface,
   {6ce08d29-9d0e-48b5-ab65-63b63b5483f3}, !- Handle
-  Surface 517,                            !- Name
+  ActiveStorage_Top_4 - RoofCeiling_a,    !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {e5b9b64e-a463-490d-aace-ded47cbf2d97}, !- Space Name
@@ -9016,7 +9016,7 @@ OS:Surface,
 
 OS:Surface,
   {ed83b7b3-425c-4c64-8e58-609c4b37dabf}, !- Handle
-  Surface 518,                            !- Name
+  ActiveStorage_Top_4 - Wall 180_b,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e5b9b64e-a463-490d-aace-ded47cbf2d97}, !- Space Name
@@ -9038,8 +9038,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  7.21911419532262e-016,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   7.9248,                                 !- Z Origin {m}
   {34c2b3a4-b93e-443b-9867-ce24d7c61c21}, !- Building Story Name
   {020322ec-6c5c-48ec-b5df-b99f6ad2cca5}, !- Thermal Zone Name
@@ -9049,7 +9049,7 @@ OS:Space,
 
 OS:Surface,
   {b24289ab-7566-494c-be40-8fd0feb2f146}, !- Handle
-  Surface 519,                            !- Name
+  Lobby_Top - Wall 270_b,                 !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3ec26761-c667-4167-89c1-197f22b958f4}, !- Space Name
@@ -9059,14 +9059,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 22.234525, 2.74319999999999,   !- X,Y,Z Vertex 1 {m}
+  23.4315, 22.234525, 2.7432,             !- X,Y,Z Vertex 1 {m}
   23.4315, 22.234525, 0,                  !- X,Y,Z Vertex 2 {m}
   23.4315, 11.0410625, 0,                 !- X,Y,Z Vertex 3 {m}
-  23.4315, 11.0410625, 2.74319999999999;  !- X,Y,Z Vertex 4 {m}
+  23.4315, 11.0410625, 2.7432;            !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {113dbbc5-d8b3-46d7-b427-2c152f53393e}, !- Handle
-  Surface 520,                            !- Name
+  Lobby_Top - Wall 090_c,                 !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3ec26761-c667-4167-89c1-197f22b958f4}, !- Space Name
@@ -9076,14 +9076,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  26.4795, 6.5611375, 2.74319999999999,   !- X,Y,Z Vertex 1 {m}
+  26.4795, 6.5611375, 2.7432,             !- X,Y,Z Vertex 1 {m}
   26.4795, 6.5611375, 0,                  !- X,Y,Z Vertex 2 {m}
   26.4795, 11.0410625, 0,                 !- X,Y,Z Vertex 3 {m}
-  26.4795, 11.0410625, 2.74319999999999;  !- X,Y,Z Vertex 4 {m}
+  26.4795, 11.0410625, 2.7432;            !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {36bd1ecd-632a-41e4-ac74-331d85be41f8}, !- Handle
-  Surface 521,                            !- Name
+  Lobby_Top - Wall 090_b,                 !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3ec26761-c667-4167-89c1-197f22b958f4}, !- Space Name
@@ -9093,14 +9093,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  26.4795, 11.0410625, 2.74319999999999,  !- X,Y,Z Vertex 1 {m}
+  26.4795, 11.0410625, 2.7432,            !- X,Y,Z Vertex 1 {m}
   26.4795, 11.0410625, 0,                 !- X,Y,Z Vertex 2 {m}
   26.4795, 22.234525, 0,                  !- X,Y,Z Vertex 3 {m}
-  26.4795, 22.234525, 2.74319999999999;   !- X,Y,Z Vertex 4 {m}
+  26.4795, 22.234525, 2.7432;             !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {7dc13738-a352-4962-b955-5f70acaf4d4f}, !- Handle
-  Surface 522,                            !- Name
+  Lobby_Top - Floor_a,                    !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {3ec26761-c667-4167-89c1-197f22b958f4}, !- Space Name
@@ -9117,7 +9117,7 @@ OS:Surface,
 
 OS:Surface,
   {c4c3e5d5-3fe1-49f5-bed2-1d73531bf661}, !- Handle
-  Surface 523,                            !- Name
+  Lobby_Top - RoofCeiling_a,              !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {3ec26761-c667-4167-89c1-197f22b958f4}, !- Space Name
@@ -9127,14 +9127,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  26.4795, 6.5611375, 2.74319999999999,   !- X,Y,Z Vertex 1 {m}
-  26.4795, 26.71445, 2.74319999999999,    !- X,Y,Z Vertex 2 {m}
-  23.4315, 26.71445, 2.74319999999999,    !- X,Y,Z Vertex 3 {m}
-  23.4315, 6.5611375, 2.74319999999999;   !- X,Y,Z Vertex 4 {m}
+  26.4795, 6.5611375, 2.7432,             !- X,Y,Z Vertex 1 {m}
+  26.4795, 26.71445, 2.7432,              !- X,Y,Z Vertex 2 {m}
+  23.4315, 26.71445, 2.7432,              !- X,Y,Z Vertex 3 {m}
+  23.4315, 6.5611375, 2.7432;             !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {a14b015d-2fb1-4d83-97f1-0324da95d7a4}, !- Handle
-  Surface 524,                            !- Name
+  Lobby_Top - Wall 180_a,                 !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3ec26761-c667-4167-89c1-197f22b958f4}, !- Space Name
@@ -9144,14 +9144,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 6.5611375, 2.74319999999999,   !- X,Y,Z Vertex 1 {m}
+  23.4315, 6.5611375, 2.7432,             !- X,Y,Z Vertex 1 {m}
   23.4315, 6.5611375, 0,                  !- X,Y,Z Vertex 2 {m}
   26.4795, 6.5611375, 0,                  !- X,Y,Z Vertex 3 {m}
-  26.4795, 6.5611375, 2.74319999999999;   !- X,Y,Z Vertex 4 {m}
+  26.4795, 6.5611375, 2.7432;             !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {68dcf7b9-19ef-4d35-b093-e14f7edea749}, !- Handle
-  Surface 525,                            !- Name
+  Lobby_Top - Wall 270_c,                 !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3ec26761-c667-4167-89c1-197f22b958f4}, !- Space Name
@@ -9161,14 +9161,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 26.71445, 2.74319999999999,    !- X,Y,Z Vertex 1 {m}
+  23.4315, 26.71445, 2.7432,              !- X,Y,Z Vertex 1 {m}
   23.4315, 26.71445, 0,                   !- X,Y,Z Vertex 2 {m}
   23.4315, 22.234525, 0,                  !- X,Y,Z Vertex 3 {m}
-  23.4315, 22.234525, 2.74319999999999;   !- X,Y,Z Vertex 4 {m}
+  23.4315, 22.234525, 2.7432;             !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {c83dfe71-e51a-4233-8311-627becb22c27}, !- Handle
-  Surface 526,                            !- Name
+  Lobby_Top - Wall 000_a,                 !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3ec26761-c667-4167-89c1-197f22b958f4}, !- Space Name
@@ -9178,14 +9178,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  26.4795, 26.71445, 2.74319999999999,    !- X,Y,Z Vertex 1 {m}
+  26.4795, 26.71445, 2.7432,              !- X,Y,Z Vertex 1 {m}
   26.4795, 26.71445, 0,                   !- X,Y,Z Vertex 2 {m}
   23.4315, 26.71445, 0,                   !- X,Y,Z Vertex 3 {m}
-  23.4315, 26.71445, 2.74319999999999;    !- X,Y,Z Vertex 4 {m}
+  23.4315, 26.71445, 2.7432;              !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {bf6edb97-47d4-4614-9e5d-ce8564bdc413}, !- Handle
-  Surface 527,                            !- Name
+  Lobby_Top - Wall 090_a,                 !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3ec26761-c667-4167-89c1-197f22b958f4}, !- Space Name
@@ -9195,14 +9195,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  26.4795, 22.234525, 2.74319999999999,   !- X,Y,Z Vertex 1 {m}
+  26.4795, 22.234525, 2.7432,             !- X,Y,Z Vertex 1 {m}
   26.4795, 22.234525, 0,                  !- X,Y,Z Vertex 2 {m}
   26.4795, 26.71445, 0,                   !- X,Y,Z Vertex 3 {m}
-  26.4795, 26.71445, 2.74319999999999;    !- X,Y,Z Vertex 4 {m}
+  26.4795, 26.71445, 2.7432;              !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {cefd0999-1c41-4340-9f9c-4cc0c6a3782f}, !- Handle
-  Surface 528,                            !- Name
+  Lobby_Top - Wall 270_a,                 !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3ec26761-c667-4167-89c1-197f22b958f4}, !- Space Name
@@ -9212,10 +9212,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 11.0410625, 2.74319999999999,  !- X,Y,Z Vertex 1 {m}
+  23.4315, 11.0410625, 2.7432,            !- X,Y,Z Vertex 1 {m}
   23.4315, 11.0410625, 0,                 !- X,Y,Z Vertex 2 {m}
   23.4315, 6.5611375, 0,                  !- X,Y,Z Vertex 3 {m}
-  23.4315, 6.5611375, 2.74319999999999;   !- X,Y,Z Vertex 4 {m}
+  23.4315, 6.5611375, 2.7432;             !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {253908e5-6fa9-4d28-aa23-cf9123080b33}, !- Handle
@@ -9224,8 +9224,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  7.21911419532262e-016,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   7.9248,                                 !- Z Origin {m}
   {34c2b3a4-b93e-443b-9867-ce24d7c61c21}, !- Building Story Name
   {e5aaa50b-0c4f-4b64-9f0f-68e37b10c8e6}, !- Thermal Zone Name
@@ -9235,7 +9235,7 @@ OS:Space,
 
 OS:Surface,
   {2ee0a8f7-031b-4e64-9b0b-3548feac6365}, !- Handle
-  Surface 529,                            !- Name
+  Dining_Top - Floor_a,                   !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {253908e5-6fa9-4d28-aa23-cf9123080b33}, !- Space Name
@@ -9252,7 +9252,7 @@ OS:Surface,
 
 OS:Surface,
   {0b13002b-1ab4-44f9-9695-f3d57c1dc533}, !- Handle
-  Surface 530,                            !- Name
+  Dining_Top - RoofCeiling_a,             !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {253908e5-6fa9-4d28-aa23-cf9123080b33}, !- Space Name
@@ -9262,14 +9262,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 22.234525, 2.74319999999999,   !- X,Y,Z Vertex 1 {m}
-  23.4315, 26.71445, 2.74319999999999,    !- X,Y,Z Vertex 2 {m}
-  18.310225, 26.71445, 2.74319999999999,  !- X,Y,Z Vertex 3 {m}
-  18.310225, 22.234525, 2.74319999999999; !- X,Y,Z Vertex 4 {m}
+  23.4315, 22.234525, 2.7432,             !- X,Y,Z Vertex 1 {m}
+  23.4315, 26.71445, 2.7432,              !- X,Y,Z Vertex 2 {m}
+  18.310225, 26.71445, 2.7432,            !- X,Y,Z Vertex 3 {m}
+  18.310225, 22.234525, 2.7432;           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {31db377a-3ed4-44b7-af06-1237ec0bc296}, !- Handle
-  Surface 531,                            !- Name
+  Dining_Top - Wall 000_a,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {253908e5-6fa9-4d28-aa23-cf9123080b33}, !- Space Name
@@ -9279,14 +9279,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 26.71445, 2.74319999999999,    !- X,Y,Z Vertex 1 {m}
+  23.4315, 26.71445, 2.7432,              !- X,Y,Z Vertex 1 {m}
   23.4315, 26.71445, 0,                   !- X,Y,Z Vertex 2 {m}
   18.310225, 26.71445, 0,                 !- X,Y,Z Vertex 3 {m}
-  18.310225, 26.71445, 2.74319999999999;  !- X,Y,Z Vertex 4 {m}
+  18.310225, 26.71445, 2.7432;            !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {f6ff6b3a-1666-4ef1-b71c-dfad4bf16652}, !- Handle
-  Surface 532,                            !- Name
+  Dining_Top - Wall 270_a,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {253908e5-6fa9-4d28-aa23-cf9123080b33}, !- Space Name
@@ -9296,14 +9296,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  18.310225, 26.71445, 2.74319999999999,  !- X,Y,Z Vertex 1 {m}
+  18.310225, 26.71445, 2.7432,            !- X,Y,Z Vertex 1 {m}
   18.310225, 26.71445, 0,                 !- X,Y,Z Vertex 2 {m}
   18.310225, 22.234525, 0,                !- X,Y,Z Vertex 3 {m}
-  18.310225, 22.234525, 2.74319999999999; !- X,Y,Z Vertex 4 {m}
+  18.310225, 22.234525, 2.7432;           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {3127f17f-ae40-4109-ad58-05367a0870e2}, !- Handle
-  Surface 533,                            !- Name
+  Dining_Top - Wall 180_a,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {253908e5-6fa9-4d28-aa23-cf9123080b33}, !- Space Name
@@ -9313,14 +9313,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  18.310225, 22.234525, 2.74319999999999, !- X,Y,Z Vertex 1 {m}
+  18.310225, 22.234525, 2.7432,           !- X,Y,Z Vertex 1 {m}
   18.310225, 22.234525, 0,                !- X,Y,Z Vertex 2 {m}
   23.4315, 22.234525, 0,                  !- X,Y,Z Vertex 3 {m}
-  23.4315, 22.234525, 2.74319999999999;   !- X,Y,Z Vertex 4 {m}
+  23.4315, 22.234525, 2.7432;             !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {7052584a-13df-4b38-8257-6d011ed9255c}, !- Handle
-  Surface 534,                            !- Name
+  Dining_Top - Wall 090_a,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {253908e5-6fa9-4d28-aa23-cf9123080b33}, !- Space Name
@@ -9330,10 +9330,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 22.234525, 2.74319999999999,   !- X,Y,Z Vertex 1 {m}
+  23.4315, 22.234525, 2.7432,             !- X,Y,Z Vertex 1 {m}
   23.4315, 22.234525, 0,                  !- X,Y,Z Vertex 2 {m}
   23.4315, 26.71445, 0,                   !- X,Y,Z Vertex 3 {m}
-  23.4315, 26.71445, 2.74319999999999;    !- X,Y,Z Vertex 4 {m}
+  23.4315, 26.71445, 2.7432;              !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {c078e3bf-4616-455a-910d-4eb58ddc485b}, !- Handle
@@ -9342,8 +9342,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  7.21911419532262e-016,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   7.9248,                                 !- Z Origin {m}
   {34c2b3a4-b93e-443b-9867-ce24d7c61c21}, !- Building Story Name
   {54cfb823-762b-47e6-8778-e96443e8f870}, !- Thermal Zone Name
@@ -9353,7 +9353,7 @@ OS:Space,
 
 OS:Surface,
   {063d7d54-13a8-4440-afc7-11cf88a6f957}, !- Handle
-  Surface 535,                            !- Name
+  Restroom_Top - Wall 000_a,              !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c078e3bf-4616-455a-910d-4eb58ddc485b}, !- Space Name
@@ -9363,14 +9363,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 22.234525, 2.74319999999999,   !- X,Y,Z Vertex 1 {m}
+  23.4315, 22.234525, 2.7432,             !- X,Y,Z Vertex 1 {m}
   23.4315, 22.234525, 0,                  !- X,Y,Z Vertex 2 {m}
   18.310225, 22.234525, 0,                !- X,Y,Z Vertex 3 {m}
-  18.310225, 22.234525, 2.74319999999999; !- X,Y,Z Vertex 4 {m}
+  18.310225, 22.234525, 2.7432;           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {0c8a6f03-5551-45cc-a4ee-ef35a0936616}, !- Handle
-  Surface 536,                            !- Name
+  Restroom_Top - Floor_a,                 !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {c078e3bf-4616-455a-910d-4eb58ddc485b}, !- Space Name
@@ -9387,7 +9387,7 @@ OS:Surface,
 
 OS:Surface,
   {5e529cac-8c2c-4bb6-aac1-1395802c78db}, !- Handle
-  Surface 537,                            !- Name
+  Restroom_Top - Wall 090_a,              !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c078e3bf-4616-455a-910d-4eb58ddc485b}, !- Space Name
@@ -9397,14 +9397,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 11.0410625, 2.74319999999999,  !- X,Y,Z Vertex 1 {m}
+  23.4315, 11.0410625, 2.7432,            !- X,Y,Z Vertex 1 {m}
   23.4315, 11.0410625, 0,                 !- X,Y,Z Vertex 2 {m}
   23.4315, 22.234525, 0,                  !- X,Y,Z Vertex 3 {m}
-  23.4315, 22.234525, 2.74319999999999;   !- X,Y,Z Vertex 4 {m}
+  23.4315, 22.234525, 2.7432;             !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {f3860240-9d00-49b3-8828-5ff508201c3f}, !- Handle
-  Surface 538,                            !- Name
+  Restroom_Top - RoofCeiling_a,           !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {c078e3bf-4616-455a-910d-4eb58ddc485b}, !- Space Name
@@ -9414,14 +9414,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  23.4315, 11.0410625, 2.74319999999999,  !- X,Y,Z Vertex 1 {m}
-  23.4315, 22.234525, 2.74319999999999,   !- X,Y,Z Vertex 2 {m}
-  18.0975, 22.234525, 2.74319999999999,   !- X,Y,Z Vertex 3 {m}
-  18.0975, 11.0410625, 2.74319999999999;  !- X,Y,Z Vertex 4 {m}
+  23.4315, 11.0410625, 2.7432,            !- X,Y,Z Vertex 1 {m}
+  23.4315, 22.234525, 2.7432,             !- X,Y,Z Vertex 2 {m}
+  18.0975, 22.234525, 2.7432,             !- X,Y,Z Vertex 3 {m}
+  18.0975, 11.0410625, 2.7432;            !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {a65e549c-7a92-482e-8d8f-adc73f9b5ddd}, !- Handle
-  Surface 539,                            !- Name
+  Restroom_Top - Wall 180_a,              !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c078e3bf-4616-455a-910d-4eb58ddc485b}, !- Space Name
@@ -9431,14 +9431,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  18.0975, 11.0410625, 2.74319999999999,  !- X,Y,Z Vertex 1 {m}
+  18.0975, 11.0410625, 2.7432,            !- X,Y,Z Vertex 1 {m}
   18.0975, 11.0410625, 0,                 !- X,Y,Z Vertex 2 {m}
   23.4315, 11.0410625, 0,                 !- X,Y,Z Vertex 3 {m}
-  23.4315, 11.0410625, 2.74319999999999;  !- X,Y,Z Vertex 4 {m}
+  23.4315, 11.0410625, 2.7432;            !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {5c392262-6df6-43c8-ba57-ab0e8baf72cd}, !- Handle
-  Surface 540,                            !- Name
+  Restroom_Top - Wall 000_b,              !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c078e3bf-4616-455a-910d-4eb58ddc485b}, !- Space Name
@@ -9448,14 +9448,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  18.310225, 22.234525, 2.74319999999999, !- X,Y,Z Vertex 1 {m}
+  18.310225, 22.234525, 2.7432,           !- X,Y,Z Vertex 1 {m}
   18.310225, 22.234525, 0,                !- X,Y,Z Vertex 2 {m}
   18.0975, 22.234525, 0,                  !- X,Y,Z Vertex 3 {m}
-  18.0975, 22.234525, 2.74319999999999;   !- X,Y,Z Vertex 4 {m}
+  18.0975, 22.234525, 2.7432;             !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {e6be93c6-a554-4444-9a99-5002c31ea0d8}, !- Handle
-  Surface 541,                            !- Name
+  Restroom_Top - Wall 270_a,              !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {c078e3bf-4616-455a-910d-4eb58ddc485b}, !- Space Name
@@ -9465,10 +9465,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  18.0975, 22.234525, 2.74319999999999,   !- X,Y,Z Vertex 1 {m}
+  18.0975, 22.234525, 2.7432,             !- X,Y,Z Vertex 1 {m}
   18.0975, 22.234525, 0,                  !- X,Y,Z Vertex 2 {m}
   18.0975, 11.0410625, 0,                 !- X,Y,Z Vertex 3 {m}
-  18.0975, 11.0410625, 2.74319999999999;  !- X,Y,Z Vertex 4 {m}
+  18.0975, 11.0410625, 2.7432;            !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {532a76a3-a007-4347-afed-4f4aa3e41419}, !- Handle
@@ -9477,8 +9477,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  7.21911419532262e-016,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   7.9248,                                 !- Z Origin {m}
   {34c2b3a4-b93e-443b-9867-ce24d7c61c21}, !- Building Story Name
   {bf624746-7178-45e3-b173-e4653888d0fd}, !- Thermal Zone Name
@@ -9488,7 +9488,7 @@ OS:Space,
 
 OS:Surface,
   {e3aa26e4-aadd-47cf-948a-67324b20585c}, !- Handle
-  Surface 542,                            !- Name
+  ConfRoom_Top_2 - Wall 000_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {532a76a3-a007-4347-afed-4f4aa3e41419}, !- Space Name
@@ -9505,7 +9505,7 @@ OS:Surface,
 
 OS:Surface,
   {90779e80-b6ad-4509-bed1-fa9f5df04a48}, !- Handle
-  Surface 543,                            !- Name
+  ConfRoom_Top_2 - Floor_a,               !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {532a76a3-a007-4347-afed-4f4aa3e41419}, !- Space Name
@@ -9522,7 +9522,7 @@ OS:Surface,
 
 OS:Surface,
   {9507f26b-d73e-4583-bddd-201f0b648079}, !- Handle
-  Surface 544,                            !- Name
+  ConfRoom_Top_2 - RoofCeiling_a,         !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {532a76a3-a007-4347-afed-4f4aa3e41419}, !- Space Name
@@ -9539,7 +9539,7 @@ OS:Surface,
 
 OS:Surface,
   {5f3e099e-570d-4b77-8450-80cb1bc848cd}, !- Handle
-  Surface 545,                            !- Name
+  ConfRoom_Top_2 - Wall 270_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {532a76a3-a007-4347-afed-4f4aa3e41419}, !- Space Name
@@ -9556,7 +9556,7 @@ OS:Surface,
 
 OS:Surface,
   {e4674b9e-70bf-41f9-828b-87c7a218e496}, !- Handle
-  Surface 546,                            !- Name
+  ConfRoom_Top_2 - Wall 180_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {532a76a3-a007-4347-afed-4f4aa3e41419}, !- Space Name
@@ -9573,7 +9573,7 @@ OS:Surface,
 
 OS:Surface,
   {eafe3f27-66c9-4191-a48a-8ed4e697bd62}, !- Handle
-  Surface 547,                            !- Name
+  ConfRoom_Top_2 - Wall 000_b,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {532a76a3-a007-4347-afed-4f4aa3e41419}, !- Space Name
@@ -9595,8 +9595,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  7.21911419532262e-016,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   7.9248,                                 !- Z Origin {m}
   {34c2b3a4-b93e-443b-9867-ce24d7c61c21}, !- Building Story Name
   {2ec9e0b6-744b-4acf-82ff-75ba8fd8d44f}, !- Thermal Zone Name
@@ -9606,7 +9606,7 @@ OS:Space,
 
 OS:Surface,
   {578b1df3-4922-4e67-8839-15c1841d9e12}, !- Handle
-  Surface 549,                            !- Name
+  ActiveStorage_Top_3 - Wall 180_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {ed4c4f3d-97af-4aee-8dd1-e5c7e0c1156f}, !- Space Name
@@ -9623,7 +9623,7 @@ OS:Surface,
 
 OS:Surface,
   {7a8d9e88-1668-44d7-9ef9-469bd5c5a14e}, !- Handle
-  Surface 550,                            !- Name
+  ActiveStorage_Top_3 - Floor_a,          !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {ed4c4f3d-97af-4aee-8dd1-e5c7e0c1156f}, !- Space Name
@@ -9640,7 +9640,7 @@ OS:Surface,
 
 OS:Surface,
   {d002babc-bc34-42b7-ac75-6c3a89e05ae1}, !- Handle
-  Surface 551,                            !- Name
+  ActiveStorage_Top_3 - Wall 180_b,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {ed4c4f3d-97af-4aee-8dd1-e5c7e0c1156f}, !- Space Name
@@ -9657,7 +9657,7 @@ OS:Surface,
 
 OS:Surface,
   {1e64584d-c3f3-41a6-a3ae-8e0be3b8d26b}, !- Handle
-  Surface 552,                            !- Name
+  ActiveStorage_Top_3 - Wall 270_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {ed4c4f3d-97af-4aee-8dd1-e5c7e0c1156f}, !- Space Name
@@ -9674,7 +9674,7 @@ OS:Surface,
 
 OS:Surface,
   {0d40073a-b648-4d72-ba4d-77f6df381666}, !- Handle
-  Surface 553,                            !- Name
+  ActiveStorage_Top_3 - RoofCeiling_a,    !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {ed4c4f3d-97af-4aee-8dd1-e5c7e0c1156f}, !- Space Name
@@ -9691,7 +9691,7 @@ OS:Surface,
 
 OS:Surface,
   {a261eba1-cd92-44f7-aaa6-9452988b12fe}, !- Handle
-  Surface 554,                            !- Name
+  ActiveStorage_Top_3 - Wall 000_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {ed4c4f3d-97af-4aee-8dd1-e5c7e0c1156f}, !- Space Name
@@ -9708,7 +9708,7 @@ OS:Surface,
 
 OS:Surface,
   {62e4f4ea-9f50-4ede-adbd-2b59bbc86224}, !- Handle
-  Surface 555,                            !- Name
+  ActiveStorage_Top_3 - Wall 090_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {ed4c4f3d-97af-4aee-8dd1-e5c7e0c1156f}, !- Space Name
@@ -9730,8 +9730,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  7.21911419532262e-016,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   7.9248,                                 !- Z Origin {m}
   {34c2b3a4-b93e-443b-9867-ce24d7c61c21}, !- Building Story Name
   {8994d32d-4b2e-4b58-a451-e239a7a6cd26}, !- Thermal Zone Name
@@ -9741,7 +9741,7 @@ OS:Space,
 
 OS:Surface,
   {2f983573-ea91-4229-b74e-11c3b8114a9e}, !- Handle
-  Surface 556,                            !- Name
+  Stair_Top_2 - Floor_a,                  !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {415020a7-0ebc-479d-817d-7158b9d145ae}, !- Space Name
@@ -9758,7 +9758,7 @@ OS:Surface,
 
 OS:Surface,
   {5d1c1b23-7a87-48d6-8ad2-b82c69108f81}, !- Handle
-  Surface 557,                            !- Name
+  Stair_Top_2 - Wall 180_a,               !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {415020a7-0ebc-479d-817d-7158b9d145ae}, !- Space Name
@@ -9775,7 +9775,7 @@ OS:Surface,
 
 OS:Surface,
   {29156c50-3095-4d02-8686-fb36c00ad6c7}, !- Handle
-  Surface 558,                            !- Name
+  Stair_Top_2 - RoofCeiling_a,            !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {415020a7-0ebc-479d-817d-7158b9d145ae}, !- Space Name
@@ -9792,7 +9792,7 @@ OS:Surface,
 
 OS:Surface,
   {5f96bebc-fcce-47e6-9d4f-99efb05b6f5b}, !- Handle
-  Surface 559,                            !- Name
+  Stair_Top_2 - Wall 270_a,               !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {415020a7-0ebc-479d-817d-7158b9d145ae}, !- Space Name
@@ -9809,7 +9809,7 @@ OS:Surface,
 
 OS:Surface,
   {fa524c05-b7e6-4e8a-86e4-cd95b225feeb}, !- Handle
-  Surface 560,                            !- Name
+  Stair_Top_2 - Wall 000_a,               !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {415020a7-0ebc-479d-817d-7158b9d145ae}, !- Space Name
@@ -9826,7 +9826,7 @@ OS:Surface,
 
 OS:Surface,
   {b11a8329-1911-4f5b-8688-77ea6e56dd6b}, !- Handle
-  Surface 561,                            !- Name
+  Stair_Top_2 - Wall 090_a,               !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {415020a7-0ebc-479d-817d-7158b9d145ae}, !- Space Name
@@ -9848,8 +9848,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  7.21911419532262e-016,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   7.9248,                                 !- Z Origin {m}
   {34c2b3a4-b93e-443b-9867-ce24d7c61c21}, !- Building Story Name
   {c09d0857-b8ca-46fc-9eb8-5192fa1a16a7}, !- Thermal Zone Name
@@ -9859,7 +9859,7 @@ OS:Space,
 
 OS:Surface,
   {fe9cbea3-885e-4493-8bce-2b4a0da280d2}, !- Handle
-  Surface 562,                            !- Name
+  ActiveStorage_Top_2 - Wall 270_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e6819e9b-a5fa-4fba-9afa-e362ffb236e0}, !- Space Name
@@ -9876,7 +9876,7 @@ OS:Surface,
 
 OS:Surface,
   {f42ffa35-9903-48b3-8358-57c85c798dfc}, !- Handle
-  Surface 563,                            !- Name
+  ActiveStorage_Top_2 - Wall 000_b,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e6819e9b-a5fa-4fba-9afa-e362ffb236e0}, !- Space Name
@@ -9893,7 +9893,7 @@ OS:Surface,
 
 OS:Surface,
   {800f1369-839f-4fd9-83ea-6fbd969b7bce}, !- Handle
-  Surface 564,                            !- Name
+  ActiveStorage_Top_2 - Floor_a,          !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {e6819e9b-a5fa-4fba-9afa-e362ffb236e0}, !- Space Name
@@ -9910,7 +9910,7 @@ OS:Surface,
 
 OS:Surface,
   {50f108d8-f2a8-4793-980c-e1ff149e1d55}, !- Handle
-  Surface 565,                            !- Name
+  ActiveStorage_Top_2 - RoofCeiling_a,    !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {e6819e9b-a5fa-4fba-9afa-e362ffb236e0}, !- Space Name
@@ -9927,7 +9927,7 @@ OS:Surface,
 
 OS:Surface,
   {9ba38eb3-66ac-4af3-a3c4-d864be170974}, !- Handle
-  Surface 566,                            !- Name
+  ActiveStorage_Top_2 - Wall 180_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e6819e9b-a5fa-4fba-9afa-e362ffb236e0}, !- Space Name
@@ -9944,7 +9944,7 @@ OS:Surface,
 
 OS:Surface,
   {22781793-7e5e-4781-be45-96e641fe132b}, !- Handle
-  Surface 567,                            !- Name
+  ActiveStorage_Top_2 - Wall 090_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e6819e9b-a5fa-4fba-9afa-e362ffb236e0}, !- Space Name
@@ -9961,7 +9961,7 @@ OS:Surface,
 
 OS:Surface,
   {6af0b48f-b640-4119-b2b0-86d8611ebac5}, !- Handle
-  Surface 568,                            !- Name
+  ActiveStorage_Top_2 - Wall 000_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e6819e9b-a5fa-4fba-9afa-e362ffb236e0}, !- Space Name
@@ -9983,8 +9983,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  7.21911419532262e-016,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   7.9248,                                 !- Z Origin {m}
   {34c2b3a4-b93e-443b-9867-ce24d7c61c21}, !- Building Story Name
   {37181995-c697-4566-b686-e314123b3060}, !- Thermal Zone Name
@@ -9994,7 +9994,7 @@ OS:Space,
 
 OS:Surface,
   {80572af9-2659-4bfc-80d0-dd3f8f7f1cb0}, !- Handle
-  Surface 569,                            !- Name
+  OpenOffice_Top_2 - Wall 090_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {39644eab-0d0f-4e37-ba13-07a4b9cb84ca}, !- Space Name
@@ -10011,7 +10011,7 @@ OS:Surface,
 
 OS:Surface,
   {96efa079-8210-4b4f-ab0a-d941631a6ed3}, !- Handle
-  Surface 570,                            !- Name
+  OpenOffice_Top_2 - Wall 270_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {39644eab-0d0f-4e37-ba13-07a4b9cb84ca}, !- Space Name
@@ -10028,7 +10028,7 @@ OS:Surface,
 
 OS:Surface,
   {a617c7ef-4fb6-45e7-bb71-a73d31f949db}, !- Handle
-  Surface 571,                            !- Name
+  OpenOffice_Top_2 - Wall 270_b,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {39644eab-0d0f-4e37-ba13-07a4b9cb84ca}, !- Space Name
@@ -10045,7 +10045,7 @@ OS:Surface,
 
 OS:Surface,
   {47b41bc0-745c-433e-bea4-6b2bff532f92}, !- Handle
-  Surface 572,                            !- Name
+  OpenOffice_Top_2 - Floor_a,             !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {39644eab-0d0f-4e37-ba13-07a4b9cb84ca}, !- Space Name
@@ -10062,7 +10062,7 @@ OS:Surface,
 
 OS:Surface,
   {a3f8b734-371f-4eb6-8a87-563b5547a87b}, !- Handle
-  Surface 573,                            !- Name
+  OpenOffice_Top_2 - RoofCeiling_a,       !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {39644eab-0d0f-4e37-ba13-07a4b9cb84ca}, !- Space Name
@@ -10079,7 +10079,7 @@ OS:Surface,
 
 OS:Surface,
   {b5367eb0-6fff-4776-82d7-ec7f50d745cb}, !- Handle
-  Surface 574,                            !- Name
+  OpenOffice_Top_2 - Wall 180_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {39644eab-0d0f-4e37-ba13-07a4b9cb84ca}, !- Space Name
@@ -10096,7 +10096,7 @@ OS:Surface,
 
 OS:Surface,
   {47d1260f-bc81-409a-af87-e65a7a4cbcc3}, !- Handle
-  Surface 575,                            !- Name
+  OpenOffice_Top_2 - Wall 090_b,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {39644eab-0d0f-4e37-ba13-07a4b9cb84ca}, !- Space Name
@@ -10113,7 +10113,7 @@ OS:Surface,
 
 OS:Surface,
   {ac2bbc6b-3789-4493-99e9-ae9a00829934}, !- Handle
-  Surface 576,                            !- Name
+  OpenOffice_Top_2 - Wall 270_c,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {39644eab-0d0f-4e37-ba13-07a4b9cb84ca}, !- Space Name
@@ -10130,7 +10130,7 @@ OS:Surface,
 
 OS:Surface,
   {9704e587-e453-4be7-800a-481e944ad190}, !- Handle
-  Surface 577,                            !- Name
+  OpenOffice_Top_2 - Wall 000_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {39644eab-0d0f-4e37-ba13-07a4b9cb84ca}, !- Space Name
@@ -10152,8 +10152,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  7.21911419532262e-016,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   7.9248,                                 !- Z Origin {m}
   {34c2b3a4-b93e-443b-9867-ce24d7c61c21}, !- Building Story Name
   {645c4cf5-8c36-4b5c-8c01-fb7daf9dd828}, !- Thermal Zone Name
@@ -10163,7 +10163,7 @@ OS:Space,
 
 OS:Surface,
   {8a3ff373-fc58-4c86-b714-fb85252c9a1f}, !- Handle
-  Surface 578,                            !- Name
+  Corridor_Top_1 - Wall 000_c,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3c299b5c-1e29-4d6b-b2ed-07d32ab6602a}, !- Space Name
@@ -10180,7 +10180,7 @@ OS:Surface,
 
 OS:Surface,
   {396bd8cc-a206-4032-8947-dcdb4fc46105}, !- Handle
-  Surface 579,                            !- Name
+  Corridor_Top_1 - Wall 180_b,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3c299b5c-1e29-4d6b-b2ed-07d32ab6602a}, !- Space Name
@@ -10197,7 +10197,7 @@ OS:Surface,
 
 OS:Surface,
   {c9a56c47-6d09-4469-aca0-6d86a42ebdd6}, !- Handle
-  Surface 580,                            !- Name
+  Corridor_Top_1 - Wall 000_d,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3c299b5c-1e29-4d6b-b2ed-07d32ab6602a}, !- Space Name
@@ -10214,7 +10214,7 @@ OS:Surface,
 
 OS:Surface,
   {95a87223-4f69-4b4d-b85c-db93b6d7f77c}, !- Handle
-  Surface 581,                            !- Name
+  Corridor_Top_1 - Wall 180_c,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3c299b5c-1e29-4d6b-b2ed-07d32ab6602a}, !- Space Name
@@ -10231,7 +10231,7 @@ OS:Surface,
 
 OS:Surface,
   {14e1e93c-e807-416a-a845-7e50afa90223}, !- Handle
-  Surface 582,                            !- Name
+  Corridor_Top_1 - Wall 000_e,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3c299b5c-1e29-4d6b-b2ed-07d32ab6602a}, !- Space Name
@@ -10248,7 +10248,7 @@ OS:Surface,
 
 OS:Surface,
   {731efc66-9eda-4319-9eac-6a56144836da}, !- Handle
-  Surface 583,                            !- Name
+  Corridor_Top_1 - Wall 180_d,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3c299b5c-1e29-4d6b-b2ed-07d32ab6602a}, !- Space Name
@@ -10265,7 +10265,7 @@ OS:Surface,
 
 OS:Surface,
   {c64ebd7d-3b83-428e-a294-c3c7d0d7b253}, !- Handle
-  Surface 584,                            !- Name
+  Corridor_Top_1 - Wall 180_e,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3c299b5c-1e29-4d6b-b2ed-07d32ab6602a}, !- Space Name
@@ -10282,7 +10282,7 @@ OS:Surface,
 
 OS:Surface,
   {33fda864-ddd5-4e25-b45a-afde95fe562f}, !- Handle
-  Surface 585,                            !- Name
+  Corridor_Top_1 - Wall 000_f,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3c299b5c-1e29-4d6b-b2ed-07d32ab6602a}, !- Space Name
@@ -10299,7 +10299,7 @@ OS:Surface,
 
 OS:Surface,
   {2034b553-7374-4ec6-affc-621a91fa983f}, !- Handle
-  Surface 586,                            !- Name
+  Corridor_Top_1 - Floor_a,               !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {3c299b5c-1e29-4d6b-b2ed-07d32ab6602a}, !- Space Name
@@ -10320,7 +10320,7 @@ OS:Surface,
 
 OS:Surface,
   {955851d9-ee71-43cf-8ef6-c6104107ba9c}, !- Handle
-  Surface 587,                            !- Name
+  Corridor_Top_1 - Wall 090_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3c299b5c-1e29-4d6b-b2ed-07d32ab6602a}, !- Space Name
@@ -10337,7 +10337,7 @@ OS:Surface,
 
 OS:Surface,
   {8274a349-2cb8-436c-8a39-9e486f8a3601}, !- Handle
-  Surface 588,                            !- Name
+  Corridor_Top_1 - RoofCeiling_a,         !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {3c299b5c-1e29-4d6b-b2ed-07d32ab6602a}, !- Space Name
@@ -10358,7 +10358,7 @@ OS:Surface,
 
 OS:Surface,
   {abfff3db-2dd7-4744-b56f-2aee25096a00}, !- Handle
-  Surface 589,                            !- Name
+  Corridor_Top_1 - Wall 000_b,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3c299b5c-1e29-4d6b-b2ed-07d32ab6602a}, !- Space Name
@@ -10375,7 +10375,7 @@ OS:Surface,
 
 OS:Surface,
   {76ab4cd6-e74e-41b1-8aab-56a049c46e6b}, !- Handle
-  Surface 590,                            !- Name
+  Corridor_Top_1 - Wall 000_g,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3c299b5c-1e29-4d6b-b2ed-07d32ab6602a}, !- Space Name
@@ -10392,7 +10392,7 @@ OS:Surface,
 
 OS:Surface,
   {cbd0a088-edb5-4279-b7b4-59635dd29e6b}, !- Handle
-  Surface 591,                            !- Name
+  Corridor_Top_1 - Wall 270_b,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3c299b5c-1e29-4d6b-b2ed-07d32ab6602a}, !- Space Name
@@ -10409,7 +10409,7 @@ OS:Surface,
 
 OS:Surface,
   {aea01a8d-5247-40cd-b5e8-3df2c9da7f1c}, !- Handle
-  Surface 592,                            !- Name
+  Corridor_Top_1 - Wall 000_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3c299b5c-1e29-4d6b-b2ed-07d32ab6602a}, !- Space Name
@@ -10426,7 +10426,7 @@ OS:Surface,
 
 OS:Surface,
   {dae2ed93-f705-4edb-b01d-91af6dd58a20}, !- Handle
-  Surface 593,                            !- Name
+  Corridor_Top_1 - Wall 090_b,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3c299b5c-1e29-4d6b-b2ed-07d32ab6602a}, !- Space Name
@@ -10443,7 +10443,7 @@ OS:Surface,
 
 OS:Surface,
   {ecd25b38-69aa-4309-a58d-a2fea2676806}, !- Handle
-  Surface 594,                            !- Name
+  Corridor_Top_1 - Wall 180_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3c299b5c-1e29-4d6b-b2ed-07d32ab6602a}, !- Space Name
@@ -10460,7 +10460,7 @@ OS:Surface,
 
 OS:Surface,
   {d41d2384-1794-4f1e-ba23-b5944afb6660}, !- Handle
-  Surface 595,                            !- Name
+  Corridor_Top_1 - Wall 270_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {3c299b5c-1e29-4d6b-b2ed-07d32ab6602a}, !- Space Name
@@ -10482,8 +10482,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  7.21911419532262e-016,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   7.9248,                                 !- Z Origin {m}
   {34c2b3a4-b93e-443b-9867-ce24d7c61c21}, !- Building Story Name
   {0d1bd9b9-16d1-4378-ba7a-4ac952440963}, !- Thermal Zone Name
@@ -10493,7 +10493,7 @@ OS:Space,
 
 OS:Surface,
   {e5cff3bd-7984-48bb-9c87-25c7da34938e}, !- Handle
-  Surface 596,                            !- Name
+  EnclosedOffice_Top_1 - Wall 090_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {2b598676-3558-42cf-ab42-7bf228720330}, !- Space Name
@@ -10510,7 +10510,7 @@ OS:Surface,
 
 OS:Surface,
   {baf4a3c5-dc75-420c-a394-3e2a8232c102}, !- Handle
-  Surface 597,                            !- Name
+  EnclosedOffice_Top_1 - Wall 090_b,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {2b598676-3558-42cf-ab42-7bf228720330}, !- Space Name
@@ -10527,7 +10527,7 @@ OS:Surface,
 
 OS:Surface,
   {80b07503-bf66-4da9-a8bf-da867c86459f}, !- Handle
-  Surface 598,                            !- Name
+  EnclosedOffice_Top_1 - Floor_a,         !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {2b598676-3558-42cf-ab42-7bf228720330}, !- Space Name
@@ -10544,7 +10544,7 @@ OS:Surface,
 
 OS:Surface,
   {a82b5eef-8de4-4fea-91f8-491f1cc825b3}, !- Handle
-  Surface 599,                            !- Name
+  EnclosedOffice_Top_1 - Wall 180_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {2b598676-3558-42cf-ab42-7bf228720330}, !- Space Name
@@ -10561,7 +10561,7 @@ OS:Surface,
 
 OS:Surface,
   {9944ab9c-d147-4548-a446-9915276c205a}, !- Handle
-  Surface 600,                            !- Name
+  EnclosedOffice_Top_1 - Wall 090_c,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {2b598676-3558-42cf-ab42-7bf228720330}, !- Space Name
@@ -10578,7 +10578,7 @@ OS:Surface,
 
 OS:Surface,
   {fdfd425e-9e85-4d74-bc81-281d983f8a70}, !- Handle
-  Surface 602,                            !- Name
+  EnclosedOffice_Top_1 - Wall 270_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {2b598676-3558-42cf-ab42-7bf228720330}, !- Space Name
@@ -10595,7 +10595,7 @@ OS:Surface,
 
 OS:Surface,
   {118c98bd-4067-420a-ac41-04ba8ba22c6d}, !- Handle
-  Surface 603,                            !- Name
+  EnclosedOffice_Top_1 - RoofCeiling_a,   !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {2b598676-3558-42cf-ab42-7bf228720330}, !- Space Name
@@ -10617,8 +10617,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  7.21911419532262e-016,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   7.9248,                                 !- Z Origin {m}
   {34c2b3a4-b93e-443b-9867-ce24d7c61c21}, !- Building Story Name
   {5d11a456-633f-4fdf-91e9-14d4dabfa08b}, !- Thermal Zone Name
@@ -10628,7 +10628,7 @@ OS:Space,
 
 OS:Surface,
   {43480694-90ca-49a9-aab0-cfb8694956fb}, !- Handle
-  Surface 604,                            !- Name
+  ActiveStorage_Top_1 - Wall 000_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {81d663af-05fb-46d2-8207-a345ceb974c3}, !- Space Name
@@ -10645,7 +10645,7 @@ OS:Surface,
 
 OS:Surface,
   {878337ad-6cf9-45cf-9258-03d2a6b04d9f}, !- Handle
-  Surface 605,                            !- Name
+  ActiveStorage_Top_1 - Floor_a,          !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {81d663af-05fb-46d2-8207-a345ceb974c3}, !- Space Name
@@ -10662,7 +10662,7 @@ OS:Surface,
 
 OS:Surface,
   {ed47f1e0-2856-4a90-86c7-d62e029f0052}, !- Handle
-  Surface 606,                            !- Name
+  ActiveStorage_Top_1 - Wall 270_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {81d663af-05fb-46d2-8207-a345ceb974c3}, !- Space Name
@@ -10679,7 +10679,7 @@ OS:Surface,
 
 OS:Surface,
   {a9d77a06-3c37-4aad-9d2a-4e714bb481a6}, !- Handle
-  Surface 607,                            !- Name
+  ActiveStorage_Top_1 - Wall 180_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {81d663af-05fb-46d2-8207-a345ceb974c3}, !- Space Name
@@ -10696,7 +10696,7 @@ OS:Surface,
 
 OS:Surface,
   {4535834d-83cb-4227-b478-ba8bd46752b6}, !- Handle
-  Surface 608,                            !- Name
+  ActiveStorage_Top_1 - Wall 090_a,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {81d663af-05fb-46d2-8207-a345ceb974c3}, !- Space Name
@@ -10713,7 +10713,7 @@ OS:Surface,
 
 OS:Surface,
   {3ffa9711-961b-4b71-a2ea-1e6c5fe14755}, !- Handle
-  Surface 609,                            !- Name
+  ActiveStorage_Top_1 - RoofCeiling_a,    !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {81d663af-05fb-46d2-8207-a345ceb974c3}, !- Space Name
@@ -10730,7 +10730,7 @@ OS:Surface,
 
 OS:Surface,
   {0491859b-308c-4553-8f17-116946fc4668}, !- Handle
-  Surface 610,                            !- Name
+  ActiveStorage_Top_1 - Wall 000_b,       !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {81d663af-05fb-46d2-8207-a345ceb974c3}, !- Space Name
@@ -10752,8 +10752,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  5.77529135625809e-015,                  !- X Origin {m}
-  7.21911419532262e-016,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   7.9248,                                 !- Z Origin {m}
   {34c2b3a4-b93e-443b-9867-ce24d7c61c21}, !- Building Story Name
   {3456fdaf-1ee8-4a3e-9844-127f74ff3c5a}, !- Thermal Zone Name
@@ -10763,7 +10763,7 @@ OS:Space,
 
 OS:Surface,
   {0da0da04-6579-4a9e-8569-c8b552e9e00b}, !- Handle
-  Surface 611,                            !- Name
+  ConfRoom_Top_1 - Wall 180_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {680a1f37-2b9f-44fa-b9d1-5ca9ea50a35b}, !- Space Name
@@ -10780,7 +10780,7 @@ OS:Surface,
 
 OS:Surface,
   {4982263f-c322-4d19-842a-79ddff827e9c}, !- Handle
-  Surface 612,                            !- Name
+  ConfRoom_Top_1 - Wall 000_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {680a1f37-2b9f-44fa-b9d1-5ca9ea50a35b}, !- Space Name
@@ -10797,7 +10797,7 @@ OS:Surface,
 
 OS:Surface,
   {6b9307b4-027d-44cf-afdc-0d03726a5264}, !- Handle
-  Surface 613,                            !- Name
+  ConfRoom_Top_1 - RoofCeiling_a,         !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {680a1f37-2b9f-44fa-b9d1-5ca9ea50a35b}, !- Space Name
@@ -10814,7 +10814,7 @@ OS:Surface,
 
 OS:Surface,
   {c0b96d1c-3110-49c5-ae41-a8c0547b31d9}, !- Handle
-  Surface 614,                            !- Name
+  ConfRoom_Top_1 - Wall 090_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {680a1f37-2b9f-44fa-b9d1-5ca9ea50a35b}, !- Space Name
@@ -10831,7 +10831,7 @@ OS:Surface,
 
 OS:Surface,
   {804b67bd-5780-4d6b-9472-6268e44431ac}, !- Handle
-  Surface 615,                            !- Name
+  ConfRoom_Top_1 - Wall 270_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {680a1f37-2b9f-44fa-b9d1-5ca9ea50a35b}, !- Space Name
@@ -10848,7 +10848,7 @@ OS:Surface,
 
 OS:Surface,
   {5f3a36b7-e112-476c-8554-929cc90085fa}, !- Handle
-  Surface 616,                            !- Name
+  ConfRoom_Top_1 - Wall 000_b,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {680a1f37-2b9f-44fa-b9d1-5ca9ea50a35b}, !- Space Name
@@ -10865,7 +10865,7 @@ OS:Surface,
 
 OS:Surface,
   {8e5fa34c-2355-43d2-8003-21ab2f44f143}, !- Handle
-  Surface 617,                            !- Name
+  ConfRoom_Top_1 - Floor_a,               !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {680a1f37-2b9f-44fa-b9d1-5ca9ea50a35b}, !- Space Name
@@ -10882,7 +10882,7 @@ OS:Surface,
 
 OS:Surface,
   {bf77f057-3768-4b34-8c6f-b38f7a94b562}, !- Handle
-  Surface 618,                            !- Name
+  FirstFloor_Plenum - RoofCeiling_i,      !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -10899,7 +10899,7 @@ OS:Surface,
 
 OS:Surface,
   {255e6293-0c97-4e6a-b3ed-fbed66d5aa1e}, !- Handle
-  Surface 619,                            !- Name
+  FirstFloor_Plenum - RoofCeiling_h,      !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -10916,7 +10916,7 @@ OS:Surface,
 
 OS:Surface,
   {d9d26bcd-6f00-4429-b945-2c9d363a5e2a}, !- Handle
-  Surface 620,                            !- Name
+  FirstFloor_Plenum - RoofCeiling_j,      !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -10937,7 +10937,7 @@ OS:Surface,
 
 OS:Surface,
   {090702bd-5ece-4d62-bca4-bd91634b8059}, !- Handle
-  Surface 621,                            !- Name
+  FirstFloor_Plenum - RoofCeiling_g,      !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -10954,7 +10954,7 @@ OS:Surface,
 
 OS:Surface,
   {92962ce7-207c-4a9c-a8f6-6ed97415c6da}, !- Handle
-  Surface 622,                            !- Name
+  FirstFloor_Plenum - RoofCeiling_c,      !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -10975,7 +10975,7 @@ OS:Surface,
 
 OS:Surface,
   {aa26130c-2a3f-4bdc-82a5-68078e97a011}, !- Handle
-  Surface 623,                            !- Name
+  FirstFloor_Plenum - RoofCeiling_e,      !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -10992,7 +10992,7 @@ OS:Surface,
 
 OS:Surface,
   {09cfb8ab-607d-417b-98dd-6d5db7d5c8d2}, !- Handle
-  Surface 624,                            !- Name
+  FirstFloor_Plenum - RoofCeiling_f,      !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -11009,7 +11009,7 @@ OS:Surface,
 
 OS:Surface,
   {9a7d8440-b43d-4303-b12a-2ff9b088ae72}, !- Handle
-  Surface 625,                            !- Name
+  FirstFloor_Plenum - RoofCeiling_k,      !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -11026,7 +11026,7 @@ OS:Surface,
 
 OS:Surface,
   {1ac23c69-201f-480c-b624-3a1fec897f76}, !- Handle
-  Surface 626,                            !- Name
+  FirstFloor_Plenum - RoofCeiling_l,      !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -11043,7 +11043,7 @@ OS:Surface,
 
 OS:Surface,
   {f4b200d5-e029-4abb-bb7b-ac82ee7f5ca9}, !- Handle
-  Surface 627,                            !- Name
+  FirstFloor_Plenum - RoofCeiling_m,      !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -11060,7 +11060,7 @@ OS:Surface,
 
 OS:Surface,
   {5037d9cc-d55c-4885-a7ef-c0b3cde2a55e}, !- Handle
-  Surface 628,                            !- Name
+  FirstFloor_Plenum - RoofCeiling_a,      !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -11077,7 +11077,7 @@ OS:Surface,
 
 OS:Surface,
   {9c2f5683-fccb-4073-8e0f-757d2596088d}, !- Handle
-  Surface 629,                            !- Name
+  FirstFloor_Plenum - RoofCeiling_n,      !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -11094,7 +11094,7 @@ OS:Surface,
 
 OS:Surface,
   {ed23d168-0b04-4a97-8880-05a5a51e3ad8}, !- Handle
-  Surface 630,                            !- Name
+  FirstFloor_Plenum - RoofCeiling_o,      !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -11111,7 +11111,7 @@ OS:Surface,
 
 OS:Surface,
   {1209aeac-8dc1-4e78-859c-21058a213a0d}, !- Handle
-  Surface 631,                            !- Name
+  FirstFloor_Plenum - RoofCeiling_p,      !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -11128,7 +11128,7 @@ OS:Surface,
 
 OS:Surface,
   {1c604607-39d2-4b88-80ad-300e2a34e74d}, !- Handle
-  Surface 632,                            !- Name
+  FirstFloor_Plenum - RoofCeiling_q,      !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -11145,7 +11145,7 @@ OS:Surface,
 
 OS:Surface,
   {3e052829-749a-4062-b03c-d4374ccc1d05}, !- Handle
-  Surface 633,                            !- Name
+  FirstFloor_Plenum - RoofCeiling_b,      !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -11162,7 +11162,7 @@ OS:Surface,
 
 OS:Surface,
   {08999080-f73d-420c-817c-147b50cdad06}, !- Handle
-  Surface 634,                            !- Name
+  MidFloor_Plenum - RoofCeiling_m,        !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -11179,7 +11179,7 @@ OS:Surface,
 
 OS:Surface,
   {37dc8fff-4432-49c2-9907-6a16b290b162}, !- Handle
-  Surface 635,                            !- Name
+  MidFloor_Plenum - RoofCeiling_n,        !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -11200,7 +11200,7 @@ OS:Surface,
 
 OS:Surface,
   {fe7c62c5-4ccd-45e1-84aa-cfcfeabcfd68}, !- Handle
-  Surface 636,                            !- Name
+  MidFloor_Plenum - RoofCeiling_o,        !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -11217,7 +11217,7 @@ OS:Surface,
 
 OS:Surface,
   {a655bbc0-8f33-4fa8-b3a7-b7324a45d4c4}, !- Handle
-  Surface 637,                            !- Name
+  MidFloor_Plenum - RoofCeiling_p,        !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -11238,7 +11238,7 @@ OS:Surface,
 
 OS:Surface,
   {a16f17d6-8fdc-4121-bd56-4726f5246c13}, !- Handle
-  Surface 638,                            !- Name
+  MidFloor_Plenum - RoofCeiling_q,        !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -11255,7 +11255,7 @@ OS:Surface,
 
 OS:Surface,
   {aec3822b-8e65-42cf-9bf1-0b94efa9cd06}, !- Handle
-  Surface 639,                            !- Name
+  MidFloor_Plenum - RoofCeiling_a,        !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -11272,7 +11272,7 @@ OS:Surface,
 
 OS:Surface,
   {4300d475-eb99-4ba4-b94d-99b9227a9e34}, !- Handle
-  Surface 640,                            !- Name
+  MidFloor_Plenum - RoofCeiling_r,        !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -11289,7 +11289,7 @@ OS:Surface,
 
 OS:Surface,
   {d4c3f039-b20e-4ef8-b2df-064d4dbb85e3}, !- Handle
-  Surface 641,                            !- Name
+  MidFloor_Plenum - RoofCeiling_c,        !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -11306,7 +11306,7 @@ OS:Surface,
 
 OS:Surface,
   {dbe28d2f-afa0-4290-a0ac-6c7b16c8253c}, !- Handle
-  Surface 642,                            !- Name
+  MidFloor_Plenum - RoofCeiling_h,        !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -11323,7 +11323,7 @@ OS:Surface,
 
 OS:Surface,
   {270a4493-20cb-4188-b3a9-c6d1913624ad}, !- Handle
-  Surface 643,                            !- Name
+  MidFloor_Plenum - RoofCeiling_s,        !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -11340,7 +11340,7 @@ OS:Surface,
 
 OS:Surface,
   {138a209e-3cba-4633-8e9a-96c77637194e}, !- Handle
-  Surface 644,                            !- Name
+  MidFloor_Plenum - RoofCeiling_j,        !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -11357,7 +11357,7 @@ OS:Surface,
 
 OS:Surface,
   {4de35918-6944-4f52-bda7-b433e5391a6c}, !- Handle
-  Surface 645,                            !- Name
+  MidFloor_Plenum - RoofCeiling_b,        !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -11374,7 +11374,7 @@ OS:Surface,
 
 OS:Surface,
   {e68f7529-b4e3-45cd-bc77-07f9ecbd1e94}, !- Handle
-  Surface 646,                            !- Name
+  MidFloor_Plenum - RoofCeiling_g,        !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -11391,7 +11391,7 @@ OS:Surface,
 
 OS:Surface,
   {22d46c33-6c9b-45d3-9fab-9e701b4da87d}, !- Handle
-  Surface 647,                            !- Name
+  MidFloor_Plenum - RoofCeiling_e,        !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -11408,7 +11408,7 @@ OS:Surface,
 
 OS:Surface,
   {c0d5f4f9-17dc-41e0-9c18-c6c3d4ecde08}, !- Handle
-  Surface 648,                            !- Name
+  MidFloor_Plenum - RoofCeiling_k,        !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -11425,7 +11425,7 @@ OS:Surface,
 
 OS:Surface,
   {75f79cb6-4452-46e4-a7be-56f414f48c89}, !- Handle
-  Surface 649,                            !- Name
+  MidFloor_Plenum - RoofCeiling_l,        !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -11442,7 +11442,7 @@ OS:Surface,
 
 OS:Surface,
   {75dc7635-47ac-4038-9a40-e8f28a325e93}, !- Handle
-  Surface 650,                            !- Name
+  MidFloor_Plenum - RoofCeiling_t,        !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -11459,7 +11459,7 @@ OS:Surface,
 
 OS:Surface,
   {521eaaa9-b63b-4e59-9c5a-5dd4807bf043}, !- Handle
-  Surface 651,                            !- Name
+  MidFloor_Plenum - RoofCeiling_f,        !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -11476,7 +11476,7 @@ OS:Surface,
 
 OS:Surface,
   {8977562c-488b-4c95-99be-3add660687a4}, !- Handle
-  Surface 652,                            !- Name
+  MidFloor_Plenum - RoofCeiling_u,        !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -11493,7 +11493,7 @@ OS:Surface,
 
 OS:Surface,
   {050cba94-a406-449d-b6fc-02f427df7233}, !- Handle
-  Surface 653,                            !- Name
+  MidFloor_Plenum - RoofCeiling_d,        !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {45fd3ae3-8f2f-44af-ad8a-4bacc76c87c7}, !- Space Name
@@ -11510,7 +11510,7 @@ OS:Surface,
 
 OS:Surface,
   {f1a48f62-a034-4d14-91c4-9499fe4ab574}, !- Handle
-  Surface 664,                            !- Name
+  ConfRoom_Mid_1 - Wall 270_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {a2f42132-0f39-42fb-a9bc-1b029ba5c56d}, !- Space Name
@@ -11565,7 +11565,7 @@ OS:RunPeriod,
 
 OS:Surface,
   {6dc27b80-4c27-40c6-b73e-3cb23e75c3ed}, !- Handle
-  Surface 686,                            !- Name
+  FirstFloor_Plenum - RoofCeiling_r,      !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -11582,7 +11582,7 @@ OS:Surface,
 
 OS:Surface,
   {57711ff8-c713-4dfa-b70c-37c70ea1c477}, !- Handle
-  Surface 685,                            !- Name
+  FirstFloor_Plenum - RoofCeiling_s,      !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -11599,7 +11599,7 @@ OS:Surface,
 
 OS:Surface,
   {63d8ee76-703c-4f39-840a-d16b781cf42e}, !- Handle
-  Surface 687,                            !- Name
+  FirstFloor_Plenum - RoofCeiling_t,      !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -11616,7 +11616,7 @@ OS:Surface,
 
 OS:Surface,
   {0da17fee-e6ea-49e6-91fc-217835e5edcd}, !- Handle
-  Surface 321,                            !- Name
+  FirstFloor_Plenum - RoofCeiling_u,      !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {0db7eb19-b972-4a96-9e47-9b6aec24f2c2}, !- Space Name
@@ -11638,8 +11638,8 @@ OS:Space,
   ,                                       !- Default Construction Set Name
   ,                                       !- Default Schedule Set Name
   -0,                                     !- Direction of Relative North {deg}
-  -1.02589783002182e-029,                 !- X Origin {m}
-  1.44377485810546e-015,                  !- Y Origin {m}
+  0,                                      !- X Origin {m}
+  0,                                      !- Y Origin {m}
   0,                                      !- Z Origin {m}
   {34c2b3a4-b93e-443b-9867-ce24d7c61c21}, !- Building Story Name
   {009ccf37-480b-4fd7-94ba-1bef9b6d6975}, !- Thermal Zone Name
@@ -11649,7 +11649,7 @@ OS:Space,
 
 OS:Surface,
   {b578ad87-bf45-49d9-9648-3bd7978643f1}, !- Handle
-  Surface 322,                            !- Name
+  TopFloor_Plenum - Floor_i,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {79ab5ef1-6729-4240-b9f0-4a689066e545}, !- Space Name
@@ -11659,14 +11659,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  4.50373750000001, 33.274, 10.668,       !- X,Y,Z Vertex 1 {m}
-  4.50373750000001, 5.3419375, 10.668,    !- X,Y,Z Vertex 2 {m}
-  5.7752913562581e-015, 5.3419375, 10.668, !- X,Y,Z Vertex 3 {m}
-  5.7752913562581e-015, 33.274, 10.668;   !- X,Y,Z Vertex 4 {m}
+  4.5037375, 33.274, 10.668,              !- X,Y,Z Vertex 1 {m}
+  4.5037375, 5.3419375, 10.668,           !- X,Y,Z Vertex 2 {m}
+  0, 5.3419375, 10.668,                   !- X,Y,Z Vertex 3 {m}
+  0, 33.274, 10.668;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {923dc1a4-8e00-4bce-9f79-26158f6bc2ab}, !- Handle
-  Surface 323,                            !- Name
+  TopFloor_Plenum - Wall 270_a,           !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {79ab5ef1-6729-4240-b9f0-4a689066e545}, !- Space Name
@@ -11676,14 +11676,14 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  5.7752913562581e-015, 33.274, 11.8872,  !- X,Y,Z Vertex 1 {m}
-  5.7752913562581e-015, 33.274, 10.668,   !- X,Y,Z Vertex 2 {m}
-  5.7752913562581e-015, 7.21911419532262e-016, 10.668, !- X,Y,Z Vertex 3 {m}
-  5.7752913562581e-015, 7.21911419532262e-016, 11.8872; !- X,Y,Z Vertex 4 {m}
+  0, 33.274, 11.8872,                     !- X,Y,Z Vertex 1 {m}
+  0, 33.274, 10.668,                      !- X,Y,Z Vertex 2 {m}
+  0, 0, 10.668,                           !- X,Y,Z Vertex 3 {m}
+  0, 0, 11.8872;                          !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {28e11e15-0b2d-442e-bd9a-9bdfb193b283}, !- Handle
-  Surface 324,                            !- Name
+  TopFloor_Plenum - RoofCeiling_a,        !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {79ab5ef1-6729-4240-b9f0-4a689066e545}, !- Space Name
@@ -11693,14 +11693,14 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  49.911, 7.21911419532262e-016, 11.8872, !- X,Y,Z Vertex 1 {m}
+  49.911, 0, 11.8872,                     !- X,Y,Z Vertex 1 {m}
   49.911, 33.274, 11.8872,                !- X,Y,Z Vertex 2 {m}
-  5.7752913562581e-015, 33.274, 11.8872,  !- X,Y,Z Vertex 3 {m}
-  5.7752913562581e-015, 7.21911419532262e-016, 11.8872; !- X,Y,Z Vertex 4 {m}
+  0, 33.274, 11.8872,                     !- X,Y,Z Vertex 3 {m}
+  0, 0, 11.8872;                          !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {a7a0f2a7-8052-4615-8e5f-5758587d8464}, !- Handle
-  Surface 325,                            !- Name
+  TopFloor_Plenum - Wall 000_a,           !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {79ab5ef1-6729-4240-b9f0-4a689066e545}, !- Space Name
@@ -11712,12 +11712,12 @@ OS:Surface,
   ,                                       !- Number of Vertices
   49.911, 33.274, 11.8872,                !- X,Y,Z Vertex 1 {m}
   49.911, 33.274, 10.668,                 !- X,Y,Z Vertex 2 {m}
-  5.7752913562581e-015, 33.274, 10.668,   !- X,Y,Z Vertex 3 {m}
-  5.7752913562581e-015, 33.274, 11.8872;  !- X,Y,Z Vertex 4 {m}
+  0, 33.274, 10.668,                      !- X,Y,Z Vertex 3 {m}
+  0, 33.274, 11.8872;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {5765faec-c253-4987-87f7-ef507061a066}, !- Handle
-  Surface 436,                            !- Name
+  TopFloor_Plenum - Wall 090_a,           !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {79ab5ef1-6729-4240-b9f0-4a689066e545}, !- Space Name
@@ -11727,14 +11727,14 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  49.911, 7.21911419532262e-016, 11.8872, !- X,Y,Z Vertex 1 {m}
-  49.911, 7.21911419532262e-016, 10.668,  !- X,Y,Z Vertex 2 {m}
+  49.911, 0, 11.8872,                     !- X,Y,Z Vertex 1 {m}
+  49.911, 0, 10.668,                      !- X,Y,Z Vertex 2 {m}
   49.911, 33.274, 10.668,                 !- X,Y,Z Vertex 3 {m}
   49.911, 33.274, 11.8872;                !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {0b34d370-cc13-4ffa-968d-b1587c96b20b}, !- Handle
-  Surface 437,                            !- Name
+  TopFloor_Plenum - Wall 180_a,           !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {79ab5ef1-6729-4240-b9f0-4a689066e545}, !- Space Name
@@ -11744,14 +11744,14 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  5.7752913562581e-015, 7.21911419532262e-016, 11.8872, !- X,Y,Z Vertex 1 {m}
-  5.7752913562581e-015, 7.21911419532262e-016, 10.668, !- X,Y,Z Vertex 2 {m}
-  49.911, 7.21911419532262e-016, 10.668,  !- X,Y,Z Vertex 3 {m}
-  49.911, 7.21911419532262e-016, 11.8872; !- X,Y,Z Vertex 4 {m}
+  0, 0, 11.8872,                          !- X,Y,Z Vertex 1 {m}
+  0, 0, 10.668,                           !- X,Y,Z Vertex 2 {m}
+  49.911, 0, 10.668,                      !- X,Y,Z Vertex 3 {m}
+  49.911, 0, 11.8872;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {539281e9-eb56-47d9-900b-5ec9fb197941}, !- Handle
-  Surface 688,                            !- Name
+  TopFloor_Plenum - Floor_j,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {79ab5ef1-6729-4240-b9f0-4a689066e545}, !- Space Name
@@ -11768,7 +11768,7 @@ OS:Surface,
 
 OS:Surface,
   {d2998121-9ea8-472f-a152-52df171d1f8b}, !- Handle
-  Surface 689,                            !- Name
+  TopFloor_Plenum - Floor_d,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {79ab5ef1-6729-4240-b9f0-4a689066e545}, !- Space Name
@@ -11780,16 +11780,16 @@ OS:Surface,
   ,                                       !- Number of Vertices
   45.4072625, 16.63779375, 10.668,        !- X,Y,Z Vertex 1 {m}
   45.4072625, 5.3419375, 10.668,          !- X,Y,Z Vertex 2 {m}
-  4.50373750000001, 5.3419375, 10.668,    !- X,Y,Z Vertex 3 {m}
-  4.50373750000001, 16.63779375, 10.668,  !- X,Y,Z Vertex 4 {m}
-  5.72293750000001, 16.63779375, 10.668,  !- X,Y,Z Vertex 5 {m}
-  5.72293750000001, 6.5611375, 10.668,    !- X,Y,Z Vertex 6 {m}
+  4.5037375, 5.3419375, 10.668,           !- X,Y,Z Vertex 3 {m}
+  4.5037375, 16.63779375, 10.668,         !- X,Y,Z Vertex 4 {m}
+  5.7229375, 16.63779375, 10.668,         !- X,Y,Z Vertex 5 {m}
+  5.7229375, 6.5611375, 10.668,           !- X,Y,Z Vertex 6 {m}
   44.1880625, 6.5611375, 10.668,          !- X,Y,Z Vertex 7 {m}
   44.1880625, 16.63779375, 10.668;        !- X,Y,Z Vertex 8 {m}
 
 OS:Surface,
   {f4ae91de-00c1-47b5-b061-5be67b38514e}, !- Handle
-  Surface 690,                            !- Name
+  TopFloor_Plenum - Floor_k,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {79ab5ef1-6729-4240-b9f0-4a689066e545}, !- Space Name
@@ -11803,14 +11803,14 @@ OS:Surface,
   45.4072625, 16.63779375, 10.668,        !- X,Y,Z Vertex 2 {m}
   44.1880625, 16.63779375, 10.668,        !- X,Y,Z Vertex 3 {m}
   44.1880625, 26.71445, 10.668,           !- X,Y,Z Vertex 4 {m}
-  5.72293750000001, 26.71445, 10.668,     !- X,Y,Z Vertex 5 {m}
-  5.72293750000001, 16.63779375, 10.668,  !- X,Y,Z Vertex 6 {m}
-  4.50373750000001, 16.63779375, 10.668,  !- X,Y,Z Vertex 7 {m}
-  4.50373750000001, 27.93365, 10.668;     !- X,Y,Z Vertex 8 {m}
+  5.7229375, 26.71445, 10.668,            !- X,Y,Z Vertex 5 {m}
+  5.7229375, 16.63779375, 10.668,         !- X,Y,Z Vertex 6 {m}
+  4.5037375, 16.63779375, 10.668,         !- X,Y,Z Vertex 7 {m}
+  4.5037375, 27.93365, 10.668;            !- X,Y,Z Vertex 8 {m}
 
 OS:Surface,
   {49c721cd-4cff-4df9-a06b-cce0bab554cf}, !- Handle
-  Surface 691,                            !- Name
+  TopFloor_Plenum - Floor_l,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {79ab5ef1-6729-4240-b9f0-4a689066e545}, !- Space Name
@@ -11827,7 +11827,7 @@ OS:Surface,
 
 OS:Surface,
   {c60fee28-a290-4e60-9b8f-280af482fc3d}, !- Handle
-  Surface 692,                            !- Name
+  TopFloor_Plenum - Floor_m,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {79ab5ef1-6729-4240-b9f0-4a689066e545}, !- Space Name
@@ -11839,12 +11839,12 @@ OS:Surface,
   ,                                       !- Number of Vertices
   15.3543, 26.71445, 10.668,              !- X,Y,Z Vertex 1 {m}
   15.3543, 6.5611375, 10.668,             !- X,Y,Z Vertex 2 {m}
-  5.72293750000001, 6.5611375, 10.668,    !- X,Y,Z Vertex 3 {m}
-  5.72293750000001, 26.71445, 10.668;     !- X,Y,Z Vertex 4 {m}
+  5.7229375, 6.5611375, 10.668,           !- X,Y,Z Vertex 3 {m}
+  5.7229375, 26.71445, 10.668;            !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {f815fd67-2859-4728-9037-4d3d48c86e39}, !- Handle
-  Surface 693,                            !- Name
+  TopFloor_Plenum - Floor_e,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {79ab5ef1-6729-4240-b9f0-4a689066e545}, !- Space Name
@@ -11861,7 +11861,7 @@ OS:Surface,
 
 OS:Surface,
   {e12c9e45-1b62-4e7f-ada1-816a881a2e4e}, !- Handle
-  Surface 694,                            !- Name
+  TopFloor_Plenum - Floor_n,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {79ab5ef1-6729-4240-b9f0-4a689066e545}, !- Space Name
@@ -11873,12 +11873,12 @@ OS:Surface,
   ,                                       !- Number of Vertices
   12.392025, 33.274, 10.668,              !- X,Y,Z Vertex 1 {m}
   12.392025, 27.93365, 10.668,            !- X,Y,Z Vertex 2 {m}
-  4.50373750000001, 27.93365, 10.668,     !- X,Y,Z Vertex 3 {m}
-  4.50373750000001, 33.274, 10.668;       !- X,Y,Z Vertex 4 {m}
+  4.5037375, 27.93365, 10.668,            !- X,Y,Z Vertex 3 {m}
+  4.5037375, 33.274, 10.668;              !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {51492ad7-078f-47af-b886-80ecd32ed976}, !- Handle
-  Surface 695,                            !- Name
+  TopFloor_Plenum - Floor_b,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {79ab5ef1-6729-4240-b9f0-4a689066e545}, !- Space Name
@@ -11895,7 +11895,7 @@ OS:Surface,
 
 OS:Surface,
   {75fb18c5-6c9a-47b1-96f6-b80e4946ba02}, !- Handle
-  Surface 696,                            !- Name
+  TopFloor_Plenum - Floor_o,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {79ab5ef1-6729-4240-b9f0-4a689066e545}, !- Space Name
@@ -11906,13 +11906,13 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   41.8417375, 5.3419375, 10.668,          !- X,Y,Z Vertex 1 {m}
-  41.8417375, 7.21911419532262e-016, 10.668, !- X,Y,Z Vertex 2 {m}
-  8.06926250000001, 7.21911419532262e-016, 10.668, !- X,Y,Z Vertex 3 {m}
-  8.06926250000001, 5.3419375, 10.668;    !- X,Y,Z Vertex 4 {m}
+  41.8417375, 0, 10.668,                  !- X,Y,Z Vertex 2 {m}
+  8.0692625, 0, 10.668,                   !- X,Y,Z Vertex 3 {m}
+  8.0692625, 5.3419375, 10.668;           !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {cbf443a5-8667-4610-aa5d-10192eeedb9e}, !- Handle
-  Surface 697,                            !- Name
+  TopFloor_Plenum - Floor_g,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {79ab5ef1-6729-4240-b9f0-4a689066e545}, !- Space Name
@@ -11929,7 +11929,7 @@ OS:Surface,
 
 OS:Surface,
   {0e4f053f-d77d-4053-ad85-bd16d0ebc430}, !- Handle
-  Surface 698,                            !- Name
+  TopFloor_Plenum - Floor_h,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {79ab5ef1-6729-4240-b9f0-4a689066e545}, !- Space Name
@@ -11940,13 +11940,13 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   49.911, 5.3419375, 10.668,              !- X,Y,Z Vertex 1 {m}
-  49.911, 7.21911419532262e-016, 10.668,  !- X,Y,Z Vertex 2 {m}
-  41.8417375, 7.21911419532262e-016, 10.668, !- X,Y,Z Vertex 3 {m}
+  49.911, 0, 10.668,                      !- X,Y,Z Vertex 2 {m}
+  41.8417375, 0, 10.668,                  !- X,Y,Z Vertex 3 {m}
   41.8417375, 5.3419375, 10.668;          !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {7ef96b26-638a-4b45-aff1-a3498308b364}, !- Handle
-  Surface 699,                            !- Name
+  TopFloor_Plenum - Floor_p,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {79ab5ef1-6729-4240-b9f0-4a689066e545}, !- Space Name
@@ -11963,7 +11963,7 @@ OS:Surface,
 
 OS:Surface,
   {1d47453d-01d8-495e-8d0e-e8e3c7436933}, !- Handle
-  Surface 700,                            !- Name
+  TopFloor_Plenum - Floor_q,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {79ab5ef1-6729-4240-b9f0-4a689066e545}, !- Space Name
@@ -11980,7 +11980,7 @@ OS:Surface,
 
 OS:Surface,
   {1b81c0ed-6983-48a9-b85d-59966dbd9456}, !- Handle
-  Surface 701,                            !- Name
+  TopFloor_Plenum - Floor_a,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {79ab5ef1-6729-4240-b9f0-4a689066e545}, !- Space Name
@@ -11997,7 +11997,7 @@ OS:Surface,
 
 OS:Surface,
   {65258233-7b2b-4199-a722-9c16d79ec952}, !- Handle
-  Surface 702,                            !- Name
+  TopFloor_Plenum - Floor_r,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {79ab5ef1-6729-4240-b9f0-4a689066e545}, !- Space Name
@@ -12014,7 +12014,7 @@ OS:Surface,
 
 OS:Surface,
   {b9109bbd-8886-4fa6-9d23-2d2fb43e5c2c}, !- Handle
-  Surface 703,                            !- Name
+  TopFloor_Plenum - Floor_s,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {79ab5ef1-6729-4240-b9f0-4a689066e545}, !- Space Name
@@ -12031,7 +12031,7 @@ OS:Surface,
 
 OS:Surface,
   {3346d3ca-f82e-4978-a5b4-df637aa8730b}, !- Handle
-  Surface 704,                            !- Name
+  TopFloor_Plenum - Floor_f,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {79ab5ef1-6729-4240-b9f0-4a689066e545}, !- Space Name
@@ -12048,7 +12048,7 @@ OS:Surface,
 
 OS:Surface,
   {388c0b36-8cee-4be0-883a-4c9382f98460}, !- Handle
-  Surface 705,                            !- Name
+  TopFloor_Plenum - Floor_t,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {79ab5ef1-6729-4240-b9f0-4a689066e545}, !- Space Name
@@ -12065,7 +12065,7 @@ OS:Surface,
 
 OS:Surface,
   {1c3f7e13-f455-4836-bef5-93510e82bacc}, !- Handle
-  Surface 706,                            !- Name
+  TopFloor_Plenum - Floor_u,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {79ab5ef1-6729-4240-b9f0-4a689066e545}, !- Space Name
@@ -12082,7 +12082,7 @@ OS:Surface,
 
 OS:Surface,
   {7649d764-c94e-46cc-b092-3f1b854be18b}, !- Handle
-  Surface 438,                            !- Name
+  TopFloor_Plenum - Floor_c,              !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {79ab5ef1-6729-4240-b9f0-4a689066e545}, !- Space Name
@@ -12092,14 +12092,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  8.06926250000001, 5.3419375, 10.668,    !- X,Y,Z Vertex 1 {m}
-  8.06926250000001, 7.21911419532262e-016, 10.668, !- X,Y,Z Vertex 2 {m}
-  5.7752913562581e-015, 7.21911419532262e-016, 10.668, !- X,Y,Z Vertex 3 {m}
-  5.7752913562581e-015, 5.3419375, 10.668; !- X,Y,Z Vertex 4 {m}
+  8.0692625, 5.3419375, 10.668,           !- X,Y,Z Vertex 1 {m}
+  8.0692625, 0, 10.668,                   !- X,Y,Z Vertex 2 {m}
+  0, 0, 10.668,                           !- X,Y,Z Vertex 3 {m}
+  0, 5.3419375, 10.668;                   !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {bb2b7e0d-439e-42fd-8468-48a775da8188}, !- Handle
-  Surface 298,                            !- Name
+  ConfRoom_Mid_2 - Wall 090_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {97d239e3-2f93-4f66-88a2-7167dc152e5a}, !- Space Name
@@ -12116,7 +12116,7 @@ OS:Surface,
 
 OS:Surface,
   {7c5ce8a2-d811-4570-933e-3488543af5b1}, !- Handle
-  Surface 300,                            !- Name
+  ConfRoom_Mid_2 - Wall 180_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {97d239e3-2f93-4f66-88a2-7167dc152e5a}, !- Space Name
@@ -12133,7 +12133,7 @@ OS:Surface,
 
 OS:Surface,
   {aa7ae702-3c5f-4dcd-8834-a851262a154b}, !- Handle
-  Surface 329,                            !- Name
+  EnclosedOffice_Mid_2 - Wall 000_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {5ce85006-2881-44f2-8075-2f399d15ba10}, !- Space Name
@@ -12150,7 +12150,7 @@ OS:Surface,
 
 OS:Surface,
   {aa8ea45f-e806-442c-82c4-6fbcd8c01f9c}, !- Handle
-  Surface 381,                            !- Name
+  EnclosedOffice_Mid_2 - Wall 090_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {5ce85006-2881-44f2-8075-2f399d15ba10}, !- Space Name
@@ -12167,7 +12167,7 @@ OS:Surface,
 
 OS:Surface,
   {3ad91f30-1874-45bf-826f-4de126ebc76a}, !- Handle
-  Surface 383,                            !- Name
+  ConfRoom_Top_2 - Wall 090_a,            !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {532a76a3-a007-4347-afed-4f4aa3e41419}, !- Space Name
@@ -12184,7 +12184,7 @@ OS:Surface,
 
 OS:Surface,
   {de02315f-5f2f-4d6f-bc9d-3c43a65f9775}, !- Handle
-  Surface 415,                            !- Name
+  EnclosedOffice_Top_1 - Wall 000_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {2b598676-3558-42cf-ab42-7bf228720330}, !- Space Name
@@ -12201,7 +12201,7 @@ OS:Surface,
 
 OS:Surface,
   {94b17f05-9f1f-420d-94db-abda53a2e5e9}, !- Handle
-  Surface 416,                            !- Name
+  EnclosedOffice_Top_3 - Wall 000_a,      !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {088fff13-3245-46c2-bd01-90dce95d2d32}, !- Space Name
@@ -12218,7 +12218,7 @@ OS:Surface,
 
 OS:SubSurface,
   {dc9147cc-463a-468d-a031-6ca2c2913868}, !- Handle
-  Sub Surface 1,                          !- Name
+  ConfRoom_Bot_1 - Wall 180_a - Sub:a,    !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {ee216b85-e4fa-45dc-adf5-783ca88f1a36}, !- Surface Name
@@ -12235,7 +12235,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {bcf30908-6803-49f7-b237-1e69f1fb6d70}, !- Handle
-  Sub Surface 2,                          !- Name
+  ConfRoom_Bot_1 - Wall 270_a - Sub:a,    !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {cbd6def7-e055-4b6a-88bf-bbe3cb1b13da}, !- Surface Name
@@ -12252,7 +12252,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {c166dc1a-dbaa-46f0-92f1-f5616b1bc37f}, !- Handle
-  Sub Surface 4,                          !- Name
+  ConfRoom_Bot_2 - Wall 090_a - Sub:a,    !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {1c501ce7-9cbd-482b-9b37-9bdee8fb66d6}, !- Surface Name
@@ -12269,7 +12269,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {a5834a56-649d-4555-b4f5-75ee0186f42f}, !- Handle
-  Sub Surface 5,                          !- Name
+  EnclosedOffice_Bot_3 - Wall 180_a - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {461fd235-e5a3-4976-a758-86cdaae6c00b}, !- Surface Name
@@ -12286,7 +12286,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {624079ad-085a-4aef-a887-454029ae125c}, !- Handle
-  Sub Surface 6,                          !- Name
+  EnclosedOffice_Bot_4 - Wall 180_a - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {f3a3e826-998e-414f-b44e-d0d1c74c33ea}, !- Surface Name
@@ -12303,7 +12303,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {f7ebe4e8-abf7-4452-be8a-5b0c9aadfc45}, !- Handle
-  Sub Surface 7,                          !- Name
+  EnclosedOffice_Mid_3 - Wall 000_a - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {cd903760-09fd-4136-8816-159cdd837f3e}, !- Surface Name
@@ -12320,7 +12320,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {e7054e25-4a82-408a-ae8d-bf753e55ed7e}, !- Handle
-  Sub Surface 8,                          !- Name
+  Lounge_Bot - Wall 180_a - Sub:a,        !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {cc4872fe-0abd-4224-bdcd-434ba9df8fa0}, !- Surface Name
@@ -12337,7 +12337,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {36748563-03df-4d5a-9056-d7a3743704cb}, !- Handle
-  Sub Surface 9,                          !- Name
+  ConfRoom_Bot_2 - Wall 180_a - Sub:a,    !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {e951ea82-4724-418a-9414-4abe1b5613cc}, !- Surface Name
@@ -12354,7 +12354,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {99a87b34-6e7d-4450-8177-fa8e2b5d0ec8}, !- Handle
-  Sub Surface 10,                         !- Name
+  EnclosedOffice_Bot_1 - Wall 000_a - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {f1f26603-9b76-4c89-8bd4-e59d6987d3c2}, !- Surface Name
@@ -12371,7 +12371,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {a11d76d6-8ee6-4155-964f-6302902c9fb1}, !- Handle
-  Sub Surface 11,                         !- Name
+  EnclosedOffice_Bot_1 - Wall 270_a - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {b04a2501-431a-4745-a51d-64230f66347d}, !- Surface Name
@@ -12388,7 +12388,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {7be38074-a682-4d75-8ba6-a804199fbe3e}, !- Handle
-  Sub Surface 13,                         !- Name
+  EnclosedOffice_Bot_2 - Wall 090_a - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {b9ded477-a976-45fb-b9b9-9cb6c12d56b8}, !- Surface Name
@@ -12405,7 +12405,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {12d0740c-5b48-4e62-8885-083a2e9a82d8}, !- Handle
-  Sub Surface 14,                         !- Name
+  EnclosedOffice_Mid_2 - Wall 000_a - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {aa7ae702-3c5f-4dcd-8834-a851262a154b}, !- Surface Name
@@ -12422,7 +12422,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {1010e28c-3bda-401a-abd7-866bf0019d4a}, !- Handle
-  Sub Surface 15,                         !- Name
+  ClassRoom_Bot - Wall 000_a - Sub:a,     !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {49438c66-0fae-4b1f-8971-6c704cbb323e}, !- Surface Name
@@ -12439,7 +12439,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {95f075b0-42f4-4ae1-8f76-487a02a173f2}, !- Handle
-  Sub Surface 16,                         !- Name
+  OpenOffice_Bot_3 - Wall 000_a - Sub:a,  !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {760b961f-fda9-4e5c-b46e-e95c97659ac9}, !- Surface Name
@@ -12456,7 +12456,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {652993e4-f12e-4a8d-aee7-2522b5433cca}, !- Handle
-  Sub Surface 17,                         !- Name
+  EnclosedOffice_Mid_1 - Wall 000_a - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {aa741c95-947f-4828-a165-c636e6a497b8}, !- Surface Name
@@ -12473,7 +12473,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {eabac292-ddbc-4e41-8607-48d5e2c89167}, !- Handle
-  Sub Surface 18,                         !- Name
+  EnclosedOffice_Bot_2 - Wall 000_a - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {85cefc1a-7279-4ed5-8774-e414b076b756}, !- Surface Name
@@ -12490,7 +12490,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {33eb6ac2-8a86-4e50-879a-cc4f1dd0c45f}, !- Handle
-  Sub Surface 19,                         !- Name
+  EnclosedOffice_Mid_1 - Wall 270_a - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {1d081beb-e1b0-4f68-ae07-bf494d782507}, !- Surface Name
@@ -12507,7 +12507,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {80d3875f-453d-467c-9940-ee008af38cd0}, !- Handle
-  Sub Surface 24,                         !- Name
+  ConfRoom_Top_2 - Wall 090_a - Sub:a,    !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {3ad91f30-1874-45bf-826f-4de126ebc76a}, !- Surface Name
@@ -12524,7 +12524,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {0f5594c1-1f59-4710-a49e-f0f9670b5cef}, !- Handle
-  Sub Surface 25,                         !- Name
+  OpenOffice_Top_4 - Wall 180_a - Sub:a,  !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {201a37ea-f8ed-42fb-9b65-f07245801d17}, !- Surface Name
@@ -12541,7 +12541,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {be420674-5c69-4af5-8ced-cd3fd8fee490}, !- Handle
-  Sub Surface 26,                         !- Name
+  ConfRoom_Mid_1 - Wall 180_a - Sub:a,    !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {0a981bab-79b7-4a02-a06a-97a9181484e6}, !- Surface Name
@@ -12558,7 +12558,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {1991bfd6-b1c0-488b-bd85-c95e55908628}, !- Handle
-  Sub Surface 27,                         !- Name
+  OpenOffice_Top_3 - Wall 000_a - Sub:a,  !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {31aaa649-a714-467a-ad54-52a464a4091d}, !- Surface Name
@@ -12575,7 +12575,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {63ccc8ea-3ba8-414c-ae32-095b3fe6fe17}, !- Handle
-  Sub Surface 28,                         !- Name
+  OpenOffice_Mid_3 - Wall 000_a - Sub:a,  !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {83ea213b-fb53-4b2a-96d3-537b60825b58}, !- Surface Name
@@ -12592,7 +12592,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {88f35a59-3820-42a9-ba09-8379983e1c61}, !- Handle
-  Sub Surface 29,                         !- Name
+  ConfRoom_Mid_1 - Wall 270_a - Sub:a,    !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {f1a48f62-a034-4d14-91c4-9499fe4ab574}, !- Surface Name
@@ -12609,7 +12609,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {4652aaba-494d-4876-93eb-0eafc3ae8f0c}, !- Handle
-  Sub Surface 31,                         !- Name
+  OpenOffice_Mid_4 - Wall 180_a - Sub:a,  !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {d1927d2b-4630-48f8-8e2b-d3d427798232}, !- Surface Name
@@ -12626,7 +12626,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {99cdf5d5-aa91-4bd4-98cb-fc69abeb5716}, !- Handle
-  Sub Surface 34,                         !- Name
+  EnclosedOffice_Top_2 - Wall 000_a - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {b077d97e-9c8a-4261-9da8-c1a47d93f40a}, !- Surface Name
@@ -12643,7 +12643,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {5551f593-09f5-4ab1-a1c8-2088453238c0}, !- Handle
-  Sub Surface 36,                         !- Name
+  EnclosedOffice_Top_2 - Wall 090_a - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {92bd749b-a0f8-4c85-9dd8-2a3845c85a89}, !- Surface Name
@@ -12660,7 +12660,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {e789c599-617f-4144-afcb-2e8cabf2bf98}, !- Handle
-  Sub Surface 37,                         !- Name
+  ConfRoom_Mid_2 - Wall 180_a - Sub:a,    !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {7c5ce8a2-d811-4570-933e-3488543af5b1}, !- Surface Name
@@ -12677,7 +12677,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {ae9e4d99-6706-40d2-a669-220e6f06e22b}, !- Handle
-  Sub Surface 38,                         !- Name
+  ConfRoom_Top_2 - Wall 180_a - Sub:a,    !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {e4674b9e-70bf-41f9-828b-87c7a218e496}, !- Surface Name
@@ -12694,7 +12694,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {777ce972-097b-405b-9c91-d6eaebb29745}, !- Handle
-  Sub Surface 39,                         !- Name
+  EnclosedOffice_Top_1 - Wall 270_a - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {fdfd425e-9e85-4d74-bc81-281d983f8a70}, !- Surface Name
@@ -12711,7 +12711,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {0099c3ab-8de6-4454-a0c0-37d0988d6850}, !- Handle
-  Sub Surface 40,                         !- Name
+  ConfRoom_Top_1 - Wall 180_a - Sub:a,    !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {0da0da04-6579-4a9e-8569-c8b552e9e00b}, !- Surface Name
@@ -12728,7 +12728,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {3d1d4243-7722-43d4-97d8-e77aa2c88afa}, !- Handle
-  Sub Surface 41,                         !- Name
+  ConfRoom_Top_1 - Wall 270_a - Sub:a,    !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {804b67bd-5780-4d6b-9472-6268e44431ac}, !- Surface Name
@@ -12745,7 +12745,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {dfddfcb9-4066-4dad-b85c-386cada1431c}, !- Handle
-  Sub Surface 42,                         !- Name
+  EnclosedOffice_Top_1 - Wall 000_a - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {de02315f-5f2f-4d6f-bc9d-3c43a65f9775}, !- Surface Name
@@ -12762,7 +12762,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {840aa250-249c-4d77-a305-b6f274a3c103}, !- Handle
-  Sub Surface 45,                         !- Name
+  EnclosedOffice_Top_3 - Wall 000_a - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {94b17f05-9f1f-420d-94db-abda53a2e5e9}, !- Surface Name
@@ -12779,7 +12779,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {90dd8d52-9895-43f4-9db0-4d06ec965cc2}, !- Handle
-  Sub Surface 46,                         !- Name
+  ConfRoom_Mid_2 - Wall 090_a - Sub:a,    !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {bb2b7e0d-439e-42fd-8468-48a775da8188}, !- Surface Name
@@ -12796,7 +12796,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {6c1fe987-f6c9-4438-9fb6-d520d5293f4a}, !- Handle
-  Sub Surface 47,                         !- Name
+  EnclosedOffice_Mid_2 - Wall 090_a - Sub:a, !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {aa8ea45f-e806-442c-82c4-6fbcd8c01f9c}, !- Surface Name
@@ -12888,7 +12888,7 @@ OS:Rendering:Color,
 
 OS:Building,
   {8ce3d32a-d3ae-476d-af4d-68f081d882ac}, !- Handle
-  Building 1,                             !- Name
+  ASHRAEMediumOfficeDetailed,             !- Name
   ,                                       !- Building Sector Type
   ,                                       !- North Axis {deg}
   6.76791955811492e-017,                  !- Nominal Floor to Floor Height {m}
@@ -12897,6 +12897,7 @@ OS:Building,
   ,                                       !- Default Schedule Set Name
   3,                                      !- Standards Number of Stories
   0,                                      !- Standards Number of Above Ground Stories
+  ,                                       !- Standards Template
   ,                                       !- Standards Building Type
   ,                                       !- Standards Number of Living Units
   ,                                       !- Relocatable
@@ -12909,6 +12910,7 @@ OS:SpaceType,
   ,                                       !- Default Schedule Set Name
   {eb522dc0-a29a-484b-bcb5-8ff1eef34cb0}, !- Group Rendering Name
   ,                                       !- Design Specification Outdoor Air Object Name
+  ,                                       !- Standards Template
   Office,                                 !- Standards Building Type
   MediumOffice - OpenOffice;              !- Standards Space Type
 
@@ -12926,6 +12928,7 @@ OS:SpaceType,
   ,                                       !- Default Schedule Set Name
   {95b38b88-279a-4835-9d48-89da8042a72e}, !- Group Rendering Name
   ,                                       !- Design Specification Outdoor Air Object Name
+  ,                                       !- Standards Template
   Office,                                 !- Standards Building Type
   MediumOffice - ClosedOffice;            !- Standards Space Type
 
@@ -12943,6 +12946,7 @@ OS:SpaceType,
   ,                                       !- Default Schedule Set Name
   {687dbd99-171a-4640-8f08-41d2fb660847}, !- Group Rendering Name
   ,                                       !- Design Specification Outdoor Air Object Name
+  ,                                       !- Standards Template
   Office,                                 !- Standards Building Type
   MediumOffice - Classroom;               !- Standards Space Type
 
@@ -12960,6 +12964,7 @@ OS:SpaceType,
   ,                                       !- Default Schedule Set Name
   {af24da99-6231-473d-a4ee-98e18dec0b26}, !- Group Rendering Name
   ,                                       !- Design Specification Outdoor Air Object Name
+  ,                                       !- Standards Template
   Office,                                 !- Standards Building Type
   MediumOffice - Conference;              !- Standards Space Type
 
@@ -12977,6 +12982,7 @@ OS:SpaceType,
   ,                                       !- Default Schedule Set Name
   {b88bdaea-5220-4f5f-8918-1277d0cb2bef}, !- Group Rendering Name
   ,                                       !- Design Specification Outdoor Air Object Name
+  ,                                       !- Standards Template
   Office,                                 !- Standards Building Type
   MediumOffice - Storage;                 !- Standards Space Type
 
@@ -12994,6 +13000,7 @@ OS:SpaceType,
   ,                                       !- Default Schedule Set Name
   {b365ceb4-b39a-4c6e-be79-d8570755bc74}, !- Group Rendering Name
   ,                                       !- Design Specification Outdoor Air Object Name
+  ,                                       !- Standards Template
   Office,                                 !- Standards Building Type
   MediumOffice - Corridor;                !- Standards Space Type
 
@@ -13011,6 +13018,7 @@ OS:SpaceType,
   ,                                       !- Default Schedule Set Name
   {b3caefa0-edb1-4409-bb19-0da21d57131f}, !- Group Rendering Name
   ,                                       !- Design Specification Outdoor Air Object Name
+  ,                                       !- Standards Template
   Office,                                 !- Standards Building Type
   MediumOffice - Dining;                  !- Standards Space Type
 
@@ -13028,6 +13036,7 @@ OS:SpaceType,
   ,                                       !- Default Schedule Set Name
   {a733da76-dbef-4059-a66c-7a259eba3233}, !- Group Rendering Name
   ,                                       !- Design Specification Outdoor Air Object Name
+  ,                                       !- Standards Template
   Office,                                 !- Standards Building Type
   MediumOffice - Lobby;                   !- Standards Space Type
 
@@ -13045,6 +13054,7 @@ OS:SpaceType,
   ,                                       !- Default Schedule Set Name
   {22c28617-85f5-4120-8ce3-46c49fba1406}, !- Group Rendering Name
   ,                                       !- Design Specification Outdoor Air Object Name
+  ,                                       !- Standards Template
   Office,                                 !- Standards Building Type
   MediumOffice - Elec/MechRoom;           !- Standards Space Type
 
@@ -13062,6 +13072,7 @@ OS:SpaceType,
   ,                                       !- Default Schedule Set Name
   {7c21f5c0-74ce-48f5-ac78-18545b8bd117}, !- Group Rendering Name
   ,                                       !- Design Specification Outdoor Air Object Name
+  ,                                       !- Standards Template
   Office,                                 !- Standards Building Type
   MediumOffice - Stair;                   !- Standards Space Type
 
@@ -13079,6 +13090,7 @@ OS:SpaceType,
   ,                                       !- Default Schedule Set Name
   {0aa78b18-9198-4ff7-ba83-ca611bc87c18}, !- Group Rendering Name
   ,                                       !- Design Specification Outdoor Air Object Name
+  ,                                       !- Standards Template
   Office,                                 !- Standards Building Type
   MediumOffice - Restroom;                !- Standards Space Type
 
@@ -13139,15 +13151,21 @@ OS:ThermalZone,
   {fc6b35e2-9941-41d0-a7cb-9562aa803315}, !- Zone Air Inlet Port List
   {bd805c8b-810b-4a0f-a354-5280252eff84}, !- Zone Air Exhaust Port List
   {700ddf99-4354-4a48-ae70-51c86d407335}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {7a5c9772-264a-43e7-9df1-2fee8bff3282}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {12c294da-77df-40c8-884a-626b4fee78fc}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {7a5c9772-264a-43e7-9df1-2fee8bff3282}, !- Handle
+  Port List 3,                            !- Name
+  {41cd6239-97fc-4edf-9fb2-e6e6b420e09f}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {94e0b8e9-dfc1-43a2-9a5a-87c26fed68b2}, !- Handle
@@ -13221,15 +13239,21 @@ OS:ThermalZone,
   {23a524a0-39ed-492f-bdef-97175209ca53}, !- Zone Air Inlet Port List
   {afb8f695-9f3f-462f-a35d-4b61890c9ef1}, !- Zone Air Exhaust Port List
   {e8b8fc5f-e567-4daa-83bf-1178455fe92f}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {d4fb714b-f188-4a27-9b93-b63db9d7caa9}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {430b3a22-2984-42d2-9d12-bb4c9d412c83}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {d4fb714b-f188-4a27-9b93-b63db9d7caa9}, !- Handle
+  Port List 4,                            !- Name
+  {4db7eee2-73e2-4fff-9953-3af33d6ba40d}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {e6a938ff-a5f7-4d17-b946-1bfdbb70e94a}, !- Handle
@@ -13303,15 +13327,21 @@ OS:ThermalZone,
   {ec0c35d2-31d8-4ccb-8ea2-7b2ab1352a8b}, !- Zone Air Inlet Port List
   {1356f7f3-fe34-4ed0-b461-cce8a289e431}, !- Zone Air Exhaust Port List
   {e1869a44-8c64-4029-85cd-941e1de43846}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {bb5c2cf8-c8a3-4322-b9f2-a6c89ce31c2b}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {7fd50ba0-d80d-4217-a45c-568693e4ac17}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {bb5c2cf8-c8a3-4322-b9f2-a6c89ce31c2b}, !- Handle
+  Port List 5,                            !- Name
+  {1bd749a4-6837-49ff-a664-93c3d1862eff}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {f2ce5df1-3d1a-4e48-85c6-1b07f527cce5}, !- Handle
@@ -13385,15 +13415,21 @@ OS:ThermalZone,
   {fc30e6dc-4dbd-49e1-b1b8-cd02a48e0d2d}, !- Zone Air Inlet Port List
   {9d4c8126-cc62-4b18-878e-61aebf557214}, !- Zone Air Exhaust Port List
   {0dba346e-8322-4dda-8ce9-0d7c912bb3bf}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {2328d6dd-c73b-4e96-af10-b664aab25df8}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {f75edb53-933e-4bfb-ae11-025802d01346}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {2328d6dd-c73b-4e96-af10-b664aab25df8}, !- Handle
+  Port List 6,                            !- Name
+  {67de5769-0be9-4996-820e-fffc469a52b0}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {e988da9e-8143-4efb-bb4a-7b4bacc62af5}, !- Handle
@@ -13467,15 +13503,21 @@ OS:ThermalZone,
   {598912ee-2dcc-4473-b042-4d09223a07e1}, !- Zone Air Inlet Port List
   {b1694f45-7c31-4fd6-8c67-e1803adff05b}, !- Zone Air Exhaust Port List
   {4ce0d0af-d92e-4648-8e89-02ae3853c9c8}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {f79d4c27-a721-426a-bbc2-c7cde76d161c}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {ef013b0a-7ccd-4efe-8582-f5f6038348d9}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {f79d4c27-a721-426a-bbc2-c7cde76d161c}, !- Handle
+  Port List 7,                            !- Name
+  {355e4c73-cb17-4378-ba21-8644519dfb5a}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {1c1b61bf-1415-4c3b-946a-0b610e62014d}, !- Handle
@@ -13549,15 +13591,21 @@ OS:ThermalZone,
   {e3b87378-19a6-4f61-97b8-76eda2a54d1c}, !- Zone Air Inlet Port List
   {cbd2f1b7-1be8-4b6b-bf90-b09c344a57db}, !- Zone Air Exhaust Port List
   {198b245b-5f7c-4a99-84fd-eb1e8f3ed21d}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {dfa9a582-52a9-45e4-9a06-45b59a247425}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {b1c8f720-9692-4f06-8f4f-331ed9ff7c04}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {dfa9a582-52a9-45e4-9a06-45b59a247425}, !- Handle
+  Port List 8,                            !- Name
+  {3456fdaf-1ee8-4a3e-9844-127f74ff3c5a}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {7c0be923-c9d7-4753-aee2-c5cf346f42af}, !- Handle
@@ -13631,15 +13679,21 @@ OS:ThermalZone,
   {825171ac-6e34-4f97-ab92-7e28e22b49be}, !- Zone Air Inlet Port List
   {92e832b9-79c2-4942-8254-68423297b159}, !- Zone Air Exhaust Port List
   {b1ff2c32-8888-442f-b0f6-618a3a9182b9}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {1a307500-d17c-41da-908f-b779614c3258}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {fce9f6d5-2a52-41aa-83e2-478359ea3765}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {1a307500-d17c-41da-908f-b779614c3258}, !- Handle
+  Port List 9,                            !- Name
+  {40974fb9-e93b-44c4-a16d-088b59a37fa6}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {15d2c51b-944c-4b3f-9abf-8d61f00edd9f}, !- Handle
@@ -13713,15 +13767,21 @@ OS:ThermalZone,
   {bfcac9c2-2742-4de7-8e3c-767020e56c48}, !- Zone Air Inlet Port List
   {adab0ff0-d7f0-42a3-b390-1799f3d7ce69}, !- Zone Air Exhaust Port List
   {e8f24604-3b1f-49a9-8410-89bdd1b06506}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {ace883c4-04fb-4fe6-b14e-3b3e2fd119cf}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {54ca428d-f284-495d-b4cd-551028b530ec}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {ace883c4-04fb-4fe6-b14e-3b3e2fd119cf}, !- Handle
+  Port List 10,                           !- Name
+  {af46f94b-979f-4baf-a003-e6a733d39a41}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {2369daac-e5c6-49f2-8b26-ac1251ed5890}, !- Handle
@@ -13795,15 +13855,21 @@ OS:ThermalZone,
   {25cb85da-3397-47b4-9339-c3f2ff112bdd}, !- Zone Air Inlet Port List
   {0aec8d2e-6f75-46e7-ba4b-f5a3de5798d1}, !- Zone Air Exhaust Port List
   {9308f7f8-85e3-4036-9e8b-241ca30e4619}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {ec0cae7a-141f-4707-ab94-2f5eb2a794bf}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {0691eafb-5c18-4b4f-bad4-feaf3c4ab347}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {ec0cae7a-141f-4707-ab94-2f5eb2a794bf}, !- Handle
+  Port List 11,                           !- Name
+  {fed42c3c-cef1-4c79-9b92-13675d5c52ae}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {275530ff-820c-4ba2-9ad3-7c8de03d4c63}, !- Handle
@@ -13877,15 +13943,21 @@ OS:ThermalZone,
   {fa173f3b-ca94-45b1-b15f-0673908223bf}, !- Zone Air Inlet Port List
   {dcf50706-92c2-4afd-b800-45929abb899c}, !- Zone Air Exhaust Port List
   {6f6577ca-554b-4351-b995-6f6dbce257dc}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {8f26c9c6-ed75-447e-a5f0-b6285626400e}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {06bb723f-de14-47cb-8063-7a637ac863e1}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {8f26c9c6-ed75-447e-a5f0-b6285626400e}, !- Handle
+  Port List 12,                           !- Name
+  {e45c6c6a-d922-4d61-a121-4f32dbc6de11}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {8b29b7a6-7e76-4e43-b394-0760418731e3}, !- Handle
@@ -13959,15 +14031,21 @@ OS:ThermalZone,
   {cb1b076a-349c-4b2e-b7e4-f321040e8884}, !- Zone Air Inlet Port List
   {6e6a9f0d-ae99-47b8-9add-a903e8bd267d}, !- Zone Air Exhaust Port List
   {3b465429-ed4e-4c7b-bd8f-85a409d228c0}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {8e6e3209-07e8-4b0d-92b4-465dba57069b}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {b7537a2b-989d-4728-95fd-e08107a7e651}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {8e6e3209-07e8-4b0d-92b4-465dba57069b}, !- Handle
+  Port List 13,                           !- Name
+  {50f269fe-e2e6-4649-9146-723f691a44fb}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {25cefcef-aa8b-461f-a688-325ad58ab553}, !- Handle
@@ -14041,15 +14119,21 @@ OS:ThermalZone,
   {23d94b94-0701-4646-9c57-4bcbe98fb923}, !- Zone Air Inlet Port List
   {ded72ebc-6141-4864-9d29-fba6406f3b69}, !- Zone Air Exhaust Port List
   {7d578e39-c571-486c-9fb2-224b431612d1}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {66ae851e-8638-46d2-8bfb-aaf20f5ad1d0}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {eb2adca0-0cb1-4cc5-a203-bbfee96f3e0d}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {66ae851e-8638-46d2-8bfb-aaf20f5ad1d0}, !- Handle
+  Port List 14,                           !- Name
+  {dd8f204f-43c7-488b-aced-b516b7634775}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {0f8d5a9f-eba1-41b8-a66b-aba16fe35520}, !- Handle
@@ -14123,15 +14207,21 @@ OS:ThermalZone,
   {88a38463-371f-4d71-ba05-981d20154d95}, !- Zone Air Inlet Port List
   {ace2cc82-995f-44b9-bd08-61c452c3be53}, !- Zone Air Exhaust Port List
   {2d167c22-bdc2-4e39-bf74-bae9b46ef912}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {dd33aea7-31c3-4daf-b286-c899a5d48c84}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {3e4cb33a-2cbf-4641-acf4-79e57fb88249}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {dd33aea7-31c3-4daf-b286-c899a5d48c84}, !- Handle
+  Port List 15,                           !- Name
+  {aefed899-7bbf-40b3-83e8-48f3aa1ab1f4}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {77a79cf3-603d-41eb-99da-e157ccb709d9}, !- Handle
@@ -14205,15 +14295,21 @@ OS:ThermalZone,
   {074f120d-1763-4305-8e50-879558abe28f}, !- Zone Air Inlet Port List
   {8b577cc9-f353-4902-99a4-8339ab9c03ca}, !- Zone Air Exhaust Port List
   {2e767ef0-ec2c-4630-8d52-9ec9e0c77f53}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {5e53da89-af97-4e88-92ca-b5b136138796}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {9baf7391-f9de-4505-ab0b-0eb3ea73669b}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {5e53da89-af97-4e88-92ca-b5b136138796}, !- Handle
+  Port List 16,                           !- Name
+  {b77be4f7-7476-403e-ba6b-617ed7b714c5}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {64c83172-2655-4e80-b5a7-be67af1992f1}, !- Handle
@@ -14287,15 +14383,21 @@ OS:ThermalZone,
   {40cf9f38-680c-4df8-85a7-bf545a06e5d3}, !- Zone Air Inlet Port List
   {87a37937-327c-4ecc-9cfc-b4565327849b}, !- Zone Air Exhaust Port List
   {cdc37dd5-7f0c-4728-b3a5-880a7cd84484}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {b6a67570-e462-4568-8610-d97fc712584c}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {5f71b63c-ba50-46f9-9a7c-c8355d37cd8b}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {b6a67570-e462-4568-8610-d97fc712584c}, !- Handle
+  Port List 17,                           !- Name
+  {7590f5b7-76ad-4e98-bbf5-6f2ef605fba6}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {ce2bebce-bd67-45b2-94d7-bd08c4261a33}, !- Handle
@@ -14369,15 +14471,21 @@ OS:ThermalZone,
   {ab322f03-01d0-46e1-8659-b11b6a11318b}, !- Zone Air Inlet Port List
   {603d90c0-21ea-4d43-a80a-4ead97ec6047}, !- Zone Air Exhaust Port List
   {cf3cb915-974f-46ae-afcc-a5379ec2e590}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {63f1e888-c267-4ef5-8f04-12487dbf5638}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {81935962-8b7a-4e96-bc12-adf27cd0f229}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {63f1e888-c267-4ef5-8f04-12487dbf5638}, !- Handle
+  Port List 18,                           !- Name
+  {4d141c4e-7af4-412e-910f-e17d39945991}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {61dd920b-e59a-4537-9762-a7a76814d899}, !- Handle
@@ -14451,15 +14559,21 @@ OS:ThermalZone,
   {7f8e6a66-c985-46a0-a157-1fbe69ac976d}, !- Zone Air Inlet Port List
   {da1fe08a-3d5e-492a-abe2-259b158f8fa1}, !- Zone Air Exhaust Port List
   {40336700-1b70-45f7-b0a7-f5f4154dc175}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {c2cad92a-53fa-4328-b03f-dd68f8eb1761}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {489119eb-566c-4949-a577-184336d0b9d4}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {c2cad92a-53fa-4328-b03f-dd68f8eb1761}, !- Handle
+  Port List 19,                           !- Name
+  {3a7886cf-2a83-410c-b706-a9101db3432f}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {712db7fe-a285-44ca-ae3a-97626dff97d4}, !- Handle
@@ -14533,15 +14647,21 @@ OS:ThermalZone,
   {f7090672-c4b6-4000-86c5-d009d4c4f639}, !- Zone Air Inlet Port List
   {5cd9172e-2e7e-498d-aa6b-74307d4e8eae}, !- Zone Air Exhaust Port List
   {ae96f91e-d7c1-4e84-bfe2-c0bd6b8e7ddd}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {7ad074e9-3d9d-4aaf-abc5-c9351e49a86f}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {b5acee01-4752-4900-b72f-8a40fd5ef1f9}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {7ad074e9-3d9d-4aaf-abc5-c9351e49a86f}, !- Handle
+  Port List 20,                           !- Name
+  {d7559f81-feff-4e7d-90a9-3719a14d60ee}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {480560cb-d004-495c-acd3-1ccff7d6bae7}, !- Handle
@@ -14615,15 +14735,21 @@ OS:ThermalZone,
   {c3a42985-13b5-42c5-bc4b-fc3952ef5bcc}, !- Zone Air Inlet Port List
   {21a2637e-70a3-4a3f-9384-45d7e69238b9}, !- Zone Air Exhaust Port List
   {c9c2264b-bc6b-4019-ae74-6bc2ccb9c470}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {2f38091e-c65e-4fe8-b557-f334125d908a}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {54627ad4-2be2-4d94-8bd5-ec330d6f971f}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {2f38091e-c65e-4fe8-b557-f334125d908a}, !- Handle
+  Port List 21,                           !- Name
+  {8c0b6af5-fb91-4b2d-a4f7-84b0129c6bac}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {4cc68057-4538-45e3-8398-ec0b71df6ebc}, !- Handle
@@ -14697,15 +14823,21 @@ OS:ThermalZone,
   {40a723e7-fb26-4fdc-9f4a-7c100e759edc}, !- Zone Air Inlet Port List
   {f5c78181-1f8c-4956-a9e2-59e44d56a132}, !- Zone Air Exhaust Port List
   {2e0e1aa0-97cc-4bbe-b65c-413a2ecc0dc0}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {7af2e83b-6306-4101-aeb3-e0c936f708a4}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {252459cd-70b6-4c13-9b76-f690a5f4a2d1}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {7af2e83b-6306-4101-aeb3-e0c936f708a4}, !- Handle
+  Port List 22,                           !- Name
+  {189c8ddc-f078-4a70-b892-259857f77f05}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {18025da5-7669-4059-b00d-ff4d4a8d25e6}, !- Handle
@@ -14779,15 +14911,21 @@ OS:ThermalZone,
   {02fff954-9266-4f9a-8c14-7d7987c58cbc}, !- Zone Air Inlet Port List
   {69fcb1e1-4bf8-4b4d-adeb-4f94ea68f8a7}, !- Zone Air Exhaust Port List
   {e0899266-c86d-44ef-813b-1d00158a00d7}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {15247638-0ce2-42f8-a5d8-27b3374e03db}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {8f5f0b58-02bf-47ae-84a2-0a28d53b5287}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {15247638-0ce2-42f8-a5d8-27b3374e03db}, !- Handle
+  Port List 23,                           !- Name
+  {565b61f6-2e86-41f6-aae0-b9a531aa9bb0}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {5cee7763-ff43-49ce-bfec-758089ba198c}, !- Handle
@@ -14861,15 +14999,21 @@ OS:ThermalZone,
   {a87e74b3-1d4e-40c8-bd5a-487f68f2a391}, !- Zone Air Inlet Port List
   {64abf24c-3251-4205-8b1a-3e6fc1478207}, !- Zone Air Exhaust Port List
   {ef46c54e-c0e2-4380-bceb-89b8b7057b6c}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {39950033-4832-4dde-8bd2-25237a2e0984}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {d453db81-b92e-4f29-a085-b4c5d473ea84}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {39950033-4832-4dde-8bd2-25237a2e0984}, !- Handle
+  Port List 24,                           !- Name
+  {2586f405-4f2a-4830-968b-a9e77efc1629}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {bde7b620-a869-480f-b8db-3741305a43cf}, !- Handle
@@ -14943,15 +15087,21 @@ OS:ThermalZone,
   {287b9214-c208-40f9-832a-7f6b21820161}, !- Zone Air Inlet Port List
   {c397f991-2d4b-443e-8a5a-f97e1c9013a7}, !- Zone Air Exhaust Port List
   {963d16ee-084c-4387-a1ee-288db5ce6482}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {1b0e9cc1-6b80-40b5-95cc-e04d55ee21bc}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {3f7486ee-ffe1-4b63-b294-6468b3b3ee17}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {1b0e9cc1-6b80-40b5-95cc-e04d55ee21bc}, !- Handle
+  Port List 25,                           !- Name
+  {6ace123f-abf3-430c-a767-2511c188ec0c}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {b7e5e578-a259-4c5a-a7ae-cf08e7cbb25f}, !- Handle
@@ -15025,15 +15175,21 @@ OS:ThermalZone,
   {9e28fd78-852a-4a13-936d-8f917ea4e67b}, !- Zone Air Inlet Port List
   {8401fca8-1bc0-42e8-8cd9-0589ece85da5}, !- Zone Air Exhaust Port List
   {91076757-7f66-4aee-9023-0c06a536fa3c}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {a3141116-6fe3-4a59-abd8-37ad4dd3c8e9}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {8b0f0c61-76d0-4b3a-9d0e-2bf2b8e55a3d}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {a3141116-6fe3-4a59-abd8-37ad4dd3c8e9}, !- Handle
+  Port List 26,                           !- Name
+  {9235bed7-49c4-4f8c-a0f5-249682f43044}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {635d8ff7-b7ba-41b3-bd5d-5f08d18db823}, !- Handle
@@ -15107,15 +15263,21 @@ OS:ThermalZone,
   {9475ff85-9161-4c2f-874e-f7227a4ba1b1}, !- Zone Air Inlet Port List
   {2f8f67b3-2525-4bdd-b011-0dabf605a4bc}, !- Zone Air Exhaust Port List
   {b111ffbe-e147-4538-a1a7-e20cbf7431ca}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {dc57d4eb-dd30-4027-b754-6f36a36cf76d}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {84c01a6c-d7fa-409e-9891-925cb0257e20}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {dc57d4eb-dd30-4027-b754-6f36a36cf76d}, !- Handle
+  Port List 27,                           !- Name
+  {bd69f731-f897-40c0-9bbc-da49b08fa43c}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {4d88fc28-af8a-4470-9960-44081dd59421}, !- Handle
@@ -15189,15 +15351,21 @@ OS:ThermalZone,
   {b68f484b-5d83-495b-af66-5bad551ae316}, !- Zone Air Inlet Port List
   {487a32e5-6b81-4bb2-a962-0e5af4027c3b}, !- Zone Air Exhaust Port List
   {036ccad2-9d56-452d-a2ff-bd5740041470}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {f15979da-195c-447e-ae94-8f49be5256ee}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {f4746951-2af7-4e45-9709-52d37f3de7a9}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {f15979da-195c-447e-ae94-8f49be5256ee}, !- Handle
+  Port List 28,                           !- Name
+  {8b6a66f3-1dc1-484b-82fc-1495af27d153}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {8b994bd7-79ec-4c53-8ce8-cf5fb69571b0}, !- Handle
@@ -15271,15 +15439,21 @@ OS:ThermalZone,
   {91253d8b-14ac-43c4-ad39-21b5338f5454}, !- Zone Air Inlet Port List
   {9821666c-e011-48f2-a978-9bb35f8306b3}, !- Zone Air Exhaust Port List
   {1897a55f-2b35-4eb7-aae0-1aa64e0521c5}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {c821e38e-50ec-4f61-b87c-c92ebb58683d}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {3df2932f-5c78-4393-ba53-1668ddc5d275}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {c821e38e-50ec-4f61-b87c-c92ebb58683d}, !- Handle
+  Port List 29,                           !- Name
+  {58a6dd06-bc3c-43f1-9705-cfcdd57e5995}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {c0362ce7-7333-494a-85c4-cf3781212dc9}, !- Handle
@@ -15353,15 +15527,21 @@ OS:ThermalZone,
   {38eb4add-253f-4bdd-9636-64c7160590ea}, !- Zone Air Inlet Port List
   {560215c1-4d17-4351-b8a1-a761d8ae0c99}, !- Zone Air Exhaust Port List
   {0406f948-77b3-49f1-817a-efb2b1d151d8}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {a0985f03-267d-4092-9977-fa98380c1ea8}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {4504d1ec-05be-4cec-b5d0-d1b05296c0c3}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {a0985f03-267d-4092-9977-fa98380c1ea8}, !- Handle
+  Port List 30,                           !- Name
+  {21213f5c-925d-448d-b9a4-22723892e069}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {e5bea7f7-4467-47e3-97a6-3ecdbcd28d9b}, !- Handle
@@ -15435,15 +15615,21 @@ OS:ThermalZone,
   {f79ba28f-8d7b-4612-ab4d-5c8f2aa16b19}, !- Zone Air Inlet Port List
   {4ea65329-6b27-4e3f-8bd9-4c74bbb8db41}, !- Zone Air Exhaust Port List
   {3a777d2a-7416-4556-a4b6-8ccc7005a5f1}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {42c0e33d-eb1e-4e44-b45a-f1f847de5e41}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {c9f29479-575b-410c-ad4b-ea554abca318}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {42c0e33d-eb1e-4e44-b45a-f1f847de5e41}, !- Handle
+  Port List 31,                           !- Name
+  {e57a208a-d0a0-483c-834b-83f1b15670ba}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {6b934b6f-e566-4d00-84ac-50be8c12a468}, !- Handle
@@ -15517,15 +15703,21 @@ OS:ThermalZone,
   {94306778-1b16-4a8f-a6f6-3de9c790fca5}, !- Zone Air Inlet Port List
   {02bf69be-956e-429a-8f6d-6c1722d9052b}, !- Zone Air Exhaust Port List
   {62e5bf01-1204-430b-aa91-ef499d23931a}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {690cec57-c847-4763-88cc-7a1ceeb55a0e}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {6471a277-f2aa-4bf4-86b0-24479b8fcc26}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {690cec57-c847-4763-88cc-7a1ceeb55a0e}, !- Handle
+  Port List 32,                           !- Name
+  {61acd950-16f4-4c9f-9bf5-f6ac94f01c7c}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {baa1aecf-fbdd-4637-9a8f-0d1f1df862ee}, !- Handle
@@ -15599,15 +15791,21 @@ OS:ThermalZone,
   {c5845238-d61b-47a4-8f59-12ab3db492ff}, !- Zone Air Inlet Port List
   {38875749-6dda-458a-ab2d-3886920b5594}, !- Zone Air Exhaust Port List
   {33a5fa01-fdf0-4157-bb55-6e12bbdfbf3f}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {746c1a15-5c59-468b-ab6a-5993b74737c1}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {3d7f50b2-f0d0-47ea-aede-2b23022f260a}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {746c1a15-5c59-468b-ab6a-5993b74737c1}, !- Handle
+  Port List 33,                           !- Name
+  {f5662b78-3bfa-482a-a1b9-0364a539e96a}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {c964b9dd-f511-4605-bdb2-ff2acdcbca12}, !- Handle
@@ -15681,15 +15879,21 @@ OS:ThermalZone,
   {664abcc8-ae9f-4e48-9a4e-a5e2b0ace753}, !- Zone Air Inlet Port List
   {4a1d29a5-2825-4677-aeee-1f88892149b7}, !- Zone Air Exhaust Port List
   {fbf3a480-d4ed-49e9-8366-2f698a87fc41}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {2cc625ab-b597-48a1-b6ef-a6c7c948d483}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {9d24487a-9737-4652-934a-151b8b323fc7}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {2cc625ab-b597-48a1-b6ef-a6c7c948d483}, !- Handle
+  Port List 34,                           !- Name
+  {c1a15444-a578-4521-8793-433c820bcd9c}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {1cfcbf43-a2a9-4f70-80e0-38b835cf492a}, !- Handle
@@ -15763,15 +15967,21 @@ OS:ThermalZone,
   {45633a52-ab73-486f-b49d-f11a91f48e2e}, !- Zone Air Inlet Port List
   {e4090c83-48bd-410d-9052-abad6228a43e}, !- Zone Air Exhaust Port List
   {72df3f8a-7501-44ec-acb8-ba3f6dfd01f7}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {3a0b9a35-f2f8-4c3e-9b83-34eb4cd8694b}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {da647ca8-532c-4e53-92f8-c57112132472}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {3a0b9a35-f2f8-4c3e-9b83-34eb4cd8694b}, !- Handle
+  Port List 35,                           !- Name
+  {3f5d3178-72bf-4636-a11d-c5edb98cbc19}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {a50464b3-d231-493d-98d1-1b3c90c2f2ce}, !- Handle
@@ -15845,15 +16055,21 @@ OS:ThermalZone,
   {8fe167b3-20d0-4a3b-afa2-01dd46a94ddb}, !- Zone Air Inlet Port List
   {cc330fac-a135-4679-9301-3b99508d4c5c}, !- Zone Air Exhaust Port List
   {9d68ee72-7a04-4b52-9723-245a08edf6f2}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {2b4cc20a-7147-4ac2-ab89-e9f941c6facd}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {1f5e12e4-7ae3-4f05-91c4-93ba04f967ed}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {2b4cc20a-7147-4ac2-ab89-e9f941c6facd}, !- Handle
+  Port List 36,                           !- Name
+  {4e496989-a555-48b1-8271-e070772f4120}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {bd2fac62-d525-49f6-88a3-f94a2fc62f30}, !- Handle
@@ -15927,15 +16143,21 @@ OS:ThermalZone,
   {4a8fb1e1-99f7-4262-93df-589c6a679578}, !- Zone Air Inlet Port List
   {6b74a1b7-9948-43ef-8848-2e266a72c9c7}, !- Zone Air Exhaust Port List
   {710c4738-fa34-436d-9847-e5fa1cb29144}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {5c081fb9-986a-4b21-8535-2917666eec6c}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {32c71217-6d8a-4f9a-9b7f-23bda8a93f0c}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {5c081fb9-986a-4b21-8535-2917666eec6c}, !- Handle
+  Port List 37,                           !- Name
+  {3f26caba-10b2-48c4-a6e2-5f74653bbc44}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {664924ad-1ee3-4c19-9fc5-29ff17cd864c}, !- Handle
@@ -16009,15 +16231,21 @@ OS:ThermalZone,
   {2b2cf5bf-eff0-4d8f-a752-23e21cea8c0b}, !- Zone Air Inlet Port List
   {95abce79-d228-4b71-ac96-484943543b8b}, !- Zone Air Exhaust Port List
   {9ad9cdcd-2c0d-4f1e-9c3b-1e1d1e8ad837}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {3acf6337-aefd-4394-a1cb-263373d226d9}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {73ee31c8-8885-43b2-9def-19eb02f5ed2a}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {3acf6337-aefd-4394-a1cb-263373d226d9}, !- Handle
+  Port List 2,                            !- Name
+  {05d36b9e-f449-426c-b8eb-b5032321d155}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {3313b6e5-0cb4-4c04-8a9f-136f82267002}, !- Handle
@@ -16091,15 +16319,21 @@ OS:ThermalZone,
   {8c426881-7117-4a87-9d82-899c17dd428a}, !- Zone Air Inlet Port List
   {737bcf18-48ab-4027-9c9c-c0f8b496947b}, !- Zone Air Exhaust Port List
   {d4de5226-4001-4d34-a787-2b62764ecfb5}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {ff4f6997-9d67-489a-8bd0-130dedcb43e6}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {aeccb516-8425-4854-8125-7bb8e1e99f0c}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {ff4f6997-9d67-489a-8bd0-130dedcb43e6}, !- Handle
+  Port List 38,                           !- Name
+  {67ed0980-f2da-40fd-994a-63fb55b9c564}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {a8761a29-774d-4b1f-b36c-bcef8dc6dbc0}, !- Handle
@@ -16173,15 +16407,21 @@ OS:ThermalZone,
   {ef22834c-dfd2-46ae-aa20-4219ea835e41}, !- Zone Air Inlet Port List
   {b4a4f4a3-2892-4bd0-8ec9-1fc0043587a3}, !- Zone Air Exhaust Port List
   {c3a29c7d-1381-44b0-bd9f-f88fd485a590}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {0f34f963-0d22-42df-ae92-b409b42d5ba9}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {a22d2463-4200-4f71-9578-2fc41681947c}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {0f34f963-0d22-42df-ae92-b409b42d5ba9}, !- Handle
+  Port List 39,                           !- Name
+  {02b55a4a-a5ec-4d4b-9841-96aad4cca002}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {469e7800-1733-4614-88e4-b4beae7bcee2}, !- Handle
@@ -16255,15 +16495,21 @@ OS:ThermalZone,
   {d6fe8fa1-50c2-4f18-870a-321c4c20e9ee}, !- Zone Air Inlet Port List
   {4a46bf2d-a5cc-4af8-944e-a7b2cd769a15}, !- Zone Air Exhaust Port List
   {1ad4a9f1-4b8f-48b6-8c20-db66060e9664}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {d0cafb37-ca5a-4d99-852f-863c8ed15f6a}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {97913224-491f-4ea5-ae89-88bf80b42ad8}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {d0cafb37-ca5a-4d99-852f-863c8ed15f6a}, !- Handle
+  Port List 40,                           !- Name
+  {a9e78f84-bbf7-4eb0-b4f0-996f80cefed9}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {b84d82b9-0197-44c9-9457-55337b0791f3}, !- Handle
@@ -16337,15 +16583,21 @@ OS:ThermalZone,
   {ee1d3177-a6fd-4c7f-bf1b-b940a4b44fb6}, !- Zone Air Inlet Port List
   {129cdb73-bc3c-45fe-a5b4-174eb80591db}, !- Zone Air Exhaust Port List
   {0fc6402d-40ad-4a0c-b505-a606a9335318}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {e471cdf2-316e-417d-acf7-6a2c353b5ce2}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {a942a074-271d-4068-8ede-cd341f709653}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {e471cdf2-316e-417d-acf7-6a2c353b5ce2}, !- Handle
+  Port List 41,                           !- Name
+  {cfe70983-ff7f-498a-a553-eae07d8e721f}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {1bc71a3d-27b4-4e5c-a788-e48dcc8c3c0c}, !- Handle
@@ -16419,15 +16671,21 @@ OS:ThermalZone,
   {2fa9eb55-2367-498b-8694-a251081d4c0e}, !- Zone Air Inlet Port List
   {ca58bf9c-6d36-4ef5-8e8d-7b54c873cf73}, !- Zone Air Exhaust Port List
   {49cb915e-d121-4779-a5d8-97ac09ddf57e}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {538f8e59-5fa7-4f8f-9dcd-fb690d6aae95}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {ea3bee3d-9067-4d87-9a25-888c5bc9345e}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {538f8e59-5fa7-4f8f-9dcd-fb690d6aae95}, !- Handle
+  Port List 42,                           !- Name
+  {80a3580d-b968-449c-a5cc-d3b35a0abc8f}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {fe82874d-bb92-49bf-85ab-35be445f6004}, !- Handle
@@ -16501,15 +16759,21 @@ OS:ThermalZone,
   {bbbad56f-b8bf-472a-8be0-08cb8b742b35}, !- Zone Air Inlet Port List
   {33491dfb-bc4d-4e33-9dfd-b83169e3910b}, !- Zone Air Exhaust Port List
   {f35b4c88-ace1-404d-bf56-bb0e386dd4a8}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {f7fd7ffb-ea5b-4e2e-a9f3-5f6264278003}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {0d9d90f8-ffc1-4c9c-bba3-ee84eccccba4}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {f7fd7ffb-ea5b-4e2e-a9f3-5f6264278003}, !- Handle
+  Port List 43,                           !- Name
+  {774bfcef-ec77-49e6-8be7-6fdfdd560d07}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {e09841d6-174c-40b1-9714-3bc7a2de8553}, !- Handle
@@ -16583,15 +16847,21 @@ OS:ThermalZone,
   {d9d7e953-bf3a-4cae-8170-453c438aea64}, !- Zone Air Inlet Port List
   {62ee3c5b-3282-4755-898b-fad38b128c45}, !- Zone Air Exhaust Port List
   {8392d943-ddb8-4efa-af40-e7b3a1f9aca1}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {e657bbac-604a-49c7-86d0-88101d8146fa}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {0932c046-0147-4fde-a625-bb336a55dac0}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {e657bbac-604a-49c7-86d0-88101d8146fa}, !- Handle
+  Port List 44,                           !- Name
+  {def599db-7c71-497c-8a7e-0f727c3b6089}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {4181c431-0281-453b-b959-9ad20bef4b52}, !- Handle
@@ -16665,15 +16935,21 @@ OS:ThermalZone,
   {b9430f32-65b0-42d5-81d1-044ba2724bf9}, !- Zone Air Inlet Port List
   {d9ebd35b-8a92-4033-ae23-f4b1b5bc6bfc}, !- Zone Air Exhaust Port List
   {74de61cd-f031-4982-b1f1-22523c4c4102}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {aba5e850-961d-4d68-9489-84de2f55a200}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {4efc049f-caff-401e-a15a-38db622d4880}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {aba5e850-961d-4d68-9489-84de2f55a200}, !- Handle
+  Port List 45,                           !- Name
+  {ecd7832e-2da2-481c-8cda-24c6441f4211}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {adc2504b-062c-4f94-b511-c24e30f8fd1b}, !- Handle
@@ -16747,15 +17023,21 @@ OS:ThermalZone,
   {38ff807f-8ef3-4d24-a9e8-7965f0ba57d7}, !- Zone Air Inlet Port List
   {d564a6fe-3c3e-4e0b-8fff-d21087b38030}, !- Zone Air Exhaust Port List
   {1ff909e4-98a7-41cc-8428-ec0f759e4ab4}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {0cdd14b9-8ff8-4c0d-8883-d68c22b1e6f8}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {722af813-c1c1-40c5-9467-5982a45ddc54}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {0cdd14b9-8ff8-4c0d-8883-d68c22b1e6f8}, !- Handle
+  Port List 46,                           !- Name
+  {5f9749b4-9adf-40cf-baf8-218be7eb55e4}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {f5c79561-8d9c-4845-882c-5861543ea7d2}, !- Handle
@@ -16829,15 +17111,21 @@ OS:ThermalZone,
   {b622786a-06ea-4c85-9223-252382154d7a}, !- Zone Air Inlet Port List
   {b3629488-10d0-46ce-9ed9-5edbbb4ee166}, !- Zone Air Exhaust Port List
   {a7ccdec8-6a12-4aab-86ec-86e26403478b}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {367f587a-c421-4312-98be-4c6e8fdd45b4}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {27374c46-4718-4719-b4ba-62d9f1d2f15f}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {367f587a-c421-4312-98be-4c6e8fdd45b4}, !- Handle
+  Port List 47,                           !- Name
+  {34e2116a-bc2e-4145-914c-ee5402691877}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {1f26c40f-b296-4673-a0cb-ea236944f556}, !- Handle
@@ -16911,15 +17199,21 @@ OS:ThermalZone,
   {d53a0eb3-994c-4440-9b4b-aae3659a3045}, !- Zone Air Inlet Port List
   {cccbd29b-5bcc-4f1b-86b2-f4bcf20f6acd}, !- Zone Air Exhaust Port List
   {163cb348-9b8c-4276-b96a-9bf545e46b08}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {8ebd78dd-282e-45c7-a7b7-3be989fee1a2}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {a714d213-fa06-42f9-8e72-d74aa5a0b4dd}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {8ebd78dd-282e-45c7-a7b7-3be989fee1a2}, !- Handle
+  Port List 48,                           !- Name
+  {37181995-c697-4566-b686-e314123b3060}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {d685ea11-34d0-46f2-a5e8-9288135cbfd4}, !- Handle
@@ -16993,15 +17287,21 @@ OS:ThermalZone,
   {8504ff64-fd33-4cc8-8fb2-ab3b026fb51c}, !- Zone Air Inlet Port List
   {4a4dc708-939b-408f-a083-d654b3e544ed}, !- Zone Air Exhaust Port List
   {5788baf0-f062-4409-b748-0f0607c7acd9}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {843aaee9-4473-4310-aa89-76eff280d933}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {a7c3405b-2e6f-4cee-9cd8-b3e589df58ef}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {843aaee9-4473-4310-aa89-76eff280d933}, !- Handle
+  Port List 49,                           !- Name
+  {26a377b7-4408-48d2-bf23-ba3ca649317e}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {27a029ce-d19d-4a01-87bf-f54e28404a0b}, !- Handle
@@ -17075,15 +17375,21 @@ OS:ThermalZone,
   {a9d07d65-3bde-4c2a-b840-ee4f4665f5e3}, !- Zone Air Inlet Port List
   {ddb25a7d-7ec2-4309-a773-009a8a7b9dc9}, !- Zone Air Exhaust Port List
   {73316560-cfe1-4509-9ffa-4229546b9c50}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {3978fba8-1006-473f-bcfb-dd788bade7dd}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {3249a696-67fa-4a5c-b5ab-68f3db3c61ff}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {3978fba8-1006-473f-bcfb-dd788bade7dd}, !- Handle
+  Port List 50,                           !- Name
+  {8ead2b82-5479-452a-ae97-540bbed210f8}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {49233823-2b15-4519-b921-af3413b653fe}, !- Handle
@@ -17157,15 +17463,21 @@ OS:ThermalZone,
   {1cf9c9d8-3b69-4929-948b-c8ba433e8b4c}, !- Zone Air Inlet Port List
   {c4642e1d-62e4-4c7c-98fe-2b4cc8dfe461}, !- Zone Air Exhaust Port List
   {63678d07-689e-4c94-abdb-ea636706cd38}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {371c3cfb-97a9-4f04-bc50-4b1e1b898208}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {abab49de-1bea-4000-8e36-1af8495425b1}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {371c3cfb-97a9-4f04-bc50-4b1e1b898208}, !- Handle
+  Port List 51,                           !- Name
+  {0d1bd9b9-16d1-4378-ba7a-4ac952440963}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {2ff024f1-5362-43f2-8f99-6454cb2d41b1}, !- Handle
@@ -17239,15 +17551,21 @@ OS:ThermalZone,
   {c6c5e674-95a6-4b45-b60e-293b467b9b7e}, !- Zone Air Inlet Port List
   {c0f287a2-9409-43a6-80ef-149cadd02ee8}, !- Zone Air Exhaust Port List
   {dab4be14-4ec8-4669-a869-34734d22432d}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {91e53309-8455-457d-933a-46b9758635f7}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {016afb78-8e52-4fc3-b4f6-e1d2bde36ecb}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {91e53309-8455-457d-933a-46b9758635f7}, !- Handle
+  Port List 52,                           !- Name
+  {1ce45898-8a87-4247-875d-8b2234ad4cd1}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {c2b653e1-454c-47d0-9742-d64c95820b70}, !- Handle
@@ -17321,15 +17639,21 @@ OS:ThermalZone,
   {93849544-1958-44c9-bd5b-5a7cf5bf7343}, !- Zone Air Inlet Port List
   {9199effa-5a2d-469b-987d-5ddf84937e09}, !- Zone Air Exhaust Port List
   {adc83bf3-3e41-4db3-bb61-2cdf18b0af74}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {a8ede77a-599a-46a8-9a21-ceebdcab31b5}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {d7701e27-62c2-4de4-9eab-1c6354197d4d}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {a8ede77a-599a-46a8-9a21-ceebdcab31b5}, !- Handle
+  Port List 53,                           !- Name
+  {eb3fcf73-8d14-45e9-ad6e-a3a1445d6895}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {028d42ca-6de3-46f3-a79e-f7cd481db9cb}, !- Handle
@@ -17403,15 +17727,21 @@ OS:ThermalZone,
   {fa842318-325b-4632-b36c-dddcfeddabd2}, !- Zone Air Inlet Port List
   {b7ae91cc-0512-4755-b36e-59a564c71b68}, !- Zone Air Exhaust Port List
   {d1986678-9d5e-4236-96dd-292cdc92e44e}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {9baa0e44-5675-410a-bed5-08bb66d3031f}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {fb0b3f12-e0aa-46f6-8917-7ac638c7336b}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {9baa0e44-5675-410a-bed5-08bb66d3031f}, !- Handle
+  Port List 54,                           !- Name
+  {5d11a456-633f-4fdf-91e9-14d4dabfa08b}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {e289bcf9-5659-42f6-9a02-20bbea3e33f8}, !- Handle
@@ -17485,15 +17815,21 @@ OS:ThermalZone,
   {4daeeef5-cece-48ca-93b8-df182435efc0}, !- Zone Air Inlet Port List
   {8e1b5fe6-a715-4203-b760-c4ca81735dcb}, !- Zone Air Exhaust Port List
   {ecd221de-d879-4b8d-b3a8-85d221cb5154}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {5c4b2e07-dfa9-4a7d-8c59-d308af0c9208}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {5bea366d-3a9a-4883-bbb8-5c69d9eff4a4}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {5c4b2e07-dfa9-4a7d-8c59-d308af0c9208}, !- Handle
+  Port List 55,                           !- Name
+  {c09d0857-b8ca-46fc-9eb8-5192fa1a16a7}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {244ff76a-8963-4367-99ba-3686510addbb}, !- Handle
@@ -17567,15 +17903,21 @@ OS:ThermalZone,
   {b6c519b9-70f2-45b1-bd00-209d47881f05}, !- Zone Air Inlet Port List
   {b75b698e-e5ac-406d-b299-000309c448d5}, !- Zone Air Exhaust Port List
   {70623d19-f1e0-47ea-a0f7-8a2cee67f8ca}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {636ca4f5-7281-49c8-a4fa-ce7989221e5c}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {a68bf190-fd99-4c89-be62-f6f8a4aef6b9}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {636ca4f5-7281-49c8-a4fa-ce7989221e5c}, !- Handle
+  Port List 56,                           !- Name
+  {2ec9e0b6-744b-4acf-82ff-75ba8fd8d44f}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {00a28442-ee04-40c8-8258-c58f2552972e}, !- Handle
@@ -17649,15 +17991,21 @@ OS:ThermalZone,
   {a54ab23c-3bc8-486a-b3c9-eb3dea0e8534}, !- Zone Air Inlet Port List
   {b5a7ecba-9662-4f93-a2be-4e4a27cb6473}, !- Zone Air Exhaust Port List
   {d9ace7e8-9016-4f03-bc5e-6d36c2e7c938}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {df48914b-0096-4ac7-b90e-6add137e835a}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {ee6f661f-e0da-49fe-8586-62ef2afe1f88}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {df48914b-0096-4ac7-b90e-6add137e835a}, !- Handle
+  Port List 57,                           !- Name
+  {5d45a573-f58e-4d13-be4b-0a4f4540251e}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {331d8dfb-e7f6-4dc7-a3c6-d638c2b1edd3}, !- Handle
@@ -17731,15 +18079,21 @@ OS:ThermalZone,
   {93965702-c985-4989-9c1d-326162e2b65f}, !- Zone Air Inlet Port List
   {b8021d81-7886-4422-b262-4085da59d27d}, !- Zone Air Exhaust Port List
   {f978c1d3-63f4-4424-a38e-8c4b2fb72285}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {6851f1c7-c1f3-483b-bd02-ba212fd21c84}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {10abe040-c8b1-4c2b-986f-1ac4883b3488}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {6851f1c7-c1f3-483b-bd02-ba212fd21c84}, !- Handle
+  Port List 58,                           !- Name
+  {bf624746-7178-45e3-b173-e4653888d0fd}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {5dc47a6d-e07a-423b-af0a-d4cd6a3e3911}, !- Handle
@@ -17813,15 +18167,21 @@ OS:ThermalZone,
   {d8b77775-5507-4594-9c26-97f2a1e001eb}, !- Zone Air Inlet Port List
   {41798bc4-ecaf-4d6a-9084-74cc544217cf}, !- Zone Air Exhaust Port List
   {4acc5f3f-10b5-436e-bca1-6b47c53f8149}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {bf80e637-b0f7-460b-999a-8e58c31acb55}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {19a968b6-941d-4c8f-899c-3fb7bd7be00f}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {bf80e637-b0f7-460b-999a-8e58c31acb55}, !- Handle
+  Port List 59,                           !- Name
+  {645c4cf5-8c36-4b5c-8c01-fb7daf9dd828}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {bf8f936c-1a8b-42ac-8a1b-d667f2cd969d}, !- Handle
@@ -17895,15 +18255,21 @@ OS:ThermalZone,
   {222a5a44-bd1a-48cb-b200-84530656a210}, !- Zone Air Inlet Port List
   {4dc2eb77-2284-4f25-8519-167be7f92d79}, !- Zone Air Exhaust Port List
   {75a0705d-cc63-430c-8884-787039534a25}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {75003de0-4572-446e-a722-ced6c278bbd4}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {560390bb-534d-4603-9606-a8c199a490d9}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {75003de0-4572-446e-a722-ced6c278bbd4}, !- Handle
+  Port List 60,                           !- Name
+  {c6b78f1d-6990-419f-accd-c9dcaa76d920}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {90b6d867-5ddc-4094-857d-31600840e083}, !- Handle
@@ -17977,15 +18343,21 @@ OS:ThermalZone,
   {13d1b7e2-f592-40b7-873e-90832ca917fc}, !- Zone Air Inlet Port List
   {9a663573-db14-4515-88f8-58c4bb5de962}, !- Zone Air Exhaust Port List
   {55e1dc14-604f-4bd1-8d81-f105b6bac183}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {44b91314-ba1f-4b95-9eaa-3233372358f2}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {3a0178c1-53e2-4933-8d37-8fd597c58ed5}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {44b91314-ba1f-4b95-9eaa-3233372358f2}, !- Handle
+  Port List 1,                            !- Name
+  {e5aaa50b-0c4f-4b64-9f0f-68e37b10c8e6}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {98f21589-fe61-40d9-9658-0d12efcb2ee6}, !- Handle
@@ -18059,15 +18431,21 @@ OS:ThermalZone,
   {0976eec2-32fe-43fb-8373-378d7a340840}, !- Zone Air Inlet Port List
   {7572d0a2-327b-41d2-bf4c-1d2c3f6d36bd}, !- Zone Air Exhaust Port List
   {349b47d6-ed04-4350-b6f2-a3d9710e5902}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {a52d0dca-1478-4868-a043-3d56bfa3faaa}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {5bbb988a-08c7-4e37-9c72-712e1ff797be}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {a52d0dca-1478-4868-a043-3d56bfa3faaa}, !- Handle
+  Port List 61,                           !- Name
+  {020322ec-6c5c-48ec-b5df-b99f6ad2cca5}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {a4f45de5-853c-4548-9642-82df22a1aaf5}, !- Handle
@@ -18141,15 +18519,21 @@ OS:ThermalZone,
   {f1bb8829-034e-4783-aa6f-a3db5a10d081}, !- Zone Air Inlet Port List
   {07d09f1a-f595-4250-852e-37035637f24c}, !- Zone Air Exhaust Port List
   {a3f28fb9-56dc-45eb-950f-1b3ad8af8c9d}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {5345257f-d4a9-41c3-aaca-17593c16d917}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {8742e19c-6ea8-46ff-b7f8-719022d29997}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {5345257f-d4a9-41c3-aaca-17593c16d917}, !- Handle
+  Port List 62,                           !- Name
+  {a752b066-febb-43d6-8ce7-a33016318c0b}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {88c18d68-1c3c-4444-9d86-41e292184a41}, !- Handle
@@ -18223,15 +18607,21 @@ OS:ThermalZone,
   {462310b1-98bd-412f-98f9-be714a3614e3}, !- Zone Air Inlet Port List
   {4a157835-eebf-4231-9169-6353f694348b}, !- Zone Air Exhaust Port List
   {99db11bf-9d64-4bff-a7fe-fb0a8ec46480}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {bfacda9b-819c-474d-ade5-7a858a337f6c}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {090190de-8c4b-4427-a886-effa1376ff7d}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {bfacda9b-819c-474d-ade5-7a858a337f6c}, !- Handle
+  Port List 63,                           !- Name
+  {54cfb823-762b-47e6-8778-e96443e8f870}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {6a2c300b-47aa-46c5-b1b2-07ea965a4d70}, !- Handle
@@ -18305,15 +18695,21 @@ OS:ThermalZone,
   {be2c0f99-96d4-422a-bc26-5544e5161237}, !- Zone Air Inlet Port List
   {311ef473-437c-490d-9459-eb18e10d0e3d}, !- Zone Air Exhaust Port List
   {b5bbef04-9469-43e3-ba66-a6e05ff68cb6}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {faddd427-4951-44bf-9ae9-57a2468b971a}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {5c54353a-9266-456f-8433-babb852af573}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {faddd427-4951-44bf-9ae9-57a2468b971a}, !- Handle
+  Port List 64,                           !- Name
+  {a1add966-6ea6-4014-95f8-f7eea197b91c}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {9c658678-07b3-40d8-b343-f8d9a678c953}, !- Handle
@@ -18387,15 +18783,21 @@ OS:ThermalZone,
   {e2913218-d349-46de-9c70-b7941eba8a71}, !- Zone Air Inlet Port List
   {4ca5049f-04db-4e67-b566-aeffec184c79}, !- Zone Air Exhaust Port List
   {0936b928-825e-457a-80da-5928d9d5256b}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {4fcdeb83-a502-4fca-a326-dd6118742828}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {d6363d2c-8d79-42bb-ad64-beac2cfe5741}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {4fcdeb83-a502-4fca-a326-dd6118742828}, !- Handle
+  Port List 65,                           !- Name
+  {8994d32d-4b2e-4b58-a451-e239a7a6cd26}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {83eec549-a431-442f-bdb3-930b27be2866}, !- Handle
@@ -18469,15 +18871,21 @@ OS:ThermalZone,
   {cd39a2d5-21e8-43f2-92c3-d965dfa5780f}, !- Zone Air Inlet Port List
   {ae6d6078-eb66-4461-8b96-059f6a27540b}, !- Zone Air Exhaust Port List
   {25628fae-8470-4774-93dd-e2623b7bf3e0}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {9a03beaa-7b93-4357-a964-4fb0911eab67}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {7bb7c16a-fcab-420f-b46a-6bfdf1a5a773}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {9a03beaa-7b93-4357-a964-4fb0911eab67}, !- Handle
+  Port List 66,                           !- Name
+  {96055c48-37e2-41ed-98fd-e2a74c79c217}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {55b350ab-093d-46cc-bba6-5ca51abee0f9}, !- Handle
@@ -18551,15 +18959,21 @@ OS:ThermalZone,
   {a51e8f0c-8cf6-4c50-91c6-dd958e17d0b5}, !- Zone Air Inlet Port List
   {dd4247b8-5bdf-4c7d-b848-f0c6d37d675f}, !- Zone Air Exhaust Port List
   {b4114c68-3424-4170-8d51-9026fb5e7abc}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {1629ac9c-6852-4cef-b62c-4e874c6b8a0a}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {ba978134-d8c3-4e1a-8736-db842f6c57b7}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {1629ac9c-6852-4cef-b62c-4e874c6b8a0a}, !- Handle
+  Port List 67,                           !- Name
+  {0d120da8-0d40-4a9f-92e4-6351ebfc47c1}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {a0790a42-c7b9-4d4f-b4b4-dfef2b0055d5}, !- Handle
@@ -18633,15 +19047,21 @@ OS:ThermalZone,
   {8fe5dbc3-cf29-4dc8-9a17-d0d1c96260da}, !- Zone Air Inlet Port List
   {6272659a-01a8-4cb7-87a0-7f80d855c481}, !- Zone Air Exhaust Port List
   {bc23f2f5-5284-41e8-ab8e-5d6b9222bfe1}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {5c05d696-63ef-4447-b16c-fb8f9f382a45}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {ccba05a4-aca7-447c-a0f0-dabb2d430826}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {5c05d696-63ef-4447-b16c-fb8f9f382a45}, !- Handle
+  Port List 68,                           !- Name
+  {009ccf37-480b-4fd7-94ba-1bef9b6d6975}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {393814bd-f360-4d44-8707-77b1c25488d7}, !- Handle
@@ -18701,4 +19121,480 @@ OS:ZoneHVAC:EquipmentList,
   {42645048-c133-4eb0-b4e1-c087f9d3480c}, !- Handle
   Zone HVAC Equipment List 9,             !- Name
   {009ccf37-480b-4fd7-94ba-1bef9b6d6975}; !- Thermal Zone
+
+OS:Rendering:Color,
+  {32c71217-6d8a-4f9a-9b7f-23bda8a93f0c}, !- Handle
+  Rendering Color 18,                     !- Name
+  173,                                    !- Rendering Red Value
+  255,                                    !- Rendering Green Value
+  47;                                     !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {ccba05a4-aca7-447c-a0f0-dabb2d430826}, !- Handle
+  Rendering Color 19,                     !- Name
+  25,                                     !- Rendering Red Value
+  25,                                     !- Rendering Green Value
+  112;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {ba978134-d8c3-4e1a-8736-db842f6c57b7}, !- Handle
+  Rendering Color 20,                     !- Name
+  255,                                    !- Rendering Red Value
+  228,                                    !- Rendering Green Value
+  181;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {7bb7c16a-fcab-420f-b46a-6bfdf1a5a773}, !- Handle
+  Rendering Color 21,                     !- Name
+  25,                                     !- Rendering Red Value
+  25,                                     !- Rendering Green Value
+  112;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {d6363d2c-8d79-42bb-ad64-beac2cfe5741}, !- Handle
+  Rendering Color 22,                     !- Name
+  255,                                    !- Rendering Red Value
+  182,                                    !- Rendering Green Value
+  193;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {5c54353a-9266-456f-8433-babb852af573}, !- Handle
+  Rendering Color 23,                     !- Name
+  255,                                    !- Rendering Red Value
+  20,                                     !- Rendering Green Value
+  147;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {090190de-8c4b-4427-a886-effa1376ff7d}, !- Handle
+  Rendering Color 24,                     !- Name
+  255,                                    !- Rendering Red Value
+  218,                                    !- Rendering Green Value
+  185;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {8742e19c-6ea8-46ff-b7f8-719022d29997}, !- Handle
+  Rendering Color 25,                     !- Name
+  238,                                    !- Rendering Red Value
+  130,                                    !- Rendering Green Value
+  238;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {5bbb988a-08c7-4e37-9c72-712e1ff797be}, !- Handle
+  Rendering Color 26,                     !- Name
+  189,                                    !- Rendering Red Value
+  183,                                    !- Rendering Green Value
+  107;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {3a0178c1-53e2-4933-8d37-8fd597c58ed5}, !- Handle
+  Rendering Color 27,                     !- Name
+  205,                                    !- Rendering Red Value
+  92,                                     !- Rendering Green Value
+  92;                                     !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {560390bb-534d-4603-9606-a8c199a490d9}, !- Handle
+  Rendering Color 28,                     !- Name
+  169,                                    !- Rendering Red Value
+  169,                                    !- Rendering Green Value
+  169;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {19a968b6-941d-4c8f-899c-3fb7bd7be00f}, !- Handle
+  Rendering Color 29,                     !- Name
+  34,                                     !- Rendering Red Value
+  139,                                    !- Rendering Green Value
+  34;                                     !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {10abe040-c8b1-4c2b-986f-1ac4883b3488}, !- Handle
+  Rendering Color 30,                     !- Name
+  240,                                    !- Rendering Red Value
+  255,                                    !- Rendering Green Value
+  240;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {ee6f661f-e0da-49fe-8586-62ef2afe1f88}, !- Handle
+  Rendering Color 31,                     !- Name
+  218,                                    !- Rendering Red Value
+  112,                                    !- Rendering Green Value
+  214;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {12c294da-77df-40c8-884a-626b4fee78fc}, !- Handle
+  Rendering Color 32,                     !- Name
+  72,                                     !- Rendering Red Value
+  209,                                    !- Rendering Green Value
+  204;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {430b3a22-2984-42d2-9d12-bb4c9d412c83}, !- Handle
+  Rendering Color 33,                     !- Name
+  135,                                    !- Rendering Red Value
+  206,                                    !- Rendering Green Value
+  250;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {7fd50ba0-d80d-4217-a45c-568693e4ac17}, !- Handle
+  Rendering Color 34,                     !- Name
+  175,                                    !- Rendering Red Value
+  238,                                    !- Rendering Green Value
+  238;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {f75edb53-933e-4bfb-ae11-025802d01346}, !- Handle
+  Rendering Color 35,                     !- Name
+  250,                                    !- Rendering Red Value
+  128,                                    !- Rendering Green Value
+  114;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {ef013b0a-7ccd-4efe-8582-f5f6038348d9}, !- Handle
+  Rendering Color 36,                     !- Name
+  72,                                     !- Rendering Red Value
+  61,                                     !- Rendering Green Value
+  139;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {b1c8f720-9692-4f06-8f4f-331ed9ff7c04}, !- Handle
+  Rendering Color 37,                     !- Name
+  72,                                     !- Rendering Red Value
+  209,                                    !- Rendering Green Value
+  204;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {fce9f6d5-2a52-41aa-83e2-478359ea3765}, !- Handle
+  Rendering Color 38,                     !- Name
+  135,                                    !- Rendering Red Value
+  206,                                    !- Rendering Green Value
+  235;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {54ca428d-f284-495d-b4cd-551028b530ec}, !- Handle
+  Rendering Color 39,                     !- Name
+  240,                                    !- Rendering Red Value
+  255,                                    !- Rendering Green Value
+  240;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {0691eafb-5c18-4b4f-bad4-feaf3c4ab347}, !- Handle
+  Rendering Color 40,                     !- Name
+  175,                                    !- Rendering Red Value
+  238,                                    !- Rendering Green Value
+  238;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {06bb723f-de14-47cb-8063-7a637ac863e1}, !- Handle
+  Rendering Color 41,                     !- Name
+  30,                                     !- Rendering Red Value
+  144,                                    !- Rendering Green Value
+  255;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {b7537a2b-989d-4728-95fd-e08107a7e651}, !- Handle
+  Rendering Color 42,                     !- Name
+  220,                                    !- Rendering Red Value
+  220,                                    !- Rendering Green Value
+  220;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {eb2adca0-0cb1-4cc5-a203-bbfee96f3e0d}, !- Handle
+  Rendering Color 43,                     !- Name
+  184,                                    !- Rendering Red Value
+  134,                                    !- Rendering Green Value
+  11;                                     !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {3e4cb33a-2cbf-4641-acf4-79e57fb88249}, !- Handle
+  Rendering Color 44,                     !- Name
+  0,                                      !- Rendering Red Value
+  0,                                      !- Rendering Green Value
+  255;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {9baf7391-f9de-4505-ab0b-0eb3ea73669b}, !- Handle
+  Rendering Color 45,                     !- Name
+  169,                                    !- Rendering Red Value
+  169,                                    !- Rendering Green Value
+  169;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {5f71b63c-ba50-46f9-9a7c-c8355d37cd8b}, !- Handle
+  Rendering Color 46,                     !- Name
+  255,                                    !- Rendering Red Value
+  0,                                      !- Rendering Green Value
+  255;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {81935962-8b7a-4e96-bc12-adf27cd0f229}, !- Handle
+  Rendering Color 47,                     !- Name
+  0,                                      !- Rendering Red Value
+  0,                                      !- Rendering Green Value
+  205;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {489119eb-566c-4949-a577-184336d0b9d4}, !- Handle
+  Rendering Color 48,                     !- Name
+  219,                                    !- Rendering Red Value
+  112,                                    !- Rendering Green Value
+  147;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {b5acee01-4752-4900-b72f-8a40fd5ef1f9}, !- Handle
+  Rendering Color 49,                     !- Name
+  124,                                    !- Rendering Red Value
+  252,                                    !- Rendering Green Value
+  0;                                      !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {54627ad4-2be2-4d94-8bd5-ec330d6f971f}, !- Handle
+  Rendering Color 50,                     !- Name
+  255,                                    !- Rendering Red Value
+  0,                                      !- Rendering Green Value
+  0;                                      !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {252459cd-70b6-4c13-9b76-f690a5f4a2d1}, !- Handle
+  Rendering Color 51,                     !- Name
+  0,                                      !- Rendering Red Value
+  206,                                    !- Rendering Green Value
+  209;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {8f5f0b58-02bf-47ae-84a2-0a28d53b5287}, !- Handle
+  Rendering Color 52,                     !- Name
+  124,                                    !- Rendering Red Value
+  252,                                    !- Rendering Green Value
+  0;                                      !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {d453db81-b92e-4f29-a085-b4c5d473ea84}, !- Handle
+  Rendering Color 53,                     !- Name
+  240,                                    !- Rendering Red Value
+  255,                                    !- Rendering Green Value
+  255;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {3f7486ee-ffe1-4b63-b294-6468b3b3ee17}, !- Handle
+  Rendering Color 54,                     !- Name
+  139,                                    !- Rendering Red Value
+  0,                                      !- Rendering Green Value
+  0;                                      !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {8b0f0c61-76d0-4b3a-9d0e-2bf2b8e55a3d}, !- Handle
+  Rendering Color 55,                     !- Name
+  34,                                     !- Rendering Red Value
+  139,                                    !- Rendering Green Value
+  34;                                     !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {84c01a6c-d7fa-409e-9891-925cb0257e20}, !- Handle
+  Rendering Color 56,                     !- Name
+  128,                                    !- Rendering Red Value
+  128,                                    !- Rendering Green Value
+  0;                                      !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {f4746951-2af7-4e45-9709-52d37f3de7a9}, !- Handle
+  Rendering Color 57,                     !- Name
+  173,                                    !- Rendering Red Value
+  216,                                    !- Rendering Green Value
+  230;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {3df2932f-5c78-4393-ba53-1668ddc5d275}, !- Handle
+  Rendering Color 58,                     !- Name
+  143,                                    !- Rendering Red Value
+  188,                                    !- Rendering Green Value
+  143;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {4504d1ec-05be-4cec-b5d0-d1b05296c0c3}, !- Handle
+  Rendering Color 59,                     !- Name
+  210,                                    !- Rendering Red Value
+  180,                                    !- Rendering Green Value
+  140;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {c9f29479-575b-410c-ad4b-ea554abca318}, !- Handle
+  Rendering Color 60,                     !- Name
+  95,                                     !- Rendering Red Value
+  158,                                    !- Rendering Green Value
+  160;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {6471a277-f2aa-4bf4-86b0-24479b8fcc26}, !- Handle
+  Rendering Color 61,                     !- Name
+  160,                                    !- Rendering Red Value
+  82,                                     !- Rendering Green Value
+  45;                                     !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {3d7f50b2-f0d0-47ea-aede-2b23022f260a}, !- Handle
+  Rendering Color 62,                     !- Name
+  255,                                    !- Rendering Red Value
+  248,                                    !- Rendering Green Value
+  220;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {9d24487a-9737-4652-934a-151b8b323fc7}, !- Handle
+  Rendering Color 63,                     !- Name
+  255,                                    !- Rendering Red Value
+  240,                                    !- Rendering Green Value
+  245;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {da647ca8-532c-4e53-92f8-c57112132472}, !- Handle
+  Rendering Color 64,                     !- Name
+  112,                                    !- Rendering Red Value
+  128,                                    !- Rendering Green Value
+  144;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {1f5e12e4-7ae3-4f05-91c4-93ba04f967ed}, !- Handle
+  Rendering Color 65,                     !- Name
+  173,                                    !- Rendering Red Value
+  255,                                    !- Rendering Green Value
+  47;                                     !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {a68bf190-fd99-4c89-be62-f6f8a4aef6b9}, !- Handle
+  Rendering Color 66,                     !- Name
+  255,                                    !- Rendering Red Value
+  99,                                     !- Rendering Green Value
+  71;                                     !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {73ee31c8-8885-43b2-9def-19eb02f5ed2a}, !- Handle
+  Rendering Color 67,                     !- Name
+  165,                                    !- Rendering Red Value
+  42,                                     !- Rendering Green Value
+  42;                                     !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {aeccb516-8425-4854-8125-7bb8e1e99f0c}, !- Handle
+  Rendering Color 68,                     !- Name
+  30,                                     !- Rendering Red Value
+  144,                                    !- Rendering Green Value
+  255;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {a22d2463-4200-4f71-9578-2fc41681947c}, !- Handle
+  Rendering Color 69,                     !- Name
+  175,                                    !- Rendering Red Value
+  238,                                    !- Rendering Green Value
+  238;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {97913224-491f-4ea5-ae89-88bf80b42ad8}, !- Handle
+  Rendering Color 70,                     !- Name
+  100,                                    !- Rendering Red Value
+  149,                                    !- Rendering Green Value
+  237;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {a942a074-271d-4068-8ede-cd341f709653}, !- Handle
+  Rendering Color 71,                     !- Name
+  143,                                    !- Rendering Red Value
+  188,                                    !- Rendering Green Value
+  143;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {ea3bee3d-9067-4d87-9a25-888c5bc9345e}, !- Handle
+  Rendering Color 72,                     !- Name
+  255,                                    !- Rendering Red Value
+  105,                                    !- Rendering Green Value
+  180;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {0d9d90f8-ffc1-4c9c-bba3-ee84eccccba4}, !- Handle
+  Rendering Color 73,                     !- Name
+  250,                                    !- Rendering Red Value
+  250,                                    !- Rendering Green Value
+  210;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {0932c046-0147-4fde-a625-bb336a55dac0}, !- Handle
+  Rendering Color 74,                     !- Name
+  255,                                    !- Rendering Red Value
+  105,                                    !- Rendering Green Value
+  180;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {4efc049f-caff-401e-a15a-38db622d4880}, !- Handle
+  Rendering Color 75,                     !- Name
+  255,                                    !- Rendering Red Value
+  182,                                    !- Rendering Green Value
+  193;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {722af813-c1c1-40c5-9467-5982a45ddc54}, !- Handle
+  Rendering Color 76,                     !- Name
+  169,                                    !- Rendering Red Value
+  169,                                    !- Rendering Green Value
+  169;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {27374c46-4718-4719-b4ba-62d9f1d2f15f}, !- Handle
+  Rendering Color 77,                     !- Name
+  0,                                      !- Rendering Red Value
+  128,                                    !- Rendering Green Value
+  0;                                      !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {a714d213-fa06-42f9-8e72-d74aa5a0b4dd}, !- Handle
+  Rendering Color 78,                     !- Name
+  0,                                      !- Rendering Red Value
+  255,                                    !- Rendering Green Value
+  255;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {5bea366d-3a9a-4883-bbb8-5c69d9eff4a4}, !- Handle
+  Rendering Color 79,                     !- Name
+  25,                                     !- Rendering Red Value
+  25,                                     !- Rendering Green Value
+  112;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {3249a696-67fa-4a5c-b5ab-68f3db3c61ff}, !- Handle
+  Rendering Color 80,                     !- Name
+  0,                                      !- Rendering Red Value
+  0,                                      !- Rendering Green Value
+  128;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {abab49de-1bea-4000-8e36-1af8495425b1}, !- Handle
+  Rendering Color 81,                     !- Name
+  100,                                    !- Rendering Red Value
+  149,                                    !- Rendering Green Value
+  237;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {016afb78-8e52-4fc3-b4f6-e1d2bde36ecb}, !- Handle
+  Rendering Color 82,                     !- Name
+  205,                                    !- Rendering Red Value
+  92,                                     !- Rendering Green Value
+  92;                                     !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {d7701e27-62c2-4de4-9eab-1c6354197d4d}, !- Handle
+  Rendering Color 83,                     !- Name
+  46,                                     !- Rendering Red Value
+  139,                                    !- Rendering Green Value
+  87;                                     !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {fb0b3f12-e0aa-46f6-8917-7ac638c7336b}, !- Handle
+  Rendering Color 84,                     !- Name
+  85,                                     !- Rendering Red Value
+  107,                                    !- Rendering Green Value
+  47;                                     !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {a7c3405b-2e6f-4cee-9cd8-b3e589df58ef}, !- Handle
+  Rendering Color 85,                     !- Name
+  46,                                     !- Rendering Red Value
+  139,                                    !- Rendering Green Value
+  87;                                     !- Rendering Blue Value
 

--- a/data/geometry/ASHRAESmallOfficeDetailed.osm
+++ b/data/geometry/ASHRAESmallOfficeDetailed.osm
@@ -1,7 +1,7 @@
 
 OS:Version,
-  {680c1f59-6f25-4443-b3cd-b8675d8746a6}, !- Handle
-  2.3.0;                                  !- Version Identifier
+  {4499e536-9c6f-4e4a-a890-223168315ea8}, !- Handle
+  2.7.1;                                  !- Version Identifier
 
 OS:Rendering:Color,
   {d1e86687-6885-4070-81da-3a576f17ff5c}, !- Handle
@@ -229,6 +229,7 @@ OS:Building,
   ,                                       !- Default Schedule Set Name
   1,                                      !- Standards Number of Stories
   0,                                      !- Standards Number of Above Ground Stories
+  ,                                       !- Standards Template
   ,                                       !- Standards Building Type
   ,                                       !- Standards Number of Living Units
   ,                                       !- Relocatable
@@ -1061,7 +1062,7 @@ OS:Space,
 
 OS:Surface,
   {d99da605-0b73-4b62-981d-16c63e41d476}, !- Handle
-  Surface 1,                              !- Name
+  ConfRoom_1 - Floor_a,                   !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {4620d0f3-e448-4cbd-87f1-b4acfead7dd0}, !- Space Name
@@ -1078,7 +1079,7 @@ OS:Surface,
 
 OS:Surface,
   {49bfbf09-d9e5-4af6-80f6-8a96947280e8}, !- Handle
-  Surface 2,                              !- Name
+  ConfRoom_1 - Wall 000_a,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {4620d0f3-e448-4cbd-87f1-b4acfead7dd0}, !- Space Name
@@ -1095,7 +1096,7 @@ OS:Surface,
 
 OS:Surface,
   {87d438ce-a903-4bfb-acd0-eb304b7b1083}, !- Handle
-  Surface 3,                              !- Name
+  ConfRoom_1 - Wall 090_a,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {4620d0f3-e448-4cbd-87f1-b4acfead7dd0}, !- Space Name
@@ -1112,7 +1113,7 @@ OS:Surface,
 
 OS:Surface,
   {4901e7bb-b81e-4a98-8564-5f93bd853631}, !- Handle
-  Surface 4,                              !- Name
+  ConfRoom_1 - Wall 180_a,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {4620d0f3-e448-4cbd-87f1-b4acfead7dd0}, !- Space Name
@@ -1129,7 +1130,7 @@ OS:Surface,
 
 OS:Surface,
   {13c9448d-a18e-4f3f-9a2c-0c2145b2f5bb}, !- Handle
-  Surface 5,                              !- Name
+  ConfRoom_1 - Wall 270_a,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {4620d0f3-e448-4cbd-87f1-b4acfead7dd0}, !- Space Name
@@ -1146,7 +1147,7 @@ OS:Surface,
 
 OS:Surface,
   {0c5b0edc-cc9c-4233-a04b-b6bb09837dca}, !- Handle
-  Surface 6,                              !- Name
+  ConfRoom_1 - RoofCeiling_a,             !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {4620d0f3-e448-4cbd-87f1-b4acfead7dd0}, !- Space Name
@@ -1179,7 +1180,7 @@ OS:Space,
 
 OS:Surface,
   {34d45edb-4c8f-475d-9a20-adb33951e559}, !- Handle
-  Surface 7,                              !- Name
+  EnclosedOffice_1 - Floor_a,             !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {0fa028e9-92fa-4f93-8cd9-898fb512ee65}, !- Space Name
@@ -1196,7 +1197,7 @@ OS:Surface,
 
 OS:Surface,
   {5b79d3e8-9395-48dd-9c92-58469bc8fcef}, !- Handle
-  Surface 9,                              !- Name
+  EnclosedOffice_1 - Wall 090_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {0fa028e9-92fa-4f93-8cd9-898fb512ee65}, !- Space Name
@@ -1213,7 +1214,7 @@ OS:Surface,
 
 OS:Surface,
   {bdf3cb71-a553-4a62-be06-eadd7d89e060}, !- Handle
-  Surface 10,                             !- Name
+  EnclosedOffice_1 - Wall 180_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {0fa028e9-92fa-4f93-8cd9-898fb512ee65}, !- Space Name
@@ -1230,7 +1231,7 @@ OS:Surface,
 
 OS:Surface,
   {0fd71c3e-1b26-40f4-babb-bf603eeebc41}, !- Handle
-  Surface 11,                             !- Name
+  EnclosedOffice_1 - Wall 270_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {0fa028e9-92fa-4f93-8cd9-898fb512ee65}, !- Space Name
@@ -1247,7 +1248,7 @@ OS:Surface,
 
 OS:Surface,
   {e7137dea-050d-41c0-9173-8a9614e76ec8}, !- Handle
-  Surface 12,                             !- Name
+  EnclosedOffice_1 - Wall 000_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {0fa028e9-92fa-4f93-8cd9-898fb512ee65}, !- Space Name
@@ -1264,7 +1265,7 @@ OS:Surface,
 
 OS:Surface,
   {af1aca26-26f2-41e8-9923-10663221ece3}, !- Handle
-  Surface 13,                             !- Name
+  EnclosedOffice_1 - RoofCeiling_a,       !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {0fa028e9-92fa-4f93-8cd9-898fb512ee65}, !- Space Name
@@ -1297,7 +1298,7 @@ OS:Space,
 
 OS:Surface,
   {afdaf650-ca90-41b6-9fb4-660a3ec742ab}, !- Handle
-  Surface 14,                             !- Name
+  Lobby - Floor_a,                        !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {9b7efe44-35f2-48b0-a194-7e682d6f8a59}, !- Space Name
@@ -1314,7 +1315,7 @@ OS:Surface,
 
 OS:Surface,
   {c28afbb9-b2e4-4eab-b719-f9e272e0c4ea}, !- Handle
-  Surface 15,                             !- Name
+  Lobby - Wall 000_a,                     !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {9b7efe44-35f2-48b0-a194-7e682d6f8a59}, !- Space Name
@@ -1331,7 +1332,7 @@ OS:Surface,
 
 OS:Surface,
   {0927b950-6603-4479-912e-cfcde681d5ad}, !- Handle
-  Surface 16,                             !- Name
+  Lobby - Wall 090_a,                     !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {9b7efe44-35f2-48b0-a194-7e682d6f8a59}, !- Space Name
@@ -1348,7 +1349,7 @@ OS:Surface,
 
 OS:Surface,
   {75f01be6-51f9-4cdc-8375-c6698bf2afdd}, !- Handle
-  Surface 17,                             !- Name
+  Lobby - Wall 180_a,                     !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {9b7efe44-35f2-48b0-a194-7e682d6f8a59}, !- Space Name
@@ -1365,7 +1366,7 @@ OS:Surface,
 
 OS:Surface,
   {0e84224c-ad2e-43dc-abf5-6ccf8ad632b1}, !- Handle
-  Surface 18,                             !- Name
+  Lobby - Wall 270_a,                     !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {9b7efe44-35f2-48b0-a194-7e682d6f8a59}, !- Space Name
@@ -1382,7 +1383,7 @@ OS:Surface,
 
 OS:Surface,
   {9f245160-55d0-490c-ad25-f6f8615d333d}, !- Handle
-  Surface 19,                             !- Name
+  Lobby - Wall 000_b,                     !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {9b7efe44-35f2-48b0-a194-7e682d6f8a59}, !- Space Name
@@ -1399,7 +1400,7 @@ OS:Surface,
 
 OS:Surface,
   {3b80f727-3f46-4ba9-aee7-8873070b0099}, !- Handle
-  Surface 20,                             !- Name
+  Lobby - RoofCeiling_a,                  !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {9b7efe44-35f2-48b0-a194-7e682d6f8a59}, !- Space Name
@@ -1432,7 +1433,7 @@ OS:Space,
 
 OS:Surface,
   {b0777362-8d2b-4b03-b11a-3a7989b3208b}, !- Handle
-  Surface 21,                             !- Name
+  EnclosedOffice_2 - Floor_a,             !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {599e3f33-0420-4a9d-b445-5bc439428a47}, !- Space Name
@@ -1449,7 +1450,7 @@ OS:Surface,
 
 OS:Surface,
   {3e6969f9-da56-4c65-a9d1-8a2ce2608914}, !- Handle
-  Surface 22,                             !- Name
+  EnclosedOffice_2 - Wall 180_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {599e3f33-0420-4a9d-b445-5bc439428a47}, !- Space Name
@@ -1466,7 +1467,7 @@ OS:Surface,
 
 OS:Surface,
   {1d8517dd-585d-4bc7-8b57-928fde0e10c1}, !- Handle
-  Surface 23,                             !- Name
+  EnclosedOffice_2 - Wall 270_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {599e3f33-0420-4a9d-b445-5bc439428a47}, !- Space Name
@@ -1483,7 +1484,7 @@ OS:Surface,
 
 OS:Surface,
   {04981049-3874-4d46-b4bd-61bf49cffa2d}, !- Handle
-  Surface 24,                             !- Name
+  EnclosedOffice_2 - Wall 000_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {599e3f33-0420-4a9d-b445-5bc439428a47}, !- Space Name
@@ -1500,7 +1501,7 @@ OS:Surface,
 
 OS:Surface,
   {34613b6e-6b05-4e2e-9d96-e2dd6d5f116d}, !- Handle
-  Surface 25,                             !- Name
+  EnclosedOffice_2 - Wall 090_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {599e3f33-0420-4a9d-b445-5bc439428a47}, !- Space Name
@@ -1517,7 +1518,7 @@ OS:Surface,
 
 OS:Surface,
   {bdf7f286-5484-481f-a460-ff7952bea804}, !- Handle
-  Surface 26,                             !- Name
+  EnclosedOffice_2 - RoofCeiling_a,       !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {599e3f33-0420-4a9d-b445-5bc439428a47}, !- Space Name
@@ -1550,7 +1551,7 @@ OS:Space,
 
 OS:Surface,
   {478da73b-147a-4579-8fcd-a19875071aad}, !- Handle
-  Surface 27,                             !- Name
+  ConfRoom_2 - Floor_a,                   !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {96afe6e1-9204-4fae-8f0c-0e6b1fd55eb4}, !- Space Name
@@ -1567,7 +1568,7 @@ OS:Surface,
 
 OS:Surface,
   {eec4a602-61c4-49a6-b89a-4fa82c6bfa80}, !- Handle
-  Surface 28,                             !- Name
+  ConfRoom_2 - Wall 180_a,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {96afe6e1-9204-4fae-8f0c-0e6b1fd55eb4}, !- Space Name
@@ -1584,7 +1585,7 @@ OS:Surface,
 
 OS:Surface,
   {0fe92708-cdf3-4730-a39b-7b98f783ed03}, !- Handle
-  Surface 29,                             !- Name
+  ConfRoom_2 - Wall 270_a,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {96afe6e1-9204-4fae-8f0c-0e6b1fd55eb4}, !- Space Name
@@ -1601,7 +1602,7 @@ OS:Surface,
 
 OS:Surface,
   {65608b4c-8389-459c-a47a-13df1e8b66b6}, !- Handle
-  Surface 30,                             !- Name
+  ConfRoom_2 - Wall 000_a,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {96afe6e1-9204-4fae-8f0c-0e6b1fd55eb4}, !- Space Name
@@ -1618,7 +1619,7 @@ OS:Surface,
 
 OS:Surface,
   {83949fd6-fad6-427a-a7ab-72d403117a5e}, !- Handle
-  Surface 31,                             !- Name
+  ConfRoom_2 - Wall 090_a,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {96afe6e1-9204-4fae-8f0c-0e6b1fd55eb4}, !- Space Name
@@ -1635,7 +1636,7 @@ OS:Surface,
 
 OS:Surface,
   {fa09aee3-3276-4ac8-8722-175151ef3dfa}, !- Handle
-  Surface 32,                             !- Name
+  ConfRoom_2 - RoofCeiling_a,             !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {96afe6e1-9204-4fae-8f0c-0e6b1fd55eb4}, !- Space Name
@@ -1668,7 +1669,7 @@ OS:Space,
 
 OS:Surface,
   {1dcda615-891c-4dc8-8e07-5b34554033c7}, !- Handle
-  Surface 33,                             !- Name
+  EnclosedOffice_3 - Floor_a,             !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {49db0a5c-ab56-4e75-abac-f70b3d43e2b8}, !- Space Name
@@ -1685,7 +1686,7 @@ OS:Surface,
 
 OS:Surface,
   {152c286d-0fe3-4241-af84-61b3b510b821}, !- Handle
-  Surface 34,                             !- Name
+  EnclosedOffice_3 - Wall 000_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {49db0a5c-ab56-4e75-abac-f70b3d43e2b8}, !- Space Name
@@ -1702,7 +1703,7 @@ OS:Surface,
 
 OS:Surface,
   {4f4b46ff-0bd1-44ea-b4d7-36f65ef36977}, !- Handle
-  Surface 35,                             !- Name
+  EnclosedOffice_3 - Wall 090_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {49db0a5c-ab56-4e75-abac-f70b3d43e2b8}, !- Space Name
@@ -1719,7 +1720,7 @@ OS:Surface,
 
 OS:Surface,
   {badfefdb-8fc9-4487-a975-e30da302c09c}, !- Handle
-  Surface 36,                             !- Name
+  EnclosedOffice_3 - Wall 180_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {49db0a5c-ab56-4e75-abac-f70b3d43e2b8}, !- Space Name
@@ -1736,7 +1737,7 @@ OS:Surface,
 
 OS:Surface,
   {6decd978-1b8b-4840-91d7-9b7626953f18}, !- Handle
-  Surface 37,                             !- Name
+  EnclosedOffice_3 - Wall 270_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {49db0a5c-ab56-4e75-abac-f70b3d43e2b8}, !- Space Name
@@ -1753,7 +1754,7 @@ OS:Surface,
 
 OS:Surface,
   {09a0545c-4cc1-4bd7-8788-dbbcd99429e5}, !- Handle
-  Surface 38,                             !- Name
+  EnclosedOffice_3 - RoofCeiling_a,       !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {49db0a5c-ab56-4e75-abac-f70b3d43e2b8}, !- Space Name
@@ -1786,7 +1787,7 @@ OS:Space,
 
 OS:Surface,
   {d7e8962d-61c9-4053-abc9-9a0821f5b39f}, !- Handle
-  Surface 39,                             !- Name
+  Corridor_1 - Floor_a,                   !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {a3d18fd3-ffb5-41ad-b703-e82844497593}, !- Space Name
@@ -1807,7 +1808,7 @@ OS:Surface,
 
 OS:Surface,
   {a6587ee2-9142-4fea-bd37-e04877dbb832}, !- Handle
-  Surface 40,                             !- Name
+  Corridor_1 - Wall 180_c,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {a3d18fd3-ffb5-41ad-b703-e82844497593}, !- Space Name
@@ -1824,7 +1825,7 @@ OS:Surface,
 
 OS:Surface,
   {63a84bd5-86fd-4d34-be7e-46fd678d05e8}, !- Handle
-  Surface 41,                             !- Name
+  Corridor_1 - Wall 270_a,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {a3d18fd3-ffb5-41ad-b703-e82844497593}, !- Space Name
@@ -1841,7 +1842,7 @@ OS:Surface,
 
 OS:Surface,
   {65f95cca-6ca8-4d94-8b6c-30922e53495d}, !- Handle
-  Surface 42,                             !- Name
+  Corridor_1 - Wall 000_b,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {a3d18fd3-ffb5-41ad-b703-e82844497593}, !- Space Name
@@ -1858,7 +1859,7 @@ OS:Surface,
 
 OS:Surface,
   {96f5a1ab-23cb-47b7-913a-7b59b6d48774}, !- Handle
-  Surface 43,                             !- Name
+  Corridor_1 - Wall 090_a,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {a3d18fd3-ffb5-41ad-b703-e82844497593}, !- Space Name
@@ -1875,7 +1876,7 @@ OS:Surface,
 
 OS:Surface,
   {79541496-5ab6-436f-a686-d9b530fb4678}, !- Handle
-  Surface 44,                             !- Name
+  Corridor_1 - Wall 180_a,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {a3d18fd3-ffb5-41ad-b703-e82844497593}, !- Space Name
@@ -1892,7 +1893,7 @@ OS:Surface,
 
 OS:Surface,
   {329524b9-8208-4a56-ba9b-eaa2cd9c1027}, !- Handle
-  Surface 45,                             !- Name
+  Corridor_1 - Wall 180_b,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {a3d18fd3-ffb5-41ad-b703-e82844497593}, !- Space Name
@@ -1909,7 +1910,7 @@ OS:Surface,
 
 OS:Surface,
   {96b28e3b-c225-4bbe-bea4-964a1d0df85f}, !- Handle
-  Surface 46,                             !- Name
+  Corridor_1 - Wall 090_c,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {a3d18fd3-ffb5-41ad-b703-e82844497593}, !- Space Name
@@ -1926,7 +1927,7 @@ OS:Surface,
 
 OS:Surface,
   {0549aed2-5851-4792-a2e9-d901b76d287b}, !- Handle
-  Surface 47,                             !- Name
+  Corridor_1 - Wall 090_d,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {a3d18fd3-ffb5-41ad-b703-e82844497593}, !- Space Name
@@ -1943,7 +1944,7 @@ OS:Surface,
 
 OS:Surface,
   {768eccbc-6a82-4816-8f06-965a4ab60cc9}, !- Handle
-  Surface 48,                             !- Name
+  Corridor_1 - Wall 000_a,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {a3d18fd3-ffb5-41ad-b703-e82844497593}, !- Space Name
@@ -1960,7 +1961,7 @@ OS:Surface,
 
 OS:Surface,
   {e86586f8-181e-4799-8788-847d3eab57bd}, !- Handle
-  Surface 49,                             !- Name
+  Corridor_1 - Wall 000_c,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {a3d18fd3-ffb5-41ad-b703-e82844497593}, !- Space Name
@@ -1977,7 +1978,7 @@ OS:Surface,
 
 OS:Surface,
   {cb8cf9c3-9a9e-4458-9f03-a691ded76937}, !- Handle
-  Surface 50,                             !- Name
+  Corridor_1 - Wall 090_b,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {a3d18fd3-ffb5-41ad-b703-e82844497593}, !- Space Name
@@ -1994,7 +1995,7 @@ OS:Surface,
 
 OS:Surface,
   {21160073-7652-463b-9d4f-a2826348213d}, !- Handle
-  Surface 51,                             !- Name
+  Corridor_1 - Wall 180_d,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {a3d18fd3-ffb5-41ad-b703-e82844497593}, !- Space Name
@@ -2004,14 +2005,14 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0.544115625, 0, 3.048,                  !- X,Y,Z Vertex 1 {m}
-  0.544115625, 0, 0,                      !- X,Y,Z Vertex 2 {m}
+  0.54411563, 0, 3.048,                   !- X,Y,Z Vertex 1 {m}
+  0.54411563, 0, 0,                       !- X,Y,Z Vertex 2 {m}
   4.57120625, 0, 0,                       !- X,Y,Z Vertex 3 {m}
   4.57120625, 0, 3.048;                   !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {8f8a7f8c-07de-493b-9d8b-fe7052db5cb0}, !- Handle
-  Surface 52,                             !- Name
+  Corridor_1 - Wall 180_e,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {a3d18fd3-ffb5-41ad-b703-e82844497593}, !- Space Name
@@ -2023,12 +2024,12 @@ OS:Surface,
   ,                                       !- Number of Vertices
   0, 0, 3.048,                            !- X,Y,Z Vertex 1 {m}
   0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
-  0.544115625, 0, 0,                      !- X,Y,Z Vertex 3 {m}
-  0.544115625, 0, 3.048;                  !- X,Y,Z Vertex 4 {m}
+  0.54411563, 0, 0,                       !- X,Y,Z Vertex 3 {m}
+  0.54411563, 0, 3.048;                   !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {8405a4b2-df92-4bdf-aeff-f77871f2e8af}, !- Handle
-  Surface 53,                             !- Name
+  Corridor_1 - RoofCeiling_a,             !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {a3d18fd3-ffb5-41ad-b703-e82844497593}, !- Space Name
@@ -2065,7 +2066,7 @@ OS:Space,
 
 OS:Surface,
   {2d25d444-0dd0-4bef-8a3a-a13279170f15}, !- Handle
-  Surface 54,                             !- Name
+  Corridor_2 - Floor_a,                   !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {32102686-6033-4031-9855-fd53d14db0ab}, !- Space Name
@@ -2086,7 +2087,7 @@ OS:Surface,
 
 OS:Surface,
   {483ad54f-92b6-499a-b2b3-18e60a7a1761}, !- Handle
-  Surface 55,                             !- Name
+  Corridor_2 - Wall 000_a,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {32102686-6033-4031-9855-fd53d14db0ab}, !- Space Name
@@ -2103,7 +2104,7 @@ OS:Surface,
 
 OS:Surface,
   {61fb88b0-4cf0-4a69-bd56-54e5497bbba3}, !- Handle
-  Surface 56,                             !- Name
+  Corridor_2 - Wall 000_b,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {32102686-6033-4031-9855-fd53d14db0ab}, !- Space Name
@@ -2120,7 +2121,7 @@ OS:Surface,
 
 OS:Surface,
   {71bd9b13-d5ef-4bd8-9bb4-cd0b4b76333c}, !- Handle
-  Surface 57,                             !- Name
+  Corridor_2 - Wall 270_b,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {32102686-6033-4031-9855-fd53d14db0ab}, !- Space Name
@@ -2137,7 +2138,7 @@ OS:Surface,
 
 OS:Surface,
   {5275623a-0ff8-4cf4-93ec-f9d76731673a}, !- Handle
-  Surface 58,                             !- Name
+  Corridor_2 - Wall 270_d,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {32102686-6033-4031-9855-fd53d14db0ab}, !- Space Name
@@ -2154,7 +2155,7 @@ OS:Surface,
 
 OS:Surface,
   {301874c9-148f-4672-830a-748fba936b87}, !- Handle
-  Surface 59,                             !- Name
+  Corridor_2 - Wall 180_b,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {32102686-6033-4031-9855-fd53d14db0ab}, !- Space Name
@@ -2171,7 +2172,7 @@ OS:Surface,
 
 OS:Surface,
   {da34923e-61dc-46da-b22c-f63af0d1b7d0}, !- Handle
-  Surface 60,                             !- Name
+  Corridor_2 - Wall 180_c,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {32102686-6033-4031-9855-fd53d14db0ab}, !- Space Name
@@ -2188,7 +2189,7 @@ OS:Surface,
 
 OS:Surface,
   {a5d0582f-09d9-4bbe-8230-4720b2bfcded}, !- Handle
-  Surface 61,                             !- Name
+  Corridor_2 - Wall 270_a,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {32102686-6033-4031-9855-fd53d14db0ab}, !- Space Name
@@ -2205,7 +2206,7 @@ OS:Surface,
 
 OS:Surface,
   {c1a84b0d-35c4-4ea3-8a47-e12a34794cf2}, !- Handle
-  Surface 62,                             !- Name
+  Corridor_2 - Wall 000_c,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {32102686-6033-4031-9855-fd53d14db0ab}, !- Space Name
@@ -2222,7 +2223,7 @@ OS:Surface,
 
 OS:Surface,
   {48f18fa6-c4b0-4793-aa11-2a0c578b6c74}, !- Handle
-  Surface 63,                             !- Name
+  Corridor_2 - Wall 090_a,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {32102686-6033-4031-9855-fd53d14db0ab}, !- Space Name
@@ -2239,7 +2240,7 @@ OS:Surface,
 
 OS:Surface,
   {096a6824-108e-4555-9ebc-2abb466342a1}, !- Handle
-  Surface 64,                             !- Name
+  Corridor_2 - Wall 180_a,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {32102686-6033-4031-9855-fd53d14db0ab}, !- Space Name
@@ -2256,7 +2257,7 @@ OS:Surface,
 
 OS:Surface,
   {cddfbd64-ceba-4e25-9c9c-873a79c05278}, !- Handle
-  Surface 65,                             !- Name
+  Corridor_2 - Wall 180_d,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {32102686-6033-4031-9855-fd53d14db0ab}, !- Space Name
@@ -2273,7 +2274,7 @@ OS:Surface,
 
 OS:Surface,
   {1b9961ed-5503-4796-8f29-4f870d3fdfca}, !- Handle
-  Surface 66,                             !- Name
+  Corridor_2 - Wall 270_c,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {32102686-6033-4031-9855-fd53d14db0ab}, !- Space Name
@@ -2290,7 +2291,7 @@ OS:Surface,
 
 OS:Surface,
   {d32b4acd-dcaf-4fe9-921a-a75ac3fe7871}, !- Handle
-  Surface 67,                             !- Name
+  Corridor_2 - RoofCeiling_a,             !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {32102686-6033-4031-9855-fd53d14db0ab}, !- Space Name
@@ -2327,7 +2328,7 @@ OS:Space,
 
 OS:Surface,
   {2254cc5e-1388-4c41-8f6f-afd5095c8e3e}, !- Handle
-  Surface 68,                             !- Name
+  EnclosedOffice_4 - Floor_a,             !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {fa0c0a35-f933-4ec7-8718-e9e0e1bd6ba0}, !- Space Name
@@ -2344,7 +2345,7 @@ OS:Surface,
 
 OS:Surface,
   {ea322868-c265-4a08-a190-e3d7729cb40d}, !- Handle
-  Surface 69,                             !- Name
+  EnclosedOffice_4 - Wall 180_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {fa0c0a35-f933-4ec7-8718-e9e0e1bd6ba0}, !- Space Name
@@ -2361,7 +2362,7 @@ OS:Surface,
 
 OS:Surface,
   {a5de5e13-030d-4802-8772-fc24b644f446}, !- Handle
-  Surface 70,                             !- Name
+  EnclosedOffice_4 - Wall 270_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {fa0c0a35-f933-4ec7-8718-e9e0e1bd6ba0}, !- Space Name
@@ -2378,7 +2379,7 @@ OS:Surface,
 
 OS:Surface,
   {f3fec7ad-5353-4af9-921e-dd7e2d536a15}, !- Handle
-  Surface 71,                             !- Name
+  EnclosedOffice_4 - Wall 000_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {fa0c0a35-f933-4ec7-8718-e9e0e1bd6ba0}, !- Space Name
@@ -2395,7 +2396,7 @@ OS:Surface,
 
 OS:Surface,
   {49cdda99-826e-49f4-8279-10d0ed88c0e4}, !- Handle
-  Surface 72,                             !- Name
+  EnclosedOffice_4 - Wall 090_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {fa0c0a35-f933-4ec7-8718-e9e0e1bd6ba0}, !- Space Name
@@ -2412,7 +2413,7 @@ OS:Surface,
 
 OS:Surface,
   {6251ade1-fa82-4998-a128-f18cccff66cc}, !- Handle
-  Surface 73,                             !- Name
+  EnclosedOffice_4 - RoofCeiling_a,       !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {fa0c0a35-f933-4ec7-8718-e9e0e1bd6ba0}, !- Space Name
@@ -2445,7 +2446,7 @@ OS:Space,
 
 OS:Surface,
   {9ab0d683-e7da-41b9-9845-295bfa4b4d53}, !- Handle
-  Surface 74,                             !- Name
+  Stair - Floor_a,                        !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {e2751eeb-4239-4cae-8f4a-05a31a252bb8}, !- Space Name
@@ -2462,7 +2463,7 @@ OS:Surface,
 
 OS:Surface,
   {189607d1-114e-4b0e-98d7-e2980abb4bb0}, !- Handle
-  Surface 75,                             !- Name
+  Stair - Wall 270_a,                     !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e2751eeb-4239-4cae-8f4a-05a31a252bb8}, !- Space Name
@@ -2479,7 +2480,7 @@ OS:Surface,
 
 OS:Surface,
   {c1faf488-c6fa-4380-91a7-fb45d52f9e3f}, !- Handle
-  Surface 76,                             !- Name
+  Stair - Wall 000_a,                     !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e2751eeb-4239-4cae-8f4a-05a31a252bb8}, !- Space Name
@@ -2496,7 +2497,7 @@ OS:Surface,
 
 OS:Surface,
   {b48baf7b-64bb-4435-871a-46838aad0ade}, !- Handle
-  Surface 77,                             !- Name
+  Stair - Wall 090_a,                     !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e2751eeb-4239-4cae-8f4a-05a31a252bb8}, !- Space Name
@@ -2513,7 +2514,7 @@ OS:Surface,
 
 OS:Surface,
   {3a0a2452-2aab-4cf5-8937-773532a15249}, !- Handle
-  Surface 78,                             !- Name
+  Stair - Wall 180_a,                     !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {e2751eeb-4239-4cae-8f4a-05a31a252bb8}, !- Space Name
@@ -2530,7 +2531,7 @@ OS:Surface,
 
 OS:Surface,
   {ad9af532-d513-4d42-b936-4c03a93e84ad}, !- Handle
-  Surface 79,                             !- Name
+  Stair - RoofCeiling_a,                  !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {e2751eeb-4239-4cae-8f4a-05a31a252bb8}, !- Space Name
@@ -2563,7 +2564,7 @@ OS:Space,
 
 OS:Surface,
   {e0d22d48-74df-4643-a5b4-66ad7b0c9274}, !- Handle
-  Surface 80,                             !- Name
+  Storage - Floor_a,                      !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {ace0428d-1111-4dda-9283-4944e0751f2f}, !- Space Name
@@ -2580,7 +2581,7 @@ OS:Surface,
 
 OS:Surface,
   {e48f5888-7eb3-4a71-ac3c-0a5aa9f66075}, !- Handle
-  Surface 81,                             !- Name
+  Storage - Wall 000_a,                   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {ace0428d-1111-4dda-9283-4944e0751f2f}, !- Space Name
@@ -2597,7 +2598,7 @@ OS:Surface,
 
 OS:Surface,
   {1012ec6a-fe91-4083-af18-9e7e0fb0e094}, !- Handle
-  Surface 82,                             !- Name
+  Storage - Wall 090_a,                   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {ace0428d-1111-4dda-9283-4944e0751f2f}, !- Space Name
@@ -2614,7 +2615,7 @@ OS:Surface,
 
 OS:Surface,
   {3a4babf2-9989-4d6c-8f60-fe2101665e6a}, !- Handle
-  Surface 83,                             !- Name
+  Storage - Wall 090_b,                   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {ace0428d-1111-4dda-9283-4944e0751f2f}, !- Space Name
@@ -2631,7 +2632,7 @@ OS:Surface,
 
 OS:Surface,
   {65ee1371-e553-423a-850f-047d65b54671}, !- Handle
-  Surface 84,                             !- Name
+  Storage - Wall 180_a,                   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {ace0428d-1111-4dda-9283-4944e0751f2f}, !- Space Name
@@ -2648,7 +2649,7 @@ OS:Surface,
 
 OS:Surface,
   {fc0c3d09-19a3-497b-8bfb-07b9a14b1b7c}, !- Handle
-  Surface 85,                             !- Name
+  Storage - Wall 180_b,                   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {ace0428d-1111-4dda-9283-4944e0751f2f}, !- Space Name
@@ -2665,7 +2666,7 @@ OS:Surface,
 
 OS:Surface,
   {7f763be1-b0ef-4d58-a078-60cd91f0be37}, !- Handle
-  Surface 86,                             !- Name
+  Storage - Wall 270_a,                   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {ace0428d-1111-4dda-9283-4944e0751f2f}, !- Space Name
@@ -2682,7 +2683,7 @@ OS:Surface,
 
 OS:Surface,
   {45498a19-a44e-4d5b-91b6-aa56c97981a7}, !- Handle
-  Surface 87,                             !- Name
+  Storage - Wall 270_b,                   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {ace0428d-1111-4dda-9283-4944e0751f2f}, !- Space Name
@@ -2699,7 +2700,7 @@ OS:Surface,
 
 OS:Surface,
   {2c13bc69-3a4c-40d7-a4d7-67096a923f3b}, !- Handle
-  Surface 88,                             !- Name
+  Storage - Wall 000_b,                   !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {ace0428d-1111-4dda-9283-4944e0751f2f}, !- Space Name
@@ -2716,7 +2717,7 @@ OS:Surface,
 
 OS:Surface,
   {87a04ccc-6e9f-4a79-badb-e501a6558f09}, !- Handle
-  Surface 89,                             !- Name
+  Storage - RoofCeiling_a,                !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {ace0428d-1111-4dda-9283-4944e0751f2f}, !- Space Name
@@ -2749,7 +2750,7 @@ OS:Space,
 
 OS:Surface,
   {6db775bb-bf63-4fd8-9520-b79f8724ecf5}, !- Handle
-  Surface 90,                             !- Name
+  Mechanical - Floor_a,                   !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {40a6f208-5550-43a6-9cc1-5d008dd8ee01}, !- Space Name
@@ -2766,7 +2767,7 @@ OS:Surface,
 
 OS:Surface,
   {b885e427-5606-45d6-80ec-53ff5a5a668c}, !- Handle
-  Surface 91,                             !- Name
+  Mechanical - Wall 270_a,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {40a6f208-5550-43a6-9cc1-5d008dd8ee01}, !- Space Name
@@ -2783,7 +2784,7 @@ OS:Surface,
 
 OS:Surface,
   {6d78db85-e8f1-4eee-b414-1561736ffb2a}, !- Handle
-  Surface 92,                             !- Name
+  Mechanical - Wall 000_a,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {40a6f208-5550-43a6-9cc1-5d008dd8ee01}, !- Space Name
@@ -2800,7 +2801,7 @@ OS:Surface,
 
 OS:Surface,
   {271f6175-6a3e-4ffb-bdc5-fc6ad6e4f73d}, !- Handle
-  Surface 93,                             !- Name
+  Mechanical - Wall 090_a,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {40a6f208-5550-43a6-9cc1-5d008dd8ee01}, !- Space Name
@@ -2817,7 +2818,7 @@ OS:Surface,
 
 OS:Surface,
   {9f10eab7-aef3-4690-bfcf-665987a04a8a}, !- Handle
-  Surface 94,                             !- Name
+  Mechanical - Wall 180_a,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {40a6f208-5550-43a6-9cc1-5d008dd8ee01}, !- Space Name
@@ -2834,7 +2835,7 @@ OS:Surface,
 
 OS:Surface,
   {a8e4825f-591d-45a9-939b-9a64fc14ef90}, !- Handle
-  Surface 95,                             !- Name
+  Mechanical - RoofCeiling_a,             !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {40a6f208-5550-43a6-9cc1-5d008dd8ee01}, !- Space Name
@@ -2867,7 +2868,7 @@ OS:Space,
 
 OS:Surface,
   {4ff9c544-41c9-4ded-8fce-28e45f53939d}, !- Handle
-  Surface 96,                             !- Name
+  Restroom_1 - Floor_a,                   !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {2d7bf70d-97ab-46c4-b834-fe6068d4c426}, !- Space Name
@@ -2884,7 +2885,7 @@ OS:Surface,
 
 OS:Surface,
   {cdb74d66-7622-4929-98bf-bc5bdb797323}, !- Handle
-  Surface 97,                             !- Name
+  Restroom_1 - Wall 090_a,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {2d7bf70d-97ab-46c4-b834-fe6068d4c426}, !- Space Name
@@ -2901,7 +2902,7 @@ OS:Surface,
 
 OS:Surface,
   {7e1a2da9-1cf3-498b-b90d-168fba081dd2}, !- Handle
-  Surface 98,                             !- Name
+  Restroom_1 - Wall 180_a,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {2d7bf70d-97ab-46c4-b834-fe6068d4c426}, !- Space Name
@@ -2918,7 +2919,7 @@ OS:Surface,
 
 OS:Surface,
   {52d4332e-c161-48ab-8df0-65658a2c71c6}, !- Handle
-  Surface 99,                             !- Name
+  Restroom_1 - Wall 270_a,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {2d7bf70d-97ab-46c4-b834-fe6068d4c426}, !- Space Name
@@ -2935,7 +2936,7 @@ OS:Surface,
 
 OS:Surface,
   {5c87364d-3421-4d6d-a8cc-9b5df3747c66}, !- Handle
-  Surface 100,                            !- Name
+  Restroom_1 - Wall 000_a,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {2d7bf70d-97ab-46c4-b834-fe6068d4c426}, !- Space Name
@@ -2952,7 +2953,7 @@ OS:Surface,
 
 OS:Surface,
   {d00f1f1b-d464-448c-9eb5-cbaf5514dc2a}, !- Handle
-  Surface 101,                            !- Name
+  Restroom_1 - RoofCeiling_a,             !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {2d7bf70d-97ab-46c4-b834-fe6068d4c426}, !- Space Name
@@ -2985,7 +2986,7 @@ OS:Space,
 
 OS:Surface,
   {4f37c7cc-e8ab-46c5-97aa-98687c7bbcba}, !- Handle
-  Surface 102,                            !- Name
+  Restroom_2 - Floor_a,                   !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {057345c0-b86d-4955-995e-7f2a58a924c5}, !- Space Name
@@ -3002,7 +3003,7 @@ OS:Surface,
 
 OS:Surface,
   {57846664-77b5-4139-abd2-17a2731640a5}, !- Handle
-  Surface 103,                            !- Name
+  Restroom_2 - Wall 090_a,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {057345c0-b86d-4955-995e-7f2a58a924c5}, !- Space Name
@@ -3019,7 +3020,7 @@ OS:Surface,
 
 OS:Surface,
   {e3d66b2b-b639-4238-9985-895bcd734bc0}, !- Handle
-  Surface 104,                            !- Name
+  Restroom_2 - Wall 180_a,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {057345c0-b86d-4955-995e-7f2a58a924c5}, !- Space Name
@@ -3036,7 +3037,7 @@ OS:Surface,
 
 OS:Surface,
   {0a722c61-5e0f-4aad-b373-0a3f374be299}, !- Handle
-  Surface 105,                            !- Name
+  Restroom_2 - Wall 270_a,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {057345c0-b86d-4955-995e-7f2a58a924c5}, !- Space Name
@@ -3053,7 +3054,7 @@ OS:Surface,
 
 OS:Surface,
   {d1412889-2f14-4092-925f-638e887ccc95}, !- Handle
-  Surface 106,                            !- Name
+  Restroom_2 - Wall 000_a,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {057345c0-b86d-4955-995e-7f2a58a924c5}, !- Space Name
@@ -3070,7 +3071,7 @@ OS:Surface,
 
 OS:Surface,
   {dbea65f0-e172-4cea-b958-2655c1a87521}, !- Handle
-  Surface 107,                            !- Name
+  Restroom_2 - RoofCeiling_a,             !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {057345c0-b86d-4955-995e-7f2a58a924c5}, !- Space Name
@@ -3103,7 +3104,7 @@ OS:Space,
 
 OS:Surface,
   {f261eb2f-a624-4d98-af06-0ef36c079521}, !- Handle
-  Surface 108,                            !- Name
+  EnclosedOffice_5 - Floor_a,             !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {bc05a667-e0b1-4d47-9799-c15207b1a31a}, !- Space Name
@@ -3120,7 +3121,7 @@ OS:Surface,
 
 OS:Surface,
   {ac66bc26-9b47-4132-bca9-c881ec0c0200}, !- Handle
-  Surface 109,                            !- Name
+  EnclosedOffice_5 - Wall 000_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {bc05a667-e0b1-4d47-9799-c15207b1a31a}, !- Space Name
@@ -3137,7 +3138,7 @@ OS:Surface,
 
 OS:Surface,
   {4d74bc24-b5cc-47e8-a4b7-b633d68cf284}, !- Handle
-  Surface 110,                            !- Name
+  EnclosedOffice_5 - Wall 090_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {bc05a667-e0b1-4d47-9799-c15207b1a31a}, !- Space Name
@@ -3154,7 +3155,7 @@ OS:Surface,
 
 OS:Surface,
   {325f2a96-fe91-4c16-8f27-1207a1e82109}, !- Handle
-  Surface 111,                            !- Name
+  EnclosedOffice_5 - Wall 180_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {bc05a667-e0b1-4d47-9799-c15207b1a31a}, !- Space Name
@@ -3171,7 +3172,7 @@ OS:Surface,
 
 OS:Surface,
   {280e0b68-2a9d-4e81-bdfe-55afd7002d84}, !- Handle
-  Surface 112,                            !- Name
+  EnclosedOffice_5 - Wall 270_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {bc05a667-e0b1-4d47-9799-c15207b1a31a}, !- Space Name
@@ -3188,7 +3189,7 @@ OS:Surface,
 
 OS:Surface,
   {6dad2d85-7599-4b09-8e1a-ee07f1b5f1a5}, !- Handle
-  Surface 113,                            !- Name
+  EnclosedOffice_5 - RoofCeiling_a,       !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {bc05a667-e0b1-4d47-9799-c15207b1a31a}, !- Space Name
@@ -3221,7 +3222,7 @@ OS:Space,
 
 OS:Surface,
   {bbd86c01-0565-4479-9263-2c2cfd1a4903}, !- Handle
-  Surface 114,                            !- Name
+  OpenOffice - Floor_a,                   !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {54b526f8-48fb-4864-a7df-736413fe0fa2}, !- Space Name
@@ -3238,7 +3239,7 @@ OS:Surface,
 
 OS:Surface,
   {aeb313e2-f6ec-4661-93d3-69155d6058f8}, !- Handle
-  Surface 115,                            !- Name
+  OpenOffice - Wall 000_a,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {54b526f8-48fb-4864-a7df-736413fe0fa2}, !- Space Name
@@ -3255,7 +3256,7 @@ OS:Surface,
 
 OS:Surface,
   {18b414e6-6e2e-4c3c-9adf-664bc3944d6d}, !- Handle
-  Surface 116,                            !- Name
+  OpenOffice - Wall 090_a,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {54b526f8-48fb-4864-a7df-736413fe0fa2}, !- Space Name
@@ -3272,7 +3273,7 @@ OS:Surface,
 
 OS:Surface,
   {d6b9cace-1bd9-45d9-b88c-ab41ed2461b5}, !- Handle
-  Surface 117,                            !- Name
+  OpenOffice - Wall 180_a,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {54b526f8-48fb-4864-a7df-736413fe0fa2}, !- Space Name
@@ -3289,7 +3290,7 @@ OS:Surface,
 
 OS:Surface,
   {7e2fa303-c2ef-48a0-b81a-0126633804bc}, !- Handle
-  Surface 118,                            !- Name
+  OpenOffice - Wall 180_b,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {54b526f8-48fb-4864-a7df-736413fe0fa2}, !- Space Name
@@ -3306,7 +3307,7 @@ OS:Surface,
 
 OS:Surface,
   {6089bd69-a1e3-4083-828e-bc18c0b0586b}, !- Handle
-  Surface 119,                            !- Name
+  OpenOffice - Wall 270_a,                !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {54b526f8-48fb-4864-a7df-736413fe0fa2}, !- Space Name
@@ -3323,7 +3324,7 @@ OS:Surface,
 
 OS:Surface,
   {48c3cdd5-3a2e-470e-af92-0837ce5d2535}, !- Handle
-  Surface 120,                            !- Name
+  OpenOffice - RoofCeiling_a,             !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {54b526f8-48fb-4864-a7df-736413fe0fa2}, !- Space Name
@@ -3356,7 +3357,7 @@ OS:Space,
 
 OS:Surface,
   {5255fd6d-b39b-4b1c-9121-e8f36d726f62}, !- Handle
-  Surface 121,                            !- Name
+  EnclosedOffice_6 - Floor_a,             !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {9fcdd6a1-5b9d-4212-9039-8ed869603b40}, !- Space Name
@@ -3373,7 +3374,7 @@ OS:Surface,
 
 OS:Surface,
   {47f6dc9b-f45a-408e-bb57-a1b0812d0c8e}, !- Handle
-  Surface 122,                            !- Name
+  EnclosedOffice_6 - Wall 180_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {9fcdd6a1-5b9d-4212-9039-8ed869603b40}, !- Space Name
@@ -3390,7 +3391,7 @@ OS:Surface,
 
 OS:Surface,
   {d52a8647-3741-41e3-b436-0fe2f5afa4e1}, !- Handle
-  Surface 123,                            !- Name
+  EnclosedOffice_6 - Wall 270_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {9fcdd6a1-5b9d-4212-9039-8ed869603b40}, !- Space Name
@@ -3407,7 +3408,7 @@ OS:Surface,
 
 OS:Surface,
   {44a77928-c80d-45aa-a6ea-e9dd2594e316}, !- Handle
-  Surface 124,                            !- Name
+  EnclosedOffice_6 - Wall 000_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {9fcdd6a1-5b9d-4212-9039-8ed869603b40}, !- Space Name
@@ -3424,7 +3425,7 @@ OS:Surface,
 
 OS:Surface,
   {69f90bcf-717c-4cab-a5eb-b4d2809222f3}, !- Handle
-  Surface 125,                            !- Name
+  EnclosedOffice_6 - Wall 090_a,          !- Name
   Wall,                                   !- Surface Type
   ,                                       !- Construction Name
   {9fcdd6a1-5b9d-4212-9039-8ed869603b40}, !- Space Name
@@ -3441,7 +3442,7 @@ OS:Surface,
 
 OS:Surface,
   {7db0758c-4b90-4963-9496-c420172ec256}, !- Handle
-  Surface 126,                            !- Name
+  EnclosedOffice_6 - RoofCeiling_a,       !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {9fcdd6a1-5b9d-4212-9039-8ed869603b40}, !- Space Name
@@ -3481,7 +3482,7 @@ OS:Space,
 
 OS:Surface,
   {ef99b342-4e49-42be-a81a-da6a7186f6f8}, !- Handle
-  Surface 128,                            !- Name
+  Attic - RoofCeiling_c,                  !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {91cfc07c-2e46-4945-8a9f-387760fa0db8}, !- Space Name
@@ -3493,11 +3494,11 @@ OS:Surface,
   ,                                       !- Number of Vertices
   9.23, 9.23, 6.328,                      !- X,Y,Z Vertex 1 {m}
   -0.6, 19.06, 3.048,                     !- X,Y,Z Vertex 2 {m}
-  -0.6, -0.599999999999999, 3.048;        !- X,Y,Z Vertex 3 {m}
+  -0.6, -0.6, 3.048;                      !- X,Y,Z Vertex 3 {m}
 
 OS:Surface,
   {ebda4e9b-6edf-446a-9a32-78b072ef6823}, !- Handle
-  Surface 129,                            !- Name
+  Attic - RoofCeiling_b,                  !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {91cfc07c-2e46-4945-8a9f-387760fa0db8}, !- Space Name
@@ -3514,7 +3515,7 @@ OS:Surface,
 
 OS:Surface,
   {cdd47afc-6855-4004-a6c6-0069f54a6d2d}, !- Handle
-  Surface 130,                            !- Name
+  Attic - RoofCeiling_a,                  !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {91cfc07c-2e46-4945-8a9f-387760fa0db8}, !- Space Name
@@ -3530,7 +3531,7 @@ OS:Surface,
 
 OS:Surface,
   {9b0f5277-255b-4d71-b324-5654de736955}, !- Handle
-  Surface 131,                            !- Name
+  Attic - RoofCeiling_d,                  !- Name
   RoofCeiling,                            !- Surface Type
   ,                                       !- Construction Name
   {91cfc07c-2e46-4945-8a9f-387760fa0db8}, !- Space Name
@@ -3541,13 +3542,13 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   9.23, 9.23, 6.328,                      !- X,Y,Z Vertex 1 {m}
-  -0.6, -0.599999999999999, 3.048,        !- X,Y,Z Vertex 2 {m}
+  -0.6, -0.6, 3.048,                      !- X,Y,Z Vertex 2 {m}
   28.29, -0.6, 3.048,                     !- X,Y,Z Vertex 3 {m}
   18.46, 9.23, 6.328;                     !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {27fed199-d1da-47ba-9d82-3adc2d31fa32}, !- Handle
-  Surface 148,                            !- Name
+  Attic - Floor_h,                        !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {91cfc07c-2e46-4945-8a9f-387760fa0db8}, !- Space Name
@@ -3564,7 +3565,7 @@ OS:Surface,
 
 OS:Surface,
   {49d8290d-8945-4fe6-968b-95ad57d55689}, !- Handle
-  Surface 149,                            !- Name
+  Attic - Floor_c,                        !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {91cfc07c-2e46-4945-8a9f-387760fa0db8}, !- Space Name
@@ -3577,11 +3578,11 @@ OS:Surface,
   -0.6, 19.06, 3.048,                     !- X,Y,Z Vertex 1 {m}
   0, 18.45945, 3.048,                     !- X,Y,Z Vertex 2 {m}
   0, 0, 3.048,                            !- X,Y,Z Vertex 3 {m}
-  -0.6, -0.599999999999999, 3.048;        !- X,Y,Z Vertex 4 {m}
+  -0.6, -0.6, 3.048;                      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {24c9f396-5b80-4675-bf79-a583464176be}, !- Handle
-  Surface 151,                            !- Name
+  Attic - Floor_i,                        !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {91cfc07c-2e46-4945-8a9f-387760fa0db8}, !- Space Name
@@ -3593,12 +3594,12 @@ OS:Surface,
   ,                                       !- Number of Vertices
   27.6907625, 0, 3.048,                   !- X,Y,Z Vertex 1 {m}
   28.29, -0.6, 3.048,                     !- X,Y,Z Vertex 2 {m}
-  -0.6, -0.599999999999999, 3.048,        !- X,Y,Z Vertex 3 {m}
+  -0.6, -0.6, 3.048,                      !- X,Y,Z Vertex 3 {m}
   0, 0, 3.048;                            !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {99bbe199-a6be-44a2-abd7-8fe40b7ae190}, !- Handle
-  Sub Surface 1,                          !- Name
+  ConfRoom_1 - Wall 180_a - Sub:a,        !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {4901e7bb-b81e-4a98-8564-5f93bd853631}, !- Surface Name
@@ -3615,7 +3616,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {8232a4ce-30b6-4305-b3e9-c80dd4cb9e2e}, !- Handle
-  Sub Surface 2,                          !- Name
+  EnclosedOffice_1 - Wall 180_a - Sub:a,  !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {bdf3cb71-a553-4a62-be06-eadd7d89e060}, !- Surface Name
@@ -3632,7 +3633,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {623635ec-2da6-4993-b435-a9f35b7b810b}, !- Handle
-  Sub Surface 3,                          !- Name
+  Lobby - Wall 180_a - Sub:b,             !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {75f01be6-51f9-4cdc-8375-c6698bf2afdd}, !- Surface Name
@@ -3649,7 +3650,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {f89f568b-ffd4-4f27-b029-29474c071a60}, !- Handle
-  Sub Surface 4,                          !- Name
+  Lobby - Wall 180_a - Sub:a,             !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {75f01be6-51f9-4cdc-8375-c6698bf2afdd}, !- Surface Name
@@ -3666,7 +3667,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {391cef8d-5b27-4658-9b55-0a5f808c1cd6}, !- Handle
-  Sub Surface 5,                          !- Name
+  Lobby - Wall 180_a - Sub:c,             !- Name
   DOOR,                                   !- Sub Surface Type
   ,                                       !- Construction Name
   {75f01be6-51f9-4cdc-8375-c6698bf2afdd}, !- Surface Name
@@ -3683,7 +3684,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {1ee2d238-021c-4538-9952-8b49bc7a0c38}, !- Handle
-  Sub Surface 6,                          !- Name
+  EnclosedOffice_2 - Wall 180_a - Sub:a,  !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {3e6969f9-da56-4c65-a9d1-8a2ce2608914}, !- Surface Name
@@ -3700,7 +3701,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {a269519c-ba2a-4bd1-90a2-a29d4504deea}, !- Handle
-  Sub Surface 7,                          !- Name
+  ConfRoom_2 - Wall 180_a - Sub:a,        !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {eec4a602-61c4-49a6-b89a-4fa82c6bfa80}, !- Surface Name
@@ -3717,7 +3718,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {baf91f49-d5f9-465e-b1ac-d2661a12e969}, !- Handle
-  Sub Surface 8,                          !- Name
+  ConfRoom_1 - Wall 270_a - Sub:a,        !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {13c9448d-a18e-4f3f-9a2c-0c2145b2f5bb}, !- Surface Name
@@ -3734,7 +3735,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {8aa5aa7c-1d04-45b6-a343-2836d66e249b}, !- Handle
-  Sub Surface 9,                          !- Name
+  EnclosedOffice_3 - Wall 270_a - Sub:a,  !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {6decd978-1b8b-4840-91d7-9b7626953f18}, !- Surface Name
@@ -3751,7 +3752,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {3b3b07e2-2ad5-4d57-b95f-8bcfa31f590c}, !- Handle
-  Sub Surface 10,                         !- Name
+  EnclosedOffice_3 - Wall 270_a - Sub:b,  !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {6decd978-1b8b-4840-91d7-9b7626953f18}, !- Surface Name
@@ -3768,7 +3769,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {0bdd2cde-aee5-43bb-98bd-e7b4154feee3}, !- Handle
-  Sub Surface 11,                         !- Name
+  EnclosedOffice_5 - Wall 270_a - Sub:a,  !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {280e0b68-2a9d-4e81-bdfe-55afd7002d84}, !- Surface Name
@@ -3785,7 +3786,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {c8f493be-712a-4edf-9c32-4359f305110f}, !- Handle
-  Sub Surface 12,                         !- Name
+  ConfRoom_2 - Wall 090_a - Sub:a,        !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {83949fd6-fad6-427a-a7ab-72d403117a5e}, !- Surface Name
@@ -3802,7 +3803,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {9da7de18-103d-4979-8559-b7b7b7e7b61f}, !- Handle
-  Sub Surface 13,                         !- Name
+  EnclosedOffice_4 - Wall 090_a - Sub:a,  !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {49cdda99-826e-49f4-8279-10d0ed88c0e4}, !- Surface Name
@@ -3819,7 +3820,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {b3f4bcb3-2500-494f-a129-6c1eb9203b62}, !- Handle
-  Sub Surface 14,                         !- Name
+  EnclosedOffice_4 - Wall 090_a - Sub:b,  !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {49cdda99-826e-49f4-8279-10d0ed88c0e4}, !- Surface Name
@@ -3836,7 +3837,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {c7644407-44a0-4fb6-a13f-b36d2a6fad87}, !- Handle
-  Sub Surface 15,                         !- Name
+  EnclosedOffice_6 - Wall 090_a - Sub:a,  !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {69f90bcf-717c-4cab-a5eb-b4d2809222f3}, !- Surface Name
@@ -3853,7 +3854,7 @@ OS:SubSurface,
 
 OS:Surface,
   {6cdc4ece-c1a5-4ec6-a5a7-afb520668c38}, !- Handle
-  Surface 127,                            !- Name
+  Attic - Floor_j,                        !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {91cfc07c-2e46-4945-8a9f-387760fa0db8}, !- Space Name
@@ -3870,7 +3871,7 @@ OS:Surface,
 
 OS:Surface,
   {f723a610-66f0-4d1b-88ce-a17db4d7f8cb}, !- Handle
-  Surface 158,                            !- Name
+  Attic - Floor_k,                        !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {91cfc07c-2e46-4945-8a9f-387760fa0db8}, !- Space Name
@@ -3887,7 +3888,7 @@ OS:Surface,
 
 OS:Surface,
   {c3c66e04-89f4-4247-b5ca-b4eec7a74fa3}, !- Handle
-  Surface 159,                            !- Name
+  Attic - Floor_f,                        !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {91cfc07c-2e46-4945-8a9f-387760fa0db8}, !- Space Name
@@ -3904,7 +3905,7 @@ OS:Surface,
 
 OS:Surface,
   {1a625b5d-5d8a-4ee6-b260-e39f845ba39a}, !- Handle
-  Surface 160,                            !- Name
+  Attic - Floor_b,                        !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {91cfc07c-2e46-4945-8a9f-387760fa0db8}, !- Space Name
@@ -3921,7 +3922,7 @@ OS:Surface,
 
 OS:Surface,
   {14fa0dff-f30e-4fee-b3b7-359bd14584f1}, !- Handle
-  Surface 161,                            !- Name
+  Attic - Floor_l,                        !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {91cfc07c-2e46-4945-8a9f-387760fa0db8}, !- Space Name
@@ -3938,7 +3939,7 @@ OS:Surface,
 
 OS:Surface,
   {6d41292d-ebb7-44ac-9416-b73e4f06026c}, !- Handle
-  Surface 163,                            !- Name
+  Attic - Floor_m,                        !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {91cfc07c-2e46-4945-8a9f-387760fa0db8}, !- Space Name
@@ -3955,7 +3956,7 @@ OS:Surface,
 
 OS:Surface,
   {3d7a3c12-3cc5-4730-aa3d-35c9574679cc}, !- Handle
-  Surface 164,                            !- Name
+  Attic - Floor_e,                        !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {91cfc07c-2e46-4945-8a9f-387760fa0db8}, !- Space Name
@@ -3972,7 +3973,7 @@ OS:Surface,
 
 OS:Surface,
   {36448359-63b1-4d3d-9028-0b7000545b12}, !- Handle
-  Surface 165,                            !- Name
+  Attic - Floor_n,                        !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {91cfc07c-2e46-4945-8a9f-387760fa0db8}, !- Space Name
@@ -3989,7 +3990,7 @@ OS:Surface,
 
 OS:Surface,
   {b4dab7b1-41ba-4353-8641-67a06e7d1208}, !- Handle
-  Surface 167,                            !- Name
+  Attic - Floor_o,                        !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {91cfc07c-2e46-4945-8a9f-387760fa0db8}, !- Space Name
@@ -4006,7 +4007,7 @@ OS:Surface,
 
 OS:Surface,
   {77798bdf-40ff-4e21-8124-467e812aa234}, !- Handle
-  Surface 168,                            !- Name
+  Attic - Floor_p,                        !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {91cfc07c-2e46-4945-8a9f-387760fa0db8}, !- Space Name
@@ -4023,7 +4024,7 @@ OS:Surface,
 
 OS:Surface,
   {1be7b2b1-49f5-4a8c-b337-ed85754d99be}, !- Handle
-  Surface 169,                            !- Name
+  Attic - Floor_g,                        !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {91cfc07c-2e46-4945-8a9f-387760fa0db8}, !- Space Name
@@ -4040,7 +4041,7 @@ OS:Surface,
 
 OS:Surface,
   {04c3d22e-aee8-4575-b62e-3e9279661eea}, !- Handle
-  Surface 171,                            !- Name
+  Attic - Floor_d,                        !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {91cfc07c-2e46-4945-8a9f-387760fa0db8}, !- Space Name
@@ -4057,7 +4058,7 @@ OS:Surface,
 
 OS:Surface,
   {f7847d71-0251-4c1c-a099-558d08532fcc}, !- Handle
-  Surface 172,                            !- Name
+  Attic - Floor_q,                        !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {91cfc07c-2e46-4945-8a9f-387760fa0db8}, !- Space Name
@@ -4074,7 +4075,7 @@ OS:Surface,
 
 OS:Surface,
   {e5dd8aae-ae22-466d-8791-2c37ab769bd2}, !- Handle
-  Surface 173,                            !- Name
+  Attic - Floor_r,                        !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {91cfc07c-2e46-4945-8a9f-387760fa0db8}, !- Space Name
@@ -4091,7 +4092,7 @@ OS:Surface,
 
 OS:SubSurface,
   {e6a3e529-b7b6-4bc7-aa83-756e6014c10d}, !- Handle
-  Sub Surface 16,                         !- Name
+  EnclosedOffice_6 - Wall 000_a - Sub:a,  !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {44a77928-c80d-45aa-a6ea-e9dd2594e316}, !- Surface Name
@@ -4108,7 +4109,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {6bcc830f-b3c0-4de4-8859-a1c69eebbf7b}, !- Handle
-  Sub Surface 17,                         !- Name
+  OpenOffice - Wall 000_a - Sub:a,        !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {aeb313e2-f6ec-4661-93d3-69155d6058f8}, !- Surface Name
@@ -4125,7 +4126,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {d97fb31a-dfa8-4af5-8af7-b5d2d0cf47f5}, !- Handle
-  Sub Surface 18,                         !- Name
+  OpenOffice - Wall 000_a - Sub:b,        !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {aeb313e2-f6ec-4661-93d3-69155d6058f8}, !- Surface Name
@@ -4142,7 +4143,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {be0a46be-6956-44af-b902-10300cd2abc9}, !- Handle
-  Sub Surface 19,                         !- Name
+  OpenOffice - Wall 000_a - Sub:c,        !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {aeb313e2-f6ec-4661-93d3-69155d6058f8}, !- Surface Name
@@ -4159,7 +4160,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {e89a9013-0566-46fe-8359-bce190abc9ed}, !- Handle
-  Sub Surface 20,                         !- Name
+  OpenOffice - Wall 000_a - Sub:d,        !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {aeb313e2-f6ec-4661-93d3-69155d6058f8}, !- Surface Name
@@ -4176,7 +4177,7 @@ OS:SubSurface,
 
 OS:SubSurface,
   {156726be-1798-4477-9c9b-b9388ccac5d0}, !- Handle
-  Sub Surface 21,                         !- Name
+  EnclosedOffice_5 - Wall 000_a - Sub:a,  !- Name
   FixedWindow,                            !- Sub Surface Type
   ,                                       !- Construction Name
   {ac66bc26-9b47-4132-bca9-c881ec0c0200}, !- Surface Name
@@ -4193,7 +4194,7 @@ OS:SubSurface,
 
 OS:Surface,
   {7aca14a8-6fd0-48c9-ac9b-097f7148c26f}, !- Handle
-  Surface 174,                            !- Name
+  Attic - Floor_s,                        !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {91cfc07c-2e46-4945-8a9f-387760fa0db8}, !- Space Name
@@ -4210,7 +4211,7 @@ OS:Surface,
 
 OS:Surface,
   {22e7b47f-b5bc-4aa3-956b-9e7ca0925245}, !- Handle
-  Surface 133,                            !- Name
+  Attic - Floor_t,                        !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {91cfc07c-2e46-4945-8a9f-387760fa0db8}, !- Space Name
@@ -4231,7 +4232,7 @@ OS:Surface,
 
 OS:Surface,
   {8a723089-6304-4418-a3a4-48ce54e3d982}, !- Handle
-  Surface 132,                            !- Name
+  Attic - Floor_a,                        !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {91cfc07c-2e46-4945-8a9f-387760fa0db8}, !- Space Name
@@ -4252,7 +4253,7 @@ OS:Surface,
 
 OS:Surface,
   {620836cb-28ae-4b50-9e15-33c6f49ab667}, !- Handle
-  Surface 135,                            !- Name
+  Attic - Floor_u,                        !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {91cfc07c-2e46-4945-8a9f-387760fa0db8}, !- Space Name
@@ -4271,7 +4272,7 @@ OS:Surface,
 
 OS:Surface,
   {b6225bfb-9bf7-47f0-8b50-6948eeb4fe48}, !- Handle
-  Surface 8,                              !- Name
+  Attic - Floor_v,                        !- Name
   Floor,                                  !- Surface Type
   ,                                       !- Construction Name
   {91cfc07c-2e46-4945-8a9f-387760fa0db8}, !- Space Name
@@ -4368,6 +4369,7 @@ OS:SpaceType,
   ,                                       !- Default Schedule Set Name
   {0e2c7c7b-5d29-4b67-8b76-6e000891c8e2}, !- Group Rendering Name
   ,                                       !- Design Specification Outdoor Air Object Name
+  ,                                       !- Standards Template
   Office,                                 !- Standards Building Type
   SmallOffice - Attic;                    !- Standards Space Type
 
@@ -4385,6 +4387,7 @@ OS:SpaceType,
   ,                                       !- Default Schedule Set Name
   {6da57b8c-46fd-4274-b97f-db06a942dfd8}, !- Group Rendering Name
   ,                                       !- Design Specification Outdoor Air Object Name
+  ,                                       !- Standards Template
   Office,                                 !- Standards Building Type
   SmallOffice - OpenOffice;               !- Standards Space Type
 
@@ -4402,6 +4405,7 @@ OS:SpaceType,
   ,                                       !- Default Schedule Set Name
   {58ddad7a-f214-4f61-9550-8655e973894a}, !- Group Rendering Name
   ,                                       !- Design Specification Outdoor Air Object Name
+  ,                                       !- Standards Template
   Office,                                 !- Standards Building Type
   SmallOffice - ClosedOffice;             !- Standards Space Type
 
@@ -4433,6 +4437,7 @@ OS:SpaceType,
   ,                                       !- Default Schedule Set Name
   {dc376b19-b9ed-4763-82e3-b08274971093}, !- Group Rendering Name
   ,                                       !- Design Specification Outdoor Air Object Name
+  ,                                       !- Standards Template
   Office,                                 !- Standards Building Type
   SmallOffice - Storage;                  !- Standards Space Type
 
@@ -4450,6 +4455,7 @@ OS:SpaceType,
   ,                                       !- Default Schedule Set Name
   {2b050801-386a-4014-bcfb-1c0716e4f9a4}, !- Group Rendering Name
   ,                                       !- Design Specification Outdoor Air Object Name
+  ,                                       !- Standards Template
   Office,                                 !- Standards Building Type
   SmallOffice - Corridor;                 !- Standards Space Type
 
@@ -4467,6 +4473,7 @@ OS:SpaceType,
   ,                                       !- Default Schedule Set Name
   {f7e3d7f9-cc2c-421f-b786-ddb373f1e608}, !- Group Rendering Name
   ,                                       !- Design Specification Outdoor Air Object Name
+  ,                                       !- Standards Template
   Office,                                 !- Standards Building Type
   SmallOffice - Restroom;                 !- Standards Space Type
 
@@ -4484,6 +4491,7 @@ OS:SpaceType,
   ,                                       !- Default Schedule Set Name
   {b8ce435c-7c1d-4617-874e-e45d9dba881a}, !- Group Rendering Name
   ,                                       !- Design Specification Outdoor Air Object Name
+  ,                                       !- Standards Template
   Office,                                 !- Standards Building Type
   SmallOffice - Lobby;                    !- Standards Space Type
 
@@ -4501,6 +4509,7 @@ OS:SpaceType,
   ,                                       !- Default Schedule Set Name
   {a33fce9b-9840-4251-8e37-99b269931de4}, !- Group Rendering Name
   ,                                       !- Design Specification Outdoor Air Object Name
+  ,                                       !- Standards Template
   Office,                                 !- Standards Building Type
   SmallOffice - Conference;               !- Standards Space Type
 
@@ -4518,6 +4527,7 @@ OS:SpaceType,
   ,                                       !- Default Schedule Set Name
   {2f523f3e-fb20-40d6-bc4a-14b65d9eb47b}, !- Group Rendering Name
   ,                                       !- Design Specification Outdoor Air Object Name
+  ,                                       !- Standards Template
   Office,                                 !- Standards Building Type
   SmallOffice - Elec/MechRoom;            !- Standards Space Type
 
@@ -4535,6 +4545,7 @@ OS:SpaceType,
   ,                                       !- Default Schedule Set Name
   {414e245c-ae4b-4d32-a008-f307b1a150c1}, !- Group Rendering Name
   ,                                       !- Design Specification Outdoor Air Object Name
+  ,                                       !- Standards Template
   Office,                                 !- Standards Building Type
   SmallOffice - Stair;                    !- Standards Space Type
 
@@ -4558,15 +4569,21 @@ OS:ThermalZone,
   {de3971a9-e849-4805-a97a-7be3f70203e2}, !- Zone Air Inlet Port List
   {de866fca-cea3-4804-869a-71ed417596d6}, !- Zone Air Exhaust Port List
   {04be8b65-f450-48e2-9413-a488b9cc28d6}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {10b7ceda-ff7e-434c-b201-8f95e0fd50ca}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {fb843d90-d797-4a77-b3e8-f4d86a98d4cb}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {10b7ceda-ff7e-434c-b201-8f95e0fd50ca}, !- Handle
+  Port List 2,                            !- Name
+  {132e896e-3460-4ca1-b171-18930604f84f}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {6be50bab-d38e-43dd-8fea-b1864e24957c}, !- Handle
@@ -4640,15 +4657,21 @@ OS:ThermalZone,
   {f33cac3c-95d7-43d8-820a-8ef5951a6e18}, !- Zone Air Inlet Port List
   {cce51fa2-2416-4a2c-99f3-d1e8be6b96b5}, !- Zone Air Exhaust Port List
   {b7f67570-29cd-47de-badf-440f2561d65f}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {03096efe-23ff-4f4a-b2bb-40fb65157e0c}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {9b521543-28ed-45b9-8792-4fdde0561620}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {03096efe-23ff-4f4a-b2bb-40fb65157e0c}, !- Handle
+  Port List 3,                            !- Name
+  {541572cf-093b-465b-b4c4-83784046c9fd}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {b69d9d1e-1b29-4415-bed8-f13d040306b1}, !- Handle
@@ -4722,15 +4745,21 @@ OS:ThermalZone,
   {79a36102-50b3-4e3e-a1c9-57907d92836b}, !- Zone Air Inlet Port List
   {cf290fb3-e346-4223-85cb-63e861083232}, !- Zone Air Exhaust Port List
   {e3fc0ffe-b0a4-4a11-9852-514b2c297dbe}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {71fcc05d-5c4d-43d1-8c19-77f43c174204}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {7ef2b77c-c2e2-4781-89a2-427f174fab04}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {71fcc05d-5c4d-43d1-8c19-77f43c174204}, !- Handle
+  Port List 4,                            !- Name
+  {fa97304b-e496-474b-8de4-5cbd7cdc0e66}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {1644968b-57cf-4753-bfa5-c2343754aa84}, !- Handle
@@ -4804,15 +4833,21 @@ OS:ThermalZone,
   {08ef9771-be05-45c3-98e2-a83d7d5eb4b1}, !- Zone Air Inlet Port List
   {06a8464b-518e-461f-8101-09c415ebec99}, !- Zone Air Exhaust Port List
   {e2173fef-9e6c-4a5b-8044-c6d723bade0a}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {7d2729b2-6a2c-44b7-a249-81c575c7d6e4}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {6fd1a8c6-318e-4eab-a4dc-872d9f03900a}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {7d2729b2-6a2c-44b7-a249-81c575c7d6e4}, !- Handle
+  Port List 5,                            !- Name
+  {166dbe5b-17b8-4b2a-ad2f-2f6838b5e81a}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {0819b756-3325-4f74-b9c2-f61bd832f92d}, !- Handle
@@ -4886,15 +4921,21 @@ OS:ThermalZone,
   {92afed1a-0368-46fc-8dba-b3b0e52a2fd3}, !- Zone Air Inlet Port List
   {e3190ce8-df64-4a61-bc89-f13254ee67d5}, !- Zone Air Exhaust Port List
   {b4c46987-2ac7-4179-b5b9-1921f1410eaf}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {a6c6bf0a-1f1c-40f7-a779-547350011147}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {7cf67187-7c9b-4177-ab02-589fe8712c36}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {a6c6bf0a-1f1c-40f7-a779-547350011147}, !- Handle
+  Port List 6,                            !- Name
+  {ffd0e311-b6ac-4c76-aacb-6d1c70316b6f}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {8a6e5b0e-6435-4af5-9354-82a2d236b555}, !- Handle
@@ -4968,15 +5009,21 @@ OS:ThermalZone,
   {16e732c3-0aee-4db9-b495-c5e6870f278d}, !- Zone Air Inlet Port List
   {971a41a5-ee0d-4327-99dc-7a5b2ecd1537}, !- Zone Air Exhaust Port List
   {68611bea-e7e4-48d4-a616-137d6a5c52ce}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {70bf94ef-d91c-4210-aec6-e0714a22ad91}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {b919fcb4-0510-489b-9238-f3021a2f054e}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {70bf94ef-d91c-4210-aec6-e0714a22ad91}, !- Handle
+  Port List 7,                            !- Name
+  {4d2e9b92-5756-4af0-934f-da299e4677fe}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {0d986d3d-a50a-4132-8722-afd4353d995e}, !- Handle
@@ -5050,15 +5097,21 @@ OS:ThermalZone,
   {ce32c098-19fe-47c7-be4a-ce6d637b6cc2}, !- Zone Air Inlet Port List
   {a3e31ff5-9cb1-447b-9025-dc4c7df1c244}, !- Zone Air Exhaust Port List
   {1a1ec2d6-8f78-4149-a83f-ed7cadf5b4cd}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {36d2e40b-1298-41ab-b0aa-374512e34741}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {1ae1ef9f-1341-4ba6-8f5b-7e5e0a2a0116}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {36d2e40b-1298-41ab-b0aa-374512e34741}, !- Handle
+  Port List 8,                            !- Name
+  {84f4ba19-5af9-422e-b7a0-42df2c971f45}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {de13729f-e744-4c8a-a5bd-06251dd9f86f}, !- Handle
@@ -5132,15 +5185,21 @@ OS:ThermalZone,
   {3159db03-8e7e-4ea8-936e-aada75be162b}, !- Zone Air Inlet Port List
   {2d09dacc-71b5-4a0c-b07a-462ff45218db}, !- Zone Air Exhaust Port List
   {891370f7-8ccd-49d9-97ec-e4a162e0679e}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {d21e3c87-33b3-486c-88bc-36286df70c9c}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {48a190d5-3200-4b8c-a089-b000e8e0a1d1}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {d21e3c87-33b3-486c-88bc-36286df70c9c}, !- Handle
+  Port List 9,                            !- Name
+  {ca902722-b1ba-43bb-97a2-6dabf5a0480a}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {df0f2dba-e86b-4bfa-8795-2ffb51ca5aa8}, !- Handle
@@ -5214,15 +5273,21 @@ OS:ThermalZone,
   {cacb88ba-456f-4263-8d3c-e1f0fe612e10}, !- Zone Air Inlet Port List
   {b6c97b0e-47f3-4b8c-9dc4-36156055f985}, !- Zone Air Exhaust Port List
   {889d95e0-64c5-41b1-b570-d083671ec0b8}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {af095d58-5f89-4884-988c-db96b8c33c3a}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {91da9dc2-8767-41f7-8ec9-00516611830e}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {af095d58-5f89-4884-988c-db96b8c33c3a}, !- Handle
+  Port List 10,                           !- Name
+  {1489d0fa-7556-47d9-94e4-9d986cef89b0}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {334cf0bc-70e1-41c3-ac0c-70746c0fd7c7}, !- Handle
@@ -5296,15 +5361,21 @@ OS:ThermalZone,
   {e686df55-ba6b-4d75-9f03-31cda793213b}, !- Zone Air Inlet Port List
   {5160bf5e-4b28-4427-9b8a-485ef917f655}, !- Zone Air Exhaust Port List
   {da70c9c8-516a-408c-a407-437f1d294a62}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {c7d5693d-1cbd-4941-8d60-d5929c35f359}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {33c6a60e-7c96-4c92-937b-699e08789977}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {c7d5693d-1cbd-4941-8d60-d5929c35f359}, !- Handle
+  Port List 11,                           !- Name
+  {9f6dc97c-a616-4611-bf7e-2b5d04ef1b87}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {66dbe8d7-71b4-4431-bae1-ddd51078d6e0}, !- Handle
@@ -5378,15 +5449,21 @@ OS:ThermalZone,
   {386d00a2-9605-4710-8bc0-de2c89fed010}, !- Zone Air Inlet Port List
   {c06056d1-7c03-4b9b-b80b-65dbb373c259}, !- Zone Air Exhaust Port List
   {098b6553-f29a-4df4-a637-41fd501a3b77}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {ad5b08d0-7ff6-423b-834c-85d3a5d1b336}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {3bb26108-d07c-450f-9280-f590df9b1b17}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {ad5b08d0-7ff6-423b-834c-85d3a5d1b336}, !- Handle
+  Port List 12,                           !- Name
+  {f4c00aa9-d18a-4472-b254-a3418c5bb367}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {4493e53b-de92-49dc-895c-07bbf896b366}, !- Handle
@@ -5460,15 +5537,21 @@ OS:ThermalZone,
   {8a6c6a01-9188-4088-a5cf-32d26e0584fd}, !- Zone Air Inlet Port List
   {4c44a190-05ac-4d13-a6bf-9d9bd6bbb9e6}, !- Zone Air Exhaust Port List
   {7eab91a1-22c6-41e5-a07a-dc77e4096715}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {e29ecf84-21a4-49dd-8d5f-4f73a69ca8c9}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {128a4a11-ef66-4257-8578-f1359616a6c2}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {e29ecf84-21a4-49dd-8d5f-4f73a69ca8c9}, !- Handle
+  Port List 13,                           !- Name
+  {52117b42-1370-4673-9c73-c0bcd5bb24bb}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {b2fad2f1-7b7e-4982-a257-3a9b5a990b71}, !- Handle
@@ -5542,15 +5625,21 @@ OS:ThermalZone,
   {d88b135b-b9a4-4291-88d9-b9d58156ede9}, !- Zone Air Inlet Port List
   {588df299-fbef-4e60-a404-8c23678073c2}, !- Zone Air Exhaust Port List
   {e671ca16-8a63-456c-aff0-ae0e82c0e6d2}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {f7fb01a6-a4e7-458c-8162-5931ed726911}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {ea7e22f5-eec3-4254-8c84-d0eb6de14229}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {f7fb01a6-a4e7-458c-8162-5931ed726911}, !- Handle
+  Port List 14,                           !- Name
+  {32636def-d15a-4883-8161-cd5ad7dd2b36}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {0a7a5246-0489-4908-ad5e-738dd67cfef0}, !- Handle
@@ -5624,15 +5713,21 @@ OS:ThermalZone,
   {941f6e0d-c20c-487d-9b47-7d91d38b93d9}, !- Zone Air Inlet Port List
   {6a012d53-02f6-40f5-be6d-f8e7be7e38ef}, !- Zone Air Exhaust Port List
   {4e9b1bf5-8c3b-4335-81ca-6f8cdddadcae}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {8d1dfc05-9c1b-45de-a7bd-d88031c013f5}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {ea832826-bb17-4476-9008-0dbf22bcf30f}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {8d1dfc05-9c1b-45de-a7bd-d88031c013f5}, !- Handle
+  Port List 15,                           !- Name
+  {68fe4b0d-55fe-43d0-8f41-6a2f0ae8d450}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {042cb9ff-a0c3-43c9-a58a-d6351e3832ee}, !- Handle
@@ -5706,15 +5801,21 @@ OS:ThermalZone,
   {8c5f95c7-2d99-4112-ba2c-52d8c226be18}, !- Zone Air Inlet Port List
   {43ccd9dc-1a5c-4a66-998b-0f82378870d0}, !- Zone Air Exhaust Port List
   {fb6c30f1-d3a8-4a6b-883a-9689a8ff7138}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {10426634-829a-4f6f-94a1-33c09bb66c10}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {79b66b13-daab-4154-9e62-22dd0acb5e7e}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {10426634-829a-4f6f-94a1-33c09bb66c10}, !- Handle
+  Port List 16,                           !- Name
+  {486b05ce-db34-4686-ab4b-b76e49c45c9d}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {60a2da78-fce8-41d7-b713-fbe519df11f3}, !- Handle
@@ -5788,15 +5889,21 @@ OS:ThermalZone,
   {dc2c4f39-ae3f-4e4c-acfe-b3e14de64c17}, !- Zone Air Inlet Port List
   {e5ca18a6-f070-4fbe-9445-69f67595570d}, !- Zone Air Exhaust Port List
   {a5d995fb-2284-4b4c-a956-704101a68c0e}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {bd808ed7-5712-40fd-b1a5-efebc7f13427}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {db12c58e-67bb-410a-8c2c-2abfb9614152}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {bd808ed7-5712-40fd-b1a5-efebc7f13427}, !- Handle
+  Port List 1,                            !- Name
+  {6a2e89bf-2b40-4bda-9f96-8fa1ed1ee493}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {5c4e4093-1e12-4358-9416-07ae48a782b3}, !- Handle
@@ -5870,15 +5977,21 @@ OS:ThermalZone,
   {7674c407-bec2-457b-b440-4aa76d7fb98d}, !- Zone Air Inlet Port List
   {c8de2e49-6bd5-44f1-ac64-5cdae4c7a206}, !- Zone Air Exhaust Port List
   {e47a3887-c69a-4767-9544-b63906c568e6}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {169d011e-1b13-463a-8e8b-cae854c3db6d}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {5fe46aa2-6e87-49eb-99a2-a2f5f629ed9f}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {169d011e-1b13-463a-8e8b-cae854c3db6d}, !- Handle
+  Port List 17,                           !- Name
+  {496d108e-1882-4d79-b31d-e795e63aaf92}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {c4d327e0-4850-4cbd-9f79-e10ec37c3339}, !- Handle
@@ -5952,15 +6065,21 @@ OS:ThermalZone,
   {2e97558b-0d3b-4366-bdd1-2c7f0bdff29d}, !- Zone Air Inlet Port List
   {3206a85b-0bbc-4325-baaa-d3d35ac8c8c3}, !- Zone Air Exhaust Port List
   {b34fec91-51f6-4db0-80ec-2ee8708c51df}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {8485e0ab-f6bd-4e18-b670-1011f4e85ab8}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
   ,                                       !- Illuminance Map Name
-  ,                                       !- Group Rendering Name
+  {f58ecb07-a229-405b-ba69-035e990fc943}, !- Group Rendering Name
   ,                                       !- Thermostat Name
   No;                                     !- Use Ideal Air Loads
+
+OS:PortList,
+  {8485e0ab-f6bd-4e18-b670-1011f4e85ab8}, !- Handle
+  Port List 18,                           !- Name
+  {15dcc532-3d37-4a26-b9e5-21dfaa066f54}, !- HVAC Component
+  ;                                       !- Port 1
 
 OS:Node,
   {286db087-9ca8-496e-a438-05b3592641ac}, !- Handle
@@ -6020,4 +6139,130 @@ OS:ZoneHVAC:EquipmentList,
   {962e44d0-d5f2-485a-a7d2-af2302fcbe9f}, !- Handle
   Zone HVAC Equipment List 18,            !- Name
   {15dcc532-3d37-4a26-b9e5-21dfaa066f54}; !- Thermal Zone
+
+OS:Rendering:Color,
+  {ea7e22f5-eec3-4254-8c84-d0eb6de14229}, !- Handle
+  Rendering Color 72,                     !- Name
+  255,                                    !- Rendering Red Value
+  0,                                      !- Rendering Green Value
+  255;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {128a4a11-ef66-4257-8578-f1359616a6c2}, !- Handle
+  Rendering Color 73,                     !- Name
+  245,                                    !- Rendering Red Value
+  245,                                    !- Rendering Green Value
+  220;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {ea832826-bb17-4476-9008-0dbf22bcf30f}, !- Handle
+  Rendering Color 74,                     !- Name
+  173,                                    !- Rendering Red Value
+  255,                                    !- Rendering Green Value
+  47;                                     !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {3bb26108-d07c-450f-9280-f590df9b1b17}, !- Handle
+  Rendering Color 75,                     !- Name
+  255,                                    !- Rendering Red Value
+  0,                                      !- Rendering Green Value
+  255;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {79b66b13-daab-4154-9e62-22dd0acb5e7e}, !- Handle
+  Rendering Color 76,                     !- Name
+  255,                                    !- Rendering Red Value
+  228,                                    !- Rendering Green Value
+  225;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {33c6a60e-7c96-4c92-937b-699e08789977}, !- Handle
+  Rendering Color 77,                     !- Name
+  0,                                      !- Rendering Red Value
+  206,                                    !- Rendering Green Value
+  209;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {db12c58e-67bb-410a-8c2c-2abfb9614152}, !- Handle
+  Rendering Color 78,                     !- Name
+  123,                                    !- Rendering Red Value
+  104,                                    !- Rendering Green Value
+  238;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {91da9dc2-8767-41f7-8ec9-00516611830e}, !- Handle
+  Rendering Color 79,                     !- Name
+  255,                                    !- Rendering Red Value
+  218,                                    !- Rendering Green Value
+  185;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {5fe46aa2-6e87-49eb-99a2-a2f5f629ed9f}, !- Handle
+  Rendering Color 80,                     !- Name
+  186,                                    !- Rendering Red Value
+  85,                                     !- Rendering Green Value
+  211;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {48a190d5-3200-4b8c-a089-b000e8e0a1d1}, !- Handle
+  Rendering Color 81,                     !- Name
+  216,                                    !- Rendering Red Value
+  191,                                    !- Rendering Green Value
+  216;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {1ae1ef9f-1341-4ba6-8f5b-7e5e0a2a0116}, !- Handle
+  Rendering Color 82,                     !- Name
+  176,                                    !- Rendering Red Value
+  196,                                    !- Rendering Green Value
+  222;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {fb843d90-d797-4a77-b3e8-f4d86a98d4cb}, !- Handle
+  Rendering Color 83,                     !- Name
+  199,                                    !- Rendering Red Value
+  21,                                     !- Rendering Green Value
+  133;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {9b521543-28ed-45b9-8792-4fdde0561620}, !- Handle
+  Rendering Color 84,                     !- Name
+  189,                                    !- Rendering Red Value
+  183,                                    !- Rendering Green Value
+  107;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {7ef2b77c-c2e2-4781-89a2-427f174fab04}, !- Handle
+  Rendering Color 85,                     !- Name
+  255,                                    !- Rendering Red Value
+  255,                                    !- Rendering Green Value
+  0;                                      !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {6fd1a8c6-318e-4eab-a4dc-872d9f03900a}, !- Handle
+  Rendering Color 86,                     !- Name
+  253,                                    !- Rendering Red Value
+  245,                                    !- Rendering Green Value
+  230;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {7cf67187-7c9b-4177-ab02-589fe8712c36}, !- Handle
+  Rendering Color 87,                     !- Name
+  160,                                    !- Rendering Red Value
+  82,                                     !- Rendering Green Value
+  45;                                     !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {b919fcb4-0510-489b-9238-f3021a2f054e}, !- Handle
+  Rendering Color 88,                     !- Name
+  0,                                      !- Rendering Red Value
+  0,                                      !- Rendering Green Value
+  139;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {f58ecb07-a229-405b-ba69-035e990fc943}, !- Handle
+  Rendering Color 89,                     !- Name
+  0,                                      !- Rendering Red Value
+  0,                                      !- Rendering Green Value
+  128;                                    !- Rendering Blue Value
 


### PR DESCRIPTION
Hi Matt,

Large office detailed had a handful of small surfaces causing issues when testing the ground FC factor updates. Upon inspection, these surfaces had incorrect outside boundary conditions (see attached screenshot). They were incorrectly flagged as having an outside boundary condition to Ground. I corrected them in this pull request.


![LargeOfficeDetailedBuggedSurfaces](https://user-images.githubusercontent.com/8460895/80543230-7a5bad80-897c-11ea-9256-79cc2cf970a9.png)
