### PR TITLE
revert the changes to CLI loading of NECB standards

### DIFF
--- a/lib/openstudio-standards/standards/necb/NECB2011/necb_2011.rb
+++ b/lib/openstudio-standards/standards/necb/NECB2011/necb_2011.rb
@@ -31,8 +31,8 @@ class NECB2011 < Standard
     if __dir__[0] == ':' # Running from OpenStudio CLI
       embedded_files_relative('../common', /.*\.json/).each do |file|
         data = JSON.parse(EmbeddedScripting.getFileAsString(file))
-        if not data["tables"].nil? and data["tables"].first["data_type"] == "table"
-          @standards_data["tables"] << data["tables"].first
+        if not data["tables"].nil?
+          @standards_data["tables"] = [*@standards_data["tables"], *data["tables"]].to_h
         else
           @standards_data[data.keys.first] = data[data.keys.first]
         end
@@ -55,8 +55,8 @@ class NECB2011 < Standard
     if __dir__[0] == ':' # Running from OpenStudio CLI
       embedded_files_relative('data/', /.*\.json/).each do |file|
         data = JSON.parse(EmbeddedScripting.getFileAsString(file))
-        if not data["tables"].nil? and data["tables"].first["data_type"] == "table"
-          @standards_data["tables"] << data["tables"].first
+        if not data["tables"].nil?
+          @standards_data["tables"] = [*@standards_data["tables"], *data["tables"]].to_h
         else
           @standards_data[data.keys.first] = data[data.keys.first]
         end


### PR DESCRIPTION
@asparke2  fixed the NECB JSON loading code for use in the OpenStudio CLI in this commit: https://github.com/NREL/openstudio-standards/commit/de4e210c

@phylroy overwrote that change to its prior state in this commit:
https://github.com/NREL/openstudio-standards/commit/f0fb3009

This commit reimplements the changes @asparke2 made.