### PR TITLE
Prm handle multiple building area types

### DIFF
--- a/lib/openstudio-standards/standards/Standards.Model.rb
+++ b/lib/openstudio-standards/standards/Standards.Model.rb
@@ -5084,12 +5084,17 @@ class Standard
       # method can however handle models with multiple building
       # area type, if they are specified through each space's
       # space type standards building type.
-      if !wwr_building_type.nil?
-        std_spc_type = wwr_building_type
-      elsif space.spaceType.is_initialized
-        std_spc_type = space.spaceType.get.standardsBuildingType.to_s
+      if space.hasAdditionalProperties && space.additionalProperties.hasFeature('building_type_for_wwr')
+        std_spc_type = space.additionalProperties.getFeatureAsString('building_type_for_wwr').get
       else
         std_spc_type = 'no_space_type'
+        if !wwr_building_type.nil?
+          std_spc_type = wwr_building_type
+        elsif space.spaceType.is_initialized
+          std_spc_type = space.spaceType.get.standardsBuildingType.to_s
+        end
+        # insert space wwr type as additional properties for later search
+        space.additionalProperties.setFeature('building_type_for_wwr', std_spc_type)
       end
 
       # Initialize intermediate variables if space type hasn't
@@ -5248,13 +5253,9 @@ class Standard
       # Reduce the window area if any of the categories necessary
       model.getSpaces.sort.each do |space|
         # Catch spaces without space types
-        if !wwr_building_type.nil?
-          std_spc_type = wwr_building_type
-        elsif space.spaceType.is_initialized
-          std_spc_type = space.spaceType.get.standardsBuildingType.to_s
-        else
-          std_spc_type = 'no_space_type'
-        end
+        std_spc_type = space.additionalProperties.getFeatureAsString('building_type_for_wwr').get
+        # skip process the space unless the space wwr type matched.
+        next unless bat == std_spc_type
 
         # Determine the space category
         # from the previously stored values

--- a/lib/openstudio-standards/standards/Standards.Model.rb
+++ b/lib/openstudio-standards/standards/Standards.Model.rb
@@ -79,6 +79,8 @@ class Standard
       # Create a deep copy of the user model if requested
       model = model_deep_copy ? BTAP::FileIO.deep_copy(user_model) : user_model
       model.getBuilding.setName("#{template}-#{building_type}-#{climate_zone} PRM baseline created: #{Time.new}")
+      # TODO userdata processing
+      handle_multi_building_area_types(model)
 
       # Rotate building if requested,
       # Site shading isn't rotated
@@ -7373,5 +7375,16 @@ class Standard
   # @return [String] Returns type of SAT reset
   def air_loop_hvac_supply_air_temperature_reset_type(air_loop_hvac)
     return 'warmest_zone'
+  end
+
+  # A template method that handles multiple building area type inputs for PRM baseline creation
+  # The inputs shall come from userdata csv files / json file.
+  # TODO DETERMINE THE RETURN VALUES.
+  # Plan 1. Add the values to space / zone additional properties.
+  # Plan 2. return hash table and pass the value into PRM function
+  # FOR NOW, just return an abitrary integer
+  # @param [Openstudio:model:Model] openstudio model
+  def handle_multi_building_area_types(model)
+    return 42
   end
 end

--- a/lib/openstudio-standards/standards/Standards.PlanarSurface.rb
+++ b/lib/openstudio-standards/standards/Standards.PlanarSurface.rb
@@ -143,8 +143,16 @@ class Standard
 
     # Check if the construction type was already created.
     # If yes, use that construction.  If no, make a new one.
+
+    # for multi-building type - search for the surface wwr type
+    surface_std_wwr_type = wwr_building_type
+    space = planar_surface.space.get
+    if space.hasAdditionalProperties && space.additionalProperties.hasFeature('building_type_for_wwr')
+      surface_std_wwr_type = space.additionalProperties.getFeatureAsString('building_type_for_wwr').get
+    end
+
     new_construction = nil
-    type = [template, climate_zone, surf_type, stds_type, occ_type]
+    type = [template, climate_zone, surf_type, stds_type, occ_type, surface_std_wwr_type]
 
     if previous_construction_map[type]
       new_construction = previous_construction_map[type]
@@ -154,7 +162,7 @@ class Standard
                                                          surf_type,
                                                          stds_type,
                                                          occ_type,
-                                                         wwr_building_type,
+                                                         surface_std_wwr_type,
                                                          wwr_info)
       if !new_construction == false
         previous_construction_map[type] = new_construction

--- a/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm_2019/ashrae_90_1_prm_2019.Model.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm_2019/ashrae_90_1_prm_2019.Model.rb
@@ -137,4 +137,30 @@ class ASHRAE901PRM2019 < ASHRAE901PRM
     srr_lim = 3.0
     return srr_lim
   end
+
+  def handle_multi_building_area_types(model)
+    user_building = @standards_data.key?('userdata_building') ? @standards_data['userdata_building'] : nil
+
+    if user_building && user_building.length >= 1
+      # userdata for each space process
+      user_spaces = @standards_data.key?('userdata_space') ? @standards_data['userdata_space'] : nil
+      if user_spaces && user_spaces.length >= 1
+        user_spaces.each do |user_space|
+          space_name = user_space['name']
+          space_building_type_for_wwr = user_space['building_type_for_wwr']
+          space = model.getSpaceByName(space_name)
+          # TODO reserved for ltg data under this user dataset.
+          if space.empty?
+            OpenStudio.logFree(OpenStudio::Error, 'openstudio.model.Model', "No space called #{space_name} was found in the model, check the inputs in the userdata_space.csv file")
+            return false
+          end
+          space = space.get
+          # add building type for wwr to the space's additional feature
+          space.additionalProperties.setFeature('building_type_for_wwr', space_building_type_for_wwr)
+        end
+      end
+
+    end
+    return true
+  end
 end


### PR DESCRIPTION
Note: This PR does not have all the implementations.

@dmaddoxwhite could you review this PR and let me know whether this is a correct implementation using the userdata for multiple wwr_building_type?

In this PR, I added a new routine called handle_multi_building_area_types . The method is overriden in the PRM class. So far it has only the wwr_building_type.
By introducing multiple wwr building types, I reorganized the wwr_info generation function to accommodate the change, as well as update the code in add construction to planar surface so that the construction for each surface is added based on their building type (applied to fenestration surfaces).

This PR is just a demonstration to show whether the change matches the expected behavior. Let me know if you have any questions.
