### PR TITLE
exposure occupancy hours for radiant controls

### DIFF
--- a/lib/openstudio-standards/prototypes/common/objects/Prototype.hvac_systems.rb
+++ b/lib/openstudio-standards/prototypes/common/objects/Prototype.hvac_systems.rb
@@ -4410,7 +4410,14 @@ class Standard
   # @param radiant_type [String] type of radiant system, floor or ceiling, to create in zone.
   # @param include_carpet [Bool] boolean to include thin carpet tile over radiant slab, default to true
   # @param carpet_thickness_in [Double] thickness of carpet in inches
-  # @param control_strategy [String] name of control strategy
+  # @param model_occ_hr_start [Double] (Optional) Only applies if control_strategy is 'proportional_control'.
+  #   Starting hour of building occupancy.
+  # @param model_occ_hr_end [Double] (Optional) Only applies if control_strategy is 'proportional_control'.
+  #   Ending hour of building occupancy.
+  # @param control_strategy [String] name of control strategy.  Options are 'proportional_control' and 'none'.
+  #   If control strategy is 'proportional_control', the method will apply the CBE radiant control sequences 
+  #   detailed in Raftery et al. (2017), “A new control strategy for high thermal mass radiant systems”.
+  #   Otherwise no control strategy will be applied and the radiant system will assume the EnergyPlus default controls.
   # @param proportional_gain [Double] (Optional) Only applies if control_strategy is 'proportional_control'.
   #   Proportional gain constant (recommended 0.3 or less).
   # @param minimum_operation [Double] (Optional) Only applies if control_strategy is 'proportional_control'.
@@ -4427,6 +4434,7 @@ class Standard
   #   Only used if radiant_lockout is true
   # @return [Array<OpenStudio::Model::ZoneHVACLowTemperatureRadiantVariableFlow>] array of radiant objects.
   # @todo Once the OpenStudio API supports it, make chilled water loops optional for heating only systems
+  # @todo Lookup occupany start and end hours from zone occupancy schedule
   def model_add_low_temp_radiant(model,
                                  thermal_zones,
                                  hot_water_loop,
@@ -4434,6 +4442,8 @@ class Standard
                                  radiant_type: 'floor',
                                  include_carpet: true,
                                  carpet_thickness_in: 0.25,
+                                 model_occ_hr_start: 6.0,
+                                 model_occ_hr_end: 18.0,
                                  control_strategy: 'proportional_control',
                                  proportional_gain: 0.3,
                                  minimum_operation: 1,
@@ -4743,6 +4753,8 @@ class Standard
       if control_strategy == 'proportional_control'
         model_add_radiant_proportional_controls(model, zone, radiant_loop,
                                                 radiant_type: radiant_type,
+                                                model_occ_hr_start: model_occ_hr_start,
+                                                model_occ_hr_end: model_occ_hr_end,
                                                 proportional_gain: proportional_gain,
                                                 minimum_operation: minimum_operation,
                                                 weekend_temperature_reset: weekend_temperature_reset,


### PR DESCRIPTION
expose the occupancy start and end hours for radiant slab controls in the model_add_low_temp_radiant method