### PR TITLE
Remove ERV exception for MZ VAV optimization

### DIFF
--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2010/ashrae_90_1_2010.AirLoopHVAC.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2010/ashrae_90_1_2010.AirLoopHVAC.rb
@@ -177,6 +177,7 @@ class ASHRAE9012010 < ASHRAE901
     end
 
     # Not required for systems that require an ERV
+    # Exception 2 to Section 6.5.3.3
     if air_loop_hvac_energy_recovery?(air_loop_hvac)
       OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.AirLoopHVAC', "For #{air_loop_hvac.name}: multizone vav optimization is not required because the system has Energy Recovery.")
       return multizone_opt_required

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2010/ashrae_90_1_2010.AirLoopHVAC.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2010/ashrae_90_1_2010.AirLoopHVAC.rb
@@ -156,6 +156,7 @@ class ASHRAE9012010 < ASHRAE901
 
   # Determine if multizone vav optimization is required.
   #
+  # @code_sections [90.1-2010_6.5.3.3]
   # @param (see #economizer_required?)
   # @return [Bool] Returns true if required, false if not.
   # @todo Add exception logic for

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2013/ashrae_90_1_2013.AirLoopHVAC.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2013/ashrae_90_1_2013.AirLoopHVAC.rb
@@ -222,6 +222,7 @@ class ASHRAE9012013 < ASHRAE901
 
   # Determine if multizone vav optimization is required.
   #
+  # @code_sections [90.1-2013_6.5.3.3]
   # @param (see #economizer_required?)
   # @return [Bool] Returns true if required, false if not.
   # @todo Add exception logic for

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2013/ashrae_90_1_2013.AirLoopHVAC.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2013/ashrae_90_1_2013.AirLoopHVAC.rb
@@ -243,6 +243,7 @@ class ASHRAE9012013 < ASHRAE901
     end
 
     # Not required for systems that require an ERV
+    # Exception 2 to Section 6.5.3.3
     if air_loop_hvac_energy_recovery?(air_loop_hvac)
       OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.AirLoopHVAC', "For #{air_loop_hvac.name}: multizone vav optimization is not required because the system has Energy Recovery.")
       return multizone_opt_required

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2016/ashrae_90_1_2016.AirLoopHVAC.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2016/ashrae_90_1_2016.AirLoopHVAC.rb
@@ -183,12 +183,6 @@ class ASHRAE9012016 < ASHRAE901
       return multizone_opt_required
     end
 
-    # Not required for systems that require an ERV
-    if air_loop_hvac_energy_recovery?(air_loop_hvac)
-      OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.AirLoopHVAC', "For #{air_loop_hvac.name}: multizone vav optimization is not required because the system has Energy Recovery.")
-      return multizone_opt_required
-    end
-
     # Get the OA intake
     controller_oa = nil
     controller_mv = nil

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2016/ashrae_90_1_2016.AirLoopHVAC.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2016/ashrae_90_1_2016.AirLoopHVAC.rb
@@ -163,6 +163,7 @@ class ASHRAE9012016 < ASHRAE901
 
   # Determine if multizone vav optimization is required.
   #
+  # @code_sections [90.1-2016_6.5.3.3]
   # @param (see #economizer_required?)
   # @return [Bool] Returns true if required, false if not.
   # @todo Add exception logic for

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2019/ashrae_90_1_2019.AirLoopHVAC.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2019/ashrae_90_1_2019.AirLoopHVAC.rb
@@ -163,7 +163,7 @@ class ASHRAE9012019 < ASHRAE901
 
   # Determine if multizone vav optimization is required.
   #
-  # @code_sections [90.1-2010_6.5.3.3]
+  # @code_sections [90.1-2019_6.5.3.3]
   # @param (see #economizer_required?)
   # @return [Bool] Returns true if required, false if not.
   # @todo Add exception logic for

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2019/ashrae_90_1_2019.AirLoopHVAC.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2019/ashrae_90_1_2019.AirLoopHVAC.rb
@@ -163,6 +163,7 @@ class ASHRAE9012019 < ASHRAE901
 
   # Determine if multizone vav optimization is required.
   #
+  # @code_sections [90.1-2010_6.5.3.3]
   # @param (see #economizer_required?)
   # @return [Bool] Returns true if required, false if not.
   # @todo Add exception logic for

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2019/ashrae_90_1_2019.AirLoopHVAC.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2019/ashrae_90_1_2019.AirLoopHVAC.rb
@@ -183,12 +183,6 @@ class ASHRAE9012019 < ASHRAE901
       return multizone_opt_required
     end
 
-    # Not required for systems that require an ERV
-    if air_loop_hvac_energy_recovery?(air_loop_hvac)
-      OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.AirLoopHVAC', "For #{air_loop_hvac.name}: multizone vav optimization is not required because the system has Energy Recovery.")
-      return multizone_opt_required
-    end
-
     # Get the OA intake
     controller_oa = nil
     controller_mv = nil


### PR DESCRIPTION
The ERV exception to Section 6.5.3.3 in 90.1-2010/3 has been removed in 90.1-2016/9. The proposed changes remove that section in the code applicable to 90.1-2016/9 and add a comment that refers to this exception in the code applicable to 90.1-2013 and 90.1-2010. Additional information in Section B1.2.3 in the [Energy Savings Analysis: ANSI/ASHRAE/IES Standard 90.1-2016 report](https://www.energycodes.gov/energy-savings-analysis-ansiashraeies-standard-901-2016).