### PR TITLE
Gem update

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -175,20 +175,23 @@ namespace :data do
   spreadsheet_titles = spreadsheets_ashrae + spreadsheets_deer + spreadsheets_comstock + spreadsheets_cbes
   spreadsheet_titles = spreadsheet_titles.uniq
 
-  desc 'Check google drive configuration'
+  desc 'Check Google Drive configuration'
   task 'apicheck' do
     check_google_drive_configuration
   end
 
-  desc 'Download all OpenStudio_Standards spreadsheets from Google & export JSONs'
-  task 'update' do
-    puts 'Due to gem updates, the download feature no longer works.  Use update:manual until this is updated.'
-    # @todo update download_google_spreadsheets method using newer google_drive gem
-    # download_google_spreadsheets(spreadsheet_titles)
-    # export_spreadsheet_to_json(spreadsheet_titles)
+  desc 'Download OpenStudio_Standards spreadsheets from Google Drive'
+  task 'download' do
+    download_google_spreadsheets(spreadsheet_titles)
   end
 
-  desc 'Export JSONs from OpenStudio_Standards'
+  desc 'Download OpenStudio_Standards spreadsheets and generate JSONs'
+  task 'update' do
+    download_google_spreadsheets(spreadsheet_titles)
+    export_spreadsheet_to_json(spreadsheet_titles)
+  end
+
+  desc 'Generate JSONs from OpenStudio_Standards spreadsheets'
   task 'update:manual' do
     export_spreadsheet_to_json(spreadsheet_titles)
   end

--- a/Rakefile
+++ b/Rakefile
@@ -175,10 +175,17 @@ namespace :data do
   spreadsheet_titles = spreadsheets_ashrae + spreadsheets_deer + spreadsheets_comstock + spreadsheets_cbes
   spreadsheet_titles = spreadsheet_titles.uniq
 
+  desc 'Check google drive configuration'
+  task 'apicheck' do
+    check_google_drive_configuration
+  end
+
   desc 'Download all OpenStudio_Standards spreadsheets from Google & export JSONs'
   task 'update' do
-    download_google_spreadsheets(spreadsheet_titles)
-    export_spreadsheet_to_json(spreadsheet_titles)
+    puts 'Due to gem updates, the download feature no longer works.  Use update:manual until this is updated.'
+    # @todo update download_google_spreadsheets method using newer google_drive gem
+    # download_google_spreadsheets(spreadsheet_titles)
+    # export_spreadsheet_to_json(spreadsheet_titles)
   end
 
   desc 'Export JSONs from OpenStudio_Standards'

--- a/data/standards/manage_OpenStudio_Standards.rb
+++ b/data/standards/manage_OpenStudio_Standards.rb
@@ -188,9 +188,11 @@ def check_google_drive_configuration
     puts "Unable to locate client_secret.json file at #{client_config_path}."
     return false
   end
+  puts 'attempting to access spreadsheets...'
+  puts 'if you get an SSL error, disconnect from the VPN and try again'
   session = GoogleDrive::Session.from_config(client_config_path)
 
-  # Gets list of remote files.
+  # Gets list of remote files
   session.files.each do |file|
     puts file.title if file.title.include? 'OpenStudio'
   end
@@ -202,98 +204,26 @@ end
 # Downloads the OpenStudio_Standards.xlsx from Google Drive
 # @note This requires you to have a client_secret.json file saved in your
 # username/.credentials folder.  To get one of these files, please contact
-# andrew.parker@nrel.gov
+# marley.praprost@nrel.gov
 def download_google_spreadsheets(spreadsheet_titles)
-
-  require 'google/api_client'
-  require 'google/api_client/client_secrets'
-  require 'google/api_client/auth/installed_app'
-  require 'google/api_client/auth/storage'
-  require 'google/api_client/auth/storages/file_store'
-  require 'fileutils'
-
-  #APPLICATION_NAME = 'openstudio-standards'
-  #CLIENT_SECRETS_PATH = 'client_secret_857202529887-mlov2utaq9apq699789gh4o1f9u2eipr.apps.googleusercontent.com.json'
-
-  ##
-  # Ensure valid credentials, either by restoring from the saved credentials
-  # files or intitiating an OAuth2 authorization request via InstalledAppFlow.
-  # If authorization is required, the user's default browser will be launched
-  # to approve the request.
-  #
-  # @return [Signet::OAuth2::Client] OAuth2 credentials
-  def authorize(credentials_path, client_secret_path)
-    FileUtils.mkdir_p(File.dirname(credentials_path))
-
-    file_store = Google::APIClient::FileStore.new(credentials_path)
-    storage = Google::APIClient::Storage.new(file_store)
-    auth = storage.authorize
-
-    if auth.nil? || (auth.expired? && auth.refresh_token.nil?)
-      app_info = Google::APIClient::ClientSecrets.load(client_secret_path)
-      flow = Google::APIClient::InstalledAppFlow.new({
-                                                         :client_id => app_info.client_id,
-                                                         :client_secret => app_info.client_secret,
-                                                         :scope => 'https://www.googleapis.com/auth/drive'})
-      auth = flow.authorize(storage)
-      puts "Credentials saved to #{credentials_path}" unless auth.nil?
-    end
-    auth
+  require 'google_drive'
+  client_config_path = File.join(Dir.home, '.credentials', "client_secret.json")
+  unless File.exists? client_config_path
+    puts "Unable to locate client_secret.json file at #{client_config_path}."
+    return false
   end
 
-  ##
-  # Download a file's content
-  #
-  # @param [Google::APIClient] client
-  #   Authorized client instance
-  # @param [Google::APIClient::Schema::Drive::V2::File]
-  #   Drive File instance
-  # @return
-  #   File's content if successful, nil otherwise
-  def download_xlsx_spreadsheet(client, google_spreadsheet, path)
-    file_name = google_spreadsheet.title
-    export_url = google_spreadsheet.export_links['application/vnd.openxmlformats-officedocument.spreadsheetml.sheet']
-    #export_url = google_spreadsheet.export_links['text/csv']
-    if export_url
-      result = client.execute(:uri => export_url)
-      if result.status == 200
-        File.open(path, "wb") do |f|
-          f.write(result.body)
-        end
-        puts "Successfully downloaded #{file_name} to .xlsx"
-        return true
-      else
-        puts "An error occurred: #{result.data['error']['message']}"
-        return false
-      end
-    else
-      puts "#{file_name} can't be downloaded as an .xlsx file."
-      return false
-    end
-  end
+  session = GoogleDrive::Session.from_config(client_config_path)
 
-  # Initialize the API
-  client_secret_path = File.join(Dir.home, '.credentials', "client_secret.json")
-
-  credentials_path = File.join(Dir.home, '.credentials', "openstudio-standards-google-drive.json")
-  client = Google::APIClient.new(:application_name => 'openstudio-standards')
-  client.authorization = authorize(credentials_path, client_secret_path)
-  drive_api = client.discovered_api('drive', 'v2')
-
-  # List the 100 most recently modified files.
-  results = client.execute!(
-      :api_method => drive_api.files.list,
-      :parameters => {:maxResults => 100})
-  puts "No files found" if results.data.items.empty?
-
-  # Find the OpenStudio_Standards google spreadsheet
-  # and save it.
-  results.data.items.each do |file|
+  # Gets list of remote files
+  session.files.each do |file|
     if spreadsheet_titles.include?(file.title)
       puts "Found #{file.title}"
-      download_xlsx_spreadsheet(client, file, "#{File.dirname(__FILE__)}/#{file.title}.xlsx")
+      file.export_as_file("#{File.dirname(__FILE__)}/#{file.title}.xlsx")
+      puts "Downloaded #{file.title} to #{File.dirname(__FILE__)}/#{file.title}.xlsx"
     end
   end
+  return true
 end
 
 def exclusion_list
@@ -418,7 +348,11 @@ def export_spreadsheet_to_json(spreadsheet_titles, dataset_type: 'os_stds')
       header_row = 2 # Base 0
 
       # Get all data
-      all_data = worksheet.extract_data
+      # extract_data was deprecated in rubyXL
+      # inputting the method here https://github.com/weshatheleopard/rubyXL/issues/201
+      all_data = worksheet.sheet_data.rows.map { |row|
+        row.cells.map { |c| c && c.value() } unless row.nil?
+      }
 
       # Get the header row data
       header_data = all_data[header_row]

--- a/data/standards/manage_OpenStudio_Standards.rb
+++ b/data/standards/manage_OpenStudio_Standards.rb
@@ -179,8 +179,21 @@ def standard_directory_name_from_template(template)
   return directory_name
 end
 
-# Downloads the OpenStudio_Standards.xlsx
-# from Google Drive
+# checks whether your authorization credentials are set up to access the spreadsheets
+# @return [Bool] returns true if api is working, false if not
+def check_google_drive_configuration
+  require 'google_drive'
+  client_config_path = File.join(Dir.home, '.credentials', "client_secret.json")
+  unless File.exists? client_config_path
+    puts "Unable to locate client_secret.json file at #{client_config_path}."
+    return false
+  end
+  session = GoogleDrive::Session.from_config(client_config_path)
+  puts 'Spreadsheets accessed successfully'
+  return true
+end
+
+# Downloads the OpenStudio_Standards.xlsx from Google Drive
 # @note This requires you to have a client_secret.json file saved in your
 # username/.credentials folder.  To get one of these files, please contact
 # andrew.parker@nrel.gov

--- a/data/standards/manage_OpenStudio_Standards.rb
+++ b/data/standards/manage_OpenStudio_Standards.rb
@@ -189,6 +189,12 @@ def check_google_drive_configuration
     return false
   end
   session = GoogleDrive::Session.from_config(client_config_path)
+
+  # Gets list of remote files.
+  session.files.each do |file|
+    puts file.title if file.title.include? 'OpenStudio'
+  end
+
   puts 'Spreadsheets accessed successfully'
   return true
 end

--- a/docs/DeveloperInformation.md
+++ b/docs/DeveloperInformation.md
@@ -54,9 +54,13 @@ This project uses [Rake](http://rake.rubyforge.org/) to run tasks from the termi
 - `bundle exec rake build`                    # Build openstudio-standards-X.X.XX.gem into the pkg directory
 - `bundle exec rake clean`                    # Remove any temporary products
 - `bundle exec rake clobber`                  # Remove any generated files
+- `bundle exec rake data:apicheck`            # Check Google Drive configuration  
+- `bundle exec rake data:download`            # Download OpenStudio_Standards spreadsheets from Google Drive
 - `bundle exec rake data:update`              # Download OpenStudio_Standards from Google & export JSONs
+- `bundle exec rake data:update`              # Download OpenStudio_Standards spreadsheets and generate JSONs
+- `bundle exec rake data:update:manual`       # Generate JSONs from OpenStudio_Standards spreadsheets
+- `bundle exec rake data:export:jsons`        # Export JSONs from OpenStudio_Standards to data library
 - `bundle exec rake data:update:costing`      # Update RS-Means Database
-- `bundle exec rake data:update:manual`       # Export JSONs from OpenStudio_Standards
 - `bundle exec rake doc`                      # Generate the documentation
 - `bundle exec rake doc:show`                 # Show the documentation in a web browser
 - `bundle exec rake install`                  # Build and install openstudio-standards-X.X.XX.gem into system gems

--- a/openstudio-standards.gemspec
+++ b/openstudio-standards.gemspec
@@ -30,24 +30,19 @@ Gem::Specification.new do |spec|
     spec.add_development_dependency 'nokogiri', '<= 1.8.2'
     spec.add_development_dependency 'bundler', '~> 2.1'
   else
-    spec.add_development_dependency 'parallel_tests', '~> 3.0.0'
-    spec.add_development_dependency 'nokogiri', '<= 1.10.10'
-    spec.add_development_dependency 'bundler', '~> 2.1'
+    spec.add_development_dependency 'parallel_tests', '~> 3.7.0'
+    spec.add_development_dependency 'nokogiri', '~> 1.11'
+    spec.add_development_dependency 'bundler', '~> 2.2'
   end
   spec.add_development_dependency 'rake', '~> 12.3.1'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'rubocop', '0.68.1'
   spec.add_development_dependency 'rubocop-checkstyle_formatter', '~> 0.1.1'
   spec.add_development_dependency 'minitest-ci', '<= 5.10.3'
-  spec.add_development_dependency 'rubyXL', '3.3.8' # install rubyXL gem to export excel files to json
-  spec.add_development_dependency 'activesupport', '4.2.5' # pairs with google-api-client, > 5.0.0 does not work
-  spec.add_development_dependency 'public_suffix', '3.0.3' # fixing version of google-api-client dependency
-  spec.add_development_dependency 'faraday', '0.15.4' # fixing version of google-api-client dependency
-  spec.add_development_dependency 'signet', '< 0.12.0' # development dependency for google-api-client
-  spec.add_development_dependency 'launchy', '< 2.5.0' # development dependency for google-api-client
-  spec.add_development_dependency 'google-api-client', '0.8.6' # to download Openstudio_Standards Google Spreadsheet
+  spec.add_development_dependency 'rubyXL', '~> 3.4'
+  spec.add_development_dependency 'google_drive'
   spec.add_development_dependency 'simplecov-html', '< 0.11.0'
-  spec.add_development_dependency 'codecov' # to perform code coverage checking
+  spec.add_development_dependency 'codecov'
   spec.add_development_dependency 'rest-client', '2.0.2'
   spec.add_development_dependency 'aes', '0.5.0'
   spec.add_development_dependency 'roo', '2.7.1'


### PR DESCRIPTION
Updates the gemspec to remove the google-api-client gem and its dependencies.  Uses the newer google_drive gem instead.

Also update rubyXL and nokogiri, which @ckirney raised has having security issues with the older versions.

Luckily, the google_drive gem is much simpler than the older version, so this was an easy refactor that got rid of a decent chunk of code.