### PR TITLE
Update SRR adjustment

### DIFF
--- a/lib/openstudio-standards/standards/Standards.Space.rb
+++ b/lib/openstudio-standards/standards/Standards.Space.rb
@@ -1422,7 +1422,7 @@ class Standard
     area_m2 = 0.0
 
     # Get the space conditioning type
-    space_cond_type = space_conditioning_category(space, climate_zone)
+    space_cond_type = space_conditioning_category(space)
 
     # Loop through all surfaces in this space
     space.surfaces.sort.each do |surface|
@@ -1446,7 +1446,7 @@ class Standard
         # TODO: add a case for 'Zone' when supported
         if surface.outsideBoundaryCondition == 'Surface'
           adj_space = surface.adjacentSurface.get.space.get
-          adj_space_cond_type = space_conditioning_category(adj_space, climate_zone)
+          adj_space_cond_type = space_conditioning_category(adj_space)
           surf_cnt = true unless adj_space_cond_type != 'Unconditioned'
         end
       end
@@ -1588,7 +1588,10 @@ class Standard
   # @param climate_zone [String] climate zone
   # @return [String] NonResConditioned, ResConditioned, Semiheated, Unconditioned
   # @todo add logic to detect indirectly-conditioned spaces based on air transfer
-  def space_conditioning_category(space, climate_zone)
+  def space_conditioning_category(space)
+    # Get climate zone
+    climate_zone = model_standards_climate_zone(space.model)
+
     # Get the zone this space is inside
     zone = space.thermalZone
 

--- a/lib/openstudio-standards/standards/Standards.SubSurface.rb
+++ b/lib/openstudio-standards/standards/Standards.SubSurface.rb
@@ -80,7 +80,8 @@ class Standard
   # @param percent_reduction [Double] the fractional amount
   # to reduce the area.
   def sub_surface_reduce_area_by_percent_by_shrinking_toward_centroid(sub_surface, percent_reduction)
-    mult = 1 - percent_reduction
+    # if percent_reduction > 1=> percent increase instead of reduction
+    mult = percent_reduction <= 1 ? 1 - percent_reduction : percent_reduction
     scale_factor = mult**0.5
 
     # Get the centroid (Point3d)

--- a/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.Space.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.Space.rb
@@ -17,7 +17,7 @@ class ASHRAE901PRM < Standard
         total_exterior_wall_area = 0
         space.model.getSpaces.sort.each do |spc|
           # Get the space conditioning type
-          space_cond_type = space_conditioning_category(spc, climate_zone)
+          space_cond_type = space_conditioning_category(spc)
           total_exterior_wall_area += spc.exteriorWallArea unless space_cond_type == "Unconditioned"
         end
         adj_infil_flow_ext_wall_area = tot_infil_m3_per_s / total_exterior_wall_area
@@ -27,7 +27,7 @@ class ASHRAE901PRM < Standard
         total_floor_area = 0
         space.model.getSpaces.sort.each do |spc|
           # Get the space conditioning type
-          space_cond_type = space_conditioning_category(spc, climate_zone)
+          space_cond_type = space_conditioning_category(spc)
           total_floor_area += spc.floorArea unless space_cond_type == "Unconditioned" || space.exteriorArea == 0
         end
         adj_infil_flow_area = tot_infil_m3_per_s / total_floor_area
@@ -63,7 +63,7 @@ class ASHRAE901PRM < Standard
     space.spaceInfiltrationDesignFlowRates.each(&:remove)
     
     # Get the space conditioning type
-    space_cond_type = space_conditioning_category(space, climate_zone)
+    space_cond_type = space_conditioning_category(space)
     if space_cond_type != "Unconditioned"
       # Create an infiltration rate object for this space
       infiltration = OpenStudio::Model::SpaceInfiltrationDesignFlowRate.new(space.model)

--- a/test/90_1_prm/data/prototype_list.json
+++ b/test/90_1_prm/data/prototype_list.json
@@ -3,6 +3,9 @@
         ["SmallOffice", "90.1-2013", "ASHRAE 169-2013-2A", []],
         ["MidriseApartment", "90.1-2013", "ASHRAE 169-2013-2A", [["remove_transformer", []]]]
     ],
+    "srr": [
+        ["RetailStandalone", "90.1-2010", "ASHRAE 169-2013-2A", [["increase_skylight_size", [10]]]]
+    ],
     "daylighting_control": [
         ["SmallOffice", "90.1-2013", "ASHRAE 169-2013-2A", []]
     ],

--- a/test/90_1_prm/test_appendix_g_prm.rb
+++ b/test/90_1_prm/test_appendix_g_prm.rb
@@ -56,8 +56,8 @@ class AppendixGPRMTests < Minitest::Test
       end
 
       # Create the prototype
-      prototype_creator = Standard.build("#{template}_#{building_type}")
-      model = prototype_creator.model_create_prototype_model(climate_zone, epw_file, run_dir)
+      @prototype_creator = Standard.build("#{template}_#{building_type}")
+      model = @prototype_creator.model_create_prototype_model(climate_zone, epw_file, run_dir)
 
       # Make modification if requested
       @bldg_type_alt_now = nil
@@ -109,7 +109,7 @@ class AppendixGPRMTests < Minitest::Test
       model = BTAP::FileIO::deep_copy(proposed_model)
 
       # Initialize Standard class
-      prototype_creator = Standard.build('90.1-PRM-2019')
+      @prototype_creator = Standard.build('90.1-PRM-2019')
 
       # Convert standardSpaceType string for each space to values expected for prm creation
       lpd_space_types = JSON.parse(File.read("#{@@json_dir}/lpd_space_types.json"))
@@ -153,7 +153,7 @@ class AppendixGPRMTests < Minitest::Test
       end
 
       # Create baseline model
-      model_baseline = prototype_creator.model_create_prm_stable_baseline_building(model, building_type, climate_zone,
+      model_baseline = @prototype_creator.model_create_prm_stable_baseline_building(model, building_type, climate_zone,
                                                                                    @@hvac_building_types[hvac_building_type],
                                                                                    @@wwr_building_types[building_type],
                                                                                    @@swh_building_types[building_type],
@@ -172,7 +172,7 @@ class AppendixGPRMTests < Minitest::Test
       sim_control = model_baseline.getSimulationControl
       sim_control.setRunSimulationforSizingPeriods(true)
       sim_control.setRunSimulationforWeatherFileRunPeriods(false)
-      baseline_run = prototype_creator.model_run_simulation_and_log_errors(model_baseline, "#{@test_dir}/#{building_type}-#{template}-#{climate_zone}-Baseline/SR1")
+      baseline_run = @prototype_creator.model_run_simulation_and_log_errors(model_baseline, "#{@test_dir}/#{model_baseline_file_name}-SR")
 
       # Add prototype to the list of baseline prototypes generated
       baseline_prototypes[id] = model_baseline
@@ -268,6 +268,22 @@ class AppendixGPRMTests < Minitest::Test
       # Check WWR against expected WWR
       wwr_goal = 100 * @@wwr_values[building_type].to_f
       assert((wwr_baseline - wwr_goal).abs < 0.1, "Baseline WWR for the #{building_type}, #{template}, #{climate_zone} model is incorrect. The WWR of the baseline model is #{wwr_baseline} but should be #{wwr_goal}.")
+    end
+  end
+
+  # Check Skylight-to-Roof Ratio (SRR) for the baseline models
+  #
+  # @param prototypes_base [Hash] Baseline prototypes
+  def check_srr(prototypes_base)
+    prototypes_base.each do |prototype, model_baseline|
+      building_type, template, climate_zone, mod = prototype
+
+      # Get srr of baseline model
+      srr_baseline = run_query_tabulardatawithstrings(model_baseline, 'InputVerificationandResultsSummary', 'Skylight-Roof Ratio', 'Skylight-Roof Ratio', 'Total', '%').to_f
+
+      # Check WWR against expected WWR
+      srr_goal = 3
+      assert((srr_baseline - srr_goal).abs < 0.1, "Baseline SRR for the #{building_type}, #{template}, #{climate_zone} model is incorrect. The SRR of the baseline model is #{srr_baseline} but should be #{srr_goal}.")
     end
   end
 
@@ -907,8 +923,37 @@ class AppendixGPRMTests < Minitest::Test
     return model
   end
 
+  # Remove transformer from model
+  # @param model [OpenStudio::model::Model] OpenStudio model object
+  # @param arguments [Array] List of arguments
   def remove_transformer(model, arguments)
     model.getElectricLoadCenterTransformers.each(&:remove)
+    return model
+  end
+
+  # Increase the size of the skylights in a model
+  # @param model [OpenStudio::model::Model] OpenStudio model object
+  # @param arguments [Array] List of arguments
+  def increase_skylight_size(model, arguments)
+    mult = arguments[0]
+    model.getSpaces.sort.each do |space|
+      next if @prototype_creator.space_conditioning_category(space) == 'Unconditioned'
+      # Loop through all surfaces in this space
+      space.surfaces.sort.each do |surface|
+        # Skip non-outdoor surfaces
+        next unless surface.outsideBoundaryCondition == 'Outdoors'
+        # Skip non-walls
+        next unless surface.surfaceType == 'RoofCeiling'
+        # Subsurfaces in this surface
+        surface.subSurfaces.sort.each do |ss|
+          next unless ss.subSurfaceType == 'Skylight'
+          # increase the size of the skylight
+
+          @prototype_creator.sub_surface_reduce_area_by_percent_by_shrinking_toward_centroid(ss, mult)
+        end
+      end
+    end
+
     return model
   end
 
@@ -919,6 +964,7 @@ class AppendixGPRMTests < Minitest::Test
     # Select test to run
     tests = [
       'wwr',
+      'srr',
       'envelope',
       'lpd',
       'isresidential',
@@ -940,6 +986,7 @@ class AppendixGPRMTests < Minitest::Test
 
     # Run tests
     check_wwr(prototypes_base['wwr']) if (tests.include? 'wwr')
+    check_srr(prototypes_base['srr']) if (tests.include? 'srr')
     check_daylighting_control(prototypes_base['daylighting_control']) if (tests.include? 'daylighting_control')
     check_residential_flag(prototypes_base['isresidential']) if (tests.include? 'isresidential')
     check_envelope(prototypes_base['envelope']) if (tests.include? 'envelope')


### PR DESCRIPTION
The proposed changes add a new 90.1-PRM method to adjust the skylight-to-roof ratio of the baseline model. The existing method was based on the 90.1-2010 PRM user manual which is different from the 90.1-2019 PRM. A "SRR" test was also added.