### PR TITLE
Heat rejection updates

### DIFF
--- a/data/standards/manage_OpenStudio_Standards.rb
+++ b/data/standards/manage_OpenStudio_Standards.rb
@@ -329,9 +329,9 @@ def export_spreadsheet_to_json(spreadsheet_titles, dataset_type: 'os_stds')
                               'OEESC 2014',
                               'ICC IECC 2015',
                               'ECBC 2017',
-                              '189.1-2009',
-                              '90.1-2016',
-                              '90.1-2019']
+                              '189.1-2009']#,
+                              #'90.1-2016',
+                              #'90.1-2019']
   else
     standards_dir = File.expand_path("#{__dir__}/../../lib/openstudio-standards/standards")
     skip_list = exclusion_list['os_stds']

--- a/data/standards/manage_OpenStudio_Standards.rb
+++ b/data/standards/manage_OpenStudio_Standards.rb
@@ -329,9 +329,7 @@ def export_spreadsheet_to_json(spreadsheet_titles, dataset_type: 'os_stds')
                               'OEESC 2014',
                               'ICC IECC 2015',
                               'ECBC 2017',
-                              '189.1-2009',
-                              '90.1-2016',
-                              '90.1-2019']
+                              '189.1-2009']
   else
     standards_dir = File.expand_path("#{__dir__}/../../lib/openstudio-standards/standards")
     skip_list = exclusion_list['os_stds']

--- a/data/standards/manage_OpenStudio_Standards.rb
+++ b/data/standards/manage_OpenStudio_Standards.rb
@@ -329,9 +329,9 @@ def export_spreadsheet_to_json(spreadsheet_titles, dataset_type: 'os_stds')
                               'OEESC 2014',
                               'ICC IECC 2015',
                               'ECBC 2017',
-                              '189.1-2009']#,
-                              #'90.1-2016',
-                              #'90.1-2019']
+                              '189.1-2009',
+                              '90.1-2016',
+                              '90.1-2019']
   else
     standards_dir = File.expand_path("#{__dir__}/../../lib/openstudio-standards/standards")
     skip_list = exclusion_list['os_stds']

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2004/data/ashrae_90_1_2004.heat_rejection.json
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2004/data/ashrae_90_1_2004.heat_rejection.json
@@ -20,6 +20,15 @@
     },
     {
       "template": "90.1-2004",
+      "equipment_type": "Dry Cooler",
+      "fan_type": "Propeller or Axial",
+      "start_date": "1919-09-09T00:00:00+00:00",
+      "end_date": "2999-09-09T00:00:00+00:00",
+      "minimum_performance": 4.0,
+      "notes": "NOTE: Not required by code. Value provided by 90.1 Mechanical Subcommittee"
+    },
+    {
+      "template": "90.1-2004",
       "equipment_type": "Open Cooling Tower",
       "fan_type": "Centrifugal",
       "start_date": "1919-09-09T00:00:00+00:00",

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2007/data/ashrae_90_1_2007.heat_rejection.json
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2007/data/ashrae_90_1_2007.heat_rejection.json
@@ -20,6 +20,15 @@
     },
     {
       "template": "90.1-2007",
+      "equipment_type": "Dry Cooler",
+      "fan_type": "Propeller or Axial",
+      "start_date": "1919-09-09T00:00:00+00:00",
+      "end_date": "2999-09-09T00:00:00+00:00",
+      "minimum_performance": 4.0,
+      "notes": "NOTE: Not required by code. Value provided by 90.1 Mechanical Subcommittee"
+    },
+    {
+      "template": "90.1-2007",
       "equipment_type": "Open Cooling Tower",
       "fan_type": "Centrifugal",
       "start_date": "1919-09-09T00:00:00+00:00",

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2010/data/ashrae_90_1_2010.heat_rejection.json
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2010/data/ashrae_90_1_2010.heat_rejection.json
@@ -20,6 +20,15 @@
     },
     {
       "template": "90.1-2010",
+      "equipment_type": "Dry Cooler",
+      "fan_type": "Propeller or Axial",
+      "start_date": "1919-09-09T00:00:00+00:00",
+      "end_date": "2999-09-09T00:00:00+00:00",
+      "minimum_performance": 4.0,
+      "notes": "NOTE: Not required by code. Value provided by 90.1 Mechanical Subcommittee"
+    },
+    {
+      "template": "90.1-2010",
       "equipment_type": "Open Cooling Tower",
       "fan_type": "Centrifugal",
       "start_date": "1919-09-09T00:00:00+00:00",

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2013/data/ashrae_90_1_2013.heat_rejection.json
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2013/data/ashrae_90_1_2013.heat_rejection.json
@@ -20,6 +20,15 @@
     },
     {
       "template": "90.1-2013",
+      "equipment_type": "Dry Cooler",
+      "fan_type": "Propeller or Axial",
+      "start_date": "1919-09-09T00:00:00+00:00",
+      "end_date": "2999-09-09T00:00:00+00:00",
+      "minimum_performance": 4.0,
+      "notes": "NOTE: Not required by code. Value provided by 90.1 Mechanical Subcommittee"
+    },
+    {
+      "template": "90.1-2013",
       "equipment_type": "Open Cooling Tower",
       "fan_type": "Centrifugal",
       "start_date": "1919-09-09T00:00:00+00:00",

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2016/data/ashrae_90_1_2016.heat_rejection.json
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2016/data/ashrae_90_1_2016.heat_rejection.json
@@ -7,7 +7,7 @@
       "start_date": "1919-09-09T00:00:00+00:00",
       "end_date": "2999-09-09T00:00:00+00:00",
       "minimum_performance": 7.0,
-      "notes": null
+      "notes": "From 90.1-2016 Table 6.8.1-7"
     },
     {
       "template": "90.1-2016",
@@ -15,8 +15,35 @@
       "fan_type": "Propeller or Axial",
       "start_date": "1919-09-09T00:00:00+00:00",
       "end_date": "2999-09-09T00:00:00+00:00",
-      "minimum_performance": 14.0,
-      "notes": null
+      "minimum_performance": 16.1,
+      "notes": "From 90.1-2016 Table 6.8.1-7"
+    },
+    {
+      "template": "90.1-2016",
+      "equipment_type": "Dry Cooler",
+      "fan_type": "Propeller or Axial",
+      "start_date": "1919-09-09T00:00:00+00:00",
+      "end_date": "2999-09-09T00:00:00+00:00",
+      "minimum_performance": 4.0,
+      "notes": "NOTE: Not required by code. Value provided by 90.1 Mechanical Subcommittee"
+    },
+    {
+      "template": "90.1-2016",
+      "equipment_type": "Open Cooling Tower",
+      "fan_type": "Centrifugal",
+      "start_date": "1919-09-09T00:00:00+00:00",
+      "end_date": "2999-09-09T00:00:00+00:00",
+      "minimum_performance": 20.0,
+      "notes": "From 90.1-2016 Table 6.8.1-7"
+    },
+    {
+      "template": "90.1-2016",
+      "equipment_type": "Open Cooling Tower",
+      "fan_type": "Propeller or Axial",
+      "start_date": "1919-09-09T00:00:00+00:00",
+      "end_date": "2999-09-09T00:00:00+00:00",
+      "minimum_performance": 40.2,
+      "notes": "From 90.1-2016 Table 6.8.1-7"
     }
   ]
 }

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2019/data/ashrae_90_1_2019.heat_rejection.json
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2019/data/ashrae_90_1_2019.heat_rejection.json
@@ -7,7 +7,7 @@
       "start_date": "1919-09-09T00:00:00+00:00",
       "end_date": "2999-09-09T00:00:00+00:00",
       "minimum_performance": 7.0,
-      "notes": null
+      "notes": "From 90.1-2019 Table 6.8.1-7"
     },
     {
       "template": "90.1-2019",
@@ -15,8 +15,35 @@
       "fan_type": "Propeller or Axial",
       "start_date": "1919-09-09T00:00:00+00:00",
       "end_date": "2999-09-09T00:00:00+00:00",
-      "minimum_performance": 14.0,
-      "notes": null
+      "minimum_performance": 16.1,
+      "notes": "From 90.1-2019 Table 6.8.1-7"
+    },
+    {
+      "template": "90.1-2019",
+      "equipment_type": "Dry Cooler",
+      "fan_type": "Propeller or Axial",
+      "start_date": "1919-09-09T00:00:00+00:00",
+      "end_date": "2999-09-09T00:00:00+00:00",
+      "minimum_performance": 4.5,
+      "notes": "From 90.1-2019 Table 6.8.1.7"
+    },
+    {
+      "template": "90.1-2019",
+      "equipment_type": "Open Cooling Tower",
+      "fan_type": "Centrifugal",
+      "start_date": "1919-09-09T00:00:00+00:00",
+      "end_date": "2999-09-09T00:00:00+00:00",
+      "minimum_performance": 20.0,
+      "notes": "From 90.1-2019 Table 6.8.1-7"
+    },
+    {
+      "template": "90.1-2019",
+      "equipment_type": "Open Cooling Tower",
+      "fan_type": "Propeller or Axial",
+      "start_date": "1919-09-09T00:00:00+00:00",
+      "end_date": "2999-09-09T00:00:00+00:00",
+      "minimum_performance": 40.2,
+      "notes": "From 90.1-2019 Table 6.8.1-7"
     }
   ]
 }

--- a/lib/openstudio-standards/standards/ashrae_90_1/doe_ref_1980_2004/data/doe_ref_1980_2004.heat_rejection.json
+++ b/lib/openstudio-standards/standards/ashrae_90_1/doe_ref_1980_2004/data/doe_ref_1980_2004.heat_rejection.json
@@ -20,6 +20,15 @@
     },
     {
       "template": "DOE Ref 1980-2004",
+      "equipment_type": "Dry Cooler",
+      "fan_type": "Propeller or Axial",
+      "start_date": "1919-09-09T00:00:00+00:00",
+      "end_date": "2999-09-09T00:00:00+00:00",
+      "minimum_performance": 4.0,
+      "notes": "NOTE: Not required by code. Value provided by 90.1 Mechanical Subcommittee"
+    },
+    {
+      "template": "DOE Ref 1980-2004",
       "equipment_type": "Open Cooling Tower",
       "fan_type": "Centrifugal",
       "start_date": "1919-09-09T00:00:00+00:00",

--- a/lib/openstudio-standards/standards/ashrae_90_1/doe_ref_pre_1980/data/doe_ref_pre_1980.heat_rejection.json
+++ b/lib/openstudio-standards/standards/ashrae_90_1/doe_ref_pre_1980/data/doe_ref_pre_1980.heat_rejection.json
@@ -20,6 +20,15 @@
     },
     {
       "template": "DOE Ref Pre-1980",
+      "equipment_type": "Dry Cooler",
+      "fan_type": "Propeller or Axial",
+      "start_date": "1919-09-09T00:00:00+00:00",
+      "end_date": "2999-09-09T00:00:00+00:00",
+      "minimum_performance": 4.0,
+      "notes": "NOTE: Not required by code. Value provided by 90.1 Mechanical Subcommittee"
+    },
+    {
+      "template": "DOE Ref Pre-1980",
       "equipment_type": "Open Cooling Tower",
       "fan_type": "Centrifugal",
       "start_date": "1919-09-09T00:00:00+00:00",


### PR DESCRIPTION
Hi Jeremy,

I have updated heat rejection performance metrics for 90.1 2016/2019 based on Table 6.8.1-7.  This also includes updated default performance for Dry Coolers