### PR TITLE
[90.1-AppG] Remove daylighting control objects in baseline

### DIFF
--- a/lib/openstudio-standards/standards/Standards.Model.rb
+++ b/lib/openstudio-standards/standards/Standards.Model.rb
@@ -88,11 +88,11 @@ class Standard
       end
     end
 
-    # Add daylighting controls to each space
-    if /prm/i =~ template
-      model_remove_daylighting_controls(model)
-    else
-      model.getSpaces.sort.each do |space|
+    # Add or remove daylighting controls to each space
+    model.getSpaces.sort.each do |space|
+      if /prm/i =~ template
+        space_remove_daylighting_controls(space)
+      else
         added = space_add_daylighting_controls(space, false, false)
       end
     end

--- a/lib/openstudio-standards/standards/Standards.Model.rb
+++ b/lib/openstudio-standards/standards/Standards.Model.rb
@@ -40,7 +40,6 @@ class Standard
     # Perform a sizing run of the proposed model.
     # Intend is to get individual space load to determine each space's
     # conditioning type: conditioned, unconditioned, semiheated.
-    puts model_create_prm_baseline_building_requires_proposed_model_sizing_run(model)
     if model_create_prm_baseline_building_requires_proposed_model_sizing_run(model)
       if model_run_sizing_run(model, "#{sizing_run_dir}/SR_PROP") == false
         return false
@@ -89,6 +88,8 @@ class Standard
     end
 
     # Add or remove daylighting controls to each space
+    # Add daylighting controls for 90.1-2013 and prior
+    # Remove daylighting control for 90.1-PRM-2019 and onward
     model.getSpaces.sort.each do |space|
       if /prm/i =~ template
         space_remove_daylighting_controls(space)

--- a/lib/openstudio-standards/standards/Standards.Space.rb
+++ b/lib/openstudio-standards/standards/Standards.Space.rb
@@ -780,6 +780,18 @@ class Standard
     return skylight_effective_aperture
   end
 
+  # Removes daylighting controls
+  def space_remove_daylighting_controls(space)
+    # Retrieves daylighting control objects
+    existing_daylighting_controls = space.daylightingControls
+    unless existing_daylighting_controls.empty?
+      existing_daylighting_controls.each(&:remove)
+      OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.Space', "For #{space.name}, removed #{existing_daylighting_controls.size} existing daylight controls before adding new controls.")
+      return true
+    end
+    return false
+  end
+
   # Adds daylighting controls (sidelighting and toplighting) per the template
   # @note This method is super complicated because of all the polygon/geometry math required.
   #   and therefore may not return perfect results.  However, it works well in most tested
@@ -809,8 +821,7 @@ class Standard
     existing_daylighting_controls = space.daylightingControls
     unless existing_daylighting_controls.empty?
       if remove_existing_controls
-        existing_daylighting_controls.each(&:remove)
-        OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.Space', "For #{space.name}, removed #{existing_daylighting_controls.size} existing daylight controls before adding new controls.")
+        space_remove_daylighting_controls(space)
       else
         OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.Space', "For #{space.name}, daylight controls were already present, no additional controls added.")
         return false

--- a/test/90_1_prm/test_create_prototype_baseline_building.rb
+++ b/test/90_1_prm/test_create_prototype_baseline_building.rb
@@ -219,6 +219,11 @@ class DOEPrototypeBaseline < CreateDOEPrototypeBuildingTest
         has_res_goal = hasres_values[building_type]
         assert(has_res == has_res_goal, "Failure to set space_residential? for #{building_type}, #{template}, #{climate_zone}.")
 
+        # Check the model include daylighting control objects
+        model_baseline.getSpaces.sort.each do |space|
+          existing_daylighting_controls = space.daylightingControls
+          assert(existing_daylighting_controls.empty?, "The baseline model for the #{building_type}-#{template} in #{climate_zone} has daylighting control.")
+        end
       end
   end
 end


### PR DESCRIPTION
Proposed changes remove all daylighting control objects for the 90.1-2019 PRM appendix G baseline and onward. Test was updated accordingly.