### PR TITLE
Add transfer air for non-kitchen spaces

### DIFF
--- a/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2010/ashrae_90_1_2010.Model.rb
+++ b/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2010/ashrae_90_1_2010.Model.rb
@@ -38,7 +38,7 @@ class ASHRAE9012010 < ASHRAE901
   # @code_sections [90.1-2010_6.5.7.1.2]
   # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @return [Boolean] true if transfer air is required, false otherwise
-  def transfer_air_required?(model)
+  def model_transfer_air_required??(model)
     # TODO: It actually is for kitchen but not implemented yet
     return false
   end

--- a/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2010/ashrae_90_1_2010.Model.rb
+++ b/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2010/ashrae_90_1_2010.Model.rb
@@ -38,7 +38,7 @@ class ASHRAE9012010 < ASHRAE901
   # @code_sections [90.1-2010_6.5.7.1.2]
   # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @return [Boolean] true if transfer air is required, false otherwise
-  def model_transfer_air_required??(model)
+  def model_transfer_air_required?(model)
     # TODO: It actually is for kitchen but not implemented yet
     return false
   end

--- a/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2010/ashrae_90_1_2010.Model.rb
+++ b/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2010/ashrae_90_1_2010.Model.rb
@@ -39,7 +39,6 @@ class ASHRAE9012010 < ASHRAE901
   # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @return [Boolean] true if transfer air is required, false otherwise
   def transfer_air_required?(model)
-
     # TODO: It actually is for kitchen but not implemented yet
     return false
   end

--- a/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2010/ashrae_90_1_2010.Model.rb
+++ b/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2010/ashrae_90_1_2010.Model.rb
@@ -32,4 +32,15 @@ class ASHRAE9012010 < ASHRAE901
                       end
     return economizer_type
   end
+
+  # Is transfer air required?
+  #
+  # @code_sections [90.1-2010_6.5.7.1.2]
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
+  # @return [Boolean] true if transfer air is required, false otherwise
+  def transfer_air_required?(model)
+
+    # TODO: It actually is for kitchen but not implemented yet
+    return false
+  end
 end

--- a/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2013/ashrae_90_1_2013.Model.rb
+++ b/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2013/ashrae_90_1_2013.Model.rb
@@ -39,7 +39,6 @@ class ASHRAE9012013 < ASHRAE901
   # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @return [Boolean] true if transfer air is required, false otherwise
   def transfer_air_required?(model)
-
     # TODO: It actually is for kitchen but not implemented yet
     return false
   end

--- a/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2013/ashrae_90_1_2013.Model.rb
+++ b/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2013/ashrae_90_1_2013.Model.rb
@@ -32,4 +32,15 @@ class ASHRAE9012013 < ASHRAE901
                       end
     return economizer_type
   end
+
+  # Is transfer air required?
+  #
+  # @code_sections [90.1-2013_6.5.7.1.2]
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
+  # @return [Boolean] true if transfer air is required, false otherwise
+  def transfer_air_required?(model)
+
+    # TODO: It actually is for kitchen but not implemented yet
+    return false
+  end
 end

--- a/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2013/ashrae_90_1_2013.Model.rb
+++ b/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2013/ashrae_90_1_2013.Model.rb
@@ -38,7 +38,7 @@ class ASHRAE9012013 < ASHRAE901
   # @code_sections [90.1-2013_6.5.7.1.2]
   # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @return [Boolean] true if transfer air is required, false otherwise
-  def transfer_air_required?(model)
+  def model_transfer_air_required??(model)
     # TODO: It actually is for kitchen but not implemented yet
     return false
   end

--- a/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2013/ashrae_90_1_2013.Model.rb
+++ b/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2013/ashrae_90_1_2013.Model.rb
@@ -38,7 +38,7 @@ class ASHRAE9012013 < ASHRAE901
   # @code_sections [90.1-2013_6.5.7.1.2]
   # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @return [Boolean] true if transfer air is required, false otherwise
-  def model_transfer_air_required??(model)
+  def model_transfer_air_required?(model)
     # TODO: It actually is for kitchen but not implemented yet
     return false
   end

--- a/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2016/ashrae_90_1_2016.Model.rb
+++ b/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2016/ashrae_90_1_2016.Model.rb
@@ -38,7 +38,7 @@ class ASHRAE9012016 < ASHRAE901
   # @code_sections [90.1-2016_6.5.7.1]
   # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @return [Boolean] true if transfer air is required, false otherwise
-  def model_transfer_air_required??(model)
+  def model_transfer_air_required?(model)
     return true
   end
 end

--- a/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2016/ashrae_90_1_2016.Model.rb
+++ b/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2016/ashrae_90_1_2016.Model.rb
@@ -32,4 +32,14 @@ class ASHRAE9012016 < ASHRAE901
                       end
     return economizer_type
   end
+
+  # Is transfer air required?
+  #
+  # @code_sections [90.1-2016_6.5.7.1]
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
+  # @return [Boolean] true if transfer air is required, false otherwise
+  def transfer_air_required?(model)
+
+    return true
+  end
 end

--- a/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2016/ashrae_90_1_2016.Model.rb
+++ b/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2016/ashrae_90_1_2016.Model.rb
@@ -39,7 +39,6 @@ class ASHRAE9012016 < ASHRAE901
   # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @return [Boolean] true if transfer air is required, false otherwise
   def transfer_air_required?(model)
-
     return true
   end
 end

--- a/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2016/ashrae_90_1_2016.Model.rb
+++ b/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2016/ashrae_90_1_2016.Model.rb
@@ -38,7 +38,7 @@ class ASHRAE9012016 < ASHRAE901
   # @code_sections [90.1-2016_6.5.7.1]
   # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @return [Boolean] true if transfer air is required, false otherwise
-  def transfer_air_required?(model)
+  def model_transfer_air_required??(model)
     return true
   end
 end

--- a/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2019/ashrae_90_1_2019.Model.rb
+++ b/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2019/ashrae_90_1_2019.Model.rb
@@ -38,7 +38,7 @@ class ASHRAE9012019 < ASHRAE901
   # @code_sections [90.1-2019_6.5.7.1]
   # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @return [Boolean] true if transfer air is required, false otherwise
-  def transfer_air_required?(model)
+  def model_transfer_air_required??(model)
     return true
   end
 end

--- a/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2019/ashrae_90_1_2019.Model.rb
+++ b/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2019/ashrae_90_1_2019.Model.rb
@@ -38,7 +38,7 @@ class ASHRAE9012019 < ASHRAE901
   # @code_sections [90.1-2019_6.5.7.1]
   # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @return [Boolean] true if transfer air is required, false otherwise
-  def model_transfer_air_required??(model)
+  def model_transfer_air_required?(model)
     return true
   end
 end

--- a/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2019/ashrae_90_1_2019.Model.rb
+++ b/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2019/ashrae_90_1_2019.Model.rb
@@ -32,4 +32,14 @@ class ASHRAE9012019 < ASHRAE901
                       end
     return economizer_type
   end
+
+  # Is transfer air required?
+  #
+  # @code_sections [90.1-2019_6.5.7.1]
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
+  # @return [Boolean] true if transfer air is required, false otherwise
+  def transfer_air_required?(model)
+
+    return true
+  end
 end

--- a/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2019/ashrae_90_1_2019.Model.rb
+++ b/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2019/ashrae_90_1_2019.Model.rb
@@ -39,7 +39,6 @@ class ASHRAE9012019 < ASHRAE901
   # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @return [Boolean] true if transfer air is required, false otherwise
   def transfer_air_required?(model)
-
     return true
   end
 end

--- a/lib/openstudio-standards/prototypes/common/buildings/Prototype.FullServiceRestaurant.rb
+++ b/lib/openstudio-standards/prototypes/common/buildings/Prototype.FullServiceRestaurant.rb
@@ -190,8 +190,8 @@ module FullServiceRestaurant
 
   def add_zone_mixing(model)
     # add zone_mixing between kitchen and dining
-    # TODO: remove zone mixing objects, 
-    # transfer air is the should be the same for 
+    # TODO: remove zone mixing objects,
+    # transfer air is the should be the same for
     # all stds, exhaust flow varies
     space_kitchen = model.getSpaceByName('Kitchen').get
     zone_kitchen = space_kitchen.thermalZone.get

--- a/lib/openstudio-standards/prototypes/common/buildings/Prototype.FullServiceRestaurant.rb
+++ b/lib/openstudio-standards/prototypes/common/buildings/Prototype.FullServiceRestaurant.rb
@@ -190,6 +190,9 @@ module FullServiceRestaurant
 
   def add_zone_mixing(model)
     # add zone_mixing between kitchen and dining
+    # TODO: remove zone mixing objects, 
+    # transfer air is the should be the same for 
+    # all stds, exhaust flow varies
     space_kitchen = model.getSpaceByName('Kitchen').get
     zone_kitchen = space_kitchen.thermalZone.get
     space_dining = model.getSpaceByName('Dining').get

--- a/lib/openstudio-standards/prototypes/common/buildings/Prototype.LargeHotel.rb
+++ b/lib/openstudio-standards/prototypes/common/buildings/Prototype.LargeHotel.rb
@@ -218,10 +218,10 @@ module LargeHotel
   #
   # code_sections [90.1-2019_6.5.7.1], [90.1-2016_6.5.7.1]
   # @return [Hash] target zones (key) and source zones (value) and air flow (value)
-  def transfer_air_target_and_source_zones(model)
-    transfer_air_target_and_source_zones_hash = {
+  def model_transfer_air_target_and_source_zones(model)
+    model_transfer_air_target_and_source_zones_hash = {
       'Laundry_Flr_1 ZN' => ['Lobby_Flr_1 ZN', 500.0]
     }
-    return transfer_air_target_and_source_zones_hash
+    return model_transfer_air_target_and_source_zones_hash
   end
 end

--- a/lib/openstudio-standards/prototypes/common/buildings/Prototype.LargeHotel.rb
+++ b/lib/openstudio-standards/prototypes/common/buildings/Prototype.LargeHotel.rb
@@ -213,4 +213,15 @@ module LargeHotel
   def air_loop_hvac_supply_air_temperature_reset_type(air_loop_hvac)
     return 'oa'
   end
+
+  # List transfer air target and source zones, and airflow (cfm)
+  #
+  # code_sections [90.1-2019_6.5.7.1], [90.1-2016_6.5.7.1]
+  # @return [Hash] target zones (key) and source zones (value) and air flow (value)
+  def transfer_air_target_and_source_zones(model)
+    transfer_air_target_and_source_zones_hash = {
+      'Laundry_Flr_1 ZN' => ['Lobby_Flr_1 ZN', 500.0]
+    }
+    return transfer_air_target_and_source_zones_hash
+  end
 end

--- a/lib/openstudio-standards/prototypes/common/buildings/Prototype.PrimarySchool.rb
+++ b/lib/openstudio-standards/prototypes/common/buildings/Prototype.PrimarySchool.rb
@@ -103,10 +103,10 @@ module PrimarySchool
   #
   # code_sections [90.1-2019_6.5.7.1], [90.1-2016_6.5.7.1]
   # @return [Hash] target zones (key) and source zones (value) and air flow (value)
-  def transfer_air_target_and_source_zones(model)
-    transfer_air_target_and_source_zones_hash = {
+  def model_transfer_air_target_and_source_zones(model)
+    model_transfer_air_target_and_source_zones_hash = {
       'Bath_ZN_1_FLR_1 ZN' => ['Library_Media_Center_ZN_1_FLR_1 ZN', 600.0]
     }
-    return transfer_air_target_and_source_zones_hash
+    return model_transfer_air_target_and_source_zones_hash
   end
 end

--- a/lib/openstudio-standards/prototypes/common/buildings/Prototype.PrimarySchool.rb
+++ b/lib/openstudio-standards/prototypes/common/buildings/Prototype.PrimarySchool.rb
@@ -98,4 +98,15 @@ module PrimarySchool
   def air_loop_hvac_supply_air_temperature_reset_type(air_loop_hvac)
     return 'oa'
   end
+
+  # List transfer air target and source zones, and air flow (cfm)
+  #
+  # code_sections [90.1-2019_6.5.7.1], [90.1-2016_6.5.7.1]
+  # @return [Hash] target zones (key) and source zones (value) and air flow (value)
+  def transfer_air_target_and_source_zones(model)
+    transfer_air_target_and_source_zones_hash = {
+      'Bath_ZN_1_FLR_1 ZN' => ['Library_Media_Center_ZN_1_FLR_1 ZN', 600.0]
+    }
+    return transfer_air_target_and_source_zones_hash
+  end
 end

--- a/lib/openstudio-standards/prototypes/common/buildings/Prototype.QuickServiceRestaurant.rb
+++ b/lib/openstudio-standards/prototypes/common/buildings/Prototype.QuickServiceRestaurant.rb
@@ -296,6 +296,9 @@ module QuickServiceRestaurant
 
   def add_zone_mixing(model)
     # add zone_mixing between kitchen and dining
+    # TODO: remove zone mixing objects, 
+    # transfer air is the should be the same for 
+    # all stds, exhaust flow varies
     space_kitchen = model.getSpaceByName('Kitchen').get
     zone_kitchen = space_kitchen.thermalZone.get
     space_dining = model.getSpaceByName('Dining').get

--- a/lib/openstudio-standards/prototypes/common/buildings/Prototype.QuickServiceRestaurant.rb
+++ b/lib/openstudio-standards/prototypes/common/buildings/Prototype.QuickServiceRestaurant.rb
@@ -296,8 +296,8 @@ module QuickServiceRestaurant
 
   def add_zone_mixing(model)
     # add zone_mixing between kitchen and dining
-    # TODO: remove zone mixing objects, 
-    # transfer air is the should be the same for 
+    # TODO: remove zone mixing objects,
+    # transfer air is the should be the same for
     # all stds, exhaust flow varies
     space_kitchen = model.getSpaceByName('Kitchen').get
     zone_kitchen = space_kitchen.thermalZone.get

--- a/lib/openstudio-standards/prototypes/common/buildings/Prototype.SecondarySchool.rb
+++ b/lib/openstudio-standards/prototypes/common/buildings/Prototype.SecondarySchool.rb
@@ -719,4 +719,16 @@ module SecondarySchool
   def air_loop_hvac_supply_air_temperature_reset_type(air_loop_hvac)
     return 'oa'
   end
+
+  # List transfer air target and source zones, and air aflow (cfm)
+  #
+  # code_sections [90.1-2019_6.5.7.1], [90.1-2016_6.5.7.1]
+  # @return [Hash] target zones (key) and source zones (value) and air flow (value)
+  def transfer_air_target_and_source_zones(model)
+    transfer_air_target_and_source_zones_hash = {
+      'Bathrooms_ZN_1_FLR_1 ZN' => ['Main_Corridor_ZN_1_FLR_1 ZN', 600.0],
+      'Bathrooms_ZN_1_FLR_2 ZN' => ['Main_Corridor_ZN_1_FLR_2 ZN', 600.0],
+    }
+    return transfer_air_target_and_source_zones_hash
+  end
 end

--- a/lib/openstudio-standards/prototypes/common/buildings/Prototype.SecondarySchool.rb
+++ b/lib/openstudio-standards/prototypes/common/buildings/Prototype.SecondarySchool.rb
@@ -727,7 +727,7 @@ module SecondarySchool
   def transfer_air_target_and_source_zones(model)
     transfer_air_target_and_source_zones_hash = {
       'Bathrooms_ZN_1_FLR_1 ZN' => ['Main_Corridor_ZN_1_FLR_1 ZN', 600.0],
-      'Bathrooms_ZN_1_FLR_2 ZN' => ['Main_Corridor_ZN_1_FLR_2 ZN', 600.0],
+      'Bathrooms_ZN_1_FLR_2 ZN' => ['Main_Corridor_ZN_1_FLR_2 ZN', 600.0]
     }
     return transfer_air_target_and_source_zones_hash
   end

--- a/lib/openstudio-standards/prototypes/common/buildings/Prototype.SecondarySchool.rb
+++ b/lib/openstudio-standards/prototypes/common/buildings/Prototype.SecondarySchool.rb
@@ -724,11 +724,11 @@ module SecondarySchool
   #
   # code_sections [90.1-2019_6.5.7.1], [90.1-2016_6.5.7.1]
   # @return [Hash] target zones (key) and source zones (value) and air flow (value)
-  def transfer_air_target_and_source_zones(model)
-    transfer_air_target_and_source_zones_hash = {
+  def model_transfer_air_target_and_source_zones(model)
+    model_transfer_air_target_and_source_zones_hash = {
       'Bathrooms_ZN_1_FLR_1 ZN' => ['Main_Corridor_ZN_1_FLR_1 ZN', 600.0],
       'Bathrooms_ZN_1_FLR_2 ZN' => ['Main_Corridor_ZN_1_FLR_2 ZN', 600.0]
     }
-    return transfer_air_target_and_source_zones_hash
+    return model_transfer_air_target_and_source_zones_hash
   end
 end

--- a/lib/openstudio-standards/prototypes/common/objects/Prototype.Fan.rb
+++ b/lib/openstudio-standards/prototypes/common/objects/Prototype.Fan.rb
@@ -9,6 +9,9 @@ module PrototypeFan
   #
   # @return [Bool] true if successful, false if not
   def prototype_fan_apply_prototype_fan_efficiency(fan)
+    # Do not modify dummy exhaust fans
+    return true unless !fan.name.to_s.downcase.include? 'dummy'
+
     # Get the max flow rate from the fan.
     maximum_flow_rate_m3_per_s = nil
     if fan.maximumFlowRate.is_initialized

--- a/lib/openstudio-standards/prototypes/common/objects/Prototype.FanZoneExhaust.rb
+++ b/lib/openstudio-standards/prototypes/common/objects/Prototype.FanZoneExhaust.rb
@@ -6,7 +6,7 @@ class Standard
   # Sets the fan pressure rise based on the Prototype buildings inputs
   def fan_zone_exhaust_apply_prototype_fan_pressure_rise(fan_zone_exhaust)
     # Do not modify dummy exhaust fans
-    return true unless !fan_zone_exhaust.name.to_s.downcase.include? 'dummy'
+    return true if fan_zone_exhaust.name.to_s.downcase.include? 'dummy'
 
     # All exhaust fans are assumed to have a pressure rise of
     # 0.5 in w.c. in the prototype building models.

--- a/lib/openstudio-standards/prototypes/common/objects/Prototype.FanZoneExhaust.rb
+++ b/lib/openstudio-standards/prototypes/common/objects/Prototype.FanZoneExhaust.rb
@@ -5,6 +5,9 @@ class Standard
 
   # Sets the fan pressure rise based on the Prototype buildings inputs
   def fan_zone_exhaust_apply_prototype_fan_pressure_rise(fan_zone_exhaust)
+    # Do not modify dummy exhaust fans
+    return true unless !fan_zone_exhaust.name.to_s.downcase.include? 'dummy'
+
     # All exhaust fans are assumed to have a pressure rise of
     # 0.5 in w.c. in the prototype building models.
     pressure_rise_in_h2o = 0.5

--- a/lib/openstudio-standards/prototypes/common/objects/Prototype.Model.rb
+++ b/lib/openstudio-standards/prototypes/common/objects/Prototype.Model.rb
@@ -41,6 +41,7 @@ Standard.class_eval do
     model_add_hvac(model, @instvarbuilding_type, climate_zone, @prototype_input, epw_file)
     model_add_constructions(model, @instvarbuilding_type, climate_zone)
     model_custom_hvac_tweaks(building_type, climate_zone, @prototype_input, model)
+    model_add_transfer_air(model)
     model_add_internal_mass(model, @instvarbuilding_type)
     model_add_swh(model, @instvarbuilding_type, climate_zone, @prototype_input, epw_file)
     model_add_exterior_lights(model, @instvarbuilding_type, climate_zone, @prototype_input)
@@ -2158,5 +2159,72 @@ Standard.class_eval do
 
       end
     end
+  end
+
+  # Is transfer air required?
+  #
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
+  # @return [Boolean] true if transfer air is required, false otherwise
+  def transfer_air_required?(model)
+
+    return false
+  end
+
+  # Add transfer to prototype for spaces that require it
+  #
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
+  # @return [Boolean] true if successful, false otherwise
+  def model_add_transfer_air(model)
+    
+    # Do not add transfer air if not required
+    return true unless transfer_air_required?(model)
+
+    # Get target and source zones
+    target_and_source_zones = transfer_air_target_and_source_zones(model)
+
+    model.getFanZoneExhausts.sort.each do |exhaust_fan|
+      # Target zone (zone with exhaust fan)
+      target_zone = exhaust_fan.thermalZone.get
+
+      # Get zone name of an exhaust fan
+      exhaust_fan_zone_name = target_zone.name.to_s
+      
+      # Go to next exhaust fan if this zone isn't using transfer air
+      next unless target_and_source_zones.keys.include? exhaust_fan_zone_name
+
+      # Add dummy exhaust fan in source zone
+      source_zone_name, transfer_air_flow_cfm = target_and_source_zones[exhaust_fan_zone_name]
+      source_zone = model.getThermalZoneByName(source_zone_name).get
+      transfer_air_source_zone_exhaust_fan = OpenStudio::Model::FanZoneExhaust.new(model)
+      transfer_air_source_zone_exhaust_fan.setName(source_zone.name.to_s + ' Dummy Transfer Air (Source) Fan')
+      transfer_air_source_zone_exhaust_fan.setAvailabilitySchedule(exhaust_fan.availabilitySchedule.get)
+      # Convert transfer air flow to m3/s
+      transfer_air_flow_m3s = OpenStudio.convert(transfer_air_flow_cfm, 'cfm', 'm^3/s').get
+      transfer_air_source_zone_exhaust_fan.setMaximumFlowRate(transfer_air_flow_m3s)
+      transfer_air_source_zone_exhaust_fan.setFanEfficiency(1.0)
+      transfer_air_source_zone_exhaust_fan.setPressureRise(0.0)
+      transfer_air_source_zone_exhaust_fan.addToThermalZone(source_zone)
+      
+      # Set exhaust fan balanced air flow schedule to only consider the transfer air to be balanced air flow 
+      balanced_air_flow_schedule = exhaust_fan.availabilitySchedule.get.clone(model).to_ScheduleRuleset.get
+      balanced_air_flow_schedule.setName("#{exhaust_fan_zone_name} Exhaust Fan Balanced Air Flow Schedule")
+      model_multiply_schedule(model, balanced_air_flow_schedule.defaultDaySchedule, transfer_air_flow_m3s / exhaust_fan.maximumFlowRate.get, 0)
+      balanced_air_flow_schedule.scheduleRules.each do |sch_rule|
+        model_multiply_schedule(model, sch_rule.daySchedule, transfer_air_flow_m3s / exhaust_fan.maximumFlowRate.get, 0)
+      end
+      transfer_air_source_zone_exhaust_fan.setBalancedExhaustFractionSchedule(balanced_air_flow_schedule)
+
+      # Modify design specification OA to take into account transfer air for sizing only
+      # OA is zero'd out for other days
+      target_zone.spaces.sort.each do |space|
+        target_zone_ventilation = space.designSpecificationOutdoorAir.get
+        target_zone_ventilation.setOutdoorAirFlowperPerson(0)
+        target_zone_ventilation.setOutdoorAirFlowperFloorArea(0)
+        target_zone_ventilation.setOutdoorAirFlowRate(exhaust_fan.maximumFlowRate.get - transfer_air_flow_m3s)
+        target_zone_ventilation.setOutdoorAirFlowRateFractionSchedule(model_add_schedule(model, 'DesignDaysOnly'))
+      end
+    end
+
+    return true
   end
 end

--- a/lib/openstudio-standards/prototypes/common/objects/Prototype.Model.rb
+++ b/lib/openstudio-standards/prototypes/common/objects/Prototype.Model.rb
@@ -2165,7 +2165,7 @@ Standard.class_eval do
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @return [Boolean] true if transfer air is required, false otherwise
-  def transfer_air_required?(model)
+  def model_transfer_air_required??(model)
     return false
   end
 
@@ -2173,10 +2173,10 @@ Standard.class_eval do
   #
   # code_sections [90.1-2019_6.5.7.1], [90.1-2016_6.5.7.1]
   # @return [Hash] target zones (key) and source zones (value) and air flow (value)
-  def transfer_air_target_and_source_zones(model)
-    transfer_air_target_and_source_zones_hash = {}
+  def model_transfer_air_target_and_source_zones(model)
+    model_transfer_air_target_and_source_zones_hash = {}
 
-    return transfer_air_target_and_source_zones_hash
+    return model_transfer_air_target_and_source_zones_hash
   end
 
   # Add transfer to prototype for spaces that require it
@@ -2185,10 +2185,10 @@ Standard.class_eval do
   # @return [Boolean] true if successful, false otherwise
   def model_add_transfer_air(model)
     # Do not add transfer air if not required
-    return true unless transfer_air_required?(model)
+    return true unless model_transfer_air_required??(model)
 
     # Get target and source zones
-    target_and_source_zones = transfer_air_target_and_source_zones(model)
+    target_and_source_zones = model_transfer_air_target_and_source_zones(model)
     return true unless !target_and_source_zones.empty?
 
     model.getFanZoneExhausts.sort.each do |exhaust_fan|

--- a/lib/openstudio-standards/prototypes/common/objects/Prototype.Model.rb
+++ b/lib/openstudio-standards/prototypes/common/objects/Prototype.Model.rb
@@ -2165,7 +2165,7 @@ Standard.class_eval do
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @return [Boolean] true if transfer air is required, false otherwise
-  def model_transfer_air_required??(model)
+  def model_transfer_air_required?(model)
     return false
   end
 
@@ -2185,7 +2185,7 @@ Standard.class_eval do
   # @return [Boolean] true if successful, false otherwise
   def model_add_transfer_air(model)
     # Do not add transfer air if not required
-    return true unless model_transfer_air_required??(model)
+    return true unless model_transfer_air_required?(model)
 
     # Get target and source zones
     target_and_source_zones = model_transfer_air_target_and_source_zones(model)

--- a/lib/openstudio-standards/prototypes/common/objects/Prototype.Model.rb
+++ b/lib/openstudio-standards/prototypes/common/objects/Prototype.Model.rb
@@ -2189,7 +2189,7 @@ Standard.class_eval do
 
     # Get target and source zones
     target_and_source_zones = model_transfer_air_target_and_source_zones(model)
-    return true unless !target_and_source_zones.empty?
+    return true if target_and_source_zones.empty?
 
     model.getFanZoneExhausts.sort.each do |exhaust_fan|
       # Target zone (zone with exhaust fan)


### PR DESCRIPTION
The proposed changes add transfer air for non-kitchen spaces, when applicable, as per Section 6.5.7.1 in 90.1-2016/9. Additional information regarding the 90.1-2016/9 implementation are provided in Section B1.2.1 in the [Energy Savings Analysis: ANSI/ASHRAE/IES Standard 90.1-2016 report](https://www.energycodes.gov/energy-savings-analysis-ansiashraeies-standard-901-2016).