### PR TITLE
Fix/ext door prm

### DIFF
--- a/lib/openstudio-standards/standards/Standards.PlanarSurface.rb
+++ b/lib/openstudio-standards/standards/Standards.PlanarSurface.rb
@@ -92,6 +92,21 @@ class Standard
         OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.PlanarSurface', "Could not determine the standards fenestration type for #{planar_surface.name} from #{construction.name}.  This surface will not have the standard applied.")
         return previous_construction_map
       end
+    # Exterior Doors
+    elsif surf_type == 'ExteriorDoor'
+      stds_type = standards_info.standardsConstructionType
+      if stds_type.is_initialized
+        stds_type = stds_type.get
+        case stds_type
+        when 'Rollup', 'NonSwinging'
+          stds_type = 'NonSwinging'
+        else
+          stds_type = 'Swinging'
+        end
+      else
+        OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.PlanarSurface', "Could not determine the standards construction type for exterior door #{planar_surface.name}.  This door will not have the standard applied.")
+        return previous_construction_map
+      end
     # All other surface types
     else
       stds_type = standards_info.standardsConstructionType

--- a/lib/openstudio-standards/standards/Standards.PlanarSurface.rb
+++ b/lib/openstudio-standards/standards/Standards.PlanarSurface.rb
@@ -98,7 +98,7 @@ class Standard
       if stds_type.is_initialized
         stds_type = stds_type.get
         case stds_type
-        when 'Rollup', 'NonSwinging'
+        when 'RollUp', 'Rollup', 'NonSwinging', 'Nonswinging'
           stds_type = 'NonSwinging'
         else
           stds_type = 'Swinging'

--- a/lib/openstudio-standards/standards/deer/deer.PlanarSurface.rb
+++ b/lib/openstudio-standards/standards/deer/deer.PlanarSurface.rb
@@ -100,7 +100,7 @@ class DEER
       if stds_type.is_initialized
         stds_type = stds_type.get
         case stds_type
-        when 'Rollup', 'NonSwinging'
+        when 'RollUp', 'Rollup', 'NonSwinging', 'Nonswinging'
           stds_type = 'NonSwinging'
         else
           stds_type = 'Swinging'

--- a/lib/openstudio-standards/standards/deer/deer.PlanarSurface.rb
+++ b/lib/openstudio-standards/standards/deer/deer.PlanarSurface.rb
@@ -94,6 +94,21 @@ class DEER
         OpenStudio.logFree(OpenStudio::Warn, 'openstudio.model.PlanarSurface', "Could not determine the standards fenestration type for #{planar_surface.name} from #{construction.name}.  This surface will not have the standard applied.")
         return previous_construction_map
       end
+    # Exterior Doors
+    elsif surf_type == 'ExteriorDoor'
+      stds_type = standards_info.standardsConstructionType
+      if stds_type.is_initialized
+        stds_type = stds_type.get
+        case stds_type
+        when 'Rollup', 'NonSwinging'
+          stds_type = 'NonSwinging'
+        else
+          stds_type = 'Swinging'
+        end
+      else
+        OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.PlanarSurface', "Could not determine the standards construction type for exterior door #{planar_surface.name}.  This door will not have the standard applied.")
+        return previous_construction_map
+      end
     # All other surface types
     else
       stds_type = standards_info.standardsConstructionType


### PR DESCRIPTION
Fixes issue #179 by explicitly setting the standards construction type in the PRM `planar_surface_apply_standard_construction()` method for exterior doors.