### PR TITLE
Zeroes elevator fraction radiant before setting fraction lost

### DIFF
--- a/lib/openstudio-standards/prototypes/common/objects/Prototype.Model.elevators.rb
+++ b/lib/openstudio-standards/prototypes/common/objects/Prototype.Model.elevators.rb
@@ -412,8 +412,9 @@ class Standard
 
     # check fraction lost on heat from elevator if traction, change to 100% lost if not setup that way.
     if elevator_type == 'Traction'
-      elevator.definition.to_ElectricEquipmentDefinition.get.setFractionLost(1.0)
+      elevator.definition.to_ElectricEquipmentDefinition.get.setFractionLatent(0.0)
       elevator.definition.to_ElectricEquipmentDefinition.get.setFractionRadiant(0.0)
+      elevator.definition.to_ElectricEquipmentDefinition.get.setFractionLost(1.0)
     end
 
     return elevator


### PR DESCRIPTION
Previously, for traction elevators, fraction lost was set to 1.0, then fraction radiant was set to 0.0.  However, [new error checks](https://github.com/NREL/OpenStudio/blob/develop/src/model/ElectricEquipmentDefinition.cpp#L209-L256) have been added to these OpenStudio setter methods to ensure that the total latent + radiant + lost fraction is below 1.0.  This makes the order that the setters are called in important now.

This should not change simulation results at all as the final model should be identical to what was previously created.