### PR TITLE
 fix non-rectangular skylight issue 

### DIFF
--- a/lib/openstudio-standards/standards/Standards.Space.rb
+++ b/lib/openstudio-standards/standards/Standards.Space.rb
@@ -321,7 +321,7 @@ class Standard
               min_y_val = vertex.y
             end
             # Max y value
-            if vertex.y > max_x_val
+            if vertex.y > max_y_val
               max_y_val = vertex.y
             end
           end


### PR DESCRIPTION
Scraping of log files helped identify that a skylight in space Gym_ZN_1_FLR_1 (primary school) is non-rectangular. This issue appears to occur in all the climate zones and for all the code versions. Standards.Space.rb was revised to fix this issue.  