### PR TITLE
Replaces hard-coded 0.15 AirLoopHVAC occ threshold

### DIFF
--- a/lib/openstudio-standards/standards/Standards.AirLoopHVAC.rb
+++ b/lib/openstudio-standards/standards/Standards.AirLoopHVAC.rb
@@ -136,7 +136,8 @@ class Standard
     if air_loop_hvac_motorized_oa_damper_required?(air_loop_hvac, climate_zone)
       # Assume that the availability schedule has already been
       # set to reflect occupancy and use this for the OA damper.
-      air_loop_hvac_add_motorized_oa_damper(air_loop_hvac, 0.15, air_loop_hvac.availabilitySchedule)
+      occ_threshold = air_loop_hvac_unoccupied_threshold
+      air_loop_hvac_add_motorized_oa_damper(air_loop_hvac, occ_threshold, air_loop_hvac.availabilitySchedule)
     else
       air_loop_hvac_remove_motorized_oa_damper(air_loop_hvac)
     end


### PR DESCRIPTION
Replaces hard-coded `0.15` AirLoopHVAC occ threshold with `air_loop_hvac_unoccupied_threshold()` return.

Right now, the occupancy threshold for motorized dampers is hard-coded to `0.15`.  Change this to instead pull the threshold from  the method `air_loop_hvac_unoccupied_threshold()` so that this threshold can be overwritten consistently by derivative classes.  Currently, `air_loop_hvac_unoccupied_threshold()` returns `0.15`, so this should not impact any of the prototypes.