### PR TITLE
Fix high-rise apartment water heater ambient temperature

### DIFF
--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2004/data/ashrae_90_1_2004.prototype_inputs.json
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2004/data/ashrae_90_1_2004.prototype_inputs.json
@@ -345,7 +345,7 @@
       "main_water_heater_capacity": 600000.0,
       "main_service_water_temperature": 140.0,
       "main_service_water_flowrate_schedule": "ApartmentHighRise APT_DHW_SCH",
-      "main_water_heater_space_name": "Ambient Temp Schedule",
+      "main_water_heater_space_name": null,
       "main_service_water_peak_flowrate": null,
       "main_off_cycle_parasitic_heat_fraction_to_tank": null,
       "other_off_cycle_parasitic_heat_fraction_to_tank": null,

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2007/data/ashrae_90_1_2007.prototype_inputs.json
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2007/data/ashrae_90_1_2007.prototype_inputs.json
@@ -345,7 +345,7 @@
       "main_water_heater_capacity": 600000.0,
       "main_service_water_temperature": 140.0,
       "main_service_water_flowrate_schedule": "ApartmentHighRise APT_DHW_SCH",
-      "main_water_heater_space_name": "Ambient Temp Schedule",
+      "main_water_heater_space_name": null,
       "main_service_water_peak_flowrate": null,
       "main_off_cycle_parasitic_heat_fraction_to_tank": null,
       "other_off_cycle_parasitic_heat_fraction_to_tank": null,

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2010/data/ashrae_90_1_2010.prototype_inputs.json
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2010/data/ashrae_90_1_2010.prototype_inputs.json
@@ -345,7 +345,7 @@
       "main_water_heater_capacity": 600000.0,
       "main_service_water_temperature": 140.0,
       "main_service_water_flowrate_schedule": "ApartmentHighRise APT_DHW_SCH",
-      "main_water_heater_space_name": "Ambient Temp Schedule",
+      "main_water_heater_space_name": null,
       "main_service_water_peak_flowrate": null,
       "main_off_cycle_parasitic_heat_fraction_to_tank": null,
       "other_off_cycle_parasitic_heat_fraction_to_tank": null,

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2013/data/ashrae_90_1_2013.prototype_inputs.json
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2013/data/ashrae_90_1_2013.prototype_inputs.json
@@ -345,7 +345,7 @@
       "main_water_heater_capacity": 600000.0,
       "main_service_water_temperature": 140.0,
       "main_service_water_flowrate_schedule": "ApartmentHighRise APT_DHW_SCH",
-      "main_water_heater_space_name": "Ambient Temp Schedule",
+      "main_water_heater_space_name": null,
       "main_service_water_peak_flowrate": null,
       "main_off_cycle_parasitic_heat_fraction_to_tank": 0.8,
       "other_off_cycle_parasitic_heat_fraction_to_tank": 0.0,

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2016/data/ashrae_90_1_2016.prototype_inputs.json
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2016/data/ashrae_90_1_2016.prototype_inputs.json
@@ -345,7 +345,7 @@
       "main_water_heater_capacity": 600000.0,
       "main_service_water_temperature": 140.0,
       "main_service_water_flowrate_schedule": "ApartmentHighRise APT_DHW_SCH",
-      "main_water_heater_space_name": "Ambient Temp Schedule",
+      "main_water_heater_space_name": null,
       "main_service_water_peak_flowrate": null,
       "main_off_cycle_parasitic_heat_fraction_to_tank": 0.8,
       "other_off_cycle_parasitic_heat_fraction_to_tank": 0.0,

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2019/data/ashrae_90_1_2019.prototype_inputs.json
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2019/data/ashrae_90_1_2019.prototype_inputs.json
@@ -345,7 +345,7 @@
       "main_water_heater_capacity": 600000.0,
       "main_service_water_temperature": 140.0,
       "main_service_water_flowrate_schedule": "ApartmentHighRise APT_DHW_SCH",
-      "main_water_heater_space_name": "Ambient Temp Schedule",
+      "main_water_heater_space_name": null,
       "main_service_water_peak_flowrate": null,
       "main_off_cycle_parasitic_heat_fraction_to_tank": 0.8,
       "other_off_cycle_parasitic_heat_fraction_to_tank": 0.0,


### PR DESCRIPTION
The proposed changes remove the value from `main_water_heater_space_name` for the high-rise apartment so a scheduled ambient temperature is used instead (expected behavior). The current value to `main_water_heater_space_name` prevents the temperature schedule from being created.