### PR TITLE
Single zone system maximum OA fraction for damper leakage rage

### DIFF
--- a/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2019/ashrae_90_1_2019.hvac_systems.rb
+++ b/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2019/ashrae_90_1_2019.hvac_systems.rb
@@ -17,7 +17,7 @@ class ASHRAE9012019 < ASHRAE901
   # @param snc [String] System name
   #
   # @return [OpenStudio::Model::ScheduleRuleset] Generated maximum outdoor air fraction schedule for later use
-  def set_max_frac_oa_sch(air_loop_hvac, oa_control, snc)
+  def set_maximum_fraction_outdoor_air_schedule(air_loop_hvac, oa_control, snc)
     max_oa_sch_name = "#{snc}maxOASch"
     max_oa_sch = OpenStudio::Model::ScheduleRuleset.new(air_loop_hvac.model)
     max_oa_sch.setName(max_oa_sch_name)

--- a/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2019/ashrae_90_1_2019.hvac_systems.rb
+++ b/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2019/ashrae_90_1_2019.hvac_systems.rb
@@ -8,4 +8,22 @@ class ASHRAE9012019 < ASHRAE901
     fan_type = 'Variable Speed Fan'
     return fan_type
   end
+
+  # Create an economizer maximum OA fraction schedule with
+  # For ASHRAE 90.1 2019, a maximum of 75% to reflect damper leakage per PNNL
+  #
+  # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] HVAC air loop object
+  # @param oa_control [OpenStudio::Model::ControllerOutdoorAir] Outdoor air controller object to have this maximum OA fraction schedule
+  # @param snc [String] System name
+  #
+  # @return [OpenStudio::Model::ScheduleRuleset] Generated maximum outdoor air fraction schedule for later use
+  def set_max_frac_oa_sch(air_loop_hvac, oa_control, snc)
+    max_oa_sch_name = "#{snc}maxOASch"
+    max_oa_sch = OpenStudio::Model::ScheduleRuleset.new(air_loop_hvac.model)
+    max_oa_sch.setName(max_oa_sch_name)
+    max_oa_sch.defaultDaySchedule.setName("#{max_oa_sch_name}Default")
+    max_oa_sch.defaultDaySchedule.addValue(OpenStudio::Time.new(0, 24, 0, 0), 0.75)
+    oa_control.setMaximumFractionofOutdoorAirSchedule(max_oa_sch)
+    max_oa_sch
+  end
 end

--- a/lib/openstudio-standards/standards/Standards.AirLoopHVAC.rb
+++ b/lib/openstudio-standards/standards/Standards.AirLoopHVAC.rb
@@ -2683,14 +2683,7 @@ class Standard
                    air_loop_hvac.model.alwaysOnDiscreteSchedule
                  end
 
-    # Create an economizer maximum OA fraction schedule with
-    # a maximum of 70% to reflect damper leakage per PNNL
-    max_oa_sch_name = "#{snc}maxOASch"
-    max_oa_sch = OpenStudio::Model::ScheduleRuleset.new(air_loop_hvac.model)
-    max_oa_sch.setName(max_oa_sch_name)
-    max_oa_sch.defaultDaySchedule.setName("#{max_oa_sch_name}Default")
-    max_oa_sch.defaultDaySchedule.addValue(OpenStudio::Time.new(0, 24, 0, 0), 0.7)
-    oa_control.setMaximumFractionofOutdoorAirSchedule(max_oa_sch)
+    max_oa_sch = set_max_frac_oa_sch(air_loop_hvac, oa_control, snc)
 
     # Get the supply fan
     if air_loop_hvac.supplyFan.empty?
@@ -3413,5 +3406,23 @@ class Standard
     end
 
     return dx_clg
+  end
+
+  # Create an economizer maximum OA fraction schedule with
+  # For ASHRAE 90.1 2019, a maximum of 75% to reflect damper leakage per PNNL
+  #
+  # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] HVAC air loop object
+  # @param oa_control [OpenStudio::Model::ControllerOutdoorAir] Outdoor air controller object to have this maximum OA fraction schedule
+  # @param snc [String] System name
+  #
+  # @return [OpenStudio::Model::ScheduleRuleset] Generated maximum outdoor air fraction schedule for later use
+  def set_max_frac_oa_sch(air_loop_hvac, oa_control, snc)
+    max_oa_sch_name = "#{snc}maxOASch"
+    max_oa_sch = OpenStudio::Model::ScheduleRuleset.new(air_loop_hvac.model)
+    max_oa_sch.setName(max_oa_sch_name)
+    max_oa_sch.defaultDaySchedule.setName("#{max_oa_sch_name}Default")
+    max_oa_sch.defaultDaySchedule.addValue(OpenStudio::Time.new(0, 24, 0, 0), 0.7)
+    oa_control.setMaximumFractionofOutdoorAirSchedule(max_oa_sch)
+    max_oa_sch
   end
 end

--- a/lib/openstudio-standards/standards/Standards.AirLoopHVAC.rb
+++ b/lib/openstudio-standards/standards/Standards.AirLoopHVAC.rb
@@ -2685,7 +2685,7 @@ class Standard
 
     # Create an economizer maximum OA fraction schedule with
     # a maximum of 70% to reflect damper leakage per PNNL
-    max_oa_sch = set_max_frac_oa_sch(air_loop_hvac, oa_control, snc) unless air_loop_hvac_uses_simple_transfer_air(air_loop_hvac)
+    max_oa_sch = set_maximum_fraction_outdoor_air_schedule(air_loop_hvac, oa_control, snc) unless air_loop_hvac_has_simple_transfer_air?(air_loop_hvac)
 
     # Get the supply fan
     if air_loop_hvac.supplyFan.empty?
@@ -3418,7 +3418,7 @@ class Standard
   # @param snc [String] System name
   #
   # @return [OpenStudio::Model::ScheduleRuleset] Generated maximum outdoor air fraction schedule for later use
-  def set_max_frac_oa_sch(air_loop_hvac, oa_control, snc)
+  def set_maximum_fraction_outdoor_air_schedule(air_loop_hvac, oa_control, snc)
     max_oa_sch_name = "#{snc}maxOASch"
     max_oa_sch = OpenStudio::Model::ScheduleRuleset.new(air_loop_hvac.model)
     max_oa_sch.setName(max_oa_sch_name)
@@ -3433,7 +3433,7 @@ class Standard
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] OpenStudio AirLoopHVAC object
   # @return [Boolean] true if simple transfer air is modeled, false otherwise
-  def air_loop_hvac_uses_simple_transfer_air(air_loop_hvac)
+  def air_loop_hvac_has_simple_transfer_air?(air_loop_hvac)
     simple_transfer_air = false
     zones = air_loop_hvac.thermalZones
     zones_name = []

--- a/lib/openstudio-standards/standards/Standards.AirLoopHVAC.rb
+++ b/lib/openstudio-standards/standards/Standards.AirLoopHVAC.rb
@@ -2683,6 +2683,15 @@ class Standard
                    air_loop_hvac.model.alwaysOnDiscreteSchedule
                  end
 
+    # Create an economizer maximum OA fraction schedule with
+    # a maximum of 70% to reflect damper leakage per PNNL
+    max_oa_sch_name = "#{snc}maxOASch"
+    max_oa_sch = OpenStudio::Model::ScheduleRuleset.new(air_loop_hvac.model)
+    max_oa_sch.setName(max_oa_sch_name)
+    max_oa_sch.defaultDaySchedule.setName("#{max_oa_sch_name}Default")
+    max_oa_sch.defaultDaySchedule.addValue(OpenStudio::Time.new(0, 24, 0, 0), 0.7)
+    oa_control.setMaximumFractionofOutdoorAirSchedule(max_oa_sch)
+
     # Get the supply fan
     if air_loop_hvac.supplyFan.empty?
       OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.AirLoopHVAC', "For #{air_loop_hvac.name}: No supply fan found, cannot apply DX fan/economizer control.")
@@ -2724,15 +2733,6 @@ class Standard
       OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.AirLoopHVAC', "For #{air_loop_hvac.name}: No heating coil found, cannot apply DX fan/economizer control.")
       return false
     end
-
-    # Create an economizer maximum OA fraction schedule with
-    # a maximum of 70% to reflect damper leakage per PNNL
-    max_oa_sch_name = "#{snc}maxOASch"
-    max_oa_sch = OpenStudio::Model::ScheduleRuleset.new(air_loop_hvac.model)
-    max_oa_sch.setName(max_oa_sch_name)
-    max_oa_sch.defaultDaySchedule.setName("#{max_oa_sch_name}Default")
-    max_oa_sch.defaultDaySchedule.addValue(OpenStudio::Time.new(0, 24, 0, 0), 0.7)
-    oa_control.setMaximumFractionofOutdoorAirSchedule(max_oa_sch)
 
     ### EMS shared by both programs ###
     # Sensors

--- a/lib/openstudio-standards/standards/Standards.AirLoopHVAC.rb
+++ b/lib/openstudio-standards/standards/Standards.AirLoopHVAC.rb
@@ -2683,6 +2683,7 @@ class Standard
                    air_loop_hvac.model.alwaysOnDiscreteSchedule
                  end
 
+    # placing this max OA schedule code before supply fan check because for single zone systems with AirLoopHVAC:UnitarySystem being a component of air_loop_hvac, air_loop_hvac.supplyFan.empty? = true
     max_oa_sch = set_max_frac_oa_sch(air_loop_hvac, oa_control, snc)
 
     # Get the supply fan


### PR DESCRIPTION
To implement Addendum A of 90.1 2016, the maximum OA fraction for single-zone systems is changed from 0.7 to 0.75 to reflect lower damper leakage requirement changes.
The proposed changes include:
1. rearrange the code snippet of adding maximum OA fraction schedule for single-zone systems ahead of supply fan check code in the single zone control method to avoid certain single-zone systems not having this schedule. This impacts all code versions.
2. extract the maximum OA fraction schedule code into a dedicated method and override it in the 90.1 2019 subclass to use 75% OA max fraction.

For more information, check Section B.2.1  in the Energy Savings Analysis: [ANSI/ASHRAE/IES Standard 90.1-2019 report](https://www.energycodes.gov/sites/default/files/2021-07/20210407_Standard_90.1-2019_Determination_TSD.pdf).