### PR TITLE
Reopen the issue. OpenStudio automatically hardsize the evaporator ai…

### DIFF
--- a/lib/openstudio-standards/prototypes/common/objects/Prototype.ServiceWaterHeating.rb
+++ b/lib/openstudio-standards/prototypes/common/objects/Prototype.ServiceWaterHeating.rb
@@ -381,12 +381,13 @@ class Standard
       hpwh.setCondenserBottomLocation(h_condbot)
       hpwh.setCondenserTopLocation(h_condtop)
       hpwh.setTankElementControlLogic('MutuallyExclusive')
+      hpwh.autocalculateEvaporatorAirFlowRate
     elsif type == 'PumpedCondenser'
       hpwh.setDeadBandTemperatureDifference(3.89)
+      hpwh.autosizeEvaporatorAirFlowRate
     end
 
     # set heat pump water heater properties
-    hpwh.autocalculateEvaporatorAirFlowRate
     hpwh.setFanPlacement('DrawThrough')
     hpwh.setOnCycleParasiticElectricLoad(0.0)
     hpwh.setOffCycleParasiticElectricLoad(0.0)
@@ -445,8 +446,10 @@ class Standard
     if type == 'WrappedCondenser'
       coil = hpwh.dXCoil.to_CoilWaterHeatingAirToWaterHeatPumpWrapped.get
       coil.setRatedCondenserWaterTemperature(48.89)
+      coil.autocalculateRatedEvaporatorAirFlowRate
     elsif type == 'PumpedCondenser'
       coil = hpwh.dXCoil.to_CoilWaterHeatingAirToWaterHeatPump.get
+      coil.autosizeRatedEvaporatorAirFlowRate
     end
 
     # set coil properties
@@ -456,7 +459,6 @@ class Standard
     coil.setRatedSensibleHeatRatio(shr)
     coil.setRatedEvaporatorInletAirDryBulbTemperature(OpenStudio.convert(67.5, 'F', 'C').get)
     coil.setRatedEvaporatorInletAirWetBulbTemperature(OpenStudio.convert(56.426, 'F', 'C').get)
-    coil.autosizeRatedEvaporatorAirFlowRate
     coil.setEvaporatorFanPowerIncludedinRatedCOP(true)
     coil.setEvaporatorAirTemperatureTypeforCurveObjects('WetBulbTemperature')
     coil.setHeatingCapacityFunctionofTemperatureCurve(hpwh_cap)

--- a/lib/openstudio-standards/prototypes/common/objects/Prototype.ServiceWaterHeating.rb
+++ b/lib/openstudio-standards/prototypes/common/objects/Prototype.ServiceWaterHeating.rb
@@ -386,6 +386,7 @@ class Standard
     end
 
     # set heat pump water heater properties
+    hpwh.autocalculateEvaporatorAirFlowRate
     hpwh.setFanPlacement('DrawThrough')
     hpwh.setOnCycleParasiticElectricLoad(0.0)
     hpwh.setOffCycleParasiticElectricLoad(0.0)
@@ -455,7 +456,7 @@ class Standard
     coil.setRatedSensibleHeatRatio(shr)
     coil.setRatedEvaporatorInletAirDryBulbTemperature(OpenStudio.convert(67.5, 'F', 'C').get)
     coil.setRatedEvaporatorInletAirWetBulbTemperature(OpenStudio.convert(56.426, 'F', 'C').get)
-    coil.setRatedEvaporatorAirFlowRate(OpenStudio.convert(181.0, 'ft^3/min', 'm^3/s').get)
+    coil.autosizeRatedEvaporatorAirFlowRate
     coil.setEvaporatorFanPowerIncludedinRatedCOP(true)
     coil.setEvaporatorAirTemperatureTypeforCurveObjects('WetBulbTemperature')
     coil.setHeatingCapacityFunctionofTemperatureCurve(hpwh_cap)


### PR DESCRIPTION
…r flow rate of the DX water heating coil and HPWH while creating the objects. Simply removing the hardsizing at the OS Standards gem side can't solve the problem, have to specifically assign "autocalculate" and "autosize" to make them vary with capacity.

@mdahlhausen 