### PR TITLE
[Appendix G] Update the infiltration calculations

### DIFF
--- a/lib/openstudio-standards/standards/Standards.Space.rb
+++ b/lib/openstudio-standards/standards/Standards.Space.rb
@@ -1460,6 +1460,7 @@ class Standard
         end
       end
     end
+
     return area_m2 * space.multiplier
   end
 

--- a/lib/openstudio-standards/standards/Standards.Space.rb
+++ b/lib/openstudio-standards/standards/Standards.Space.rb
@@ -1435,12 +1435,9 @@ class Standard
       # Conditioned space OR semi-heated space <-> ground
       #
       # isGroundSurface does not check for Foundation outside boundary condition
-      # TODO: 90.1 excludes slab-on-grade as "floors", hence, they're currently excluded
       if surface.outsideBoundaryCondition == 'Outdoors' ||
-         (surface.isGroundSurface && surface.surfaceType == 'Wall') ||
-         (surface.outsideBoundaryCondition == 'Foundation' && surface.surfaceType == 'Wall') ||
-         (surface.isGroundSurface && surface.surfaceType == 'Roof') ||
-         (surface.outsideBoundaryCondition == 'Foundation' && surface.surfaceType == 'Roof')
+         surface.isGroundSurface ||
+         surface.outsideBoundaryCondition == 'Foundation'
         surf_cnt = true
       end
 
@@ -1463,7 +1460,6 @@ class Standard
         end
       end
     end
-
     return area_m2 * space.multiplier
   end
 

--- a/lib/openstudio-standards/standards/Standards.ThermalZone.rb
+++ b/lib/openstudio-standards/standards/Standards.ThermalZone.rb
@@ -1221,6 +1221,7 @@ class Standard
     # From Table 3.1 Heated Space Criteria
     htg_lim_btu_per_ft2 = 0.0
     case template
+      # TODO: Add addendum db rules to 90.1-2019 for 90.1-2022
     when '90.1-2016', '90.1-PRM-2019'
       case climate_zone
       when 'ASHRAE 169-2006-0A',

--- a/lib/openstudio-standards/standards/Standards.ThermalZone.rb
+++ b/lib/openstudio-standards/standards/Standards.ThermalZone.rb
@@ -1221,7 +1221,7 @@ class Standard
     # From Table 3.1 Heated Space Criteria
     htg_lim_btu_per_ft2 = 0.0
     case template
-      # TODO: Add addendum db rules to 90.1-2019 for 90.1-2022
+    # TODO: Add addendum db rules to 90.1-2019 for 90.1-2022
     when '90.1-2016', '90.1-PRM-2019'
       case climate_zone
       when 'ASHRAE 169-2006-0A',

--- a/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.Model.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.Model.rb
@@ -165,14 +165,14 @@ class ASHRAE901PRM < Standard
     #
     # If multiple methods are used, use per above grade wall
     # area (i.e. exterior wall area), if air/changes per hour
-    # or exterior surface area is used, use flow/area
+    # or exterior surface area is used, use Flow/ExteriorWallArea
     infil_method = model_get_infiltration_method(model)
-    infil_method = 'Flow/Area' if infil_method != 'Flow/Area' || infil_method != 'Flow/ExteriorWallArea'
+    infil_method = 'Flow/ExteriorWallArea' if infil_method != 'Flow/Area' || infil_method != 'Flow/ExteriorWallArea'
     infil_coefficients = model_get_infiltration_coefficients(model)
 
     # Set the infiltration rate at each space
     model.getSpaces.sort.each do |space|
-      space_apply_infiltration_rate(space, tot_infil_m3_per_s, infil_method, infil_coefficients)
+      space_apply_infiltration_rate(space, tot_infil_m3_per_s, infil_method, infil_coefficients, climate_zone)
     end
 
     # Remove infiltration rates set at the space type

--- a/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.Model.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.Model.rb
@@ -172,7 +172,7 @@ class ASHRAE901PRM < Standard
 
     # Set the infiltration rate at each space
     model.getSpaces.sort.each do |space|
-      space_apply_infiltration_rate(space, tot_infil_m3_per_s, infil_method, infil_coefficients, climate_zone)
+      space_apply_infiltration_rate(space, tot_infil_m3_per_s, infil_method, infil_coefficients)
     end
 
     # Remove infiltration rates set at the space type

--- a/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.Space.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.Space.rb
@@ -5,7 +5,11 @@ class ASHRAE901PRM < Standard
   # the impact of air leakage requirements in the standard.
   #
   # @return [Double] true if successful, false if not
-  def space_apply_infiltration_rate(space, tot_infil_m3_per_s, infil_method, infil_coefficients, climate_zone)
+  def space_apply_infiltration_rate(space, tot_infil_m3_per_s, infil_method, infil_coefficients)
+
+    # get the climate zone
+    climate_zone = model_standards_climate_zone(space.model)
+
     # Calculate infiltration rate
     case infil_method.to_s
       when 'Flow/ExteriorWallArea'

--- a/test/90_1_prm/data/space_envelope_areas.json
+++ b/test/90_1_prm/data/space_envelope_areas.json
@@ -1,5 +1,5 @@
 {
-    "SmallOffice_90.1-2013_ASHRAE 169-2013-2A_": 792.67,
+    "SmallOffice_90.1-2013_ASHRAE 169-2013-2A_": 1303.8298,
     "LargeHotel_90.1-2013_ASHRAE 169-2013-2A_": 7983.50,
-    "Warehouse_90.1-2013_ASHRAE 169-2013-2A_": 2693.93
+    "Warehouse_90.1-2013_ASHRAE 169-2013-2A_": 4087.34
 }


### PR DESCRIPTION
After checking with the 90.1-2019 PRM development team regarding which space conditioning type should be used for the baseline model (we noticed that the space conditioning can change after assigning baseline internal load assumptions), it was decided to assume that the baseline space conditioning be the same as the proposed/user model.

A `TODO` was added as a reminder to take into account addendum db when adding rules for 90.1-2022 Appendix G.

The proposed changes also include a change in the default infiltration method from `Flow/Area` to `Flow/ExteriorWallArea` (more reasonable assumption). Changes also include a check to only count space floor area of non-unconditioned spaces that have non-zero surface area with outside boundaries set to outdoors (i.e. core spaces are excluded from the calculation since they have no infiltration, just transfer air).

The proposed changes also include an errata to the appendix language that by including floors in italic excluded the slab-on grade floors from the building envelope calculations.