### PR TITLE
nrcan_315 - doas systems and office room of the highrise apartment

### DIFF
--- a/lib/openstudio-standards/standards/necb/NECB2011/autozone.rb
+++ b/lib/openstudio-standards/standards/necb/NECB2011/autozone.rb
@@ -1018,7 +1018,7 @@ class NECB2011
 
     system_zones_hash = {}
     # Detemine if dwelling units have a shared AHU.  If user entered building stories > 4 then set to true.
-    dwelling_shared_ahu = model.getBuilding.standardsNumberOfAboveGroundStories.get > 4
+    dwelling_shared_ahu = model.getBuilding.standardsNumberOfAboveGroundStories.get > 1000000000 #4  Sara
     # store dwelling zones into array
     zones = []
     model.getSpaces.select { |space| is_a_necb_dwelling_unit?(space) }.each do |space|

--- a/lib/openstudio-standards/standards/necb/NECB2011/data/geometry/HighriseApartment.osm
+++ b/lib/openstudio-standards/standards/necb/NECB2011/data/geometry/HighriseApartment.osm
@@ -21543,7 +21543,7 @@ OS:SpaceType,
   {60033ff6-8b3e-4fb2-9f59-6687c207d7be}, !- Group Rendering Name
   ,                                       !- Design Specification Outdoor Air Object Name
   Space Function,                         !- Standards Building Type
-  Office - enclosed;                      !- Standards Space Type
+  Dwelling Unit(s);                      !- Standards Space Type
 
 OS:Rendering:Color,
   {60033ff6-8b3e-4fb2-9f59-6687c207d7be}, !- Handle


### PR DESCRIPTION
If this adjustment makes sense, we would need to update the 'auto_system_dwelling_units' method in a way to consider other building types where maximum number of storeys to have shared AHUs may differ from the highrise)