### PR TITLE
Including code for SHW tank efficiency ECM

### DIFF
--- a/lib/openstudio-standards/standards/necb/ECMS/data/boiler_set.json
+++ b/lib/openstudio-standards/standards/necb/ECMS/data/boiler_set.json
@@ -14,13 +14,13 @@
         {
           "name": "NECB 88% Efficient Condensing Boiler",
           "efficiency": 0.88,
-          "part_load_curve": "SWH-EFFFPLR-NECB2011",
+          "part_load_curve": "BOILER-EFFPLR-COND-NECB2011",
           "notes": "From NECB 2011 and AHRI."
         },
         {
           "name": "Viessmann Vitocrossal 300 CT3-17 96.2% Efficient Condensing Gas Boiler",
           "efficiency": 0.962,
-          "part_load_curve": "SWH-EFFFPLR-NECB2011",
+          "part_load_curve": "BOILER-EFFPLR-COND-VIESSMANN",
           "notes": "From analysis by Kamel Haddad based on Viessmann Vitocrossal 300 CT3-17 condensing boiler."
         }
       ]

--- a/lib/openstudio-standards/standards/necb/ECMS/data/curves.json
+++ b/lib/openstudio-standards/standards/necb/ECMS/data/curves.json
@@ -881,6 +881,31 @@
           "minimum_dependent_variable_output": null,
           "maximum_dependent_variable_output": null,
           "notes": "From NECB 2011 Table 8.4.4.21.-A (4) for condensing furnaces.  Converted EIR curve to PLF via curve fit."
+        },
+        {
+          "name": "SWH-EFFFPLR-NECB2011",
+          "category": "Water Heater",
+          "form": "Cubic",
+          "dependent_variable": "FIRRatio",
+          "independent_variable_1": "QRatio",
+          "independent_variable_2": null,
+          "coeff_1": 0.7576,
+          "coeff_2": 1.0071,
+          "coeff_3": -1.4443,
+          "coeff_4": 0.6844,
+          "coeff_5": null,
+          "coeff_6": null,
+          "coeff_7": null,
+          "coeff_8": null,
+          "coeff_9": null,
+          "coeff_10": null,
+          "minimum_independent_variable_1": 0.0,
+          "maximum_independent_variable_1": 1.0,
+          "minimum_independent_variable_2": null,
+          "maximum_independent_variable_2": null,
+          "minimum_dependent_variable_output": null,
+          "maximum_dependent_variable_output": null,
+          "notes": "From NECB 2011 Table 8.4.4.21.-G (2).  Converted EIR curve to PLF via curve fit.  Note this is treating the Water Heater as a boiler not a tank."
         }
       ]
     }

--- a/lib/openstudio-standards/standards/necb/ECMS/data/furnace_set.json
+++ b/lib/openstudio-standards/standards/necb/ECMS/data/furnace_set.json
@@ -6,7 +6,7 @@
       ],
       "table": [
         {
-          "name": "Standard Default",
+          "name": "NECB_Default",
           "efficiency": null,
           "part_load_curve": null,
           "notes": "Do nothing."
@@ -15,7 +15,7 @@
           "name": "NECB 85% Efficient Condensing Gas Furnace",
           "efficiency": 0.85,
           "part_load_curve": "FURNACE-EFFPLR-COND-NECB2011",
-          "notes": "From NECB 2011."
+          "notes": "From NECB 2011 and AHRI."
         }
       ]
     }

--- a/lib/openstudio-standards/standards/necb/ECMS/data/shw_set.json
+++ b/lib/openstudio-standards/standards/necb/ECMS/data/shw_set.json
@@ -1,6 +1,6 @@
 {
   "tables": {
-    "boiler_eff_ecm": {
+    "shw_eff_ecm": {
       "refs": [
         "assumption"
       ],
@@ -12,16 +12,16 @@
           "notes": "Do nothing."
         },
         {
-          "name": "NECB 88% Efficient Condensing Boiler",
-          "efficiency": 0.88,
+          "name": "Natural Gas Power Vent with Electric Ignition",
+          "efficiency": 0.94,
           "part_load_curve": "SWH-EFFFPLR-NECB2011",
-          "notes": "From NECB 2011 and AHRI."
+          "notes": "From AHRI."
         },
         {
-          "name": "Viessmann Vitocrossal 300 CT3-17 96.2% Efficient Condensing Gas Boiler",
-          "efficiency": 0.962,
+          "name": "Natural Gas Direct Vent with Electric Ignition",
+          "efficiency": 0.91,
           "part_load_curve": "SWH-EFFFPLR-NECB2011",
-          "notes": "From analysis by Kamel Haddad based on Viessmann Vitocrossal 300 CT3-17 condensing boiler."
+          "notes": "From AHRI."
         }
       ]
     }

--- a/lib/openstudio-standards/standards/necb/ECMS/hvac_systems.rb
+++ b/lib/openstudio-standards/standards/necb/ECMS/hvac_systems.rb
@@ -1447,10 +1447,8 @@ class ECMS
       elsif eff_package.size > 1
         raise "More than one furnace efficiency package with the name #{furnace_eff["name"]} was found.  Please check the ECMS class furnace_set.json file and make sure that each boiler efficiency package has a unique name."
       else
-        return if eff_package['efficiency'].nil? && eff_package['part_load_curve'].nil?
-        raise "You attempted to set either the efficiency or part load curve for this furnace to nil.  Please check the ECMS class furnace_set.json file and make sure that either both efficiency and part load curve are properly set or both are nil (if you do not want to change the furnace performance properties)." if eff_package['efficiency'].nil? || eff_package['part_load_curve'].nil?
-        furnace_eff['efficiency'] = eff_package['efficiency']
-        furnace_eff['part_load_curve'] = eff_package['part_load_curve']
+        furnace_eff['efficiency'] = eff_package[0]['efficiency']
+        furnace_eff['part_load_curve'] = eff_package[0]['part_load_curve']
       end
     end
     # If no efficiency or partload curve are found (either passed directly or via the furnace_set.json file) then assume
@@ -1524,10 +1522,8 @@ class ECMS
       elsif eff_package.size > 1
         raise "More than one shw efficiency package with the name #{shw_eff["name"]} was found.  Please check the ECMS class shw_set.json file and make sure that each boiler efficiency package has a unique name."
       else
-        return if eff_package['efficiency'].nil? && eff_package['part_load_curve'].nil?
-        raise "You attempted to set either the efficiency or part load curve for this shw tank to nil.  Please check the ECMS class shw_set.json file and make sure that either both efficiency and part load curve are properly set or both are nil (if you do not want to change the shw performance properties)." if eff_package['efficiency'].nil? || eff_package['part_load_curve'].nil?
-        shw_eff['efficiency'] = eff_package['efficiency']
-        shw_eff['part_load_curve'] = eff_package['part_load_curve']
+        shw_eff['efficiency'] = eff_package[0]['efficiency']
+        shw_eff['part_load_curve'] = eff_package[0]['part_load_curve']
       end
     end
     # If no efficiency or partload curve are found (either passed directly or via the shw_set.json file) then assume

--- a/lib/openstudio-standards/standards/necb/NECB2011/necb_2011.rb
+++ b/lib/openstudio-standards/standards/necb/NECB2011/necb_2011.rb
@@ -353,6 +353,8 @@ class NECB2011 < Standard
     ecm.modify_boiler_efficiency(model: model, boiler_eff: boiler_eff)
     # Apply Furnace Efficiency
     ecm.modify_furnace_efficiency(model: model, furnace_eff: furnace_eff)
+    # Apply SHW Efficiency
+    ecm.modify_shw_efficiency(model: model, shw_eff: shw_eff)
     # Apply daylight controls.
     model_add_daylighting_controls(model) if daylighting_type == 'add_daylighting_controls'
 

--- a/test/necb/unit_tests/expected_results/boiler_efficiency_modification_expected_results.json
+++ b/test/necb/unit_tests/expected_results/boiler_efficiency_modification_expected_results.json
@@ -29,7 +29,7 @@
   },
   {
     "template": "NECB2011",
-    "boiler_name": "Secondary NECB 88% Efficient Condensing Boiler 0 kBtu/hr",
+    "boiler_name": "Secondary NECB 88% Efficient Condensing Boiler 0kBtu/hr 0.88 Thermal Eff",
     "boiler_eff": 0.88,
     "eff_curve_name": "BOILER-EFFPLR-COND-NECB2011",
     "curve_coefficients": [
@@ -43,7 +43,7 @@
   },
   {
     "template": "NECB2011",
-    "boiler_name": "Primary NECB 88% Efficient Condensing Boiler 5118 kBtu/hr",
+    "boiler_name": "Primary NECB 88% Efficient Condensing Boiler 5118kBtu/hr 0.88 Thermal Eff",
     "boiler_eff": 0.88,
     "eff_curve_name": "BOILER-EFFPLR-COND-NECB2011",
     "curve_coefficients": [
@@ -57,7 +57,7 @@
   },
   {
     "template": "NECB2011",
-    "boiler_name": "Secondary Viessmann Vitocrossal 300 CT3-17 96.2% Efficient Condensing Gas Boiler 0 kBtu/hr",
+    "boiler_name": "Secondary Viessmann Vitocrossal 300 CT3-17 96.2% Efficient Condensing Gas Boiler 0kBtu/hr 0.962 Thermal Eff",
     "boiler_eff": 0.962,
     "eff_curve_name": "BOILER-EFFPLR-COND-VIESSMANN",
     "curve_coefficients": [
@@ -75,7 +75,7 @@
   },
   {
     "template": "NECB2011",
-    "boiler_name": "Primary Viessmann Vitocrossal 300 CT3-17 96.2% Efficient Condensing Gas Boiler 5118 kBtu/hr",
+    "boiler_name": "Primary Viessmann Vitocrossal 300 CT3-17 96.2% Efficient Condensing Gas Boiler 5118kBtu/hr 0.962 Thermal Eff",
     "boiler_eff": 0.962,
     "eff_curve_name": "BOILER-EFFPLR-COND-VIESSMANN",
     "curve_coefficients": [
@@ -121,7 +121,7 @@
   },
   {
     "template": "BTAPPRE1980",
-    "boiler_name": "Secondary NECB 88% Efficient Condensing Boiler 0 kBtu/hr",
+    "boiler_name": "Secondary NECB 88% Efficient Condensing Boiler 0kBtu/hr 0.88 Thermal Eff",
     "boiler_eff": 0.88,
     "eff_curve_name": "BOILER-EFFPLR-COND-NECB2011",
     "curve_coefficients": [
@@ -135,7 +135,7 @@
   },
   {
     "template": "BTAPPRE1980",
-    "boiler_name": "Primary NECB 88% Efficient Condensing Boiler 5118 kBtu/hr",
+    "boiler_name": "Primary NECB 88% Efficient Condensing Boiler 5118kBtu/hr 0.88 Thermal Eff",
     "boiler_eff": 0.88,
     "eff_curve_name": "BOILER-EFFPLR-COND-NECB2011",
     "curve_coefficients": [
@@ -149,7 +149,7 @@
   },
   {
     "template": "BTAPPRE1980",
-    "boiler_name": "Secondary Viessmann Vitocrossal 300 CT3-17 96.2% Efficient Condensing Gas Boiler 0 kBtu/hr",
+    "boiler_name": "Secondary Viessmann Vitocrossal 300 CT3-17 96.2% Efficient Condensing Gas Boiler 0kBtu/hr 0.962 Thermal Eff",
     "boiler_eff": 0.962,
     "eff_curve_name": "BOILER-EFFPLR-COND-VIESSMANN",
     "curve_coefficients": [
@@ -167,7 +167,7 @@
   },
   {
     "template": "BTAPPRE1980",
-    "boiler_name": "Primary Viessmann Vitocrossal 300 CT3-17 96.2% Efficient Condensing Gas Boiler 5118 kBtu/hr",
+    "boiler_name": "Primary Viessmann Vitocrossal 300 CT3-17 96.2% Efficient Condensing Gas Boiler 5118kBtu/hr 0.962 Thermal Eff",
     "boiler_eff": 0.962,
     "eff_curve_name": "BOILER-EFFPLR-COND-VIESSMANN",
     "curve_coefficients": [

--- a/test/necb/unit_tests/tests/test_necb_shw.rb
+++ b/test/necb/unit_tests/tests/test_necb_shw.rb
@@ -27,6 +27,11 @@ class SHW_test < Minitest::Test
   def test_shw_test()
     output_array = []
     climate_zone = 'none'
+
+    #get shw efficiency measure data from ECMS class shw_set.json
+    ecm_standard = Standard.build("ECMS")
+    shw_measures = ecm_standard.standards_data['tables']['shw_eff_ecm']['table']
+
     #Iterate through NECB2011 and NECB2015 as well as weather locations heated by gas and electricity.
     Templates.sort.each do |template|
       Epw_files.sort.each do |epw_file|
@@ -79,97 +84,19 @@ class SHW_test < Minitest::Test
           # actually in it).
 
           standard.model_add_swh(model: model, swh_fueltype: 'DefaultFuel')
-          # Go through the model and check what tank, pump, and water use connections were added.
-          plantloops = model.getPlantLoops
 
-          # Before doing anything check if any plant loops are present.  If it is continue, otherwise skip to the next
-          # set of space types.
-
-          unless plantloops.empty?
-            # Start with the demand components (water use connections).
-            demand_comps = plantloops[0].demandComponents
-            water_conns = []
-            demand_equip_info = []
-            # Get all the water use connections and add them to an array.
-            demand_comps.sort.each do |demand_comp|
-              if demand_comp.iddObjectType.valueName.to_s == "OS_WaterUse_Connections"
-                water_conns << demand_comp.to_WaterUseConnections.get
+          # Apply measure info if gas
+          apply_shw_ecm = false
+          model.getWaterHeaterMixeds.sort.each do |waterheater_test|
+            if waterheater_test.heaterFuelType == "NaturalGas"
+              shw_measures.each do |shw_measure|
+                #ecm_standard.modify_shw_efficiency(model: model, shw_eff: shw_measure)
               end
             end
-            # Go through the water use connections and get the flow rate and schedule information.
-            water_conns.sort.each do |water_conn|
-              day_scheds = []
-              water_equip = water_conn.waterUseEquipment
-              flow_rate_fract_sched = water_equip[0].flowRateFractionSchedule.get.to_ScheduleRuleset.get
-              flow_rate_fract_sched.scheduleRules.sort.each do |sched_rule|
-                day_sched = {
-                    "day_sched_name" => sched_rule.daySchedule.name,
-                    "times" => sched_rule.daySchedule.times,
-                    "values" => sched_rule.daySchedule.values
-                }
-                day_scheds << day_sched
-              end
-              # The next bit of code truncates the flow rate because sometimes the last digit will change depending on
-              # the vagaries of Ruby, the processor, whatever and cause the test to fail when really it should have
-              # passed.  Thinking about this more I made it way too complicated.  I could have just truncated the result
-              # but decided to keep the same number of (non-zero) significant digits regardless of if the result was
-              # scaled by 10E-6 or 10E-7 the two common ones).  Hence the next few lines of code where I check if the flow
-              # rate is 10E-6 or 10E-7, keep the result to 12 digits, then convert it back to the right flow rate.
-
-              water_equip_def = water_equip[0].waterUseEquipmentDefinition
-              digit_exponent = 10**7
-              last_digit_check = water_equip_def.peakFlowRate*digit_exponent
-              if last_digit_check >= 10
-                digit_exponent = 10**6
-              end
-              exponent_mult =(10**12)*digit_exponent
-              last_digit_check = (water_equip_def.peakFlowRate*exponent_mult).to_i
-              water_flow_out = last_digit_check.to_f/exponent_mult
-              # Put the water use equipment name, flow rate, and schedule in a hash
-              equip_info = {
-                  "equip_name" => water_equip[0].name,
-                  "flow_rate_m3_per_s" => water_flow_out,
-                  "day_schedules" => day_scheds
-              }
-              # Add the above hash containing info for all of the water use equipment defined in the model.
-              demand_equip_info << equip_info
-            end
-            pumps = []
-            water_heaters = []
-            # Next get the supply component information.
-            supply_comps = plantloops[0].supplyComponents
-            # Go through each of the supply components and get either the pumps or the water heaters.
-            supply_comps.sort.each do |supplycomp|
-              case supplycomp.iddObjectType.valueName.to_s
-              when 'OS_Pump_ConstantSpeed'
-                pumps << supplycomp.to_PumpConstantSpeed.get
-              when 'OS_WaterHeater_Mixed'
-                water_heaters << supplycomp.to_WaterHeaterMixed.get
-              end
-            end
-            # Add the water heater tank volume and capacity and the pump head and moter efficiency to a hash.  Although
-            # I collect all of the pumps and water heaters in the plant loop above here I assume there is only one of
-            # each in the model.  I really should check, but I don't.
-            supply_equip_info = {
-                "water_heater_vol_m3" => water_heaters[0].tankVolume,
-                "water_heater_capacity_w" => water_heaters[0].heaterMaximumCapacity,
-                "pump_head_Pa" => pumps[0].ratedPumpHead.to_f.round(8),
-                "pump_motor_eff" => pumps[0].motorEfficiency
-            }
-            # make hash containing the template applied, weather file used, water heater name, space types applied (or
-            # I should say renamed), the supply equipment info (from the supply_equip_info hash) and demand equipment info
-            # (from the demand_equip_info array defined above).
-            set_output = {
-                "template" => template,
-                "epw_file" => epw_file,
-                "water_heater_name" => water_heaters[0].name,
-                "space_types" => space_type_names,
-                "suppy_equipment" => supply_equip_info,
-                "demand_equipment" => demand_equip_info
-            }
-            # Add this hash to an array containing the same info for all of the sets of space types applied to the model.
-            output_array << set_output
           end
+
+          # Collect shw loop info to add to output
+          add_shw_test_output_info(model: model, output_array: output_array, template: template, epw_file: epw_file, space_type_names: space_type_names)
         end
       end #loop to the next epw_file
     end #loop to the next Template
@@ -183,5 +110,99 @@ class SHW_test < Minitest::Test
     assert( b_result, 
       "shw test results do not match expected results! Compare/diff the output with the stored values here #{expected_result_file} and #{test_result_file}"
     )
+  end
+
+  def add_shw_test_output_info(model:, output_array:, template:, epw_file:, space_type_names:)
+    # Go through the model and check what tank, pump, and water use connections were added.
+    plantloops = model.getPlantLoops
+
+    # Before doing anything check if any plant loops are present.  If it is continue, otherwise skip to the next
+    # set of space types.
+
+    unless plantloops.empty?
+      # Start with the demand components (water use connections).
+      demand_comps = plantloops[0].demandComponents
+      water_conns = []
+      demand_equip_info = []
+      # Get all the water use connections and add them to an array.
+      demand_comps.sort.each do |demand_comp|
+        if demand_comp.iddObjectType.valueName.to_s == "OS_WaterUse_Connections"
+          water_conns << demand_comp.to_WaterUseConnections.get
+        end
+      end
+      # Go through the water use connections and get the flow rate and schedule information.
+      water_conns.sort.each do |water_conn|
+        day_scheds = []
+        water_equip = water_conn.waterUseEquipment
+        flow_rate_fract_sched = water_equip[0].flowRateFractionSchedule.get.to_ScheduleRuleset.get
+        flow_rate_fract_sched.scheduleRules.sort.each do |sched_rule|
+          day_sched = {
+              "day_sched_name" => sched_rule.daySchedule.name,
+              "times" => sched_rule.daySchedule.times,
+              "values" => sched_rule.daySchedule.values
+          }
+          day_scheds << day_sched
+        end
+        # The next bit of code truncates the flow rate because sometimes the last digit will change depending on
+        # the vagaries of Ruby, the processor, whatever and cause the test to fail when really it should have
+        # passed.  Thinking about this more I made it way too complicated.  I could have just truncated the result
+        # but decided to keep the same number of (non-zero) significant digits regardless of if the result was
+        # scaled by 10E-6 or 10E-7 the two common ones).  Hence the next few lines of code where I check if the flow
+        # rate is 10E-6 or 10E-7, keep the result to 12 digits, then convert it back to the right flow rate.
+
+        water_equip_def = water_equip[0].waterUseEquipmentDefinition
+        digit_exponent = 10**7
+        last_digit_check = water_equip_def.peakFlowRate*digit_exponent
+        if last_digit_check >= 10
+          digit_exponent = 10**6
+        end
+        exponent_mult =(10**12)*digit_exponent
+        last_digit_check = (water_equip_def.peakFlowRate*exponent_mult).to_i
+        water_flow_out = last_digit_check.to_f/exponent_mult
+        # Put the water use equipment name, flow rate, and schedule in a hash
+        equip_info = {
+            "equip_name" => water_equip[0].name,
+            "flow_rate_m3_per_s" => water_flow_out,
+            "day_schedules" => day_scheds
+        }
+        # Add the above hash containing info for all of the water use equipment defined in the model.
+        demand_equip_info << equip_info
+      end
+      pumps = []
+      water_heaters = []
+      # Next get the supply component information.
+      supply_comps = plantloops[0].supplyComponents
+      # Go through each of the supply components and get either the pumps or the water heaters.
+      supply_comps.sort.each do |supplycomp|
+        case supplycomp.iddObjectType.valueName.to_s
+        when 'OS_Pump_ConstantSpeed'
+          pumps << supplycomp.to_PumpConstantSpeed.get
+        when 'OS_WaterHeater_Mixed'
+          water_heaters << supplycomp.to_WaterHeaterMixed.get
+        end
+      end
+      # Add the water heater tank volume and capacity and the pump head and moter efficiency to a hash.  Although
+      # I collect all of the pumps and water heaters in the plant loop above here I assume there is only one of
+      # each in the model.  I really should check, but I don't.
+      supply_equip_info = {
+          "water_heater_vol_m3" => water_heaters[0].tankVolume,
+          "water_heater_capacity_w" => water_heaters[0].heaterMaximumCapacity,
+          "pump_head_Pa" => pumps[0].ratedPumpHead.to_f.round(8),
+          "pump_motor_eff" => pumps[0].motorEfficiency
+      }
+      # make hash containing the template applied, weather file used, water heater name, space types applied (or
+      # I should say renamed), the supply equipment info (from the supply_equip_info hash) and demand equipment info
+      # (from the demand_equip_info array defined above).
+      set_output = {
+          "template" => template,
+          "epw_file" => epw_file,
+          "water_heater_name" => water_heaters[0].name,
+          "space_types" => space_type_names,
+          "suppy_equipment" => supply_equip_info,
+          "demand_equipment" => demand_equip_info
+      }
+      # Add this hash to an array containing the same info for all of the sets of space types applied to the model.
+      output_array << set_output
+    end
   end
 end


### PR DESCRIPTION
Also, changing code for boiler and furnace efficiency ECMs so that they can accept a string and a hash.  When a string is passed to the:
modify_boiler_efficiency,
modify_furnace_efficiency, or
modify_shw_efficiency
methods the method looks for the string in the associated boiler_set.json, furnace_set.json, or shw_set.json files in the "name" field.  If the string matches the "name" field in the json it takes the performance information from the file and uses that to set the efficiency and part load curve.  A hash containing the performance information can still be passed to the above methods and they will adjust the performance of the associated equipment to match what is in the hash.