### PR TITLE
Fix the bug that adding 'PumpedCondenser' type heat pump water heater…

### DIFF
--- a/lib/openstudio-standards/prototypes/common/objects/Prototype.ServiceWaterHeating.rb
+++ b/lib/openstudio-standards/prototypes/common/objects/Prototype.ServiceWaterHeating.rb
@@ -386,7 +386,6 @@ class Standard
     end
 
     # set heat pump water heater properties
-    # hpwh.setEvaporatorAirFlowRate(OpenStudio.convert(181.0, 'ft^3/min', 'm^3/s').get)   # shouldn't be hardsized, should be autocalculated as it varies with the capacity
     hpwh.setFanPlacement('DrawThrough')
     hpwh.setOnCycleParasiticElectricLoad(0.0)
     hpwh.setOffCycleParasiticElectricLoad(0.0)

--- a/lib/openstudio-standards/prototypes/common/objects/Prototype.ServiceWaterHeating.rb
+++ b/lib/openstudio-standards/prototypes/common/objects/Prototype.ServiceWaterHeating.rb
@@ -386,7 +386,7 @@ class Standard
     end
 
     # set heat pump water heater properties
-    hpwh.setEvaporatorAirFlowRate(OpenStudio.convert(181.0, 'ft^3/min', 'm^3/s').get)
+    # hpwh.setEvaporatorAirFlowRate(OpenStudio.convert(181.0, 'ft^3/min', 'm^3/s').get)   # shouldn't be hardsized, should be autocalculated as it varies with the capacity
     hpwh.setFanPlacement('DrawThrough')
     hpwh.setOnCycleParasiticElectricLoad(0.0)
     hpwh.setOffCycleParasiticElectricLoad(0.0)
@@ -446,8 +446,7 @@ class Standard
       coil = hpwh.dXCoil.to_CoilWaterHeatingAirToWaterHeatPumpWrapped.get
       coil.setRatedCondenserWaterTemperature(48.89)
     elsif type == 'PumpedCondenser'
-      coil = OpenStudio::Model::CoilWaterHeatingAirToWaterHeatPump.new(model)
-      hpwh.setDXCoil(coil)
+      coil = hpwh.dXCoil.to_CoilWaterHeatingAirToWaterHeatPump.get
     end
 
     # set coil properties

--- a/lib/openstudio-standards/prototypes/common/objects/Prototype.ServiceWaterHeating.rb
+++ b/lib/openstudio-standards/prototypes/common/objects/Prototype.ServiceWaterHeating.rb
@@ -507,8 +507,7 @@ class Standard
       tank.setSourceSideInletHeight(0)
       tank.setSourceSideOutletHeight(0)
     elsif type == 'PumpedCondenser'
-      tank = OpenStudio::Model::WaterHeaterMixed.new(model)
-      hpwh.setTank(tank)
+      tank = hpwh.tank.to_WaterHeaterMixed.get
       tank.setDeadbandTemperatureDifference(3.89)
       tank.setHeaterControlType('Cycle')
       tank.setHeaterMaximumCapacity(electric_backup_capacity)


### PR DESCRIPTION
… will generate a redundant unused tank (WaterHeaterMixed).

OpenStudio::Model::WaterHeaterHeatPump.new will automatically generate a new WaterHeaterMixed as the tank and attach to the HPWH. But later in the method another WaterHeaterMixed is created and linked to the HPWH, which leaves the initial one unused and redundant. Same thing for the coil (WaterHeatingAirToWater). Fixed the bug.

Another issue is that the evaporator air flow rate was hardsized, which may cause fatal error when the capacity doesn't fit the hardsized flow rate. It should be autocalculated as it varies with the capacity.

@mdahlhausen Please help review. Thanks!