### PR TITLE
add version toggle for deprecated setZoneMinimumAirFlowMethod

### DIFF
--- a/lib/openstudio-standards/prototypes/common/buildings/Prototype.Hospital.rb
+++ b/lib/openstudio-standards/prototypes/common/buildings/Prototype.Hospital.rb
@@ -300,7 +300,11 @@ module Hospital
       model.getAirTerminalSingleDuctVAVReheats.sort.each do |air_terminal|
         air_terminal_name = air_terminal.name.get
         if air_terminal_name.include?('OR1') || air_terminal_name.include?('OR2') || air_terminal_name.include?('OR3') || air_terminal_name.include?('OR4')
-          air_terminal.setZoneMinimumAirFlowInputMethod('Scheduled')
+          if model.version < OpenStudio::VersionString.new('3.1.0')
+            air_terminal.setZoneMinimumAirFlowMethod('Scheduled')
+          else
+            air_terminal.setZoneMinimumAirFlowInputMethod('Scheduled')
+          end
           air_terminal.setMinimumAirFlowFractionSchedule(model_add_schedule(model, 'Hospital OR_MinSA_Sched'))
         end
       end

--- a/lib/openstudio-standards/prototypes/common/buildings/Prototype.Hospital.rb
+++ b/lib/openstudio-standards/prototypes/common/buildings/Prototype.Hospital.rb
@@ -300,7 +300,7 @@ module Hospital
       model.getAirTerminalSingleDuctVAVReheats.sort.each do |air_terminal|
         air_terminal_name = air_terminal.name.get
         if air_terminal_name.include?('OR1') || air_terminal_name.include?('OR2') || air_terminal_name.include?('OR3') || air_terminal_name.include?('OR4')
-          if model.version < OpenStudio::VersionString.new('3.1.0')
+          if model.version < OpenStudio::VersionString.new('3.0.1')
             air_terminal.setZoneMinimumAirFlowMethod('Scheduled')
           else
             air_terminal.setZoneMinimumAirFlowInputMethod('Scheduled')

--- a/lib/openstudio-standards/prototypes/common/buildings/Prototype.Outpatient.rb
+++ b/lib/openstudio-standards/prototypes/common/buildings/Prototype.Outpatient.rb
@@ -348,7 +348,11 @@ module Outpatient
       model.getAirTerminalSingleDuctVAVReheats.sort.each do |air_terminal|
         air_terminal_name = air_terminal.name.get
         if air_terminal_name.include?('Floor 1 Operating Room 1') || air_terminal_name.include?('Floor 1 Operating Room 2')
-          air_terminal.setZoneMinimumAirFlowInputMethod('Scheduled')
+          if model.version < OpenStudio::VersionString.new('3.1.0')
+            air_terminal.setZoneMinimumAirFlowMethod('Scheduled')
+          else
+            air_terminal.setZoneMinimumAirFlowInputMethod('Scheduled')
+          end
           air_terminal.setMinimumAirFlowFractionSchedule(model_add_schedule(model, 'OutPatientHealthCare OR_MinSA_Sched'))
         end
       end

--- a/lib/openstudio-standards/prototypes/common/buildings/Prototype.Outpatient.rb
+++ b/lib/openstudio-standards/prototypes/common/buildings/Prototype.Outpatient.rb
@@ -348,7 +348,7 @@ module Outpatient
       model.getAirTerminalSingleDuctVAVReheats.sort.each do |air_terminal|
         air_terminal_name = air_terminal.name.get
         if air_terminal_name.include?('Floor 1 Operating Room 1') || air_terminal_name.include?('Floor 1 Operating Room 2')
-          if model.version < OpenStudio::VersionString.new('3.1.0')
+          if model.version < OpenStudio::VersionString.new('3.0.1')
             air_terminal.setZoneMinimumAirFlowMethod('Scheduled')
           else
             air_terminal.setZoneMinimumAirFlowInputMethod('Scheduled')

--- a/lib/openstudio-standards/prototypes/common/objects/Prototype.hvac_systems.rb
+++ b/lib/openstudio-standards/prototypes/common/objects/Prototype.hvac_systems.rb
@@ -1493,11 +1493,19 @@ class Standard
         end
         # VAV reheat terminal
         air_terminal = OpenStudio::Model::AirTerminalSingleDuctVAVReheat.new(model, model.alwaysOnDiscreteSchedule, rht_coil)
-        air_terminal.setZoneMinimumAirFlowInputMethod('Constant')
+        if model.version < OpenStudio::VersionString.new('3.1.0')
+          air_terminal.setZoneMinimumAirFlowMethod('Constant')
+        else
+          air_terminal.setZoneMinimumAirFlowInputMethod('Constant')
+        end
         air_terminal.setControlForOutdoorAir(true) if demand_control_ventilation
       else # 'DOASVAV'
         air_terminal = OpenStudio::Model::AirTerminalSingleDuctVAVNoReheat.new(model, model.alwaysOnDiscreteSchedule)
-        air_terminal.setZoneMinimumAirFlowInputMethod('Constant')
+        if model.version < OpenStudio::VersionString.new('3.1.0')
+          air_terminal.setZoneMinimumAirFlowMethod('Constant')
+        else
+          air_terminal.setZoneMinimumAirFlowInputMethod('Constant')
+        end
         air_terminal.setConstantMinimumAirFlowFraction(0.1)
         air_terminal.setControlForOutdoorAir(true) if demand_control_ventilation
       end
@@ -1736,7 +1744,11 @@ class Standard
         # create vav terminal
         terminal = OpenStudio::Model::AirTerminalSingleDuctVAVReheat.new(model, model.alwaysOnDiscreteSchedule, rht_coil)
         terminal.setName("#{zone.name} VAV Terminal")
-        terminal.setZoneMinimumAirFlowInputMethod('Constant')
+        if model.version < OpenStudio::VersionString.new('3.1.0')
+          terminal.setZoneMinimumAirFlowMethod('Constant')
+        else
+          terminal.setZoneMinimumAirFlowInputMethod('Constant')
+        end
         terminal.setMaximumFlowFractionDuringReheat(0.5)
         terminal.setMaximumReheatAirTemperature(dsgn_temps['zn_htg_dsgn_sup_air_temp_c'])
         air_loop.multiAddBranchForZone(zone, terminal.to_HVACComponent.get)
@@ -1753,7 +1765,11 @@ class Standard
         # create vav terminal
         terminal = OpenStudio::Model::AirTerminalSingleDuctVAVNoReheat.new(model, model.alwaysOnDiscreteSchedule)
         terminal.setName("#{zone.name} VAV Terminal")
-        terminal.setZoneMinimumAirFlowInputMethod('Constant')
+        if model.version < OpenStudio::VersionString.new('3.1.0')
+          terminal.setZoneMinimumAirFlowMethod('Constant')
+        else
+          terminal.setZoneMinimumAirFlowInputMethod('Constant')
+        end
         air_loop.multiAddBranchForZone(zone, terminal.to_HVACComponent.get)
         air_terminal_single_duct_vav_reheat_apply_initial_prototype_damper_position(terminal, thermal_zone_outdoor_airflow_rate_per_area(zone))
 
@@ -2067,7 +2083,11 @@ class Standard
       # create VAV terminal
       terminal = OpenStudio::Model::AirTerminalSingleDuctVAVReheat.new(model, model.alwaysOnDiscreteSchedule, rht_coil)
       terminal.setName("#{zone.name} VAV Terminal")
-      terminal.setZoneMinimumAirFlowInputMethod('Constant')
+      if model.version < OpenStudio::VersionString.new('3.1.0')
+        terminal.setZoneMinimumAirFlowMethod('Constant')
+      else
+        terminal.setZoneMinimumAirFlowInputMethod('Constant')
+      end
       terminal.setMaximumReheatAirTemperature(dsgn_temps['zn_htg_dsgn_sup_air_temp_c'])
       air_loop.multiAddBranchForZone(zone, terminal.to_HVACComponent.get)
       air_terminal_single_duct_vav_reheat_apply_initial_prototype_damper_position(terminal, thermal_zone_outdoor_airflow_rate_per_area(zone))
@@ -2366,7 +2386,11 @@ class Standard
       # VAV terminal
       terminal = OpenStudio::Model::AirTerminalSingleDuctVAVReheat.new(model, model.alwaysOnDiscreteSchedule, rht_coil)
       terminal.setName("#{zone.name} VAV Terminal")
-      terminal.setZoneMinimumAirFlowInputMethod('Constant')
+      if model.version < OpenStudio::VersionString.new('3.1.0')
+        terminal.setZoneMinimumAirFlowMethod('Constant')
+      else
+        terminal.setZoneMinimumAirFlowInputMethod('Constant')
+      end
       terminal.setMaximumFlowPerZoneFloorAreaDuringReheat(0.0)
       terminal.setMaximumFlowFractionDuringReheat(0.5)
       terminal.setMaximumReheatAirTemperature(dsgn_temps['zn_htg_dsgn_sup_air_temp_c'])
@@ -3195,7 +3219,11 @@ class Standard
       # Create a diffuser and attach the zone/diffuser pair to the air loop
       diffuser = OpenStudio::Model::AirTerminalSingleDuctVAVNoReheat.new(model, model.alwaysOnDiscreteSchedule)
       diffuser.setName("#{air_loop.name} Diffuser")
-      diffuser.setZoneMinimumAirFlowInputMethod('Constant')
+      if model.version < OpenStudio::VersionString.new('3.1.0')
+        diffuser.setZoneMinimumAirFlowMethod('Constant')
+      else
+        diffuser.setZoneMinimumAirFlowInputMethod('Constant')
+      end
       diffuser.setConstantMinimumAirFlowFraction(0.1)
       air_loop.multiAddBranchForZone(zone, diffuser.to_HVACComponent.get)
 
@@ -3331,7 +3359,11 @@ class Standard
       # Create a diffuser and attach the zone/diffuser pair to the air loop
       diffuser = OpenStudio::Model::AirTerminalSingleDuctVAVNoReheat.new(model, model.alwaysOnDiscreteSchedule)
       diffuser.setName("#{zone.name} VAV terminal")
-      diffuser.setZoneMinimumAirFlowInputMethod('Constant')
+      if model.version < OpenStudio::VersionString.new('3.1.0')
+        diffuser.setZoneMinimumAirFlowMethod('Constant')
+      else
+        diffuser.setZoneMinimumAirFlowInputMethod('Constant')
+      end
       diffuser.setConstantMinimumAirFlowFraction(0.1)
       air_loop.multiAddBranchForZone(zone, diffuser.to_HVACComponent.get)
 

--- a/lib/openstudio-standards/prototypes/common/objects/Prototype.hvac_systems.rb
+++ b/lib/openstudio-standards/prototypes/common/objects/Prototype.hvac_systems.rb
@@ -1493,7 +1493,7 @@ class Standard
         end
         # VAV reheat terminal
         air_terminal = OpenStudio::Model::AirTerminalSingleDuctVAVReheat.new(model, model.alwaysOnDiscreteSchedule, rht_coil)
-        if model.version < OpenStudio::VersionString.new('3.1.0')
+        if model.version < OpenStudio::VersionString.new('3.0.1')
           air_terminal.setZoneMinimumAirFlowMethod('Constant')
         else
           air_terminal.setZoneMinimumAirFlowInputMethod('Constant')
@@ -1501,7 +1501,7 @@ class Standard
         air_terminal.setControlForOutdoorAir(true) if demand_control_ventilation
       else # 'DOASVAV'
         air_terminal = OpenStudio::Model::AirTerminalSingleDuctVAVNoReheat.new(model, model.alwaysOnDiscreteSchedule)
-        if model.version < OpenStudio::VersionString.new('3.1.0')
+        if model.version < OpenStudio::VersionString.new('3.0.1')
           air_terminal.setZoneMinimumAirFlowMethod('Constant')
         else
           air_terminal.setZoneMinimumAirFlowInputMethod('Constant')
@@ -1744,7 +1744,7 @@ class Standard
         # create vav terminal
         terminal = OpenStudio::Model::AirTerminalSingleDuctVAVReheat.new(model, model.alwaysOnDiscreteSchedule, rht_coil)
         terminal.setName("#{zone.name} VAV Terminal")
-        if model.version < OpenStudio::VersionString.new('3.1.0')
+        if model.version < OpenStudio::VersionString.new('3.0.1')
           terminal.setZoneMinimumAirFlowMethod('Constant')
         else
           terminal.setZoneMinimumAirFlowInputMethod('Constant')
@@ -1765,7 +1765,7 @@ class Standard
         # create vav terminal
         terminal = OpenStudio::Model::AirTerminalSingleDuctVAVNoReheat.new(model, model.alwaysOnDiscreteSchedule)
         terminal.setName("#{zone.name} VAV Terminal")
-        if model.version < OpenStudio::VersionString.new('3.1.0')
+        if model.version < OpenStudio::VersionString.new('3.0.1')
           terminal.setZoneMinimumAirFlowMethod('Constant')
         else
           terminal.setZoneMinimumAirFlowInputMethod('Constant')
@@ -2083,7 +2083,7 @@ class Standard
       # create VAV terminal
       terminal = OpenStudio::Model::AirTerminalSingleDuctVAVReheat.new(model, model.alwaysOnDiscreteSchedule, rht_coil)
       terminal.setName("#{zone.name} VAV Terminal")
-      if model.version < OpenStudio::VersionString.new('3.1.0')
+      if model.version < OpenStudio::VersionString.new('3.0.1')
         terminal.setZoneMinimumAirFlowMethod('Constant')
       else
         terminal.setZoneMinimumAirFlowInputMethod('Constant')
@@ -2386,7 +2386,7 @@ class Standard
       # VAV terminal
       terminal = OpenStudio::Model::AirTerminalSingleDuctVAVReheat.new(model, model.alwaysOnDiscreteSchedule, rht_coil)
       terminal.setName("#{zone.name} VAV Terminal")
-      if model.version < OpenStudio::VersionString.new('3.1.0')
+      if model.version < OpenStudio::VersionString.new('3.0.1')
         terminal.setZoneMinimumAirFlowMethod('Constant')
       else
         terminal.setZoneMinimumAirFlowInputMethod('Constant')
@@ -3219,7 +3219,7 @@ class Standard
       # Create a diffuser and attach the zone/diffuser pair to the air loop
       diffuser = OpenStudio::Model::AirTerminalSingleDuctVAVNoReheat.new(model, model.alwaysOnDiscreteSchedule)
       diffuser.setName("#{air_loop.name} Diffuser")
-      if model.version < OpenStudio::VersionString.new('3.1.0')
+      if model.version < OpenStudio::VersionString.new('3.0.1')
         diffuser.setZoneMinimumAirFlowMethod('Constant')
       else
         diffuser.setZoneMinimumAirFlowInputMethod('Constant')
@@ -3359,7 +3359,7 @@ class Standard
       # Create a diffuser and attach the zone/diffuser pair to the air loop
       diffuser = OpenStudio::Model::AirTerminalSingleDuctVAVNoReheat.new(model, model.alwaysOnDiscreteSchedule)
       diffuser.setName("#{zone.name} VAV terminal")
-      if model.version < OpenStudio::VersionString.new('3.1.0')
+      if model.version < OpenStudio::VersionString.new('3.0.1')
         diffuser.setZoneMinimumAirFlowMethod('Constant')
       else
         diffuser.setZoneMinimumAirFlowInputMethod('Constant')


### PR DESCRIPTION
setZoneMinimumAirFlowMethod was deprecated in 3.1. setZoneMinimumAirFlowInputMethod is the new method.  Adding the deprecated method for pre OS v3.1 compatibility