### PR TITLE
Update furnace and boiler efficiency to match values from ASHRAE 90.1-2004 through 2019

### DIFF
--- a/data/standards/manage_OpenStudio_Standards.rb
+++ b/data/standards/manage_OpenStudio_Standards.rb
@@ -98,6 +98,8 @@ def unique_properties(sheet_name)
            ['template', 'fluid_type', 'fuel_type', 'condensing', 'condensing_control', 'minimum_capacity', 'maximum_capacity', 'start_date', 'end_date']
          when 'chillers'
            ['template', 'cooling_type', 'condenser_type', 'compressor_type', 'absorption_type', 'variable_speed_drive', 'minimum_capacity', 'maximum_capacity', 'start_date', 'end_date']
+         when 'furnaces'
+           ['template', 'minimum_capacity', 'maximum_capacity', 'start_date', 'end_date']
          when 'heat_rejection'
            ['template', 'equipment_type', 'fan_type', 'start_date', 'end_date']
          when 'water_source_heat_pumps'

--- a/data/standards/metadata_units_OpenStudio_Standards-ashrae_90_1.csv
+++ b/data/standards/metadata_units_OpenStudio_Standards-ashrae_90_1.csv
@@ -282,6 +282,15 @@ boilers,minimum_thermal_efficiency,%
 boilers,minimum_combustion_efficiency,%
 boilers,efffplr,
 boilers,notes,
+furnaces,template,
+furnaces,minimum_capacity,Btu/hr
+furnaces,maximum_capacity,Btu/hr
+furnaces,start_date,
+furnaces,end_date,
+furnaces,minimum_annual_fuel_utilization_efficiency,AFUE
+furnaces,minimum_thermal_efficiency,%
+furnaces,minimum_combustion_efficiency,%
+furnaces,notes,
 chillers,template,
 chillers,cooling_type,
 chillers,condenser_type,

--- a/lib/openstudio-standards/standards/Standards.CoilHeatingGas.rb
+++ b/lib/openstudio-standards/standards/Standards.CoilHeatingGas.rb
@@ -66,6 +66,7 @@ class Standard
       # Set the name
       coil_heating_gas.setName(new_comp_name)
       coil_heating_gas.setGasBurnerEfficiency(thermal_eff)
+      successfully_set_all_properties = true
     end
 
     return successfully_set_all_properties

--- a/lib/openstudio-standards/standards/Standards.CoilHeatingGas.rb
+++ b/lib/openstudio-standards/standards/Standards.CoilHeatingGas.rb
@@ -23,7 +23,9 @@ class Standard
     capacity_btu_per_hr = OpenStudio.convert(capacity_w, 'W', 'Btu/hr').get
     capacity_kbtu_per_hr = OpenStudio.convert(capacity_w, 'W', 'kBtu/hr').get
 
-    # Get the boiler properties
+    # Get the boiler properties, if it exists for this template
+    return false unless standards_data.include?('furnaces')
+
     furnace_props = model_find_object(standards_data['furnaces'], search_criteria, capacity_btu_per_hr)
     unless furnace_props
       OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.CoilHeatingGas', "For #{coil_heating_gas.name}, cannot find furnace properties with search criteria #{search_criteria}, cannot apply efficiency standard.")

--- a/lib/openstudio-standards/standards/Standards.CoilHeatingGas.rb
+++ b/lib/openstudio-standards/standards/Standards.CoilHeatingGas.rb
@@ -35,7 +35,7 @@ class Standard
     thermal_eff = nil
 
     # If specified as thermal efficiency, this takes precedent
-    if not furnace_props['minimum_thermal_efficiency'].nil?
+    if !furnace_props['minimum_thermal_efficiency'].nil?
       thermal_eff = furnace_props['minimum_thermal_efficiency']
       new_comp_name = "#{coil_heating_gas.name} #{capacity_kbtu_per_hr.round}kBtu/hr #{thermal_eff} Thermal Eff"
       OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.CoilHeatingGas', "For #{template}: #{coil_heating_gas.name}: = #{capacity_kbtu_per_hr.round}kBtu/hr; Thermal Efficiency = #{thermal_eff}")

--- a/lib/openstudio-standards/standards/Standards.CoilHeatingGas.rb
+++ b/lib/openstudio-standards/standards/Standards.CoilHeatingGas.rb
@@ -1,12 +1,91 @@
 class Standard
   # @!group CoilHeatingGas
 
-  # Applies the standard efficiency ratings and typical performance curves to this object.
+  # Applies the standard efficiency ratings to CoilHeatingGas.
   #
+  # @param coil_heating_gas [OpenStudio::Model::CoilHeatingGas] the object to modify
   # @return [Bool] true if successful, false if not
   def coil_heating_gas_apply_efficiency_and_curves(coil_heating_gas)
-    successfully_set_all_properties = true
+    successfully_set_all_properties = false
+
+    # Initialize search criteria
+    search_criteria = {}
+    search_criteria['template'] = template
+
+    # Get the capacity, but return false if not available
+    capacity_w = coil_heating_gas_find_capacity(coil_heating_gas)
+
+    # Return false if the coil does not have a heating capacity associated with it. Cannot apply the standard if without
+    # it.
+    return successfully_set_all_properties if capacity_w == false
+
+    # Convert capacity to Btu/hr
+    capacity_btu_per_hr = OpenStudio.convert(capacity_w, 'W', 'Btu/hr').get
+    capacity_kbtu_per_hr = OpenStudio.convert(capacity_w, 'W', 'kBtu/hr').get
+
+    # Get the boiler properties
+    furnace_props = model_find_object(standards_data['furnaces'], search_criteria, capacity_btu_per_hr)
+    unless furnace_props
+      OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.CoilHeatingGas', "For #{coil_heating_gas.name}, cannot find furnace properties with search criteria #{search_criteria}, cannot apply efficiency standard.")
+      successfully_set_all_properties = false
+      return successfully_set_all_properties
+    end
+
+    # Get the minimum efficiency standards
+    thermal_eff = nil
+
+    # If specified as thermal efficiency, this takes precedent
+    if not furnace_props['minimum_thermal_efficiency'].nil?
+      thermal_eff = furnace_props['minimum_thermal_efficiency']
+      new_comp_name = "#{coil_heating_gas.name} #{capacity_kbtu_per_hr.round}kBtu/hr #{thermal_eff} Thermal Eff"
+      OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.CoilHeatingGas', "For #{template}: #{coil_heating_gas.name}: = #{capacity_kbtu_per_hr.round}kBtu/hr; Thermal Efficiency = #{thermal_eff}")
+
+    else # If not thermal efficiency, check other parameters
+
+      # If specified as AFUE
+      unless furnace_props['minimum_annual_fuel_utilization_efficiency'].nil?
+        min_afue = furnace_props['minimum_annual_fuel_utilization_efficiency']
+        thermal_eff = afue_to_thermal_eff(min_afue)
+        new_comp_name = "#{coil_heating_gas.name} #{capacity_kbtu_per_hr.round}kBtu/hr #{min_afue} AFUE"
+        OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.CoilHeatingGas', "For #{template}: #{coil_heating_gas.name}: = #{capacity_kbtu_per_hr.round}kBtu/hr; AFUE = #{min_afue}")
+      end
+
+      # If specified as combustion efficiency
+      unless furnace_props['minimum_combustion_efficiency'].nil?
+        min_comb_eff = furnace_props['minimum_combustion_efficiency']
+        thermal_eff = combustion_eff_to_thermal_eff(min_comb_eff)
+        new_comp_name = "#{coil_heating_gas.name} #{capacity_kbtu_per_hr.round}kBtu/hr #{min_comb_eff} Combustion Eff"
+        OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.CoilHeatingGas', "For #{template}: #{coil_heating_gas.name}: = #{capacity_kbtu_per_hr.round}kBtu/hr; Combustion Efficiency = #{min_comb_eff}")
+      end
+
+    end
+
+    # Set the efficiency values
+    unless thermal_eff.nil?
+
+      # Set the name
+      coil_heating_gas.setName(new_comp_name)
+      coil_heating_gas.setGasBurnerEfficiency(thermal_eff)
+    end
 
     return successfully_set_all_properties
+  end
+
+  # Find capacity in W
+  #
+  # @return [Double] capacity in W
+  def coil_heating_gas_find_capacity(coil_heating_gas)
+    capacity_w = nil
+    if coil_heating_gas.nominalCapacity.is_initialized
+      capacity_w = coil_heating_gas.nominalCapacity.get
+    elsif coil_heating_gas.autosizedNominalCapacity.is_initialized
+      capacity_w = coil_heating_gas.autosizedNominalCapacity.get
+    else
+      OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.CoilHeatingGas', "For #{coil_heating_gas.name} capacity is not available, cannot apply efficiency standard.")
+      successfully_set_all_properties = false
+      return successfully_set_all_properties
+    end
+
+    return capacity_w
   end
 end

--- a/lib/openstudio-standards/standards/Standards.CoilHeatingGas.rb
+++ b/lib/openstudio-standards/standards/Standards.CoilHeatingGas.rb
@@ -72,9 +72,11 @@ class Standard
     return successfully_set_all_properties
   end
 
-  # Find capacity in W
+  # Retrieves the capacity of an OpenStudio::Model::CoilHeatingGas in watts
   #
-  # @return [Double] capacity in W
+  # @param coil_heating_gas [OpenStudio::Model::CoilHeatingGas] the gas heating coil
+  # @return [Double, false] a double representing the capacity of the CoilHeatingGas object in watts. If unsuccessful in
+  #   determining the capacity, this function returns false.
   def coil_heating_gas_find_capacity(coil_heating_gas)
     capacity_w = nil
     if coil_heating_gas.nominalCapacity.is_initialized

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2004/data/ashrae_90_1_2004.furnaces.json
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2004/data/ashrae_90_1_2004.furnaces.json
@@ -1,0 +1,26 @@
+{
+  "furnaces": [
+    {
+      "template": "90.1-2004",
+      "minimum_capacity": 0.0,
+      "maximum_capacity": 224999.0,
+      "start_date": "1919-09-09T00:00:00+00:00",
+      "end_date": "2999-09-09T00:00:00+00:00",
+      "minimum_annual_fuel_utilization_efficiency": 0.78,
+      "minimum_thermal_efficiency": 0.8,
+      "minimum_combustion_efficiency": null,
+      "notes": "Table 6.8.1E page 49\n"
+    },
+    {
+      "template": "90.1-2004",
+      "minimum_capacity": 225000.0,
+      "maximum_capacity": 249999999.0,
+      "start_date": "1919-09-09T00:00:00+00:00",
+      "end_date": "2999-09-09T00:00:00+00:00",
+      "minimum_annual_fuel_utilization_efficiency": null,
+      "minimum_thermal_efficiency": null,
+      "minimum_combustion_efficiency": 0.8,
+      "notes": "Table 6.8.1E page 49\n"
+    }
+  ]
+}

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2007/data/ashrae_90_1_2007.furnaces.json
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2007/data/ashrae_90_1_2007.furnaces.json
@@ -1,0 +1,26 @@
+{
+  "furnaces": [
+    {
+      "template": "90.1-2007",
+      "minimum_capacity": 0.0,
+      "maximum_capacity": 224999.0,
+      "start_date": "1919-09-09T00:00:00+00:00",
+      "end_date": "2999-09-09T00:00:00+00:00",
+      "minimum_annual_fuel_utilization_efficiency": 0.78,
+      "minimum_thermal_efficiency": 0.8,
+      "minimum_combustion_efficiency": null,
+      "notes": "Table 6.8.1E page 49\n"
+    },
+    {
+      "template": "90.1-2007",
+      "minimum_capacity": 225000.0,
+      "maximum_capacity": 249999999.0,
+      "start_date": "1919-09-09T00:00:00+00:00",
+      "end_date": "2999-09-09T00:00:00+00:00",
+      "minimum_annual_fuel_utilization_efficiency": null,
+      "minimum_thermal_efficiency": null,
+      "minimum_combustion_efficiency": 0.8,
+      "notes": "Table 6.8.1E page 49\n"
+    }
+  ]
+}

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2010/data/ashrae_90_1_2010.furnaces.json
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2010/data/ashrae_90_1_2010.furnaces.json
@@ -1,0 +1,26 @@
+{
+  "furnaces": [
+    {
+      "template": "90.1-2010",
+      "minimum_capacity": 0.0,
+      "maximum_capacity": 224999.0,
+      "start_date": "1919-09-09T00:00:00+00:00",
+      "end_date": "2999-09-09T00:00:00+00:00",
+      "minimum_annual_fuel_utilization_efficiency": 0.78,
+      "minimum_thermal_efficiency": 0.8,
+      "minimum_combustion_efficiency": null,
+      "notes": "Table 6.8.1E page 62\n"
+    },
+    {
+      "template": "90.1-2010",
+      "minimum_capacity": 225000.0,
+      "maximum_capacity": 249999999.0,
+      "start_date": "1919-09-09T00:00:00+00:00",
+      "end_date": "2999-09-09T00:00:00+00:00",
+      "minimum_annual_fuel_utilization_efficiency": null,
+      "minimum_thermal_efficiency": 0.8,
+      "minimum_combustion_efficiency": null,
+      "notes": "Table 6.8.1E page 62\n"
+    }
+  ]
+}

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2013/data/ashrae_90_1_2013.furnaces.json
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2013/data/ashrae_90_1_2013.furnaces.json
@@ -1,0 +1,26 @@
+{
+  "furnaces": [
+    {
+      "template": "90.1-2013",
+      "minimum_capacity": 0.0,
+      "maximum_capacity": 224999.0,
+      "start_date": "1919-09-09T00:00:00+00:00",
+      "end_date": "2999-09-09T00:00:00+00:00",
+      "minimum_annual_fuel_utilization_efficiency": 0.78,
+      "minimum_thermal_efficiency": 0.8,
+      "minimum_combustion_efficiency": null,
+      "notes": "Table 6.8.1E page 72\n"
+    },
+    {
+      "template": "90.1-2013",
+      "minimum_capacity": 225000.0,
+      "maximum_capacity": 249999999.0,
+      "start_date": "1919-09-09T00:00:00+00:00",
+      "end_date": "2999-09-09T00:00:00+00:00",
+      "minimum_annual_fuel_utilization_efficiency": null,
+      "minimum_thermal_efficiency": 0.8,
+      "minimum_combustion_efficiency": null,
+      "notes": "Table 6.8.1E page 72\n"
+    }
+  ]
+}

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2016/data/ashrae_90_1_2016.furnaces.json
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2016/data/ashrae_90_1_2016.furnaces.json
@@ -1,0 +1,26 @@
+{
+  "furnaces": [
+    {
+      "template": "90.1-2016",
+      "minimum_capacity": 0.0,
+      "maximum_capacity": 224999.0,
+      "start_date": "1919-09-09T00:00:00+00:00",
+      "end_date": "2999-09-09T00:00:00+00:00",
+      "minimum_annual_fuel_utilization_efficiency": 0.78,
+      "minimum_thermal_efficiency": 0.8,
+      "minimum_combustion_efficiency": null,
+      "notes": "Table 6.8.1E page 116\n"
+    },
+    {
+      "template": "90.1-2016",
+      "minimum_capacity": 225000.0,
+      "maximum_capacity": 249999999.0,
+      "start_date": "1919-09-09T00:00:00+00:00",
+      "end_date": "2999-09-09T00:00:00+00:00",
+      "minimum_annual_fuel_utilization_efficiency": null,
+      "minimum_thermal_efficiency": 0.8,
+      "minimum_combustion_efficiency": null,
+      "notes": "Table 6.8.1E page 116\n"
+    }
+  ]
+}

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2019/data/ashrae_90_1_2019.boilers.json
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2019/data/ashrae_90_1_2019.boilers.json
@@ -10,7 +10,7 @@
       "maximum_capacity": 299999.0,
       "start_date": "1919-09-09T00:00:00+00:00",
       "end_date": "2999-09-09T00:00:00+00:00",
-      "minimum_annual_fuel_utilization_efficiency": 0.82,
+      "minimum_annual_fuel_utilization_efficiency": 0.84,
       "minimum_thermal_efficiency": null,
       "minimum_combustion_efficiency": null,
       "efffplr": "Boiler with No Minimum Turndown",

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2019/data/ashrae_90_1_2019.furnaces.json
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2019/data/ashrae_90_1_2019.furnaces.json
@@ -1,0 +1,26 @@
+{
+  "furnaces": [
+    {
+      "template": "90.1-2019",
+      "minimum_capacity": 0.0,
+      "maximum_capacity": 224999.0,
+      "start_date": "1919-09-09T00:00:00+00:00",
+      "end_date": "2999-09-09T00:00:00+00:00",
+      "minimum_annual_fuel_utilization_efficiency": null,
+      "minimum_thermal_efficiency": 0.81,
+      "minimum_combustion_efficiency": null,
+      "notes": "Table 6.8.1-6 for > 225 ktbu/hr\nTable F-4 for < 225 ktbu/hr"
+    },
+    {
+      "template": "90.1-2019",
+      "minimum_capacity": 225000.0,
+      "maximum_capacity": 249999999.0,
+      "start_date": "1919-09-09T00:00:00+00:00",
+      "end_date": "2999-09-09T00:00:00+00:00",
+      "minimum_annual_fuel_utilization_efficiency": null,
+      "minimum_thermal_efficiency": 0.8,
+      "minimum_combustion_efficiency": null,
+      "notes": "Table 6.8.1-6 for > 225 ktbu/hr\nTable F-4 for < 225 ktbu/hr"
+    }
+  ]
+}

--- a/lib/openstudio-standards/standards/ashrae_90_1/doe_ref_1980_2004/data/doe_ref_1980_2004.furnaces.json
+++ b/lib/openstudio-standards/standards/ashrae_90_1/doe_ref_1980_2004/data/doe_ref_1980_2004.furnaces.json
@@ -7,7 +7,7 @@
       "start_date": "1919-09-09T00:00:00+00:00",
       "end_date": "2999-09-09T00:00:00+00:00",
       "minimum_annual_fuel_utilization_efficiency": null,
-      "minimum_thermal_efficiency": null,
+      "minimum_thermal_efficiency": 0.8,
       "minimum_combustion_efficiency": null,
       "notes": null
     },
@@ -18,7 +18,7 @@
       "start_date": "1919-09-09T00:00:00+00:00",
       "end_date": "2999-09-09T00:00:00+00:00",
       "minimum_annual_fuel_utilization_efficiency": null,
-      "minimum_thermal_efficiency": null,
+      "minimum_thermal_efficiency": 0.8,
       "minimum_combustion_efficiency": null,
       "notes": null
     }

--- a/lib/openstudio-standards/standards/ashrae_90_1/doe_ref_1980_2004/data/doe_ref_1980_2004.furnaces.json
+++ b/lib/openstudio-standards/standards/ashrae_90_1/doe_ref_1980_2004/data/doe_ref_1980_2004.furnaces.json
@@ -1,0 +1,26 @@
+{
+  "furnaces": [
+    {
+      "template": "DOE Ref 1980-2004",
+      "minimum_capacity": 0.0,
+      "maximum_capacity": 299999.0,
+      "start_date": "1919-09-09T00:00:00+00:00",
+      "end_date": "2999-09-09T00:00:00+00:00",
+      "minimum_annual_fuel_utilization_efficiency": null,
+      "minimum_thermal_efficiency": null,
+      "minimum_combustion_efficiency": null,
+      "notes": null
+    },
+    {
+      "template": "DOE Ref 1980-2004",
+      "minimum_capacity": 300000.0,
+      "maximum_capacity": 249999999.0,
+      "start_date": "1919-09-09T00:00:00+00:00",
+      "end_date": "2999-09-09T00:00:00+00:00",
+      "minimum_annual_fuel_utilization_efficiency": null,
+      "minimum_thermal_efficiency": null,
+      "minimum_combustion_efficiency": null,
+      "notes": null
+    }
+  ]
+}

--- a/lib/openstudio-standards/standards/ashrae_90_1/doe_ref_pre_1980/data/doe_ref_pre_1980.furnaces.json
+++ b/lib/openstudio-standards/standards/ashrae_90_1/doe_ref_pre_1980/data/doe_ref_pre_1980.furnaces.json
@@ -1,0 +1,37 @@
+{
+  "furnaces": [
+    {
+      "template": "DOE Ref Pre-1980",
+      "minimum_capacity": 0.0,
+      "maximum_capacity": 249999.0,
+      "start_date": "1919-09-09T00:00:00+00:00",
+      "end_date": "2999-09-09T00:00:00+00:00",
+      "minimum_annual_fuel_utilization_efficiency": null,
+      "minimum_thermal_efficiency": null,
+      "minimum_combustion_efficiency": null,
+      "notes": null
+    },
+    {
+      "template": "DOE Ref Pre-1980",
+      "minimum_capacity": 250000.0,
+      "maximum_capacity": 9999999999.0,
+      "start_date": "1919-09-09T00:00:00+00:00",
+      "end_date": "2999-09-09T00:00:00+00:00",
+      "minimum_annual_fuel_utilization_efficiency": null,
+      "minimum_thermal_efficiency": null,
+      "minimum_combustion_efficiency": null,
+      "notes": null
+    },
+    {
+      "template": "DOE Ref Pre-1980",
+      "minimum_capacity": 250000000.0,
+      "maximum_capacity": 9999999999.0,
+      "start_date": "1919-09-09T00:00:00+00:00",
+      "end_date": "2999-09-09T00:00:00+00:00",
+      "minimum_annual_fuel_utilization_efficiency": null,
+      "minimum_thermal_efficiency": null,
+      "minimum_combustion_efficiency": null,
+      "notes": null
+    }
+  ]
+}

--- a/lib/openstudio-standards/standards/ashrae_90_1/doe_ref_pre_1980/data/doe_ref_pre_1980.furnaces.json
+++ b/lib/openstudio-standards/standards/ashrae_90_1/doe_ref_pre_1980/data/doe_ref_pre_1980.furnaces.json
@@ -7,7 +7,7 @@
       "start_date": "1919-09-09T00:00:00+00:00",
       "end_date": "2999-09-09T00:00:00+00:00",
       "minimum_annual_fuel_utilization_efficiency": null,
-      "minimum_thermal_efficiency": null,
+      "minimum_thermal_efficiency": 0.8,
       "minimum_combustion_efficiency": null,
       "notes": null
     },
@@ -18,7 +18,7 @@
       "start_date": "1919-09-09T00:00:00+00:00",
       "end_date": "2999-09-09T00:00:00+00:00",
       "minimum_annual_fuel_utilization_efficiency": null,
-      "minimum_thermal_efficiency": null,
+      "minimum_thermal_efficiency": 0.8,
       "minimum_combustion_efficiency": null,
       "notes": null
     },
@@ -29,7 +29,7 @@
       "start_date": "1919-09-09T00:00:00+00:00",
       "end_date": "2999-09-09T00:00:00+00:00",
       "minimum_annual_fuel_utilization_efficiency": null,
-      "minimum_thermal_efficiency": null,
+      "minimum_thermal_efficiency": 0.8,
       "minimum_combustion_efficiency": null,
       "notes": null
     }

--- a/lib/openstudio-standards/standards/ashrae_90_1/nrel_zne_ready_2017/data/nrel_zne_ready_2017.furnaces.json
+++ b/lib/openstudio-standards/standards/ashrae_90_1/nrel_zne_ready_2017/data/nrel_zne_ready_2017.furnaces.json
@@ -1,0 +1,15 @@
+{
+  "furnaces": [
+    {
+      "template": "NREL ZNE Ready 2017",
+      "minimum_capacity": 0.0,
+      "maximum_capacity": 9999999999.0,
+      "start_date": "1919-09-09T00:00:00+00:00",
+      "end_date": "2999-09-09T00:00:00+00:00",
+      "minimum_annual_fuel_utilization_efficiency": null,
+      "minimum_thermal_efficiency": 0.94,
+      "minimum_combustion_efficiency": null,
+      "notes": "Assume condensing furnace"
+    }
+  ]
+}

--- a/lib/openstudio-standards/standards/ashrae_90_1/ze_aedg_multifamily/data/ze_aedg_multifamily.furnaces.json
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ze_aedg_multifamily/data/ze_aedg_multifamily.furnaces.json
@@ -1,0 +1,15 @@
+{
+  "furnaces": [
+    {
+      "template": "ZE AEDG Multifamily",
+      "minimum_capacity": 0.0,
+      "maximum_capacity": 9999999999.0,
+      "start_date": "1919-09-09T00:00:00+00:00",
+      "end_date": "2999-09-09T00:00:00+00:00",
+      "minimum_annual_fuel_utilization_efficiency": null,
+      "minimum_thermal_efficiency": 0.94,
+      "minimum_combustion_efficiency": null,
+      "notes": "Assume condensing furnace"
+    }
+  ]
+}


### PR DESCRIPTION
The proposed changes includes two changes: 
1) Update 90.1-2019 boilers to use the correct 84% minimum annual fuel utilization efficiency in high capacity boilers
2) Update the 90.1 2004-2019 furnace gas heating coils to use their respective minimum efficiency values (based on year and capacity), updated with relevant documentation. This required adding json files for furnaces to the repository and workflow.

For more information regarding the motivation for this update, consider looking into [Addendum 90.1-2019 BP and Addendum 90.1-2019 BO](https://www.ashrae.org/file%20library/technical%20resources/standards%20and%20guidelines/standards%20addenda/90.1-2016/90_1_2016_be_bm_bn_bo_bp_br_bs_bu_bv_cf_cl_cm_cq_ct_cu_cv_cw_cy_20210324.pdf).