### PR TITLE
Version-specific electric equipment output variable for E+ 9.4 change

### DIFF
--- a/lib/openstudio-standards/prototypes/common/buildings/Prototype.HighRiseApartment.rb
+++ b/lib/openstudio-standards/prototypes/common/buildings/Prototype.HighRiseApartment.rb
@@ -19,12 +19,19 @@ module HighriseApartment
     end
     return true unless !transformer_efficiency.nil?
 
+    # Change to output variable name in E+ 9.4 (OS 3.1.0)
+    excluded_interiorequip_variable = if model.version < OpenStudio::VersionString.new('3.1.0')
+                                        'Electric Equipment Electric Energy'
+                                      else
+                                        'Electric Equipment Electricity Energy'
+                                      end
+
     model_add_transformer(model,
                           wired_lighting_frac: 0.0015,
                           transformer_size: 75000,
                           transformer_efficiency: transformer_efficiency,
                           excluded_interiorequip_key: 'T Corridor_Elevators_Equip',
-                          excluded_interiorequip_meter: 'Electric Equipment Electric Energy')
+                          excluded_interiorequip_meter: excluded_interiorequip_variable)
 
     return true
   end

--- a/lib/openstudio-standards/prototypes/common/buildings/Prototype.MediumOffice.rb
+++ b/lib/openstudio-standards/prototypes/common/buildings/Prototype.MediumOffice.rb
@@ -16,12 +16,19 @@ module MediumOffice
     end
     return true unless !transformer_efficiency.nil?
 
+    # Change to output variable name in E+ 9.4 (OS 3.1.0)
+    excluded_interiorequip_variable = if model.version < OpenStudio::VersionString.new('3.1.0')
+                                        'Electric Equipment Electric Energy'
+                                      else
+                                        'Electric Equipment Electricity Energy'
+                                      end
+
     model_add_transformer(model,
                           wired_lighting_frac: 0.0281,
                           transformer_size: 45000,
                           transformer_efficiency: transformer_efficiency,
                           excluded_interiorequip_key: '2 Elevator Lift Motors',
-                          excluded_interiorequip_meter: 'Electric Equipment Electric Energy')
+                          excluded_interiorequip_meter: excluded_interiorequip_variable)
 
     model.getSpaces.sort.each do |space|
       if space.name.get.to_s == 'Core_bottom'

--- a/lib/openstudio-standards/prototypes/common/buildings/Prototype.SecondarySchool.rb
+++ b/lib/openstudio-standards/prototypes/common/buildings/Prototype.SecondarySchool.rb
@@ -16,12 +16,19 @@ module SecondarySchool
     end
     return true unless !transformer_efficiency.nil?
 
+    # Change to output variable name in E+ 9.4 (OS 3.1.0)
+    excluded_interiorequip_variable = if model.version < OpenStudio::VersionString.new('3.1.0')
+                                        'Electric Equipment Electric Energy'
+                                      else
+                                        'Electric Equipment Electricity Energy'
+                                      end
+
     model_add_transformer(model,
                           wired_lighting_frac: 0.0194,
                           transformer_size: 225000,
                           transformer_efficiency: transformer_efficiency,
                           excluded_interiorequip_key: '2 Elevator Lift Motors',
-                          excluded_interiorequip_meter: 'Electric Equipment Electric Energy')
+                          excluded_interiorequip_meter: excluded_interiorequip_variable)
 
     # add extra equipment for kitchen
     add_extra_equip_kitchen(model)


### PR DESCRIPTION
In EnergyPlus 9.4 (OS 3.1.0), the output variable for `ElectricEquipment` changed from `Electric Equipment Electric Energy` to `Electric Equipment Electricity Energy`.  openstudio-standards was creating a `Meter:CustomDecrement` to feed a `Transformer`, so this PR adds a switch statement to use the correct variable name depending on the version of OpenStudio being used.

This should have no impact on simulation results.