### PR TITLE
move climate zone to within space_daylighting_control_required? method

### DIFF
--- a/lib/openstudio-standards/prototypes/common/buildings/Prototype.Hospital.rb
+++ b/lib/openstudio-standards/prototypes/common/buildings/Prototype.Hospital.rb
@@ -246,7 +246,7 @@ module Hospital
     end
   end
 
-  def model_add_daylighting_controls(model, climate_zone)
+  def model_add_daylighting_controls(model)
     space_names = ['Office1_Flr_5', 'Office3_Flr_5', 'Lobby_Records_Flr_1']
     space_names.each do |space_name|
       space = model.getSpaceByName(space_name).get

--- a/lib/openstudio-standards/prototypes/common/buildings/Prototype.LargeHotel.rb
+++ b/lib/openstudio-standards/prototypes/common/buildings/Prototype.LargeHotel.rb
@@ -167,7 +167,7 @@ module LargeHotel
   end
 
   # Add the daylighting controls for lobby, cafe, dinning and banquet
-  def model_add_daylighting_controls(model, climate_zone)
+  def model_add_daylighting_controls(model)
     space_names = ['Banquet_Flr_6', 'Dining_Flr_6', 'Cafe_Flr_1', 'Lobby_Flr_1']
     space_names.each do |space_name|
       space = model.getSpaceByName(space_name).get

--- a/lib/openstudio-standards/prototypes/common/objects/Prototype.Model.rb
+++ b/lib/openstudio-standards/prototypes/common/objects/Prototype.Model.rb
@@ -75,7 +75,7 @@ Standard.class_eval do
     # Add daylighting controls per standard
     # only four zones in large hotel have daylighting controls
     # todo: YXC to merge to the main function
-    model_add_daylighting_controls(model, climate_zone)
+    model_add_daylighting_controls(model)
     model_custom_daylighting_tweaks(building_type, climate_zone, @prototype_input, model)
     model_update_exhaust_fan_efficiency(model)
     model_update_fan_efficiency(model)

--- a/lib/openstudio-standards/standards/Standards.Model.rb
+++ b/lib/openstudio-standards/standards/Standards.Model.rb
@@ -69,7 +69,7 @@ class Standard
 
     # Add daylighting controls to each space
     model.getSpaces.sort.each do |space|
-      added = space_add_daylighting_controls(space, false, false, climate_zone)
+      added = space_add_daylighting_controls(space, false, false)
     end
 
     OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.Model', '*** Applying Baseline Constructions ***')
@@ -1549,12 +1549,12 @@ class Standard
   end
 
   # Applies daylighting controls to each space in the model per the standard.
-  def model_add_daylighting_controls(model, climate_zone)
+  def model_add_daylighting_controls(model)
     OpenStudio.logFree(OpenStudio::Info, 'openstudio.model.Model', 'Started adding daylighting controls.')
 
     # Add daylighting controls to each space
     model.getSpaces.sort.each do |space|
-      added = space_add_daylighting_controls(space, false, false, climate_zone)
+      added = space_add_daylighting_controls(space, false, false)
     end
 
     OpenStudio.logFree(OpenStudio::Info, 'openstudio.model.Model', 'Finished adding daylighting controls.')

--- a/lib/openstudio-standards/standards/Standards.Space.rb
+++ b/lib/openstudio-standards/standards/Standards.Space.rb
@@ -801,7 +801,7 @@ class Standard
   # @todo stop skipping non-horizontal roofs
   # @todo Determine the illuminance setpoint for the controls based on space type
   # @todo rotate sensor to face window (only needed for glare calcs)
-  def space_add_daylighting_controls(space, remove_existing_controls, draw_daylight_areas_for_debugging = false, climate_zone)
+  def space_add_daylighting_controls(space, remove_existing_controls, draw_daylight_areas_for_debugging = false)
     OpenStudio.logFree(OpenStudio::Debug, 'openstudio.standards.Space', "******For #{space.name}, adding daylight controls.")
 
     # Check for existing daylighting controls
@@ -843,7 +843,7 @@ class Standard
     areas = space_daylighted_areas(space, draw_daylight_areas_for_debugging)
 
     # Determine the type of daylighting controls required
-    req_top_ctrl, req_pri_ctrl, req_sec_ctrl = space_daylighting_control_required?(space, areas, climate_zone)
+    req_top_ctrl, req_pri_ctrl, req_sec_ctrl = space_daylighting_control_required?(space, areas)
 
     # Stop here if no controls are required
     if !req_top_ctrl && !req_pri_ctrl && !req_sec_ctrl
@@ -1052,8 +1052,7 @@ class Standard
                                                                                                              sorted_skylights,
                                                                                                              req_top_ctrl,
                                                                                                              req_pri_ctrl,
-                                                                                                             req_sec_ctrl,
-                                                                                                             climate_zone)
+                                                                                                             req_sec_ctrl)
 
     # Further adjust the sensor controlled fraction for the three
     # office prototypes based on assumptions about geometry that is not explicitly
@@ -1188,7 +1187,7 @@ class Standard
   # @param space [OpenStudio::Model::Space] the space in question
   # @param areas [Hash] a hash of daylighted areas
   # @return [Array<Bool>] req_top_ctrl, req_pri_ctrl, req_sec_ctrl
-  def space_daylighting_control_required?(space, areas, climate_zone)
+  def space_daylighting_control_required?(space, areas)
     req_top_ctrl = false
     req_pri_ctrl = false
     req_sec_ctrl = false
@@ -1208,8 +1207,7 @@ class Standard
                                               sorted_skylights,
                                               req_top_ctrl,
                                               req_pri_ctrl,
-                                              req_sec_ctrl,
-                                              climate_zone)
+                                              req_sec_ctrl)
     sensor_1_frac = 0.0
     sensor_2_frac = 0.0
     sensor_1_window = nil

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2010/ashrae_90_1_2010.Space.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2010/ashrae_90_1_2010.Space.rb
@@ -20,7 +20,7 @@ class ASHRAE9012010 < ASHRAE901
   # @param space [OpenStudio::Model::Space] the space in question
   # @param areas [Hash] a hash of daylighted areas
   # @return [Array<Bool>] req_top_ctrl, req_pri_ctrl, req_sec_ctrl
-  def space_daylighting_control_required?(space, areas, climate_zone)
+  def space_daylighting_control_required?(space, areas)
     req_top_ctrl = true
     req_pri_ctrl = true
     req_sec_ctrl = false
@@ -106,8 +106,7 @@ class ASHRAE9012010 < ASHRAE901
                                               sorted_skylights,
                                               req_top_ctrl,
                                               req_pri_ctrl,
-                                              req_sec_ctrl,
-                                              climate_zone)
+                                              req_sec_ctrl)
     sensor_1_frac = 0.0
     sensor_2_frac = 0.0
     sensor_1_window = nil
@@ -115,6 +114,9 @@ class ASHRAE9012010 < ASHRAE901
 
     # Get the area of the space
     space_area_m2 = space.floorArea
+
+    # get the climate zone
+    climate_zone = model_standards_climate_zone(space.model)
 
     if req_top_ctrl && req_pri_ctrl
       # Sensor 1 controls toplighted area

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2013/ashrae_90_1_2013.Space.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2013/ashrae_90_1_2013.Space.rb
@@ -20,7 +20,7 @@ class ASHRAE9012013 < ASHRAE901
   # @param space [OpenStudio::Model::Space] the space in question
   # @param areas [Hash] a hash of daylighted areas
   # @return [Array<Bool>] req_top_ctrl, req_pri_ctrl, req_sec_ctrl
-  def space_daylighting_control_required?(space, areas, climate_zone)
+  def space_daylighting_control_required?(space, areas)
     req_top_ctrl = true
     req_pri_ctrl = true
     req_sec_ctrl = true
@@ -111,8 +111,7 @@ class ASHRAE9012013 < ASHRAE901
                                               sorted_skylights,
                                               req_top_ctrl,
                                               req_pri_ctrl,
-                                              req_sec_ctrl,
-                                              climate_zone)
+                                              req_sec_ctrl)
     sensor_1_frac = 0.0
     sensor_2_frac = 0.0
     sensor_1_window = nil
@@ -120,6 +119,9 @@ class ASHRAE9012013 < ASHRAE901
 
     # Get the area of the space
     space_area_m2 = space.floorArea
+
+    # get the climate zone
+    climate_zone = model_standards_climate_zone(space.model)
 
     if req_top_ctrl && req_pri_ctrl && req_sec_ctrl
       # Sensor 1 controls toplighted area

--- a/lib/openstudio-standards/standards/ashrae_90_1/nrel_zne_ready_2017/nrel_zne_ready_2017.Space.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/nrel_zne_ready_2017/nrel_zne_ready_2017.Space.rb
@@ -20,7 +20,7 @@ class NRELZNEReady2017 < ASHRAE901
   # @param space [OpenStudio::Model::Space] the space in question
   # @param areas [Hash] a hash of daylighted areas
   # @return [Array<Bool>] req_top_ctrl, req_pri_ctrl, req_sec_ctrl
-  def space_daylighting_control_required?(space, areas, climate_zone)
+  def space_daylighting_control_required?(space, areas)
     req_top_ctrl = true
     req_pri_ctrl = true
     req_sec_ctrl = true
@@ -88,8 +88,7 @@ class NRELZNEReady2017 < ASHRAE901
                                               sorted_skylights,
                                               req_top_ctrl,
                                               req_pri_ctrl,
-                                              req_sec_ctrl,
-                                              climate_zone)
+                                              req_sec_ctrl)
     sensor_1_frac = 0.0
     sensor_2_frac = 0.0
     sensor_1_window = nil

--- a/lib/openstudio-standards/standards/ashrae_90_1/ze_aedg_multifamily/ze_aedg_multifamily.Space.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ze_aedg_multifamily/ze_aedg_multifamily.Space.rb
@@ -20,7 +20,7 @@ class ZEAEDGMultifamily < ASHRAE901
   # @param space [OpenStudio::Model::Space] the space in question
   # @param areas [Hash] a hash of daylighted areas
   # @return [Array<Bool>] req_top_ctrl, req_pri_ctrl, req_sec_ctrl
-  def space_daylighting_control_required?(space, areas, climate_zone)
+  def space_daylighting_control_required?(space, areas)
     req_top_ctrl = true
     req_pri_ctrl = true
     req_sec_ctrl = true
@@ -88,8 +88,7 @@ class ZEAEDGMultifamily < ASHRAE901
                                               sorted_skylights,
                                               req_top_ctrl,
                                               req_pri_ctrl,
-                                              req_sec_ctrl,
-                                              climate_zone)
+                                              req_sec_ctrl)
     sensor_1_frac = 0.0
     sensor_2_frac = 0.0
     sensor_1_window = nil

--- a/lib/openstudio-standards/standards/deer/deer_2014/deer_2014.Space.rb
+++ b/lib/openstudio-standards/standards/deer/deer_2014/deer_2014.Space.rb
@@ -20,7 +20,7 @@ class DEER2014 < DEER
   # @param space [OpenStudio::Model::Space] the space in question
   # @param areas [Hash] a hash of daylighted areas
   # @return [Array<Bool>] req_top_ctrl, req_pri_ctrl, req_sec_ctrl
-  def space_daylighting_control_required?(space, areas, climate_zone)
+  def space_daylighting_control_required?(space, areas)
     req_top_ctrl = true
     req_pri_ctrl = true
     req_sec_ctrl = true
@@ -88,8 +88,7 @@ class DEER2014 < DEER
                                               sorted_skylights,
                                               req_top_ctrl,
                                               req_pri_ctrl,
-                                              req_sec_ctrl,
-                                              climate_zone)
+                                              req_sec_ctrl)
     sensor_1_frac = 0.0
     sensor_2_frac = 0.0
     sensor_1_window = nil

--- a/lib/openstudio-standards/standards/deer/deer_2015/deer_2015.Space.rb
+++ b/lib/openstudio-standards/standards/deer/deer_2015/deer_2015.Space.rb
@@ -20,7 +20,7 @@ class DEER2015 < DEER
   # @param space [OpenStudio::Model::Space] the space in question
   # @param areas [Hash] a hash of daylighted areas
   # @return [Array<Bool>] req_top_ctrl, req_pri_ctrl, req_sec_ctrl
-  def space_daylighting_control_required?(space, areas, climate_zone)
+  def space_daylighting_control_required?(space, areas)
     req_top_ctrl = true
     req_pri_ctrl = true
     req_sec_ctrl = true
@@ -88,8 +88,7 @@ class DEER2015 < DEER
                                               sorted_skylights,
                                               req_top_ctrl,
                                               req_pri_ctrl,
-                                              req_sec_ctrl,
-                                              climate_zone)
+                                              req_sec_ctrl)
     sensor_1_frac = 0.0
     sensor_2_frac = 0.0
     sensor_1_window = nil

--- a/lib/openstudio-standards/standards/deer/deer_2017/deer_2017.Space.rb
+++ b/lib/openstudio-standards/standards/deer/deer_2017/deer_2017.Space.rb
@@ -20,7 +20,7 @@ class DEER2017 < DEER
   # @param space [OpenStudio::Model::Space] the space in question
   # @param areas [Hash] a hash of daylighted areas
   # @return [Array<Bool>] req_top_ctrl, req_pri_ctrl, req_sec_ctrl
-  def space_daylighting_control_required?(space, areas, climate_zone)
+  def space_daylighting_control_required?(space, areas)
     req_top_ctrl = true
     req_pri_ctrl = true
     req_sec_ctrl = true
@@ -88,8 +88,7 @@ class DEER2017 < DEER
                                               sorted_skylights,
                                               req_top_ctrl,
                                               req_pri_ctrl,
-                                              req_sec_ctrl,
-                                              climate_zone)
+                                              req_sec_ctrl)
     sensor_1_frac = 0.0
     sensor_2_frac = 0.0
     sensor_1_window = nil

--- a/lib/openstudio-standards/standards/deer/deer_2020/deer_2020.Space.rb
+++ b/lib/openstudio-standards/standards/deer/deer_2020/deer_2020.Space.rb
@@ -20,7 +20,7 @@ class DEER2020 < DEER
   # @param space [OpenStudio::Model::Space] the space in question
   # @param areas [Hash] a hash of daylighted areas
   # @return [Array<Bool>] req_top_ctrl, req_pri_ctrl, req_sec_ctrl
-  def space_daylighting_control_required?(space, areas, climate_zone)
+  def space_daylighting_control_required?(space, areas)
     req_top_ctrl = true
     req_pri_ctrl = true
     req_sec_ctrl = true
@@ -88,8 +88,7 @@ class DEER2020 < DEER
                                               sorted_skylights,
                                               req_top_ctrl,
                                               req_pri_ctrl,
-                                              req_sec_ctrl,
-                                              climate_zone)
+                                              req_sec_ctrl)
     sensor_1_frac = 0.0
     sensor_2_frac = 0.0
     sensor_1_window = nil

--- a/lib/openstudio-standards/standards/deer/deer_2025/deer_2025.Space.rb
+++ b/lib/openstudio-standards/standards/deer/deer_2025/deer_2025.Space.rb
@@ -20,7 +20,7 @@ class DEER2025 < DEER
   # @param space [OpenStudio::Model::Space] the space in question
   # @param areas [Hash] a hash of daylighted areas
   # @return [Array<Bool>] req_top_ctrl, req_pri_ctrl, req_sec_ctrl
-  def space_daylighting_control_required?(space, areas, climate_zone)
+  def space_daylighting_control_required?(space, areas)
     req_top_ctrl = true
     req_pri_ctrl = true
     req_sec_ctrl = true
@@ -88,8 +88,7 @@ class DEER2025 < DEER
                                               sorted_skylights,
                                               req_top_ctrl,
                                               req_pri_ctrl,
-                                              req_sec_ctrl,
-                                              climate_zone)
+                                              req_sec_ctrl)
     sensor_1_frac = 0.0
     sensor_2_frac = 0.0
     sensor_1_window = nil

--- a/lib/openstudio-standards/standards/deer/deer_2030/deer_2030.Space.rb
+++ b/lib/openstudio-standards/standards/deer/deer_2030/deer_2030.Space.rb
@@ -20,7 +20,7 @@ class DEER2030 < DEER
   # @param space [OpenStudio::Model::Space] the space in question
   # @param areas [Hash] a hash of daylighted areas
   # @return [Array<Bool>] req_top_ctrl, req_pri_ctrl, req_sec_ctrl
-  def space_daylighting_control_required?(space, areas, climate_zone)
+  def space_daylighting_control_required?(space, areas)
     req_top_ctrl = true
     req_pri_ctrl = true
     req_sec_ctrl = true
@@ -88,8 +88,7 @@ class DEER2030 < DEER
                                               sorted_skylights,
                                               req_top_ctrl,
                                               req_pri_ctrl,
-                                              req_sec_ctrl,
-                                              climate_zone)
+                                              req_sec_ctrl)
     sensor_1_frac = 0.0
     sensor_2_frac = 0.0
     sensor_1_window = nil

--- a/lib/openstudio-standards/standards/deer/deer_2035/deer_2035.Space.rb
+++ b/lib/openstudio-standards/standards/deer/deer_2035/deer_2035.Space.rb
@@ -20,7 +20,7 @@ class DEER2035 < DEER
   # @param space [OpenStudio::Model::Space] the space in question
   # @param areas [Hash] a hash of daylighted areas
   # @return [Array<Bool>] req_top_ctrl, req_pri_ctrl, req_sec_ctrl
-  def space_daylighting_control_required?(space, areas, climate_zone)
+  def space_daylighting_control_required?(space, areas)
     req_top_ctrl = true
     req_pri_ctrl = true
     req_sec_ctrl = true
@@ -88,8 +88,7 @@ class DEER2035 < DEER
                                               sorted_skylights,
                                               req_top_ctrl,
                                               req_pri_ctrl,
-                                              req_sec_ctrl,
-                                              climate_zone)
+                                              req_sec_ctrl)
     sensor_1_frac = 0.0
     sensor_2_frac = 0.0
     sensor_1_window = nil

--- a/lib/openstudio-standards/standards/deer/deer_2040/deer_2040.Space.rb
+++ b/lib/openstudio-standards/standards/deer/deer_2040/deer_2040.Space.rb
@@ -20,7 +20,7 @@ class DEER2040 < DEER
   # @param space [OpenStudio::Model::Space] the space in question
   # @param areas [Hash] a hash of daylighted areas
   # @return [Array<Bool>] req_top_ctrl, req_pri_ctrl, req_sec_ctrl
-  def space_daylighting_control_required?(space, areas, climate_zone)
+  def space_daylighting_control_required?(space, areas)
     req_top_ctrl = true
     req_pri_ctrl = true
     req_sec_ctrl = true
@@ -88,8 +88,7 @@ class DEER2040 < DEER
                                               sorted_skylights,
                                               req_top_ctrl,
                                               req_pri_ctrl,
-                                              req_sec_ctrl,
-                                              climate_zone)
+                                              req_sec_ctrl)
     sensor_1_frac = 0.0
     sensor_2_frac = 0.0
     sensor_1_window = nil

--- a/lib/openstudio-standards/standards/deer/deer_2045/deer_2045.Space.rb
+++ b/lib/openstudio-standards/standards/deer/deer_2045/deer_2045.Space.rb
@@ -20,7 +20,7 @@ class DEER2045 < DEER
   # @param space [OpenStudio::Model::Space] the space in question
   # @param areas [Hash] a hash of daylighted areas
   # @return [Array<Bool>] req_top_ctrl, req_pri_ctrl, req_sec_ctrl
-  def space_daylighting_control_required?(space, areas, climate_zone)
+  def space_daylighting_control_required?(space, areas)
     req_top_ctrl = true
     req_pri_ctrl = true
     req_sec_ctrl = true
@@ -88,8 +88,7 @@ class DEER2045 < DEER
                                               sorted_skylights,
                                               req_top_ctrl,
                                               req_pri_ctrl,
-                                              req_sec_ctrl,
-                                              climate_zone)
+                                              req_sec_ctrl)
     sensor_1_frac = 0.0
     sensor_2_frac = 0.0
     sensor_1_window = nil

--- a/lib/openstudio-standards/standards/deer/deer_2050/deer_2050.Space.rb
+++ b/lib/openstudio-standards/standards/deer/deer_2050/deer_2050.Space.rb
@@ -20,7 +20,7 @@ class DEER2050 < DEER
   # @param space [OpenStudio::Model::Space] the space in question
   # @param areas [Hash] a hash of daylighted areas
   # @return [Array<Bool>] req_top_ctrl, req_pri_ctrl, req_sec_ctrl
-  def space_daylighting_control_required?(space, areas, climate_zone)
+  def space_daylighting_control_required?(space, areas)
     req_top_ctrl = true
     req_pri_ctrl = true
     req_sec_ctrl = true
@@ -88,8 +88,7 @@ class DEER2050 < DEER
                                               sorted_skylights,
                                               req_top_ctrl,
                                               req_pri_ctrl,
-                                              req_sec_ctrl,
-                                              climate_zone)
+                                              req_sec_ctrl)
     sensor_1_frac = 0.0
     sensor_2_frac = 0.0
     sensor_1_window = nil

--- a/lib/openstudio-standards/standards/deer/deer_2055/deer_2055.Space.rb
+++ b/lib/openstudio-standards/standards/deer/deer_2055/deer_2055.Space.rb
@@ -20,7 +20,7 @@ class DEER2055 < DEER
   # @param space [OpenStudio::Model::Space] the space in question
   # @param areas [Hash] a hash of daylighted areas
   # @return [Array<Bool>] req_top_ctrl, req_pri_ctrl, req_sec_ctrl
-  def space_daylighting_control_required?(space, areas, climate_zone)
+  def space_daylighting_control_required?(space, areas)
     req_top_ctrl = true
     req_pri_ctrl = true
     req_sec_ctrl = true
@@ -88,8 +88,7 @@ class DEER2055 < DEER
                                               sorted_skylights,
                                               req_top_ctrl,
                                               req_pri_ctrl,
-                                              req_sec_ctrl,
-                                              climate_zone)
+                                              req_sec_ctrl)
     sensor_1_frac = 0.0
     sensor_2_frac = 0.0
     sensor_1_window = nil

--- a/lib/openstudio-standards/standards/deer/deer_2060/deer_2060.Space.rb
+++ b/lib/openstudio-standards/standards/deer/deer_2060/deer_2060.Space.rb
@@ -20,7 +20,7 @@ class DEER2060 < DEER
   # @param space [OpenStudio::Model::Space] the space in question
   # @param areas [Hash] a hash of daylighted areas
   # @return [Array<Bool>] req_top_ctrl, req_pri_ctrl, req_sec_ctrl
-  def space_daylighting_control_required?(space, areas, climate_zone)
+  def space_daylighting_control_required?(space, areas)
     req_top_ctrl = true
     req_pri_ctrl = true
     req_sec_ctrl = true
@@ -88,8 +88,7 @@ class DEER2060 < DEER
                                               sorted_skylights,
                                               req_top_ctrl,
                                               req_pri_ctrl,
-                                              req_sec_ctrl,
-                                              climate_zone)
+                                              req_sec_ctrl)
     sensor_1_frac = 0.0
     sensor_2_frac = 0.0
     sensor_1_window = nil

--- a/lib/openstudio-standards/standards/deer/deer_2065/deer_2065.Space.rb
+++ b/lib/openstudio-standards/standards/deer/deer_2065/deer_2065.Space.rb
@@ -20,7 +20,7 @@ class DEER2065 < DEER
   # @param space [OpenStudio::Model::Space] the space in question
   # @param areas [Hash] a hash of daylighted areas
   # @return [Array<Bool>] req_top_ctrl, req_pri_ctrl, req_sec_ctrl
-  def space_daylighting_control_required?(space, areas, climate_zone)
+  def space_daylighting_control_required?(space, areas)
     req_top_ctrl = true
     req_pri_ctrl = true
     req_sec_ctrl = true
@@ -88,8 +88,7 @@ class DEER2065 < DEER
                                               sorted_skylights,
                                               req_top_ctrl,
                                               req_pri_ctrl,
-                                              req_sec_ctrl,
-                                              climate_zone)
+                                              req_sec_ctrl)
     sensor_1_frac = 0.0
     sensor_2_frac = 0.0
     sensor_1_window = nil

--- a/lib/openstudio-standards/standards/deer/deer_2070/deer_2070.Space.rb
+++ b/lib/openstudio-standards/standards/deer/deer_2070/deer_2070.Space.rb
@@ -20,7 +20,7 @@ class DEER2070 < DEER
   # @param space [OpenStudio::Model::Space] the space in question
   # @param areas [Hash] a hash of daylighted areas
   # @return [Array<Bool>] req_top_ctrl, req_pri_ctrl, req_sec_ctrl
-  def space_daylighting_control_required?(space, areas, climate_zone)
+  def space_daylighting_control_required?(space, areas)
     req_top_ctrl = true
     req_pri_ctrl = true
     req_sec_ctrl = true
@@ -88,8 +88,7 @@ class DEER2070 < DEER
                                               sorted_skylights,
                                               req_top_ctrl,
                                               req_pri_ctrl,
-                                              req_sec_ctrl,
-                                              climate_zone)
+                                              req_sec_ctrl)
     sensor_1_frac = 0.0
     sensor_2_frac = 0.0
     sensor_1_window = nil

--- a/lib/openstudio-standards/standards/deer/deer_2075/deer_2075.Space.rb
+++ b/lib/openstudio-standards/standards/deer/deer_2075/deer_2075.Space.rb
@@ -20,7 +20,7 @@ class DEER2075 < DEER
   # @param space [OpenStudio::Model::Space] the space in question
   # @param areas [Hash] a hash of daylighted areas
   # @return [Array<Bool>] req_top_ctrl, req_pri_ctrl, req_sec_ctrl
-  def space_daylighting_control_required?(space, areas, climate_zone)
+  def space_daylighting_control_required?(space, areas)
     req_top_ctrl = true
     req_pri_ctrl = true
     req_sec_ctrl = true
@@ -88,8 +88,7 @@ class DEER2075 < DEER
                                               sorted_skylights,
                                               req_top_ctrl,
                                               req_pri_ctrl,
-                                              req_sec_ctrl,
-                                              climate_zone)
+                                              req_sec_ctrl)
     sensor_1_frac = 0.0
     sensor_2_frac = 0.0
     sensor_1_window = nil

--- a/lib/openstudio-standards/standards/necb/NECB2011/necb_2011.rb
+++ b/lib/openstudio-standards/standards/necb/NECB2011/necb_2011.rb
@@ -254,7 +254,7 @@ class NECB2011 < Standard
   def apply_fdwr_srr_daylighting(model:, fdwr_set: -1.0, srr_set: -1.0)
     apply_standard_window_to_wall_ratio(model: model, fdwr_set: fdwr_set)
     apply_standard_skylight_to_roof_ratio(model: model, srr_set: srr_set)
-    model_add_daylighting_controls(model, nil) # to be removed after refactor.
+    model_add_daylighting_controls(model) # to be removed after refactor.
   end
 
   def apply_standard_efficiencies(model:, sizing_run_dir:)


### PR DESCRIPTION
use climate_zone = model_standards_climate_zone(space.model) directly in the method instead of requiring it as an input argument