### PR TITLE
exterior parking lpd update based on updated building population

### DIFF
--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2004/comstock_ashrae_90_1_2004/data/comstock_ashrae_90_1_2004.ext_ltg.json
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2004/comstock_ashrae_90_1_2004/data/comstock_ashrae_90_1_2004.ext_ltg.json
@@ -108,7 +108,7 @@
       "occupancy_setback_reduction": 0.0,
       "base_site_allowance_power": null,
       "base_site_allowance_fraction": 0.05,
-      "parking_areas_and_drives": 0.045444,
+      "parking_areas_and_drives": 0.041457711,
       "walkways_less_than_10ft_wide": 1.0,
       "walkways_10ft_wide_or_greater": 0.2,
       "stairways": 1.0,

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2007/comstock_ashrae_90_1_2007/data/comstock_ashrae_90_1_2007.ext_ltg.json
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2007/comstock_ashrae_90_1_2007/data/comstock_ashrae_90_1_2007.ext_ltg.json
@@ -108,7 +108,7 @@
       "occupancy_setback_reduction": 0.0,
       "base_site_allowance_power": null,
       "base_site_allowance_fraction": 0.05,
-      "parking_areas_and_drives": 0.045444,
+      "parking_areas_and_drives": 0.041457711,
       "walkways_less_than_10ft_wide": 1.0,
       "walkways_10ft_wide_or_greater": 0.2,
       "stairways": 1.0,

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2010/comstock_ashrae_90_1_2010/data/comstock_ashrae_90_1_2010.ext_ltg.json
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2010/comstock_ashrae_90_1_2010/data/comstock_ashrae_90_1_2010.ext_ltg.json
@@ -108,7 +108,7 @@
       "occupancy_setback_reduction": 0.3,
       "base_site_allowance_power": 750.0,
       "base_site_allowance_fraction": null,
-      "parking_areas_and_drives": 0.030296,
+      "parking_areas_and_drives": 0.027638474,
       "walkways_less_than_10ft_wide": 0.8,
       "walkways_10ft_wide_or_greater": 0.16,
       "stairways": 1.0,

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2013/comstock_ashrae_90_1_2013/data/comstock_ashrae_90_1_2013.ext_ltg.json
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2013/comstock_ashrae_90_1_2013/data/comstock_ashrae_90_1_2013.ext_ltg.json
@@ -108,7 +108,7 @@
       "occupancy_setback_reduction": 0.3,
       "base_site_allowance_power": 750.0,
       "base_site_allowance_fraction": null,
-      "parking_areas_and_drives": 0.030296,
+      "parking_areas_and_drives": 0.027638474,
       "walkways_less_than_10ft_wide": 0.8,
       "walkways_10ft_wide_or_greater": 0.16,
       "stairways": 1.0,

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2016/comstock_ashrae_90_1_2016/data/comstock_ashrae_90_1_2016.ext_ltg.json
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2016/comstock_ashrae_90_1_2016/data/comstock_ashrae_90_1_2016.ext_ltg.json
@@ -108,7 +108,7 @@
       "occupancy_setback_reduction": 0.3,
       "base_site_allowance_power": 750.0,
       "base_site_allowance_fraction": null,
-      "parking_areas_and_drives": 0.030296,
+      "parking_areas_and_drives": 0.027638474,
       "walkways_less_than_10ft_wide": 0.8,
       "walkways_10ft_wide_or_greater": 0.16,
       "stairways": 1.0,

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2019/comstock_ashrae_90_1_2019/data/comstock_ashrae_90_1_2019.ext_ltg.json
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2019/comstock_ashrae_90_1_2019/data/comstock_ashrae_90_1_2019.ext_ltg.json
@@ -108,7 +108,7 @@
       "occupancy_setback_reduction": 0.3,
       "base_site_allowance_power": 750.0,
       "base_site_allowance_fraction": null,
-      "parking_areas_and_drives": 0.030296,
+      "parking_areas_and_drives": 0.027638474,
       "walkways_less_than_10ft_wide": 0.8,
       "walkways_10ft_wide_or_greater": 0.16,
       "stairways": 1.0,

--- a/lib/openstudio-standards/standards/ashrae_90_1/doe_ref_1980_2004/comstock_doe_ref_1980_2004/data/comstock_doe_ref_1980_2004.ext_ltg.json
+++ b/lib/openstudio-standards/standards/ashrae_90_1/doe_ref_1980_2004/comstock_doe_ref_1980_2004/data/comstock_doe_ref_1980_2004.ext_ltg.json
@@ -108,7 +108,7 @@
       "occupancy_setback_reduction": 0.0,
       "base_site_allowance_power": null,
       "base_site_allowance_fraction": 0.05,
-      "parking_areas_and_drives": 0.054533,
+      "parking_areas_and_drives": 0.049749436,
       "walkways_less_than_10ft_wide": 1.0,
       "walkways_10ft_wide_or_greater": 0.2,
       "stairways": 1.0,

--- a/lib/openstudio-standards/standards/deer/deer_1985/comstock_deer_1985/data/comstock_deer_1985.ext_ltg.json
+++ b/lib/openstudio-standards/standards/deer/deer_1985/comstock_deer_1985/data/comstock_deer_1985.ext_ltg.json
@@ -108,7 +108,7 @@
       "occupancy_setback_reduction": 0.0,
       "base_site_allowance_power": null,
       "base_site_allowance_fraction": 0.05,
-      "parking_areas_and_drives": 0.04,
+      "parking_areas_and_drives": 0.036491252,
       "walkways_less_than_10ft_wide": 1.0,
       "walkways_10ft_wide_or_greater": 0.2,
       "stairways": 1.0,
@@ -130,7 +130,7 @@
       "drive_through_windows_and_doors": 400.0,
       "parking_near_24_hour_entrances": 800.0,
       "roadway_parking": 0.0,
-      "notes": "Same as DOE Ref 1980-2004; parking capped at 0.04 W/sf to account for replacement; canopies LPD adjusted from online research of actual hotels"
+      "notes": "Same as DOE Ref 1980-2004; parking capped at 0.04 W/sf to account for replacement; canopies LPD adjusted from online research of actual hotels. Parking Areas and Drives lpd updated based on values derived from 2015 U.S. Lighting Market Characterization report."
     },
     {
       "exterior_lighting_zone_number": 4.0,

--- a/lib/openstudio-standards/standards/deer/deer_1996/comstock_deer_1996/data/comstock_deer_1996.ext_ltg.json
+++ b/lib/openstudio-standards/standards/deer/deer_1996/comstock_deer_1996/data/comstock_deer_1996.ext_ltg.json
@@ -108,7 +108,7 @@
       "occupancy_setback_reduction": 0.0,
       "base_site_allowance_power": null,
       "base_site_allowance_fraction": 0.05,
-      "parking_areas_and_drives": 0.04,
+      "parking_areas_and_drives": 0.036491252,
       "walkways_less_than_10ft_wide": 1.0,
       "walkways_10ft_wide_or_greater": 0.2,
       "stairways": 1.0,
@@ -130,7 +130,7 @@
       "drive_through_windows_and_doors": 400.0,
       "parking_near_24_hour_entrances": 800.0,
       "roadway_parking": 0.0,
-      "notes": "Same as DOE Ref 1980-2004; parking capped at 0.04 W/sf to account for replacement; canopies LPD adjusted from online research of actual hotels"
+      "notes": "Same as DOE Ref 1980-2004; parking capped at 0.04 W/sf to account for replacement; canopies LPD adjusted from online research of actual hotels. Parking Areas and Drives lpd updated based on values derived from 2015 U.S. Lighting Market Characterization report."
     },
     {
       "exterior_lighting_zone_number": 4.0,

--- a/lib/openstudio-standards/standards/deer/deer_2003/comstock_deer_2003/data/comstock_deer_2003.ext_ltg.json
+++ b/lib/openstudio-standards/standards/deer/deer_2003/comstock_deer_2003/data/comstock_deer_2003.ext_ltg.json
@@ -108,7 +108,7 @@
       "occupancy_setback_reduction": 0.0,
       "base_site_allowance_power": null,
       "base_site_allowance_fraction": 0.05,
-      "parking_areas_and_drives": 0.04,
+      "parking_areas_and_drives": 0.036491252,
       "walkways_less_than_10ft_wide": 1.0,
       "walkways_10ft_wide_or_greater": 0.2,
       "stairways": 1.0,
@@ -130,7 +130,7 @@
       "drive_through_windows_and_doors": 400.0,
       "parking_near_24_hour_entrances": 800.0,
       "roadway_parking": 0.0,
-      "notes": "Same as 90.1-2004; parking capped at 0.04 W/sf to account for replacement"
+      "notes": "Same as 90.1-2004; parking capped at 0.04 W/sf to account for replacement. Parking Areas and Drives lpd updated based on values derived from 2015 U.S. Lighting Market Characterization report."
     },
     {
       "exterior_lighting_zone_number": 4.0,

--- a/lib/openstudio-standards/standards/deer/deer_2007/comstock_deer_2007/data/comstock_deer_2007.ext_ltg.json
+++ b/lib/openstudio-standards/standards/deer/deer_2007/comstock_deer_2007/data/comstock_deer_2007.ext_ltg.json
@@ -108,7 +108,7 @@
       "occupancy_setback_reduction": 0.0,
       "base_site_allowance_power": null,
       "base_site_allowance_fraction": 0.05,
-      "parking_areas_and_drives": 0.04,
+      "parking_areas_and_drives": 0.036491252,
       "walkways_less_than_10ft_wide": 1.0,
       "walkways_10ft_wide_or_greater": 0.2,
       "stairways": 1.0,
@@ -130,7 +130,7 @@
       "drive_through_windows_and_doors": 400.0,
       "parking_near_24_hour_entrances": 800.0,
       "roadway_parking": 0.0,
-      "notes": "Same as 90.1-2007; parking capped at 0.04 W/sf to account for replacement"
+      "notes": "Same as 90.1-2007; parking capped at 0.04 W/sf to account for replacement. Parking Areas and Drives lpd updated based on values derived from 2015 U.S. Lighting Market Characterization report."
     },
     {
       "exterior_lighting_zone_number": 4.0,

--- a/lib/openstudio-standards/standards/deer/deer_2011/comstock_deer_2011/data/comstock_deer_2011.ext_ltg.json
+++ b/lib/openstudio-standards/standards/deer/deer_2011/comstock_deer_2011/data/comstock_deer_2011.ext_ltg.json
@@ -108,7 +108,7 @@
       "occupancy_setback_reduction": 0.3,
       "base_site_allowance_power": 750.0,
       "base_site_allowance_fraction": null,
-      "parking_areas_and_drives": 0.04,
+      "parking_areas_and_drives": 0.036491252,
       "walkways_less_than_10ft_wide": 0.8,
       "walkways_10ft_wide_or_greater": 0.16,
       "stairways": 1.0,
@@ -130,7 +130,7 @@
       "drive_through_windows_and_doors": 400.0,
       "parking_near_24_hour_entrances": 800.0,
       "roadway_parking": 0.0,
-      "notes": "Same as 90.1-2010; parking capped at 0.04 W/sf to account for replacement"
+      "notes": "Same as 90.1-2010; parking capped at 0.04 W/sf to account for replacement. Parking Areas and Drives lpd updated based on values derived from 2015 U.S. Lighting Market Characterization report."
     },
     {
       "exterior_lighting_zone_number": 4.0,

--- a/lib/openstudio-standards/standards/deer/deer_2014/comstock_deer_2014/data/comstock_deer_2014.ext_ltg.json
+++ b/lib/openstudio-standards/standards/deer/deer_2014/comstock_deer_2014/data/comstock_deer_2014.ext_ltg.json
@@ -108,7 +108,7 @@
       "occupancy_setback_reduction": 0.3,
       "base_site_allowance_power": 750.0,
       "base_site_allowance_fraction": null,
-      "parking_areas_and_drives": 0.02,
+      "parking_areas_and_drives": 0.018245626,
       "walkways_less_than_10ft_wide": 0.8,
       "walkways_10ft_wide_or_greater": 0.16,
       "stairways": 1.0,
@@ -130,7 +130,7 @@
       "drive_through_windows_and_doors": 125.0,
       "parking_near_24_hour_entrances": 800.0,
       "roadway_parking": 0.0,
-      "notes": "From T24-2013 and 90.1-2013; parking assumed to be LED at 0.02 W/sf"
+      "notes": "From T24-2013 and 90.1-2013; parking assumed to be LED at 0.02 W/sf. Parking Areas and Drives lpd updated based on values derived from 2015 U.S. Lighting Market Characterization report."
     },
     {
       "exterior_lighting_zone_number": 4.0,

--- a/lib/openstudio-standards/standards/deer/deer_2015/comstock_deer_2015/data/comstock_deer_2015.ext_ltg.json
+++ b/lib/openstudio-standards/standards/deer/deer_2015/comstock_deer_2015/data/comstock_deer_2015.ext_ltg.json
@@ -108,7 +108,7 @@
       "occupancy_setback_reduction": 0.3,
       "base_site_allowance_power": 750.0,
       "base_site_allowance_fraction": null,
-      "parking_areas_and_drives": 0.02,
+      "parking_areas_and_drives": 0.018245626,
       "walkways_less_than_10ft_wide": 0.8,
       "walkways_10ft_wide_or_greater": 0.16,
       "stairways": 1.0,
@@ -130,7 +130,7 @@
       "drive_through_windows_and_doors": 125.0,
       "parking_near_24_hour_entrances": 800.0,
       "roadway_parking": 0.0,
-      "notes": "From T24-2013 and 90.1-2013; parking assumed to be LED at 0.02 W/sf"
+      "notes": "From T24-2013 and 90.1-2013; parking assumed to be LED at 0.02 W/sf. Parking Areas and Drives lpd updated based on values derived from 2015 U.S. Lighting Market Characterization report."
     },
     {
       "exterior_lighting_zone_number": 4.0,

--- a/lib/openstudio-standards/standards/deer/deer_2017/comstock_deer_2017/data/comstock_deer_2017.ext_ltg.json
+++ b/lib/openstudio-standards/standards/deer/deer_2017/comstock_deer_2017/data/comstock_deer_2017.ext_ltg.json
@@ -108,7 +108,7 @@
       "occupancy_setback_reduction": 0.3,
       "base_site_allowance_power": 520.0,
       "base_site_allowance_fraction": null,
-      "parking_areas_and_drives": 0.02,
+      "parking_areas_and_drives": 0.018245626,
       "walkways_less_than_10ft_wide": 0.6,
       "walkways_10ft_wide_or_greater": 0.11,
       "stairways": 0.7,
@@ -130,7 +130,7 @@
       "drive_through_windows_and_doors": 125.0,
       "parking_near_24_hour_entrances": 800.0,
       "roadway_parking": 0.0,
-      "notes": "From T24-2016 and 90.1-2016; parking assumed to be LED at 0.02 W/sf"
+      "notes": "From T24-2016 and 90.1-2016; parking assumed to be LED at 0.02 W/sf. Parking Areas and Drives lpd updated based on values derived from 2015 U.S. Lighting Market Characterization report."
     },
     {
       "exterior_lighting_zone_number": 4.0,

--- a/lib/openstudio-standards/standards/deer/deer_pre_1975/comstock_deer_pre_1975/data/comstock_deer_pre_1975.ext_ltg.json
+++ b/lib/openstudio-standards/standards/deer/deer_pre_1975/comstock_deer_pre_1975/data/comstock_deer_pre_1975.ext_ltg.json
@@ -108,7 +108,7 @@
       "occupancy_setback_reduction": 0.0,
       "base_site_allowance_power": null,
       "base_site_allowance_fraction": 0.05,
-      "parking_areas_and_drives": 0.04,
+      "parking_areas_and_drives": 0.036491252,
       "walkways_less_than_10ft_wide": 1.0,
       "walkways_10ft_wide_or_greater": 0.2,
       "stairways": 1.0,
@@ -130,7 +130,7 @@
       "drive_through_windows_and_doors": 400.0,
       "parking_near_24_hour_entrances": 800.0,
       "roadway_parking": null,
-      "notes": "Same as DOE Ref 1980-2004; parking capped at 0.04 W/sf to account for replacement; canopies LPD adjusted from online research of actual hotels"
+      "notes": "Same as DOE Ref 1980-2004; parking capped at 0.04 W/sf to account for replacement; canopies LPD adjusted from online research of actual hotels. Parking Areas and Drives lpd updated based on values derived from 2015 U.S. Lighting Market Characterization report."
     },
     {
       "exterior_lighting_zone_number": 4.0,


### PR DESCRIPTION
- this update is from EULP enduse data analysis

- summary slide deck is located in [here](https://nrel.sharepoint.com/:p:/r/sites/LoadProfiles/Shared%20Documents/05%20Calibration/4%20Calibration%20and%20Validation/ComStock_Lighting_Analysis/LightingPowerDensity/201207_LightingPowerDensityFromDataSources.pptx?d=we753e224cdc04daea774e80bf4409a63&csf=1&web=1&e=cSmkV7)

- LPDs for exterior parking lot are revisited based on the latest buildstock.csv including the latest building population

- not going to make huge difference in the simulation results but this update is to use the same approach that was used before but with updated input data to match weighted average of LPDs in models against LMC report's national average (0.04103 W/ft2).

- values are updated on both 90.1 and DEER standards as shown below
![image](https://user-images.githubusercontent.com/26775789/131586985-73cd5af1-a680-4fde-9a0d-bfc0db949d62.png)
