### PR TITLE
nrcan 321- Fixing PV, NV, VSD chiller, and loads scaling tests

### DIFF
--- a/test/circleci_tests.txt
+++ b/test/circleci_tests.txt
@@ -87,6 +87,10 @@ necb/unit_tests/tests/test_daylighting_sensor_control.rb
 necb/unit_tests/tests/test_led_lighting.rb
 necb/unit_tests/tests/test_dcv.rb
 necb/unit_tests/tests/test_ecm_erv.rb
+necb/unit_tests/tests/test_pv_ground.rb
+necb/unit_tests/tests/test_nv.rb
+necb/unit_tests/tests/test_ecm_chiller.rb
+necb/unit_tests/tests/test_ecm_scaling_loads.rb
 
 necb/system_tests/tests/test_necb_hvac_system_2_natural_gas_scroll_hydronic_fpfc.rb
 necb/system_tests/tests/test_necb_hvac_system_2_natural_gas_scroll_dx_fpfc.rb

--- a/test/necb/unit_tests/tests/test_daylighting_sensor_control.rb
+++ b/test/necb/unit_tests/tests/test_daylighting_sensor_control.rb
@@ -10,7 +10,6 @@ class NECB_Daylighting_Sensor_Control_Tests < Minitest::Test
     @output_folder = File.join(__dir__, 'output/test_daylight_sensor')
     @expected_results_file = File.join(__dir__, '../expected_results/daylighting_expected_results.json')
     @test_results_file = File.join(__dir__, '../expected_results/daylighting_test_results.json')
-    @sizing_run_dir = File.join(@output_folder, 'sizing_folder')
 
     # Initial test condition
     @test_passed = true

--- a/test/necb/unit_tests/tests/test_ecm_chiller.rb
+++ b/test/necb/unit_tests/tests/test_ecm_chiller.rb
@@ -102,7 +102,7 @@ class NECB_VSDchiller_Tests < Minitest::Test
                                                     fdwr_set: -1.0,
                                                     srr_set: -1.0)
                 standard.apply_auto_zoning(model: model,
-                                           sizing_run_dir: Dir.pwd,
+                                           sizing_run_dir: @sizing_run_dir,
                                            lights_type: 'NECB_Default',
                                            lights_scale: 1.0)
                 ##### Here, do not implement VSD chiller. This is because in the next step,
@@ -110,7 +110,7 @@ class NECB_VSDchiller_Tests < Minitest::Test
                 ##### to avoid hard coding for chiller's capacity (as per Kamel Haddad's comment)
                 standard.apply_systems_and_efficiencies(model: model,
                                                         primary_heating_fuel: primary_heating_fuel,
-                                                        sizing_run_dir: Dir.pwd,
+                                                        sizing_run_dir: @sizing_run_dir,
                                                         dcv_type: 'NECB_Default',
                                                         ecm_system_name: 'NECB_Default',
                                                         erv_package: 'NECB_Default',

--- a/test/necb/unit_tests/tests/test_ecm_scaling_loads.rb
+++ b/test/necb/unit_tests/tests/test_ecm_scaling_loads.rb
@@ -100,12 +100,12 @@ class NECB_scaling_loads_Tests < Minitest::Test
                                                   fdwr_set: -1.0,
                                                   srr_set: -1.0)
               standard.apply_auto_zoning(model: model,
-                                         sizing_run_dir: Dir.pwd,
+                                         sizing_run_dir: @sizing_run_dir,
                                          lights_type: 'NECB_Default',
                                          lights_scale: 1.0)
               standard.apply_systems_and_efficiencies(model: model,
                                                       primary_heating_fuel: primary_heating_fuel,
-                                                      sizing_run_dir: Dir.pwd,
+                                                      sizing_run_dir: @sizing_run_dir,
                                                       dcv_type: 'NECB_Default',
                                                       ecm_system_name: 'NECB_Default',
                                                       erv_package: 'NECB_Default',

--- a/test/necb/unit_tests/tests/test_led_lighting.rb
+++ b/test/necb/unit_tests/tests/test_led_lighting.rb
@@ -10,7 +10,6 @@ class NECB_LED_Lighting_Tests < Minitest::Test
     @output_folder = File.join(__dir__, 'output/test_led_lighting')
     @expected_results_file = File.join(__dir__, '../expected_results/led_lighting_expected_results.json')
     @test_results_file = File.join(__dir__, '../expected_results/led_lighting_test_results.json')
-    @sizing_run_dir = File.join(@output_folder, 'sizing_folder')
 
     # Intial test condition
     @test_passed = true

--- a/test/necb/unit_tests/tests/test_nv.rb
+++ b/test/necb/unit_tests/tests/test_nv.rb
@@ -19,8 +19,8 @@ class NECB_nv_Tests < Minitest::Test
 
     #Range of test options.
     @templates = [
-        'NECB2011',
-        'NECB2015',
+        # 'NECB2011',
+        # 'NECB2015',
         'NECB2017'
     ]
     @building_types = [
@@ -95,12 +95,12 @@ class NECB_nv_Tests < Minitest::Test
                                                   fdwr_set: -1.0,
                                                   srr_set: -1.0)
               standard.apply_auto_zoning(model: model,
-                                         sizing_run_dir: Dir.pwd,
+                                         sizing_run_dir: @sizing_run_dir,
                                          lights_type: 'NECB_Default',
                                          lights_scale: 1.0)
               standard.apply_systems_and_efficiencies(model: model,
                                                       primary_heating_fuel: primary_heating_fuel,
-                                                      sizing_run_dir: Dir.pwd,
+                                                      sizing_run_dir: @sizing_run_dir,
                                                       dcv_type: 'NECB_Default',
                                                       ecm_system_name: 'NECB_Default',
                                                       erv_package: 'NECB_Default',

--- a/test/necb/unit_tests/tests/test_pv_ground.rb
+++ b/test/necb/unit_tests/tests/test_pv_ground.rb
@@ -94,12 +94,12 @@ class NECB_PVground_Tests < Minitest::Test
                                          fdwr_set: -1.0,
                                          srr_set: -1.0)
               standard.apply_auto_zoning(model: model,
-                                sizing_run_dir: Dir.pwd,
+                                sizing_run_dir: @sizing_run_dir,
                                 lights_type: 'NECB_Default',
                                 lights_scale: 1.0)
               standard.apply_systems_and_efficiencies(model: model,
                                              primary_heating_fuel: primary_heating_fuel,
-                                             sizing_run_dir: Dir.pwd,
+                                             sizing_run_dir: @sizing_run_dir,
                                              dcv_type: 'NECB_Default',
                                              ecm_system_name: 'NECB_Default',
                                              erv_package: 'NECB_Default',


### PR DESCRIPTION
updated inputs for sizing_run_dir in pv_ground, nv, loads scaling, and advanced chiller ecms; removed sizing_run_dir from daylighting sensor controls and led lighting ecms as it was not needed; updated nv ecm and its expected results file to only run tests for necb2017 for making it faster