### PR TITLE
remove AirLoopHVACDedicatedOutdoorAirSystem in remove method

### DIFF
--- a/lib/openstudio-standards/standards/Standards.Model.rb
+++ b/lib/openstudio-standards/standards/Standards.Model.rb
@@ -3984,6 +3984,9 @@ class Standard
 
     # Air loops
     model.getAirLoopHVACs.each(&:remove)
+    if model.version > OpenStudio::VersionString.new('3.1.0')
+      model.getAirLoopHVACDedicatedOutdoorAirSystems.each(&:remove)
+    end
 
     # Zone equipment
     model.getThermalZones.sort.each do |zone|


### PR DESCRIPTION
The AirLoopHVACDedicatedOutdoorAirSystem object was added in OS v3.2.0.  Remove these objects as part of the model_remove_prm_hvac() method.

Address issue #1226 