### PR TITLE
always reassign limits on temperature schedule limits to match default

### DIFF
--- a/lib/openstudio-standards/standards/Standards.Model.rb
+++ b/lib/openstudio-standards/standards/Standards.Model.rb
@@ -1993,47 +1993,54 @@ class Standard
       schedule_type_limits = model.getScheduleTypeLimitsByName(standard_sch_type_limit)
       if !schedule_type_limits.empty?
         schedule_type_limits = schedule_type_limits.get
+        if schedule_type_limits.name.to_s.downcase == 'temperature'
+          schedule_type_limits.setName('Temperature')
+          schedule_type_limits.setLowerLimitValue(0.0)
+          schedule_type_limits.setUpperLimitValue(100.0)
+          schedule_type_limits.setNumericType('Continuous')
+          schedule_type_limits.setUnitType('Temperature')
+        end
       else
         case standard_sch_type_limit.downcase
           when 'temperature'
             schedule_type_limits = OpenStudio::Model::ScheduleTypeLimits.new(model)
-            schedule_type_limits.setName("Temperature")
+            schedule_type_limits.setName('Temperature')
             schedule_type_limits.setLowerLimitValue(0.0)
             schedule_type_limits.setUpperLimitValue(100.0)
-            schedule_type_limits.setNumericType("Continuous")
-            schedule_type_limits.setUnitType("Temperature")
+            schedule_type_limits.setNumericType('Continuous')
+            schedule_type_limits.setUnitType('Temperature')
 
           when 'humidity ratio'
             schedule_type_limits = OpenStudio::Model::ScheduleTypeLimits.new(model)
-            schedule_type_limits.setName("Humidity Ratio")
+            schedule_type_limits.setName('Humidity Ratio')
             schedule_type_limits.setLowerLimitValue(0.0)
             schedule_type_limits.setUpperLimitValue(0.3)
-            schedule_type_limits.setNumericType("Continuous")
-            schedule_type_limits.setUnitType("Dimensionless")
+            schedule_type_limits.setNumericType('Continuous')
+            schedule_type_limits.setUnitType('Dimensionless')
 
           when 'fraction', 'fractional'
             schedule_type_limits = OpenStudio::Model::ScheduleTypeLimits.new(model)
-            schedule_type_limits.setName("Fraction")
+            schedule_type_limits.setName('Fraction')
             schedule_type_limits.setLowerLimitValue(0.0)
             schedule_type_limits.setUpperLimitValue(1.0)
-            schedule_type_limits.setNumericType("Continuous")
-            schedule_type_limits.setUnitType("Dimensionless")
+            schedule_type_limits.setNumericType('Continuous')
+            schedule_type_limits.setUnitType('Dimensionless')
 
           when 'onoff'
             schedule_type_limits = OpenStudio::Model::ScheduleTypeLimits.new(model)
-            schedule_type_limits.setName("OnOff")
+            schedule_type_limits.setName('OnOff')
             schedule_type_limits.setLowerLimitValue(0)
             schedule_type_limits.setUpperLimitValue(1)
-            schedule_type_limits.setNumericType("Discrete")
-            schedule_type_limits.setUnitType("Availability")
+            schedule_type_limits.setNumericType('Discrete')
+            schedule_type_limits.setUnitType('Availability')
 
           when 'activity'
             schedule_type_limits = OpenStudio::Model::ScheduleTypeLimits.new(model)
-            schedule_type_limits.setName("Activity")
+            schedule_type_limits.setName('Activity')
             schedule_type_limits.setLowerLimitValue(70.0)
             schedule_type_limits.setUpperLimitValue(1000.0)
-            schedule_type_limits.setNumericType("Continuous")
-            schedule_type_limits.setUnitType("ActivityLevel")
+            schedule_type_limits.setNumericType('Continuous')
+            schedule_type_limits.setUnitType('ActivityLevel')
         else
           OpenStudio.logFree(OpenStudio::Error, 'openstudio.standards.Model', "Invalid standard_sch_type_limit for method model_add_schedule_type_limits.")
         end

--- a/lib/openstudio-standards/standards/Standards.Model.rb
+++ b/lib/openstudio-standards/standards/Standards.Model.rb
@@ -1994,7 +1994,6 @@ class Standard
       if !schedule_type_limits.empty?
         schedule_type_limits = schedule_type_limits.get
         if schedule_type_limits.name.to_s.downcase == 'temperature'
-          schedule_type_limits.setName('Temperature')
           schedule_type_limits.resetLowerLimitValue
           schedule_type_limits.resetUpperLimitValue
           schedule_type_limits.setNumericType('Continuous')

--- a/lib/openstudio-standards/standards/Standards.Model.rb
+++ b/lib/openstudio-standards/standards/Standards.Model.rb
@@ -1995,8 +1995,8 @@ class Standard
         schedule_type_limits = schedule_type_limits.get
         if schedule_type_limits.name.to_s.downcase == 'temperature'
           schedule_type_limits.setName('Temperature')
-          schedule_type_limits.setLowerLimitValue(0.0)
-          schedule_type_limits.setUpperLimitValue(100.0)
+          schedule_type_limits.resetLowerLimitValue
+          schedule_type_limits.resetUpperLimitValue
           schedule_type_limits.setNumericType('Continuous')
           schedule_type_limits.setUnitType('Temperature')
         end


### PR DESCRIPTION
This gets the exisiting schedule limits type in the model and resets the limits to the openstudio-standards default.

This will avoid issue #821 some users were facing when using the create baseline building measure.  If the schedule type limits was already defined, the model would not make a new one, but this may cause a failure if the baseline system included a hot water loop with temperatures above the baseline models limits.


