### PR TITLE
exterior (parking and entry canopy) lighting power density update

### DIFF
--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2004/comstock_ashrae_90_1_2004/data/comstock_ashrae_90_1_2004.ext_ltg.json
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2004/comstock_ashrae_90_1_2004/data/comstock_ashrae_90_1_2004.ext_ltg.json
@@ -2,7 +2,7 @@
   "exterior_lighting": [
     {
       "exterior_lighting_zone_number": 0.0,
-      "exerior_lighting_zone_name": "Undeveloped Areas Parks",
+      "exterior_lighting_zone_name": "Undeveloped Areas Parks",
       "template": "ComStock 90.1-2004",
       "control_option": "AstronomicalClock",
       "building_facade_and_landscape_automatic_shut_off": 1,
@@ -35,7 +35,7 @@
     },
     {
       "exterior_lighting_zone_number": 1.0,
-      "exerior_lighting_zone_name": "Developed Areas Parks",
+      "exterior_lighting_zone_name": "Developed Areas Parks",
       "template": "ComStock 90.1-2004",
       "control_option": "AstronomicalClock",
       "building_facade_and_landscape_automatic_shut_off": 1,
@@ -68,7 +68,7 @@
     },
     {
       "exterior_lighting_zone_number": 2.0,
-      "exerior_lighting_zone_name": "Neighborhood",
+      "exterior_lighting_zone_name": "Neighborhood",
       "template": "ComStock 90.1-2004",
       "control_option": "AstronomicalClock",
       "building_facade_and_landscape_automatic_shut_off": 1,
@@ -101,7 +101,7 @@
     },
     {
       "exterior_lighting_zone_number": 3.0,
-      "exerior_lighting_zone_name": "All Other Areas",
+      "exterior_lighting_zone_name": "All Other Areas",
       "template": "ComStock 90.1-2004",
       "control_option": "AstronomicalClock",
       "building_facade_and_landscape_automatic_shut_off": 1,
@@ -134,7 +134,7 @@
     },
     {
       "exterior_lighting_zone_number": 4.0,
-      "exerior_lighting_zone_name": "High Activity",
+      "exterior_lighting_zone_name": "High Activity",
       "template": "ComStock 90.1-2004",
       "control_option": "AstronomicalClock",
       "building_facade_and_landscape_automatic_shut_off": 1,

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2004/comstock_ashrae_90_1_2004/data/comstock_ashrae_90_1_2004.ext_ltg.json
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2004/comstock_ashrae_90_1_2004/data/comstock_ashrae_90_1_2004.ext_ltg.json
@@ -108,7 +108,7 @@
       "occupancy_setback_reduction": 0.0,
       "base_site_allowance_power": null,
       "base_site_allowance_fraction": 0.05,
-      "parking_areas_and_drives": 0.15,
+      "parking_areas_and_drives": 0.045444,
       "walkways_less_than_10ft_wide": 1.0,
       "walkways_10ft_wide_or_greater": 0.2,
       "stairways": 1.0,
@@ -130,7 +130,7 @@
       "drive_through_windows_and_doors": 400.0,
       "parking_near_24_hour_entrances": 800.0,
       "roadway_parking": null,
-      "notes": null
+      "notes": "Parking Areas and Drives lpd updated based on values derived from 2015 U.S. Lighting Market Characterization report."
     },
     {
       "exterior_lighting_zone_number": 4.0,

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2007/comstock_ashrae_90_1_2007/data/comstock_ashrae_90_1_2007.ext_ltg.json
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2007/comstock_ashrae_90_1_2007/data/comstock_ashrae_90_1_2007.ext_ltg.json
@@ -2,7 +2,7 @@
   "exterior_lighting": [
     {
       "exterior_lighting_zone_number": 0.0,
-      "exerior_lighting_zone_name": "Undeveloped Areas Parks",
+      "exterior_lighting_zone_name": "Undeveloped Areas Parks",
       "template": "ComStock 90.1-2007",
       "control_option": "AstronomicalClock",
       "building_facade_and_landscape_automatic_shut_off": 1,
@@ -35,7 +35,7 @@
     },
     {
       "exterior_lighting_zone_number": 1.0,
-      "exerior_lighting_zone_name": "Developed Areas Parks",
+      "exterior_lighting_zone_name": "Developed Areas Parks",
       "template": "ComStock 90.1-2007",
       "control_option": "AstronomicalClock",
       "building_facade_and_landscape_automatic_shut_off": 1,
@@ -68,7 +68,7 @@
     },
     {
       "exterior_lighting_zone_number": 2.0,
-      "exerior_lighting_zone_name": "Neighborhood",
+      "exterior_lighting_zone_name": "Neighborhood",
       "template": "ComStock 90.1-2007",
       "control_option": "AstronomicalClock",
       "building_facade_and_landscape_automatic_shut_off": 1,
@@ -101,7 +101,7 @@
     },
     {
       "exterior_lighting_zone_number": 3.0,
-      "exerior_lighting_zone_name": "All Other Areas",
+      "exterior_lighting_zone_name": "All Other Areas",
       "template": "ComStock 90.1-2007",
       "control_option": "AstronomicalClock",
       "building_facade_and_landscape_automatic_shut_off": 1,
@@ -134,7 +134,7 @@
     },
     {
       "exterior_lighting_zone_number": 4.0,
-      "exerior_lighting_zone_name": "High Activity",
+      "exterior_lighting_zone_name": "High Activity",
       "template": "ComStock 90.1-2007",
       "control_option": "AstronomicalClock",
       "building_facade_and_landscape_automatic_shut_off": 1,

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2007/comstock_ashrae_90_1_2007/data/comstock_ashrae_90_1_2007.ext_ltg.json
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2007/comstock_ashrae_90_1_2007/data/comstock_ashrae_90_1_2007.ext_ltg.json
@@ -108,7 +108,7 @@
       "occupancy_setback_reduction": 0.0,
       "base_site_allowance_power": null,
       "base_site_allowance_fraction": 0.05,
-      "parking_areas_and_drives": 0.15,
+      "parking_areas_and_drives": 0.045444,
       "walkways_less_than_10ft_wide": 1.0,
       "walkways_10ft_wide_or_greater": 0.2,
       "stairways": 1.0,
@@ -130,7 +130,7 @@
       "drive_through_windows_and_doors": 400.0,
       "parking_near_24_hour_entrances": 800.0,
       "roadway_parking": null,
-      "notes": null
+      "notes": "Parking Areas and Drives lpd updated based on values derived from 2015 U.S. Lighting Market Characterization report."
     },
     {
       "exterior_lighting_zone_number": 4.0,

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2010/comstock_ashrae_90_1_2010/data/comstock_ashrae_90_1_2010.ext_ltg.json
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2010/comstock_ashrae_90_1_2010/data/comstock_ashrae_90_1_2010.ext_ltg.json
@@ -108,7 +108,7 @@
       "occupancy_setback_reduction": 0.3,
       "base_site_allowance_power": 750.0,
       "base_site_allowance_fraction": null,
-      "parking_areas_and_drives": 0.1,
+      "parking_areas_and_drives": 0.030296,
       "walkways_less_than_10ft_wide": 0.8,
       "walkways_10ft_wide_or_greater": 0.16,
       "stairways": 1.0,
@@ -130,7 +130,7 @@
       "drive_through_windows_and_doors": 400.0,
       "parking_near_24_hour_entrances": 800.0,
       "roadway_parking": 0.0,
-      "notes": null
+      "notes": "Parking Areas and Drives lpd updated based on values derived from 2015 U.S. Lighting Market Characterization report."
     },
     {
       "exterior_lighting_zone_number": 4.0,

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2010/comstock_ashrae_90_1_2010/data/comstock_ashrae_90_1_2010.ext_ltg.json
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2010/comstock_ashrae_90_1_2010/data/comstock_ashrae_90_1_2010.ext_ltg.json
@@ -2,7 +2,7 @@
   "exterior_lighting": [
     {
       "exterior_lighting_zone_number": 0.0,
-      "exerior_lighting_zone_name": "Undeveloped Areas Parks",
+      "exterior_lighting_zone_name": "Undeveloped Areas Parks",
       "template": "ComStock 90.1-2010",
       "control_option": "AstronomicalClock",
       "building_facade_and_landscape_automatic_shut_off": 1,
@@ -35,7 +35,7 @@
     },
     {
       "exterior_lighting_zone_number": 1.0,
-      "exerior_lighting_zone_name": "Developed Areas Parks",
+      "exterior_lighting_zone_name": "Developed Areas Parks",
       "template": "ComStock 90.1-2010",
       "control_option": "AstronomicalClock",
       "building_facade_and_landscape_automatic_shut_off": 1,
@@ -68,7 +68,7 @@
     },
     {
       "exterior_lighting_zone_number": 2.0,
-      "exerior_lighting_zone_name": "Neighborhood",
+      "exterior_lighting_zone_name": "Neighborhood",
       "template": "ComStock 90.1-2010",
       "control_option": "AstronomicalClock",
       "building_facade_and_landscape_automatic_shut_off": 1,
@@ -101,7 +101,7 @@
     },
     {
       "exterior_lighting_zone_number": 3.0,
-      "exerior_lighting_zone_name": "All Other Areas",
+      "exterior_lighting_zone_name": "All Other Areas",
       "template": "ComStock 90.1-2010",
       "control_option": "AstronomicalClock",
       "building_facade_and_landscape_automatic_shut_off": 1,
@@ -134,7 +134,7 @@
     },
     {
       "exterior_lighting_zone_number": 4.0,
-      "exerior_lighting_zone_name": "High Activity",
+      "exterior_lighting_zone_name": "High Activity",
       "template": "ComStock 90.1-2010",
       "control_option": "AstronomicalClock",
       "building_facade_and_landscape_automatic_shut_off": 1,

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2013/comstock_ashrae_90_1_2013/data/comstock_ashrae_90_1_2013.ext_ltg.json
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2013/comstock_ashrae_90_1_2013/data/comstock_ashrae_90_1_2013.ext_ltg.json
@@ -108,7 +108,7 @@
       "occupancy_setback_reduction": 0.3,
       "base_site_allowance_power": 750.0,
       "base_site_allowance_fraction": null,
-      "parking_areas_and_drives": 0.1,
+      "parking_areas_and_drives": 0.030296,
       "walkways_less_than_10ft_wide": 0.8,
       "walkways_10ft_wide_or_greater": 0.16,
       "stairways": 1.0,
@@ -130,7 +130,7 @@
       "drive_through_windows_and_doors": 400.0,
       "parking_near_24_hour_entrances": 800.0,
       "roadway_parking": 0.0,
-      "notes": null
+      "notes": "Parking Areas and Drives lpd updated based on values derived from 2015 U.S. Lighting Market Characterization report."
     },
     {
       "exterior_lighting_zone_number": 4.0,

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2013/comstock_ashrae_90_1_2013/data/comstock_ashrae_90_1_2013.ext_ltg.json
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2013/comstock_ashrae_90_1_2013/data/comstock_ashrae_90_1_2013.ext_ltg.json
@@ -2,7 +2,7 @@
   "exterior_lighting": [
     {
       "exterior_lighting_zone_number": 0.0,
-      "exerior_lighting_zone_name": "Undeveloped Areas Parks",
+      "exterior_lighting_zone_name": "Undeveloped Areas Parks",
       "template": "ComStock 90.1-2013",
       "control_option": "AstronomicalClock",
       "building_facade_and_landscape_automatic_shut_off": 1,
@@ -35,7 +35,7 @@
     },
     {
       "exterior_lighting_zone_number": 1.0,
-      "exerior_lighting_zone_name": "Developed Areas Parks",
+      "exterior_lighting_zone_name": "Developed Areas Parks",
       "template": "ComStock 90.1-2013",
       "control_option": "AstronomicalClock",
       "building_facade_and_landscape_automatic_shut_off": 1,
@@ -68,7 +68,7 @@
     },
     {
       "exterior_lighting_zone_number": 2.0,
-      "exerior_lighting_zone_name": "Neighborhood",
+      "exterior_lighting_zone_name": "Neighborhood",
       "template": "ComStock 90.1-2013",
       "control_option": "AstronomicalClock",
       "building_facade_and_landscape_automatic_shut_off": 1,
@@ -101,7 +101,7 @@
     },
     {
       "exterior_lighting_zone_number": 3.0,
-      "exerior_lighting_zone_name": "All Other Areas",
+      "exterior_lighting_zone_name": "All Other Areas",
       "template": "ComStock 90.1-2013",
       "control_option": "AstronomicalClock",
       "building_facade_and_landscape_automatic_shut_off": 1,
@@ -134,7 +134,7 @@
     },
     {
       "exterior_lighting_zone_number": 4.0,
-      "exerior_lighting_zone_name": "High Activity",
+      "exterior_lighting_zone_name": "High Activity",
       "template": "ComStock 90.1-2013",
       "control_option": "AstronomicalClock",
       "building_facade_and_landscape_automatic_shut_off": 1,

--- a/lib/openstudio-standards/standards/ashrae_90_1/doe_ref_1980_2004/comstock_doe_ref_1980_2004/data/comstock_doe_ref_1980_2004.ext_ltg.json
+++ b/lib/openstudio-standards/standards/ashrae_90_1/doe_ref_1980_2004/comstock_doe_ref_1980_2004/data/comstock_doe_ref_1980_2004.ext_ltg.json
@@ -2,7 +2,7 @@
   "exterior_lighting": [
     {
       "exterior_lighting_zone_number": 0.0,
-      "exerior_lighting_zone_name": "Undeveloped Areas Parks",
+      "exterior_lighting_zone_name": "Undeveloped Areas Parks",
       "template": "ComStock DOE Ref 1980-2004",
       "control_option": "AstronomicalClock",
       "building_facade_and_landscape_automatic_shut_off": 0,
@@ -35,7 +35,7 @@
     },
     {
       "exterior_lighting_zone_number": 1.0,
-      "exerior_lighting_zone_name": "Developed Areas Parks",
+      "exterior_lighting_zone_name": "Developed Areas Parks",
       "template": "ComStock DOE Ref 1980-2004",
       "control_option": "AstronomicalClock",
       "building_facade_and_landscape_automatic_shut_off": 0,
@@ -64,11 +64,11 @@
       "drive_through_windows_and_doors": 400.0,
       "parking_near_24_hour_entrances": 800.0,
       "roadway_parking": null,
-      "notes": "Values not specified by DOE Reference Buildings use values from 90.1-2005"
+      "notes": "Values not specified by DOE Reference Buildings use values from 90.1-2004"
     },
     {
       "exterior_lighting_zone_number": 2.0,
-      "exerior_lighting_zone_name": "Neighborhood",
+      "exterior_lighting_zone_name": "Neighborhood",
       "template": "ComStock DOE Ref 1980-2004",
       "control_option": "AstronomicalClock",
       "building_facade_and_landscape_automatic_shut_off": 0,
@@ -97,11 +97,11 @@
       "drive_through_windows_and_doors": 400.0,
       "parking_near_24_hour_entrances": 800.0,
       "roadway_parking": null,
-      "notes": "Values not specified by DOE Reference Buildings use values from 90.1-2006"
+      "notes": "Values not specified by DOE Reference Buildings use values from 90.1-2004"
     },
     {
       "exterior_lighting_zone_number": 3.0,
-      "exerior_lighting_zone_name": "All Other Areas",
+      "exterior_lighting_zone_name": "All Other Areas",
       "template": "ComStock DOE Ref 1980-2004",
       "control_option": "AstronomicalClock",
       "building_facade_and_landscape_automatic_shut_off": 0,
@@ -130,11 +130,11 @@
       "drive_through_windows_and_doors": 400.0,
       "parking_near_24_hour_entrances": 800.0,
       "roadway_parking": null,
-      "notes": "Values not specified by DOE Reference Buildings use values from 90.1-2007. Parking Areas and Drives lpd updated based on values derived from 2015 U.S. Lighting Market Characterization report. Entry Canopies lpd updated based on updates applied in DEER pre-1975 to 1985."
+      "notes": "Values not specified by DOE Reference Buildings use values from 90.1-2004. Parking Areas and Drives lpd updated based on values derived from 2015 U.S. Lighting Market Characterization report. Entry Canopies lpd updated based on updates applied in DEER pre-1975 to 1985."
     },
     {
       "exterior_lighting_zone_number": 4.0,
-      "exerior_lighting_zone_name": "High Activity",
+      "exterior_lighting_zone_name": "High Activity",
       "template": "ComStock DOE Ref 1980-2004",
       "control_option": "AstronomicalClock",
       "building_facade_and_landscape_automatic_shut_off": 0,
@@ -163,7 +163,7 @@
       "drive_through_windows_and_doors": 400.0,
       "parking_near_24_hour_entrances": 800.0,
       "roadway_parking": null,
-      "notes": "Values not specified by DOE Reference Buildings use values from 90.1-2008"
+      "notes": "Values not specified by DOE Reference Buildings use values from 90.1-2004"
     }
   ]
 }

--- a/lib/openstudio-standards/standards/ashrae_90_1/doe_ref_1980_2004/comstock_doe_ref_1980_2004/data/comstock_doe_ref_1980_2004.ext_ltg.json
+++ b/lib/openstudio-standards/standards/ashrae_90_1/doe_ref_1980_2004/comstock_doe_ref_1980_2004/data/comstock_doe_ref_1980_2004.ext_ltg.json
@@ -108,7 +108,7 @@
       "occupancy_setback_reduction": 0.0,
       "base_site_allowance_power": null,
       "base_site_allowance_fraction": 0.05,
-      "parking_areas_and_drives": 0.18,
+      "parking_areas_and_drives": 0.054533,
       "walkways_less_than_10ft_wide": 1.0,
       "walkways_10ft_wide_or_greater": 0.2,
       "stairways": 1.0,
@@ -116,7 +116,7 @@
       "landscaping": null,
       "main_entries": 30.0,
       "other_doors": 25.0,
-      "entry_canopies": 10.0,
+      "entry_canopies": 1.5,
       "loading_docks": null,
       "sales_canopies": null,
       "outdoor_sales_open_areas": 0.5,
@@ -130,7 +130,7 @@
       "drive_through_windows_and_doors": 400.0,
       "parking_near_24_hour_entrances": 800.0,
       "roadway_parking": null,
-      "notes": "Values not specified by DOE Reference Buildings use values from 90.1-2007"
+      "notes": "Values not specified by DOE Reference Buildings use values from 90.1-2007. Parking Areas and Drives lpd updated based on values derived from 2015 U.S. Lighting Market Characterization report. Entry Canopies lpd updated based on updates applied in DEER pre-1975 to 1985."
     },
     {
       "exterior_lighting_zone_number": 4.0,

--- a/lib/openstudio-standards/standards/ashrae_90_1/doe_ref_pre_1980/comstock_doe_ref_pre_1980/data/comstock_doe_ref_pre_1980.ext_ltg.json
+++ b/lib/openstudio-standards/standards/ashrae_90_1/doe_ref_pre_1980/comstock_doe_ref_pre_1980/data/comstock_doe_ref_pre_1980.ext_ltg.json
@@ -2,7 +2,7 @@
   "exterior_lighting": [
     {
       "exterior_lighting_zone_number": 0.0,
-      "exerior_lighting_zone_name": "Undeveloped Areas Parks",
+      "exterior_lighting_zone_name": "Undeveloped Areas Parks",
       "template": "ComStock DOE Ref Pre-1980",
       "control_option": "AstronomicalClock",
       "building_facade_and_landscape_automatic_shut_off": 0,
@@ -31,11 +31,11 @@
       "drive_through_windows_and_doors": 400.0,
       "parking_near_24_hour_entrances": 800.0,
       "roadway_parking": null,
-      "notes": "Values not specified by DOE Reference Buildings use values from 90.1-2009"
+      "notes": "Values not specified by DOE Reference Buildings use values from 90.1-2004"
     },
     {
       "exterior_lighting_zone_number": 1.0,
-      "exerior_lighting_zone_name": "Developed Areas Parks",
+      "exterior_lighting_zone_name": "Developed Areas Parks",
       "template": "ComStock DOE Ref Pre-1980",
       "control_option": "AstronomicalClock",
       "building_facade_and_landscape_automatic_shut_off": 0,
@@ -64,11 +64,11 @@
       "drive_through_windows_and_doors": 400.0,
       "parking_near_24_hour_entrances": 800.0,
       "roadway_parking": null,
-      "notes": "Values not specified by DOE Reference Buildings use values from 90.1-2010"
+      "notes": "Values not specified by DOE Reference Buildings use values from 90.1-2004"
     },
     {
       "exterior_lighting_zone_number": 2.0,
-      "exerior_lighting_zone_name": "Neighborhood",
+      "exterior_lighting_zone_name": "Neighborhood",
       "template": "ComStock DOE Ref Pre-1980",
       "control_option": "AstronomicalClock",
       "building_facade_and_landscape_automatic_shut_off": 0,
@@ -97,11 +97,11 @@
       "drive_through_windows_and_doors": 400.0,
       "parking_near_24_hour_entrances": 800.0,
       "roadway_parking": null,
-      "notes": "Values not specified by DOE Reference Buildings use values from 90.1-2011"
+      "notes": "Values not specified by DOE Reference Buildings use values from 90.1-2004"
     },
     {
       "exterior_lighting_zone_number": 3.0,
-      "exerior_lighting_zone_name": "All Other Areas",
+      "exterior_lighting_zone_name": "All Other Areas",
       "template": "ComStock DOE Ref Pre-1980",
       "control_option": "AstronomicalClock",
       "building_facade_and_landscape_automatic_shut_off": 0,
@@ -130,11 +130,11 @@
       "drive_through_windows_and_doors": 400.0,
       "parking_near_24_hour_entrances": 800.0,
       "roadway_parking": null,
-      "notes": "Values not specified by DOE Reference Buildings use values from 90.1-2012. "
+      "notes": "Values not specified by DOE Reference Buildings use values from 90.1-2004"
     },
     {
       "exterior_lighting_zone_number": 4.0,
-      "exerior_lighting_zone_name": "High Activity",
+      "exterior_lighting_zone_name": "High Activity",
       "template": "ComStock DOE Ref Pre-1980",
       "control_option": "AstronomicalClock",
       "building_facade_and_landscape_automatic_shut_off": 0,
@@ -163,7 +163,7 @@
       "drive_through_windows_and_doors": 400.0,
       "parking_near_24_hour_entrances": 800.0,
       "roadway_parking": null,
-      "notes": "Values not specified by DOE Reference Buildings use values from 90.1-2013"
+      "notes": "Values not specified by DOE Reference Buildings use values from 90.1-2004"
     }
   ]
 }

--- a/lib/openstudio-standards/standards/ashrae_90_1/doe_ref_pre_1980/comstock_doe_ref_pre_1980/data/comstock_doe_ref_pre_1980.ext_ltg.json
+++ b/lib/openstudio-standards/standards/ashrae_90_1/doe_ref_pre_1980/comstock_doe_ref_pre_1980/data/comstock_doe_ref_pre_1980.ext_ltg.json
@@ -130,7 +130,7 @@
       "drive_through_windows_and_doors": 400.0,
       "parking_near_24_hour_entrances": 800.0,
       "roadway_parking": null,
-      "notes": "Values not specified by DOE Reference Buildings use values from 90.1-2012"
+      "notes": "Values not specified by DOE Reference Buildings use values from 90.1-2012. "
     },
     {
       "exterior_lighting_zone_number": 4.0,


### PR DESCRIPTION
- parking LPD updated based on values derived from [2015 LMC report](https://www.energy.gov/eere/ssl/2015-us-lighting-market-characterization)

- entry canopy LPD was also udpated based on updates already made on DEER pre1975 to 1996

- refer to [summary slide deck](https://nrel.sharepoint.com/:p:/r/sites/LoadProfiles/Shared%20Documents/05%20Calibration/4%20Calibration%20and%20Validation/ComStock_Lighting_Analysis/LightingPowerDensity/201207_ExteriorLightingPowerDensityFromDataSources.pptx?d=we753e224cdc04daea774e80bf4409a63&csf=1&web=1&e=0beiZO) for details