### PR TITLE
Update the small data center CRAC fan type from CAV to VAV

### DIFF
--- a/data/geometry/ASHRAESmallDataCenter.json
+++ b/data/geometry/ASHRAESmallDataCenter.json
@@ -4,7 +4,7 @@
     "name": "CRAC",
     "CRAC_operation_schedule": "DataCenter HVACOperationSchd",
     "CRAC_oa_damper_schedule": "DataCenter MinOA_MotorizedDamper_Sched",
-    "CRAC_fan_type": "ConstantVolume",
+    "CRAC_fan_type": "VariableVolume",
     "CRAC_cooling_type": "Single Speed DX AC",
     "space_names": [
       "ComputerRoom"


### PR DESCRIPTION
Super minor update on the data center model.  @mdahlhausen 

So that both CRAC (small DC) and CRAH (large DC) are able to adjust AHU supply air flow rate based on CPU load.