### PR TITLE
Freezer and reach-in refrigerator efficiency update

### DIFF
--- a/lib/openstudio-standards/prototypes/common/buildings/Prototype.FullServiceRestaurant.rb
+++ b/lib/openstudio-standards/prototypes/common/buildings/Prototype.FullServiceRestaurant.rb
@@ -228,9 +228,12 @@ module FullServiceRestaurant
         elec_equip_def2.setFractionLatent(0)
         elec_equip_def2.setFractionRadiant(0.25)
         elec_equip_def2.setFractionLost(0)
-        if template == '90.1-2013' || template == '90.1-2016' || template == '90.1-2019'
+        if template == '90.1-2013' || template == '90.1-2016'
           elec_equip_def1.setDesignLevel(457.5)
           elec_equip_def2.setDesignLevel(570)
+        elsif template == '90.1-2019'
+          elec_equip_def1.setDesignLevel(277.5)
+          elec_equip_def2.setDesignLevel(313.3)
         else
           elec_equip_def1.setDesignLevel(515.917)
           elec_equip_def2.setDesignLevel(851.67)

--- a/lib/openstudio-standards/prototypes/common/buildings/Prototype.Hospital.rb
+++ b/lib/openstudio-standards/prototypes/common/buildings/Prototype.Hospital.rb
@@ -141,12 +141,15 @@ module Hospital
         elec_equip_def2.setFractionLatent(0)
         elec_equip_def2.setFractionRadiant(0.25)
         elec_equip_def2.setFractionLost(0)
-        if template == '90.1-2013' || template == '90.1-2016' || template == '90.1-2019'
+        if template == '90.1-2013' || template == '90.1-2016'
           elec_equip_def1.setDesignLevel(915)
           elec_equip_def2.setDesignLevel(855)
+        elsif template == '90.1-2019'
+          elec_equip_def1.setDesignLevel(555)
+          elec_equip_def2.setDesignLevel(470)
         else
-          elec_equip_def1.setDesignLevel(915)
-          elec_equip_def2.setDesignLevel(855)
+          elec_equip_def1.setDesignLevel(1031.8)
+          elec_equip_def2.setDesignLevel(1277.5)
         end
         # Create the electric equipment instance and hook it up to the space type
         elec_equip1 = OpenStudio::Model::ElectricEquipment.new(elec_equip_def1)

--- a/lib/openstudio-standards/prototypes/common/buildings/Prototype.LargeHotel.rb
+++ b/lib/openstudio-standards/prototypes/common/buildings/Prototype.LargeHotel.rb
@@ -151,12 +151,15 @@ module LargeHotel
         elec_equip_def2.setFractionLatent(0)
         elec_equip_def2.setFractionRadiant(0.25)
         elec_equip_def2.setFractionLost(0)
-        if template == '90.1-2013' || template == '90.1-2016' || template == '90.1-2019'
+        if template == '90.1-2013' || template == '90.1-2016'
           elec_equip_def1.setDesignLevel(457.7)
           elec_equip_def2.setDesignLevel(285)
+        elsif template == '90.1-2019'
+          elec_equip_def1.setDesignLevel(277.5)
+          elec_equip_def2.setDesignLevel(156.7)
         else
-          elec_equip_def1.setDesignLevel(457.7)
-          elec_equip_def2.setDesignLevel(285)
+          elec_equip_def1.setDesignLevel(515.917)
+          elec_equip_def2.setDesignLevel(425.8)
         end
         # Create the electric equipment instance and hook it up to the space type
         elec_equip1 = OpenStudio::Model::ElectricEquipment.new(elec_equip_def1)

--- a/lib/openstudio-standards/prototypes/common/buildings/Prototype.PrimarySchool.rb
+++ b/lib/openstudio-standards/prototypes/common/buildings/Prototype.PrimarySchool.rb
@@ -47,9 +47,12 @@ module PrimarySchool
         elec_equip_def2.setFractionLatent(0)
         elec_equip_def2.setFractionRadiant(0.25)
         elec_equip_def2.setFractionLost(0)
-        if template == '90.1-2013' || template == '90.1-2016' || template == '90.1-2019'
+        if template == '90.1-2013' || template == '90.1-2016'
           elec_equip_def1.setDesignLevel(915)
           elec_equip_def2.setDesignLevel(570)
+        elsif template == '90.1-2019'
+          elec_equip_def1.setDesignLevel(555)
+          elec_equip_def2.setDesignLevel(313.3)
         else
           elec_equip_def1.setDesignLevel(1032)
           elec_equip_def2.setDesignLevel(852)

--- a/lib/openstudio-standards/prototypes/common/buildings/Prototype.QuickServiceRestaurant.rb
+++ b/lib/openstudio-standards/prototypes/common/buildings/Prototype.QuickServiceRestaurant.rb
@@ -185,9 +185,12 @@ module QuickServiceRestaurant
         elec_equip_def2.setFractionLatent(0)
         elec_equip_def2.setFractionRadiant(0.25)
         elec_equip_def2.setFractionLost(0)
-        if template == '90.1-2013' || template == '90.1-2016' || template == '90.1-2019'
+        if template == '90.1-2013' || template == '90.1-2016'
           elec_equip_def1.setDesignLevel(457.5)
           elec_equip_def2.setDesignLevel(570)
+        elsif template == '90.1-2019'
+          elec_equip_def1.setDesignLevel(277.5)
+          elec_equip_def2.setDesignLevel(313.3)
         else
           elec_equip_def1.setDesignLevel(515.917)
           elec_equip_def2.setDesignLevel(851.67)

--- a/lib/openstudio-standards/prototypes/common/buildings/Prototype.SecondarySchool.rb
+++ b/lib/openstudio-standards/prototypes/common/buildings/Prototype.SecondarySchool.rb
@@ -83,9 +83,12 @@ module SecondarySchool
         elec_equip_def2.setFractionLatent(0)
         elec_equip_def2.setFractionRadiant(0.25)
         elec_equip_def2.setFractionLost(0)
-        if template == '90.1-2013' || template == '90.1-2016' || template == '90.1-2019'
+        if template == '90.1-2013' || template == '90.1-2016'
           elec_equip_def1.setDesignLevel(915)
           elec_equip_def2.setDesignLevel(570)
+        elsif template == '90.1-2019'
+          elec_equip_def1.setDesignLevel(555)
+          elec_equip_def2.setDesignLevel(313.3)
         else
           elec_equip_def1.setDesignLevel(1032)
           elec_equip_def2.setDesignLevel(852)


### PR DESCRIPTION
Per addendum BR of 90.1 2019. efficiency values of freezer and reach-in refrigerator are updated. Incorrect default values in certain prototypes are modified.

Energy Savings Analysis: [ANSI/ASHRAE/IES Standard 90.1-2019 report](https://www.energycodes.gov/sites/default/files/2021-07/20210407_Standard_90.1-2019_Determination_TSD.pdf) does not contain a dedicated section for Addendum BR because the impacted refrigerators and freezers are federally-regulated.