### PR TITLE
Furnace efficiency lookup for coils without capacity

### DIFF
--- a/lib/openstudio-standards/standards/Standards.CoilHeatingGas.rb
+++ b/lib/openstudio-standards/standards/Standards.CoilHeatingGas.rb
@@ -22,6 +22,8 @@ class Standard
     capacity_btu_per_hr = OpenStudio.convert(capacity_w, 'W', 'Btu/hr').get
     capacity_kbtu_per_hr = OpenStudio.convert(capacity_w, 'W', 'kBtu/hr').get
 
+    return false unless capacity_btu_per_hr > 0
+
     # Get the boiler properties, if it exists for this template
     return false unless standards_data.include?('furnaces')
 


### PR DESCRIPTION
The proposed change add a guard clause to not lookup efficiency for coils with no capacity. The current code will post a warning stating that the efficiency cannot be looked-up which can be confusing because it doesn't specify why.