### PR TITLE
Disables HVAC Sizing Simulations for Sizing Periods after running a sizing run

### DIFF
--- a/lib/openstudio-standards/utilities/simulation.rb
+++ b/lib/openstudio-standards/utilities/simulation.rb
@@ -190,6 +190,9 @@ Standard.class_eval do
     # Change the model back to running the weather file
     sim_control.setRunSimulationforSizingPeriods(false)
     sim_control.setRunSimulationforWeatherFileRunPeriods(true)
+    if model.version >= OpenStudio::VersionString.new('3.0.0')
+      sim_control.setDoHVACSizingSimulationforSizingPeriods(false)
+    end
 
     return success
   end


### PR DESCRIPTION
Disables HVAC Sizing Simulations for Sizing Periods after running a sizing run.  If this isn't disabled, READVARSESO will export both the annual timeseries AND the timeseries for the HVAC sizing periods, which breaks ComStock output reporting.  The downside to disabling this after the sizing run is that some of the sizes calculated for the autosized plant equipment which use this flag will then change during a later annual simulation, which could be confusing.  An alternate approach would be to adjust this in ComStock model creation measures separately from openstudio-standard.  @mdahlhausen I'll make a PR into ComStock using that approach and if we like this approach of doing in openstudio-standards better we can use this instead.