### PR TITLE
add handling for propane

### DIFF
--- a/data/standards/export_OpenStudio_libraries.rb
+++ b/data/standards/export_OpenStudio_libraries.rb
@@ -87,6 +87,8 @@ def export_openstudio_libraries
               boiler.setFuelType('NaturalGas')
             when 'Electric'
               boiler.setFuelType('Electricity')
+            when 'Propane', 'PropaneGas'
+              boiler.setFuelType('Propane')
             when 'Oil'
               boiler.setFuelType('FuelOilNo2')
           end

--- a/lib/openstudio-standards/hvac_sizing/Siz.ThermalZone.rb
+++ b/lib/openstudio-standards/hvac_sizing/Siz.ThermalZone.rb
@@ -236,7 +236,7 @@ class OpenStudio::Model::ThermalZone
   # serving those air loops.
   #
   # return [Array<String>] An array. Possible values are 
-  # Electricity, NaturalGas, PropaneGas, FuelOilNo1, FuelOilNo2,
+  # Electricity, NaturalGas, Propane, PropaneGas, FuelOilNo1, FuelOilNo2,
   # Coal, Diesel, Gasoline, DistrictCooling, DistrictHeating, 
   # and SolarEnergy.
   def heating_fuels
@@ -278,7 +278,7 @@ class OpenStudio::Model::ThermalZone
   # serving those air loops.
   #
   # return [Array<String>] An array. Possible values are
-  # Electricity, NaturalGas, PropaneGas, FuelOilNo1, FuelOilNo2,
+  # Electricity, NaturalGas, Propane, PropaneGas, FuelOilNo1, FuelOilNo2,
   # Coal, Diesel, Gasoline, DistrictCooling, DistrictHeating, 
   # and SolarEnergy.
   def cooling_fuels

--- a/lib/openstudio-standards/prototypes/common/objects/Prototype.BoilerHotWater.rb
+++ b/lib/openstudio-standards/prototypes/common/objects/Prototype.BoilerHotWater.rb
@@ -48,6 +48,8 @@ class Standard
 
     if fuel_type.nil? || fuel_type == 'Gas'
       boiler.setFuelType('NaturalGas')
+    elsif fuel_type == 'Propane' || fuel_type == 'PropaneGas'
+      boiler.setFuelType('Propane')
     else
       boiler.setFuelType(fuel_type)
     end

--- a/lib/openstudio-standards/prototypes/common/objects/Prototype.hvac_systems.rb
+++ b/lib/openstudio-standards/prototypes/common/objects/Prototype.hvac_systems.rb
@@ -24,7 +24,7 @@ class Standard
   # Creates a hot water loop with a boiler, district heating, or a water-to-water heat pump and adds it to the model.
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param boiler_fuel_type [String] valid choices are Electricity, NaturalGas, PropaneGas, FuelOilNo1, FuelOilNo2, DistrictHeating, HeatPump
+  # @param boiler_fuel_type [String] valid choices are Electricity, NaturalGas, Propane, PropaneGas, FuelOilNo1, FuelOilNo2, DistrictHeating, HeatPump
   # @param ambient_loop [OpenStudio::Model::PlantLoop] The condenser loop for the heat pump. Only used when boiler_fuel_type is HeatPump.
   # @param system_name [String] the name of the system, or nil in which case it will be defaulted
   # @param dsgn_sup_wtr_temp [Double] design supply water temperature in degrees Fahrenheit, default 180F
@@ -128,7 +128,7 @@ class Standard
       when 'AirSourceHeatPump', 'ASHP'
         create_central_air_source_heat_pump(model, hot_water_loop)
       # Boiler
-      when 'Electricity', 'Gas', 'NaturalGas', 'PropaneGas', 'FuelOilNo1', 'FuelOilNo2'
+      when 'Electricity', 'Gas', 'NaturalGas', 'Propane', 'PropaneGas', 'FuelOilNo1', 'FuelOilNo2'
         if boiler_lvg_temp_dsgn.nil?
           lvg_temp_dsgn = dsgn_sup_wtr_temp
         else
@@ -803,7 +803,7 @@ class Standard
     when 'AirSourceHeatPump', 'ASHP'
       heating_equipment = create_central_air_source_heat_pump(model, heat_pump_water_loop)
       heating_equipment_stpt_manager.setName("#{heat_pump_water_loop.name} ASHP Scheduled Dual Setpoint")
-    when 'Electricity', 'Gas', 'NaturalGas', 'PropaneGas', 'FuelOilNo1', 'FuelOilNo2'
+    when 'Electricity', 'Gas', 'NaturalGas', 'Propane', 'PropaneGas', 'FuelOilNo1', 'FuelOilNo2'
       heating_equipment = create_boiler_hot_water(model,
                                                   hot_water_loop: heat_pump_water_loop,
                                                   name: "#{heat_pump_water_loop.name} Supplemental Boiler",
@@ -4031,7 +4031,7 @@ class Standard
       high_temp_radiant = OpenStudio::Model::ZoneHVACHighTemperatureRadiant.new(model)
       high_temp_radiant.setName("#{zone.name} High Temp Radiant")
 
-      if heating_type.nil? || heating_type == 'Gas'
+      if heating_type.nil? || heating_type == 'NaturalGas' || heating_type == 'Gas'
         high_temp_radiant.setFuelType('NaturalGas')
       else
         high_temp_radiant.setFuelType(heating_type)

--- a/lib/openstudio-standards/standards/Standards.Model.rb
+++ b/lib/openstudio-standards/standards/Standards.Model.rb
@@ -5210,6 +5210,7 @@ class Standard
       electric = true
 
       if htg_fuels.include?('NaturalGas') ||
+         htg_fuels.include?('Propane') ||
          htg_fuels.include?('PropaneGas') ||
          htg_fuels.include?('FuelOilNo1') ||
          htg_fuels.include?('FuelOilNo2') ||

--- a/lib/openstudio-standards/standards/Standards.ThermalZone.rb
+++ b/lib/openstudio-standards/standards/Standards.ThermalZone.rb
@@ -602,12 +602,13 @@ class Standard
 
     # Get an array of the heating fuels
     # used by the zone.  Possible values are
-    # Electricity, NaturalGas, PropaneGas, FuelOilNo1, FuelOilNo2,
+    # Electricity, NaturalGas, Propane, PropaneGas, FuelOilNo1, FuelOilNo2,
     # Coal, Diesel, Gasoline, DistrictHeating,
     # and SolarEnergy.
     htg_fuels = thermal_zone.heating_fuels
 
     if htg_fuels.include?('NaturalGas') ||
+       htg_fuels.include?('Propane') ||
        htg_fuels.include?('PropaneGas') ||
        htg_fuels.include?('FuelOilNo1') ||
        htg_fuels.include?('FuelOilNo2') ||
@@ -641,6 +642,7 @@ class Standard
     # Fossil heating
     htg_fuels = thermal_zone.heating_fuels
     if htg_fuels.include?('NaturalGas') ||
+       htg_fuels.include?('Propane') ||
        htg_fuels.include?('PropaneGas') ||
        htg_fuels.include?('FuelOilNo1') ||
        htg_fuels.include?('FuelOilNo2') ||
@@ -703,7 +705,7 @@ class Standard
 
     # Get an array of the heating fuels
     # used by the zone.  Possible values are
-    # Electricity, NaturalGas, PropaneGas, FuelOilNo1, FuelOilNo2,
+    # Electricity, NaturalGas, Propane, PropaneGas, FuelOilNo1, FuelOilNo2,
     # Coal, Diesel, Gasoline, DistrictHeating,
     # and SolarEnergy.
     htg_fuels = thermal_zone.heating_fuels
@@ -711,6 +713,7 @@ class Standard
     # Includes fossil
     fossil = false
     if htg_fuels.include?('NaturalGas') ||
+       htg_fuels.include?('Propane') ||
        htg_fuels.include?('PropaneGas') ||
        htg_fuels.include?('FuelOilNo1') ||
        htg_fuels.include?('FuelOilNo2') ||


### PR DESCRIPTION
Add handling for propane as a heating fuel type accounting for the fuel name adjustments in #1100