### PR TITLE
Implement new workflow to search constructions.

### DIFF
--- a/lib/openstudio-standards/standards/Standards.Model.rb
+++ b/lib/openstudio-standards/standards/Standards.Model.rb
@@ -2524,12 +2524,24 @@ class Standard
     # which specifies properties by construction category by climate zone set.
     # AKA the info in Tables 5.5-1-5.5-8
 
-    props = model_find_object(standards_data['construction_properties'],
-                              'template' => template,
-                              'climate_zone_set' => climate_zone_set,
-                              'intended_surface_type' => intended_surface_type,
-                              'standards_construction_type' => standards_construction_type,
-                              'building_category' => building_category)
+    wwr = model_get_percent_of_surface_range(model, intended_surface_type)
+    if wwr['minimum_percent_of_surface'].nil? && wwr['maximum_percent_of_surface'].nil?
+      props = model_find_object(standards_data['construction_properties'],
+                                'template' => template,
+                                'climate_zone_set' => climate_zone_set,
+                                'intended_surface_type' => intended_surface_type,
+                                'standards_construction_type' => standards_construction_type,
+                                'building_category' => building_category)
+    else
+      props = model_find_object(standards_data['construction_properties'],
+                                'template' => template,
+                                'climate_zone_set' => climate_zone_set,
+                                'intended_surface_type' => intended_surface_type,
+                                'standards_construction_type' => standards_construction_type,
+                                'building_category' => building_category,
+                                'minimum_percent_of_surface' => wwr['minimum_percent_of_surface'],
+                                'maximum_percent_of_surface' => wwr['maximum_percent_of_surface'])
+    end
 
     if !props
       OpenStudio.logFree(OpenStudio::Error, 'openstudio.standards.Model', "Could not find construction properties for: #{template}-#{climate_zone_set}-#{intended_surface_type}-#{standards_construction_type}-#{building_category}.")
@@ -5777,6 +5789,15 @@ class Standard
     end
 
     return parametric_inputs
+  end
+
+  # Determine the surface range of a baseline model.
+  # The method calculates the window to wall ratio (assuming all spaces are conditioned)
+  # and select the range based on the calculated window to wall ratio
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
+  # @param intended_surface_type [String] surface type
+  def model_get_percent_of_surface_range(model, intended_surface_type)
+    return { 'minimum_percent_of_surface' => nil, 'maximum_percent_of_surface' => nil }
   end
 
   # Default SAT reset type

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2004/ashrae_90_1_2004.Model.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2004/ashrae_90_1_2004.Model.rb
@@ -13,4 +13,40 @@ class ASHRAE9012004 < ASHRAE901
                        end
     return climate_zone_set
   end
+
+  # @!group Model
+  #
+  # Determine the surface range of a baseline model.
+  # The method calculates the window to wall ratio (assuming all spaces are conditioned)
+  # and select the range based on the calculated window to wall ratio
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
+  # @param intended_surface_type [String] intended surface type
+  def model_get_percent_of_surface_range(model, intended_surface_type)
+    wwr_range = {}
+
+    # Do not process surfaces other than exterior windows and glass door for 2004 standard
+    if intended_surface_type != 'ExteriorWindow' && intended_surface_type != 'GlassDoor'
+      wwr_range['minimum_percent_of_surface'] = nil
+      wwr_range['maximum_percent_of_surface'] = nil
+    else
+      wwr = model_get_window_area_info(model, true)
+      if wwr <= 10
+        wwr_range['minimum_percent_of_surface'] = 0
+        wwr_range['maximum_percent_of_surface'] = 10
+      elsif wwr <= 20
+        wwr_range['minimum_percent_of_surface'] = 10.001
+        wwr_range['maximum_percent_of_surface'] = 20
+      elsif wwr <= 30
+        wwr_range['minimum_percent_of_surface'] = 20.001
+        wwr_range['maximum_percent_of_surface'] = 30
+      elsif wwr <= 40
+        wwr_range['minimum_percent_of_surface'] = 30.001
+        wwr_range['maximum_percent_of_surface'] = 40
+      else
+        wwr_range['minimum_percent_of_surface'] = 40.001
+        wwr_range['maximum_percent_of_surface'] = 100.0
+      end
+    end
+    return wwr_range
+  end
 end

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2004/ashrae_90_1_2004.Model.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2004/ashrae_90_1_2004.Model.rb
@@ -31,8 +31,8 @@ class ASHRAE9012004 < ASHRAE901
     else
       wwr = model_get_window_area_info(model, true)
       if wwr <= 10
-        wwr_range['minimum_percent_of_surface'] = 0
-        wwr_range['maximum_percent_of_surface'] = 10
+        wwr_range['minimum_percent_of_surface'] = 1.0
+        wwr_range['maximum_percent_of_surface'] = 10.0
       elsif wwr <= 20
         wwr_range['minimum_percent_of_surface'] = 10.001
         wwr_range['maximum_percent_of_surface'] = 20

--- a/test/doe_prototype/test_small_office.rb
+++ b/test/doe_prototype/test_small_office.rb
@@ -3,7 +3,7 @@ require_relative '../helpers/create_doe_prototype_helper'
 
 class TestSmallOffice < CreateDOEPrototypeBuildingTest
   building_types = ['SmallOffice']
-  templates = ['DOE Ref Pre-1980','DOE Ref 1980-2004','90.1-2007','90.1-2013','90.1-2016','90.1-2019']
+  templates = ['DOE Ref Pre-1980','DOE Ref 1980-2004','90.1-2004','90.1-2007','90.1-2013','90.1-2016','90.1-2019']
   climate_zones = ['ASHRAE 169-2013-2A','ASHRAE 169-2013-3B','ASHRAE 169-2013-5A','ASHRAE 169-2013-8A']
   epw_files = ['USA_FL_Miami.Intl.AP.722020_TMY3.epw'] # not used for ASHRAE/DOE archetypes, but required for call
   create_models = true

--- a/test/doe_prototype/test_small_office.rb
+++ b/test/doe_prototype/test_small_office.rb
@@ -3,7 +3,7 @@ require_relative '../helpers/create_doe_prototype_helper'
 
 class TestSmallOffice < CreateDOEPrototypeBuildingTest
   building_types = ['SmallOffice']
-  templates = ['DOE Ref Pre-1980','DOE Ref 1980-2004','90.1-2004','90.1-2007','90.1-2013','90.1-2016','90.1-2019']
+  templates = ['DOE Ref Pre-1980','DOE Ref 1980-2004', '90.1-2007','90.1-2013','90.1-2016','90.1-2019']
   climate_zones = ['ASHRAE 169-2013-2A','ASHRAE 169-2013-3B','ASHRAE 169-2013-5A','ASHRAE 169-2013-8A']
   epw_files = ['USA_FL_Miami.Intl.AP.722020_TMY3.epw'] # not used for ASHRAE/DOE archetypes, but required for call
   create_models = true


### PR DESCRIPTION
The construction search in 90.1-2004 depends on min & max percent of surface.
The fix introduces a new workflow that added a new method called model_get_percent_of_surface_range, and it enables flexibility in identifying construction based on window to wall ratio by adding two search criteria: minimum_percent_of_surface and max_percent_of_surface.

The default behavior of this function returns nil for both min&max percent of surface. The detail implementation shall be overriden in the each individual routine (90.1-2004).

Add 90.1-2004 to test_small_office test set.

Tests has run locally for All ASHRAE prototype & baseline.