### PR TITLE
Update opaque doors U-factor minimum code requirements

### DIFF
--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2016/data/ashrae_90_1_2016.construction_properties.json
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2016/data/ashrae_90_1_2016.construction_properties.json
@@ -11,14 +11,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 1.45,
+      "assembly_maximum_u_value": 0.31,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2016",
@@ -31,14 +31,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.31,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2016",
@@ -71,14 +71,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.7,
+      "assembly_maximum_u_value": 0.37,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2016",
@@ -91,14 +91,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.37,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2016",
@@ -1471,14 +1471,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 1.45,
+      "assembly_maximum_u_value": 0.31,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2016",
@@ -1491,14 +1491,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.31,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2016",
@@ -1531,14 +1531,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.7,
+      "assembly_maximum_u_value": 0.37,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2016",
@@ -1551,14 +1551,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.37,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2016",
@@ -1571,7 +1571,7 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.7,
+      "assembly_maximum_u_value": 0.37,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
@@ -2931,14 +2931,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.31,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2016",
@@ -2951,14 +2951,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.31,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2016",
@@ -2991,14 +2991,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.7,
+      "assembly_maximum_u_value": 0.37,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2016",
@@ -3011,14 +3011,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.37,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2016",
@@ -4391,14 +4391,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.31,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2016",
@@ -4411,14 +4411,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.31,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2016",
@@ -4431,14 +4431,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 1.45,
+      "assembly_maximum_u_value": 0.36,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2016",
@@ -4451,14 +4451,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.7,
+      "assembly_maximum_u_value": 0.37,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2016",
@@ -4471,14 +4471,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.37,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2016",
@@ -4491,14 +4491,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.7,
+      "assembly_maximum_u_value": 0.37,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2016",
@@ -5851,14 +5851,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.31,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2016",
@@ -5871,14 +5871,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.31,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2016",
@@ -5891,14 +5891,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 1.45,
+      "assembly_maximum_u_value": 0.36,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2016",
@@ -5911,14 +5911,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.37,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2016",
@@ -5931,14 +5931,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.37,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2016",
@@ -5951,14 +5951,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.7,
+      "assembly_maximum_u_value": 0.37,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2016",
@@ -7311,14 +7311,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.31,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2016",
@@ -7331,14 +7331,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.31,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2016",
@@ -7351,14 +7351,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 1.45,
+      "assembly_maximum_u_value": 0.36,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2016",
@@ -7371,14 +7371,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.37,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2016",
@@ -7391,14 +7391,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.37,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2016",
@@ -7411,14 +7411,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.7,
+      "assembly_maximum_u_value": 0.37,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2016",
@@ -8771,14 +8771,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.31,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2016",
@@ -8791,14 +8791,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.31,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2016",
@@ -8811,14 +8811,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.36,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2016",
@@ -8831,14 +8831,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.37,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2016",
@@ -8851,14 +8851,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.37,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2016",
@@ -8871,14 +8871,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.7,
+      "assembly_maximum_u_value": 0.37,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2016",
@@ -10231,14 +10231,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.31,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2016",
@@ -10251,14 +10251,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.31,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2016",
@@ -10271,14 +10271,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.31,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2016",
@@ -10291,14 +10291,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.37,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2016",
@@ -10311,14 +10311,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.37,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2016",
@@ -10331,14 +10331,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.7,
+      "assembly_maximum_u_value": 0.37,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2016",
@@ -11691,14 +11691,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.31,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2016",
@@ -11711,14 +11711,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.31,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2016",
@@ -11731,14 +11731,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.31,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2016",
@@ -11751,14 +11751,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.37,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2016",
@@ -11771,14 +11771,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.37,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2016",
@@ -11791,14 +11791,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.37,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2016",

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2019/data/ashrae_90_1_2019.construction_properties.json
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2019/data/ashrae_90_1_2019.construction_properties.json
@@ -11,14 +11,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 1.45,
+      "assembly_maximum_u_value": 0.31,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2019",
@@ -31,14 +31,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.31,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2019",
@@ -71,14 +71,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.7,
+      "assembly_maximum_u_value": 0.37,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2019",
@@ -91,14 +91,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.37,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2019",
@@ -1471,14 +1471,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 1.45,
+      "assembly_maximum_u_value": 0.31,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2019",
@@ -1491,14 +1491,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.31,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2019",
@@ -1531,14 +1531,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.7,
+      "assembly_maximum_u_value": 0.37,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2019",
@@ -1551,14 +1551,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.37,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2019",
@@ -2931,14 +2931,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.31,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2019",
@@ -2951,14 +2951,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.31,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2019",
@@ -2991,14 +2991,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.7,
+      "assembly_maximum_u_value": 0.37,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2019",
@@ -3011,14 +3011,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.37,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2019",
@@ -4391,14 +4391,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.31,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2019",
@@ -4411,14 +4411,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.31,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2019",
@@ -4431,14 +4431,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 1.45,
+      "assembly_maximum_u_value": 0.36,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2019",
@@ -4451,14 +4451,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.7,
+      "assembly_maximum_u_value": 0.37,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2019",
@@ -4471,14 +4471,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.37,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2019",
@@ -4491,14 +4491,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.7,
+      "assembly_maximum_u_value": 0.37,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2019",
@@ -5851,14 +5851,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.31,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2019",
@@ -5871,14 +5871,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.31,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2019",
@@ -5891,14 +5891,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 1.45,
+      "assembly_maximum_u_value": 0.36,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2019",
@@ -5911,14 +5911,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.37,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2019",
@@ -5931,14 +5931,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.37,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2019",
@@ -5951,14 +5951,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.7,
+      "assembly_maximum_u_value": 0.37,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2019",
@@ -7311,14 +7311,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.31,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2019",
@@ -7331,14 +7331,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.31,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2019",
@@ -7351,14 +7351,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 1.45,
+      "assembly_maximum_u_value": 0.36,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2019",
@@ -7371,14 +7371,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.37,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2019",
@@ -7391,14 +7391,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.37,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2019",
@@ -7411,14 +7411,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.7,
+      "assembly_maximum_u_value": 0.37,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2019",
@@ -8771,14 +8771,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.31,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2019",
@@ -8791,14 +8791,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.31,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2019",
@@ -8811,14 +8811,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.36,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2019",
@@ -8831,14 +8831,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.37,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2019",
@@ -8851,14 +8851,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.37,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2019",
@@ -8871,14 +8871,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.7,
+      "assembly_maximum_u_value": 0.37,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2019",
@@ -10231,14 +10231,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.31,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2019",
@@ -10251,14 +10251,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.31,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2019",
@@ -10271,14 +10271,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.31,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2019",
@@ -10291,14 +10291,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.37,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2019",
@@ -10311,14 +10311,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.37,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2019",
@@ -10331,14 +10331,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.7,
+      "assembly_maximum_u_value": 0.37,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2019",
@@ -11691,14 +11691,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.31,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2019",
@@ -11711,14 +11711,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.31,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2019",
@@ -11731,14 +11731,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.31,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2019",
@@ -11751,14 +11751,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.37,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2019",
@@ -11771,14 +11771,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.37,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2019",
@@ -11791,14 +11791,14 @@
       "orientation": null,
       "minimum_percent_of_surface": null,
       "maximum_percent_of_surface": null,
-      "assembly_maximum_u_value": 0.5,
+      "assembly_maximum_u_value": 0.37,
       "u_value_includes_interior_film_coefficient": true,
       "u_value_includes_exterior_film_coefficient": true,
       "assembly_maximum_f_factor": null,
       "assembly_maximum_c_factor": null,
       "assembly_maximum_solar_heat_gain_coefficient": null,
       "assembly_minimum_vt_shgc": null,
-      "notes": null
+      "notes": "Exceptions 1. and 2. from Section 5.5.3.6 is not captured in this table"
     },
     {
       "template": "90.1-2019",


### PR DESCRIPTION
The proposed changes update the minimum code requirements for opaque doors for ASHRAE 90.1-2016/9. Additional information regarding the 90.1-2016/9 implementation are provided in Section B1.1.4 in the [Energy Savings Analysis: ANSI/ASHRAE/IES Standard 90.1-2016 report](https://www.energycodes.gov/energy-savings-analysis-ansiashraeies-standard-901-2016), note that this sections mentions adding doors to the prototypes which was added by #678.