### PR TITLE
Multizone VAV supply air temperature reset exceptions

### DIFF
--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2019/ashrae_90_1_2019.AirLoopHVAC.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2019/ashrae_90_1_2019.AirLoopHVAC.rb
@@ -320,13 +320,32 @@ class ASHRAE9012019 < ASHRAE901
     case climate_zone
     when 'ASHRAE 169-2006-0A',
          'ASHRAE 169-2006-1A',
-         'ASHRAE 169-2006-2A',
          'ASHRAE 169-2006-3A',
          'ASHRAE 169-2013-0A',
          'ASHRAE 169-2013-1A',
-         'ASHRAE 169-2013-2A',
          'ASHRAE 169-2013-3A'
-      OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.AirLoopHVAC', "For #{air_loop_hvac.name}: Supply air temperature reset is not required per 6.5.3.4 Exception 1, the system is located in climate zone #{climate_zone}.")
+      # check if design outside air is less than 10,000cfm (5000L/s) 90.1 2019 Exceptions to 6.5.3.5
+      design_oa_m3s = air_loop_hvac.sizingSystem.designOutdoorAirFlowRate.to_f
+      design_oa_cfm = OpenStudio.convert(design_oa_m3s, 'm^3/s', 'cfm').get
+      if design_oa_cfm >= 3000
+        is_sat_reset_required = true
+        OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.AirLoopHVAC', "For #{air_loop_hvac.name}: Supply air temperature reset is required.")
+      else
+        is_sat_reset_required = false
+        OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.AirLoopHVAC', "For #{air_loop_hvac.name}: Supply air temperature reset is not required per 6.5.3.5 Exception 1, the system is located in climate zone #{climate_zone}.")
+      end
+      return is_sat_reset_required
+    when 'ASHRAE 169-2006-2A',
+         'ASHRAE 169-2013-2A'
+      # check if design outside air is less than 10,000cfm (5000L/s) 90.1 2019 Exceptions to 6.5.3.5
+      design_oa = nil
+      if design_oa_cfm >= 10000
+        is_sat_reset_required = true
+        OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.AirLoopHVAC', "For #{air_loop_hvac.name}: Supply air temperature reset is required.")
+      else
+        is_sat_reset_required = false
+        OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.AirLoopHVAC', "For #{air_loop_hvac.name}: Supply air temperature reset is not required per 6.5.3.5 Exception 2, the system is located in climate zone #{climate_zone}.")
+      end
       return is_sat_reset_required
     when 'ASHRAE 169-2006-0B',
          'ASHRAE 169-2006-1B',

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2019/ashrae_90_1_2019.AirLoopHVAC.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2019/ashrae_90_1_2019.AirLoopHVAC.rb
@@ -344,33 +344,33 @@ class ASHRAE9012019 < ASHRAE901
          'ASHRAE 169-2013-0A',
          'ASHRAE 169-2013-1A',
          'ASHRAE 169-2013-3A'
-      if design_oa_cfm >= 3000
-        if has_erv && has_large_oa
-          is_sat_reset_required = false
-          OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.AirLoopHVAC', "For #{air_loop_hvac.name}: Supply air temperature reset is not required per 6.5.3.5 Exception 3, the system is located in climate zone #{climate_zone}.")
-        else
-          is_sat_reset_required = true
-          OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.AirLoopHVAC', "For #{air_loop_hvac.name}: Supply air temperature reset is required.")
-        end
-      else
+      if design_oa_cfm < 3000
         is_sat_reset_required = false
         OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.AirLoopHVAC', "For #{air_loop_hvac.name}: Supply air temperature reset is not required per 6.5.3.5 Exception 1, the system is located in climate zone #{climate_zone}.")
+        return is_sat_reset_required
       end
+      if has_erv && has_large_oa
+        is_sat_reset_required = false
+        OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.AirLoopHVAC', "For #{air_loop_hvac.name}: Supply air temperature reset is not required per 6.5.3.5 Exception 3, the system is located in climate zone #{climate_zone}.")
+        return is_sat_reset_required
+      end
+      is_sat_reset_required = true
+      OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.AirLoopHVAC', "For #{air_loop_hvac.name}: Supply air temperature reset is required.")
       return is_sat_reset_required
     when 'ASHRAE 169-2006-2A',
          'ASHRAE 169-2013-2A'
-      if design_oa_cfm >= 10000
-        if has_erv && has_large_oa
-          is_sat_reset_required = false
-          OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.AirLoopHVAC', "For #{air_loop_hvac.name}: Supply air temperature reset is not required per 6.5.3.5 Exception 3, the system is located in climate zone #{climate_zone}.")
-        else
-          is_sat_reset_required = true
-          OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.AirLoopHVAC', "For #{air_loop_hvac.name}: Supply air temperature reset is required.")
-        end
-      else
+      if design_oa_cfm < 10000
         is_sat_reset_required = false
         OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.AirLoopHVAC', "For #{air_loop_hvac.name}: Supply air temperature reset is not required per 6.5.3.5 Exception 2, the system is located in climate zone #{climate_zone}.")
+        return is_sat_reset_required
       end
+      if has_erv && has_large_oa
+        is_sat_reset_required = false
+        OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.AirLoopHVAC', "For #{air_loop_hvac.name}: Supply air temperature reset is not required per 6.5.3.5 Exception 3, the system is located in climate zone #{climate_zone}.")
+        return is_sat_reset_required
+      end
+      is_sat_reset_required = true
+      OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.AirLoopHVAC', "For #{air_loop_hvac.name}: Supply air temperature reset is required.")
       return is_sat_reset_required
     when 'ASHRAE 169-2006-0B',
          'ASHRAE 169-2006-1B',

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2019/ashrae_90_1_2019.AirLoopHVAC.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2019/ashrae_90_1_2019.AirLoopHVAC.rb
@@ -303,9 +303,9 @@ class ASHRAE9012019 < ASHRAE901
 
     return num_stages
   end
-
+  
   # Determine if the system required supply air temperature (SAT) reset.
-  # For 90.1-2019, SAT reset requirements are based on climate zone.
+  # For 90.1-2019, SAT reset requirements are based on climate zone. More exceptions are added for 90.1 2019 6.5.3.5
   #
   # @param (see #economizer_required?)
   # @return [Bool] Returns true if required, false if not.

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2019/ashrae_90_1_2019.AirLoopHVAC.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2019/ashrae_90_1_2019.AirLoopHVAC.rb
@@ -318,18 +318,19 @@ class ASHRAE9012019 < ASHRAE901
     end
 
     # check if design outside air is less than 10,000cfm (5000L/s) 90.1 2019 6.5.3.5 Exception 1 and 2
-    design_oa_m3s = air_loop_hvac.sizingSystem.designOutdoorAirFlowRate.to_f
-    if design_oa_m3s < 0.0001
-      design_oa_m3s = air_loop_hvac.sizingSystem.autosizedDesignOutdoorAirFlowRate.to_f
+    design_oa_m3s = nil
+    if air_loop_hvac.sizingSystem.designOutdoorAirFlowRate.is_initialized
+      design_oa_m3s = air_loop_hvac.sizingSystem.designOutdoorAirFlowRate.get
+    elsif air_loop_hvac.sizingSystem.autosizedDesignOutdoorAirFlowRate.is_initialized
+      design_oa_m3s = air_loop_hvac.sizingSystem.autosizedDesignOutdoorAirFlowRate.get
+    else
+      OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.AirLoopHVAC', "For #{air_loop_hvac.name} design outdoor air flow rate is not available.")
     end
     design_oa_cfm = OpenStudio.convert(design_oa_m3s, 'm^3/s', 'cfm').get
 
     # check if there is erv 90.1 2019 Exceptions to 6.5.3.5 Exception 3
     has_erv = air_loop_hvac_energy_recovery?(air_loop_hvac)
-    design_sa_m3s = air_loop_hvac.designSupplyAirFlowRate.to_f
-    if design_sa_m3s < 0.0001
-      design_sa_m3s = air_loop_hvac.autosizedDesignSupplyAirFlowRate.to_f
-    end
+    design_sa_m3s = air_loop_hvac_find_design_supply_air_flow_rate(air_loop_hvac)
 
     oa_ratio = 0
     if design_sa_m3s > 0

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2019/ashrae_90_1_2019.AirLoopHVAC.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2019/ashrae_90_1_2019.AirLoopHVAC.rb
@@ -317,6 +317,13 @@ class ASHRAE9012019 < ASHRAE901
       return is_sat_reset_required
     end
 
+    # check if design outside air is less than 10,000cfm (5000L/s) 90.1 2019 6.5.3.5 Exception 1 and 2
+    design_oa_m3s = air_loop_hvac.sizingSystem.designOutdoorAirFlowRate.to_f
+    design_oa_cfm = OpenStudio.convert(design_oa_m3s, 'm^3/s', 'cfm').get
+
+    # check if there is erv 90.1 2019 Exceptions to 6.5.3.5 Exception 3
+    has_erv = air_loop_hvac_energy_recovery?(air_loop_hvac)
+
     case climate_zone
     when 'ASHRAE 169-2006-0A',
          'ASHRAE 169-2006-1A',
@@ -324,12 +331,14 @@ class ASHRAE9012019 < ASHRAE901
          'ASHRAE 169-2013-0A',
          'ASHRAE 169-2013-1A',
          'ASHRAE 169-2013-3A'
-      # check if design outside air is less than 10,000cfm (5000L/s) 90.1 2019 Exceptions to 6.5.3.5
-      design_oa_m3s = air_loop_hvac.sizingSystem.designOutdoorAirFlowRate.to_f
-      design_oa_cfm = OpenStudio.convert(design_oa_m3s, 'm^3/s', 'cfm').get
       if design_oa_cfm >= 3000
-        is_sat_reset_required = true
-        OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.AirLoopHVAC', "For #{air_loop_hvac.name}: Supply air temperature reset is required.")
+        if has_erv
+          is_sat_reset_required = false
+          OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.AirLoopHVAC', "For #{air_loop_hvac.name}: Supply air temperature reset is not required per 6.5.3.5 Exception 3, the system is located in climate zone #{climate_zone}.")
+        else
+          is_sat_reset_required = true
+          OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.AirLoopHVAC', "For #{air_loop_hvac.name}: Supply air temperature reset is required.")
+        end
       else
         is_sat_reset_required = false
         OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.AirLoopHVAC', "For #{air_loop_hvac.name}: Supply air temperature reset is not required per 6.5.3.5 Exception 1, the system is located in climate zone #{climate_zone}.")
@@ -337,11 +346,14 @@ class ASHRAE9012019 < ASHRAE901
       return is_sat_reset_required
     when 'ASHRAE 169-2006-2A',
          'ASHRAE 169-2013-2A'
-      # check if design outside air is less than 10,000cfm (5000L/s) 90.1 2019 Exceptions to 6.5.3.5
-      design_oa = nil
       if design_oa_cfm >= 10000
-        is_sat_reset_required = true
-        OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.AirLoopHVAC', "For #{air_loop_hvac.name}: Supply air temperature reset is required.")
+        if has_erv
+          is_sat_reset_required = false
+          OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.AirLoopHVAC', "For #{air_loop_hvac.name}: Supply air temperature reset is not required per 6.5.3.5 Exception 3, the system is located in climate zone #{climate_zone}.")
+        else
+          is_sat_reset_required = true
+          OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.AirLoopHVAC', "For #{air_loop_hvac.name}: Supply air temperature reset is required.")
+        end
       else
         is_sat_reset_required = false
         OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.AirLoopHVAC', "For #{air_loop_hvac.name}: Supply air temperature reset is not required per 6.5.3.5 Exception 2, the system is located in climate zone #{climate_zone}.")

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2019/ashrae_90_1_2019.AirLoopHVAC.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2019/ashrae_90_1_2019.AirLoopHVAC.rb
@@ -303,7 +303,7 @@ class ASHRAE9012019 < ASHRAE901
 
     return num_stages
   end
-  
+
   # Determine if the system required supply air temperature (SAT) reset.
   # For 90.1-2019, SAT reset requirements are based on climate zone. More exceptions are added for 90.1 2019 6.5.3.5
   #


### PR DESCRIPTION
 Addendum AP of 90.1 2016 further details exceptions for multi-zone VAV system SAT reset requirements. The additional exemptions are implemented as:

1. Differentiate exceptions between climate zones (0A, 1A and 3A) and (2A).
2. Add design OA requirements for these two groups of exceptions.
3. Add ERV and design OA ratio check for additional exception.

For more information check Section B.2.6 in the Energy Savings Analysis: [ANSI/ASHRAE/IES Standard 90.1-2019 report](https://www.energycodes.gov/sites/default/files/2021-07/20210407_Standard_90.1-2019_Determination_TSD.pdf).