### PR TITLE
Update economizer threshold

### DIFF
--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2016/data/ashrae_90_1_2016.economizers.json
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2016/data/ashrae_90_1_2016.economizers.json
@@ -76,7 +76,7 @@
       "template": "90.1-2016",
       "climate_zone": "ASHRAE 169-2006-2A",
       "data_center": true,
-      "capacity_limit": null,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 75.0,
       "notes": "90.1-2016 Table 6.5.1.1.3"
     },
@@ -92,7 +92,7 @@
       "template": "90.1-2016",
       "climate_zone": "ASHRAE 169-2006-2B",
       "data_center": true,
-      "capacity_limit": 135000.0,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 75.0,
       "notes": "90.1-2016 Table 6.5.1.1.3"
     },
@@ -108,7 +108,7 @@
       "template": "90.1-2016",
       "climate_zone": "ASHRAE 169-2006-3A",
       "data_center": true,
-      "capacity_limit": null,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 75.0,
       "notes": "90.1-2016 Table 6.5.1.1.3"
     },
@@ -124,7 +124,7 @@
       "template": "90.1-2016",
       "climate_zone": "ASHRAE 169-2006-3B",
       "data_center": true,
-      "capacity_limit": 65000.0,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 75.0,
       "notes": "90.1-2016 Table 6.5.1.1.3"
     },
@@ -140,7 +140,7 @@
       "template": "90.1-2016",
       "climate_zone": "ASHRAE 169-2006-3C",
       "data_center": true,
-      "capacity_limit": 65000.0,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 75.0,
       "notes": "90.1-2016 Table 6.5.1.1.3"
     },
@@ -156,7 +156,7 @@
       "template": "90.1-2016",
       "climate_zone": "ASHRAE 169-2006-4A",
       "data_center": true,
-      "capacity_limit": null,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 75.0,
       "notes": "90.1-2016 Table 6.5.1.1.3"
     },
@@ -172,7 +172,7 @@
       "template": "90.1-2016",
       "climate_zone": "ASHRAE 169-2006-4B",
       "data_center": true,
-      "capacity_limit": 65000.0,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 75.0,
       "notes": "90.1-2016 Table 6.5.1.1.3"
     },
@@ -188,7 +188,7 @@
       "template": "90.1-2016",
       "climate_zone": "ASHRAE 169-2006-4C",
       "data_center": true,
-      "capacity_limit": 65000.0,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 75.0,
       "notes": "90.1-2016 Table 6.5.1.1.3"
     },
@@ -204,7 +204,7 @@
       "template": "90.1-2016",
       "climate_zone": "ASHRAE 169-2006-5A",
       "data_center": true,
-      "capacity_limit": 135000.0,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 70.0,
       "notes": "90.1-2016 Table 6.5.1.1.3"
     },
@@ -220,7 +220,7 @@
       "template": "90.1-2016",
       "climate_zone": "ASHRAE 169-2006-5B",
       "data_center": true,
-      "capacity_limit": 65000.0,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 75.0,
       "notes": "90.1-2016 Table 6.5.1.1.3"
     },
@@ -236,7 +236,7 @@
       "template": "90.1-2016",
       "climate_zone": "ASHRAE 169-2006-5C",
       "data_center": true,
-      "capacity_limit": 65000.0,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 75.0,
       "notes": "90.1-2016 Table 6.5.1.1.3"
     },
@@ -252,7 +252,7 @@
       "template": "90.1-2016",
       "climate_zone": "ASHRAE 169-2006-6A",
       "data_center": true,
-      "capacity_limit": 135000.0,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 70.0,
       "notes": "90.1-2016 Table 6.5.1.1.3"
     },
@@ -268,7 +268,7 @@
       "template": "90.1-2016",
       "climate_zone": "ASHRAE 169-2006-6B",
       "data_center": true,
-      "capacity_limit": 65000.0,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 75.0,
       "notes": "90.1-2016 Table 6.5.1.1.3"
     },
@@ -284,7 +284,7 @@
       "template": "90.1-2016",
       "climate_zone": "ASHRAE 169-2006-7A",
       "data_center": true,
-      "capacity_limit": 135000.0,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 75.0,
       "notes": "90.1-2016 Table 6.5.1.1.3"
     },
@@ -300,7 +300,7 @@
       "template": "90.1-2016",
       "climate_zone": "ASHRAE 169-2006-7B",
       "data_center": true,
-      "capacity_limit": 135000.0,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 75.0,
       "notes": "90.1-2016 Table 6.5.1.1.3"
     },
@@ -316,7 +316,7 @@
       "template": "90.1-2016",
       "climate_zone": "ASHRAE 169-2006-8A",
       "data_center": true,
-      "capacity_limit": 135000.0,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 75.0,
       "notes": "90.1-2016 Table 6.5.1.1.3"
     },
@@ -332,7 +332,7 @@
       "template": "90.1-2016",
       "climate_zone": "ASHRAE 169-2006-8B",
       "data_center": true,
-      "capacity_limit": 135000.0,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 75.0,
       "notes": "90.1-2016 Table 6.5.1.1.3"
     },
@@ -412,7 +412,7 @@
       "template": "90.1-2016",
       "climate_zone": "ASHRAE 169-2013-2A",
       "data_center": true,
-      "capacity_limit": null,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 75.0,
       "notes": "90.1-2016 Table 6.5.1.1.3"
     },
@@ -428,7 +428,7 @@
       "template": "90.1-2016",
       "climate_zone": "ASHRAE 169-2013-2B",
       "data_center": true,
-      "capacity_limit": 135000.0,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 75.0,
       "notes": "90.1-2016 Table 6.5.1.1.3"
     },
@@ -444,7 +444,7 @@
       "template": "90.1-2016",
       "climate_zone": "ASHRAE 169-2013-3A",
       "data_center": true,
-      "capacity_limit": null,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 75.0,
       "notes": "90.1-2016 Table 6.5.1.1.3"
     },
@@ -460,7 +460,7 @@
       "template": "90.1-2016",
       "climate_zone": "ASHRAE 169-2013-3B",
       "data_center": true,
-      "capacity_limit": 65000.0,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 75.0,
       "notes": "90.1-2016 Table 6.5.1.1.3"
     },
@@ -476,7 +476,7 @@
       "template": "90.1-2016",
       "climate_zone": "ASHRAE 169-2013-3C",
       "data_center": true,
-      "capacity_limit": 65000.0,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 75.0,
       "notes": "90.1-2016 Table 6.5.1.1.3"
     },
@@ -492,7 +492,7 @@
       "template": "90.1-2016",
       "climate_zone": "ASHRAE 169-2013-4A",
       "data_center": true,
-      "capacity_limit": null,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 75.0,
       "notes": "90.1-2016 Table 6.5.1.1.3"
     },
@@ -508,7 +508,7 @@
       "template": "90.1-2016",
       "climate_zone": "ASHRAE 169-2013-4B",
       "data_center": true,
-      "capacity_limit": 65000.0,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 75.0,
       "notes": "90.1-2016 Table 6.5.1.1.3"
     },
@@ -524,7 +524,7 @@
       "template": "90.1-2016",
       "climate_zone": "ASHRAE 169-2013-4C",
       "data_center": true,
-      "capacity_limit": 65000.0,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 75.0,
       "notes": "90.1-2016 Table 6.5.1.1.3"
     },
@@ -540,7 +540,7 @@
       "template": "90.1-2016",
       "climate_zone": "ASHRAE 169-2013-5A",
       "data_center": true,
-      "capacity_limit": 135000.0,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 70.0,
       "notes": "90.1-2016 Table 6.5.1.1.3"
     },
@@ -556,7 +556,7 @@
       "template": "90.1-2016",
       "climate_zone": "ASHRAE 169-2013-5B",
       "data_center": true,
-      "capacity_limit": 65000.0,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 75.0,
       "notes": "90.1-2016 Table 6.5.1.1.3"
     },
@@ -572,7 +572,7 @@
       "template": "90.1-2016",
       "climate_zone": "ASHRAE 169-2013-5C",
       "data_center": true,
-      "capacity_limit": 65000.0,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 75.0,
       "notes": "90.1-2016 Table 6.5.1.1.3"
     },
@@ -588,7 +588,7 @@
       "template": "90.1-2016",
       "climate_zone": "ASHRAE 169-2013-6A",
       "data_center": true,
-      "capacity_limit": 135000.0,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 70.0,
       "notes": "90.1-2016 Table 6.5.1.1.3"
     },
@@ -604,7 +604,7 @@
       "template": "90.1-2016",
       "climate_zone": "ASHRAE 169-2013-6B",
       "data_center": true,
-      "capacity_limit": 65000.0,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 75.0,
       "notes": "90.1-2016 Table 6.5.1.1.3"
     },
@@ -620,7 +620,7 @@
       "template": "90.1-2016",
       "climate_zone": "ASHRAE 169-2013-7A",
       "data_center": true,
-      "capacity_limit": 135000.0,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 75.0,
       "notes": "90.1-2016 Table 6.5.1.1.3"
     },
@@ -636,7 +636,7 @@
       "template": "90.1-2016",
       "climate_zone": "ASHRAE 169-2013-7B",
       "data_center": true,
-      "capacity_limit": 135000.0,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 75.0,
       "notes": "90.1-2016 Table 6.5.1.1.3"
     },
@@ -652,7 +652,7 @@
       "template": "90.1-2016",
       "climate_zone": "ASHRAE 169-2013-8A",
       "data_center": true,
-      "capacity_limit": 135000.0,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 75.0,
       "notes": "90.1-2016 Table 6.5.1.1.3"
     },
@@ -668,7 +668,7 @@
       "template": "90.1-2016",
       "climate_zone": "ASHRAE 169-2013-8B",
       "data_center": true,
-      "capacity_limit": 135000.0,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 75.0,
       "notes": "90.1-2016 Table 6.5.1.1.3"
     }

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2019/data/ashrae_90_1_2019.economizers.json
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2019/data/ashrae_90_1_2019.economizers.json
@@ -76,7 +76,7 @@
       "template": "90.1-2019",
       "climate_zone": "ASHRAE 169-2006-2A",
       "data_center": true,
-      "capacity_limit": null,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 75.0,
       "notes": "90.1-2019 Table 6.5.1.1.3"
     },
@@ -92,7 +92,7 @@
       "template": "90.1-2019",
       "climate_zone": "ASHRAE 169-2006-2B",
       "data_center": true,
-      "capacity_limit": 135000.0,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 75.0,
       "notes": "90.1-2019 Table 6.5.1.1.3"
     },
@@ -108,7 +108,7 @@
       "template": "90.1-2019",
       "climate_zone": "ASHRAE 169-2006-3A",
       "data_center": true,
-      "capacity_limit": null,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 75.0,
       "notes": "90.1-2019 Table 6.5.1.1.3"
     },
@@ -124,7 +124,7 @@
       "template": "90.1-2019",
       "climate_zone": "ASHRAE 169-2006-3B",
       "data_center": true,
-      "capacity_limit": 65000.0,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 75.0,
       "notes": "90.1-2019 Table 6.5.1.1.3"
     },
@@ -140,7 +140,7 @@
       "template": "90.1-2019",
       "climate_zone": "ASHRAE 169-2006-3C",
       "data_center": true,
-      "capacity_limit": 65000.0,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 75.0,
       "notes": "90.1-2019 Table 6.5.1.1.3"
     },
@@ -156,7 +156,7 @@
       "template": "90.1-2019",
       "climate_zone": "ASHRAE 169-2006-4A",
       "data_center": true,
-      "capacity_limit": null,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 75.0,
       "notes": "90.1-2019 Table 6.5.1.1.3"
     },
@@ -172,7 +172,7 @@
       "template": "90.1-2019",
       "climate_zone": "ASHRAE 169-2006-4B",
       "data_center": true,
-      "capacity_limit": 65000.0,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 75.0,
       "notes": "90.1-2019 Table 6.5.1.1.3"
     },
@@ -188,7 +188,7 @@
       "template": "90.1-2019",
       "climate_zone": "ASHRAE 169-2006-4C",
       "data_center": true,
-      "capacity_limit": 65000.0,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 75.0,
       "notes": "90.1-2019 Table 6.5.1.1.3"
     },
@@ -204,7 +204,7 @@
       "template": "90.1-2019",
       "climate_zone": "ASHRAE 169-2006-5A",
       "data_center": true,
-      "capacity_limit": 135000.0,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 70.0,
       "notes": "90.1-2019 Table 6.5.1.1.3"
     },
@@ -220,7 +220,7 @@
       "template": "90.1-2019",
       "climate_zone": "ASHRAE 169-2006-5B",
       "data_center": true,
-      "capacity_limit": 65000.0,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 75.0,
       "notes": "90.1-2019 Table 6.5.1.1.3"
     },
@@ -236,7 +236,7 @@
       "template": "90.1-2019",
       "climate_zone": "ASHRAE 169-2006-5C",
       "data_center": true,
-      "capacity_limit": 65000.0,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 75.0,
       "notes": "90.1-2019 Table 6.5.1.1.3"
     },
@@ -252,7 +252,7 @@
       "template": "90.1-2019",
       "climate_zone": "ASHRAE 169-2006-6A",
       "data_center": true,
-      "capacity_limit": 135000.0,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 70.0,
       "notes": "90.1-2019 Table 6.5.1.1.3"
     },
@@ -268,7 +268,7 @@
       "template": "90.1-2019",
       "climate_zone": "ASHRAE 169-2006-6B",
       "data_center": true,
-      "capacity_limit": 65000.0,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 75.0,
       "notes": "90.1-2019 Table 6.5.1.1.3"
     },
@@ -284,7 +284,7 @@
       "template": "90.1-2019",
       "climate_zone": "ASHRAE 169-2006-7A",
       "data_center": true,
-      "capacity_limit": 135000.0,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 75.0,
       "notes": "90.1-2019 Table 6.5.1.1.3"
     },
@@ -300,7 +300,7 @@
       "template": "90.1-2019",
       "climate_zone": "ASHRAE 169-2006-7B",
       "data_center": true,
-      "capacity_limit": 135000.0,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 75.0,
       "notes": "90.1-2019 Table 6.5.1.1.3"
     },
@@ -316,7 +316,7 @@
       "template": "90.1-2019",
       "climate_zone": "ASHRAE 169-2006-8A",
       "data_center": true,
-      "capacity_limit": 135000.0,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 75.0,
       "notes": "90.1-2019 Table 6.5.1.1.3"
     },
@@ -332,7 +332,7 @@
       "template": "90.1-2019",
       "climate_zone": "ASHRAE 169-2006-8B",
       "data_center": true,
-      "capacity_limit": 135000.0,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 75.0,
       "notes": "90.1-2019 Table 6.5.1.1.3"
     },
@@ -412,7 +412,7 @@
       "template": "90.1-2019",
       "climate_zone": "ASHRAE 169-2013-2A",
       "data_center": true,
-      "capacity_limit": null,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 75.0,
       "notes": "90.1-2019 Table 6.5.1.1.3"
     },
@@ -428,7 +428,7 @@
       "template": "90.1-2019",
       "climate_zone": "ASHRAE 169-2013-2B",
       "data_center": true,
-      "capacity_limit": 135000.0,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 75.0,
       "notes": "90.1-2019 Table 6.5.1.1.3"
     },
@@ -444,7 +444,7 @@
       "template": "90.1-2019",
       "climate_zone": "ASHRAE 169-2013-3A",
       "data_center": true,
-      "capacity_limit": null,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 75.0,
       "notes": "90.1-2019 Table 6.5.1.1.3"
     },
@@ -460,7 +460,7 @@
       "template": "90.1-2019",
       "climate_zone": "ASHRAE 169-2013-3B",
       "data_center": true,
-      "capacity_limit": 65000.0,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 75.0,
       "notes": "90.1-2019 Table 6.5.1.1.3"
     },
@@ -476,7 +476,7 @@
       "template": "90.1-2019",
       "climate_zone": "ASHRAE 169-2013-3C",
       "data_center": true,
-      "capacity_limit": 65000.0,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 75.0,
       "notes": "90.1-2019 Table 6.5.1.1.3"
     },
@@ -492,7 +492,7 @@
       "template": "90.1-2019",
       "climate_zone": "ASHRAE 169-2013-4A",
       "data_center": true,
-      "capacity_limit": null,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 75.0,
       "notes": "90.1-2019 Table 6.5.1.1.3"
     },
@@ -508,7 +508,7 @@
       "template": "90.1-2019",
       "climate_zone": "ASHRAE 169-2013-4B",
       "data_center": true,
-      "capacity_limit": 65000.0,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 75.0,
       "notes": "90.1-2019 Table 6.5.1.1.3"
     },
@@ -524,7 +524,7 @@
       "template": "90.1-2019",
       "climate_zone": "ASHRAE 169-2013-4C",
       "data_center": true,
-      "capacity_limit": 65000.0,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 75.0,
       "notes": "90.1-2019 Table 6.5.1.1.3"
     },
@@ -540,7 +540,7 @@
       "template": "90.1-2019",
       "climate_zone": "ASHRAE 169-2013-5A",
       "data_center": true,
-      "capacity_limit": 135000.0,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 70.0,
       "notes": "90.1-2019 Table 6.5.1.1.3"
     },
@@ -556,7 +556,7 @@
       "template": "90.1-2019",
       "climate_zone": "ASHRAE 169-2013-5B",
       "data_center": true,
-      "capacity_limit": 65000.0,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 75.0,
       "notes": "90.1-2019 Table 6.5.1.1.3"
     },
@@ -572,7 +572,7 @@
       "template": "90.1-2019",
       "climate_zone": "ASHRAE 169-2013-5C",
       "data_center": true,
-      "capacity_limit": 65000.0,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 75.0,
       "notes": "90.1-2019 Table 6.5.1.1.3"
     },
@@ -588,7 +588,7 @@
       "template": "90.1-2019",
       "climate_zone": "ASHRAE 169-2013-6A",
       "data_center": true,
-      "capacity_limit": 135000.0,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 70.0,
       "notes": "90.1-2019 Table 6.5.1.1.3"
     },
@@ -604,7 +604,7 @@
       "template": "90.1-2019",
       "climate_zone": "ASHRAE 169-2013-6B",
       "data_center": true,
-      "capacity_limit": 65000.0,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 75.0,
       "notes": "90.1-2019 Table 6.5.1.1.3"
     },
@@ -620,7 +620,7 @@
       "template": "90.1-2019",
       "climate_zone": "ASHRAE 169-2013-7A",
       "data_center": true,
-      "capacity_limit": 135000.0,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 75.0,
       "notes": "90.1-2019 Table 6.5.1.1.3"
     },
@@ -636,7 +636,7 @@
       "template": "90.1-2019",
       "climate_zone": "ASHRAE 169-2013-7B",
       "data_center": true,
-      "capacity_limit": 135000.0,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 75.0,
       "notes": "90.1-2019 Table 6.5.1.1.3"
     },
@@ -652,7 +652,7 @@
       "template": "90.1-2019",
       "climate_zone": "ASHRAE 169-2013-8A",
       "data_center": true,
-      "capacity_limit": 135000.0,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 75.0,
       "notes": "90.1-2019 Table 6.5.1.1.3"
     },
@@ -668,7 +668,7 @@
       "template": "90.1-2019",
       "climate_zone": "ASHRAE 169-2013-8B",
       "data_center": true,
-      "capacity_limit": 135000.0,
+      "capacity_limit": 54000.0,
       "fixed_dry_bulb_high_limit_shutoff_temp": 75.0,
       "notes": "90.1-2019 Table 6.5.1.1.3"
     }


### PR DESCRIPTION
Table 6.5.1.2 (minimum fan cooling unit size for which an economizer is required for computer room) from 90.1-2013 has been removed in 90.1-2016/9. Economizer are now required for all climate zones except in climate zone 0/1 A/B. Additional information in Section B1.2.2 in the [Energy Savings Analysis: ANSI/ASHRAE/IES Standard 90.1-2016 report](https://www.energycodes.gov/energy-savings-analysis-ansiashraeies-standard-901-2016).