### PR TITLE
implement pre ruby 2.6 method for slicing

### DIFF
--- a/lib/openstudio-standards/standards/necb/ECMS/hvac_systems.rb
+++ b/lib/openstudio-standards/standards/necb/ECMS/hvac_systems.rb
@@ -482,7 +482,7 @@ class ECMS
       system_zones_map = update_system_zones_map(model,system_zones_map,ecm_system_zones_map_option,'sys_1')
     else
       updated_system_zones_map = {}
-      system_zones_map.each {|sname,zones| updated_system_zones_map["sys_1#{sname[5..]}"] = zones}  # doas unit is an NECB sys_1 
+      system_zones_map.each {|sname,zones| updated_system_zones_map["sys_1#{sname[5..-1]}"] = zones}  # doas unit is an NECB sys_1 
       system_zones_map = updated_system_zones_map
     end
     # Add outdoor VRF unit
@@ -1196,7 +1196,7 @@ class ECMS
       system_zones_map = update_system_zones_map(model,system_zones_map,ecm_system_zones_map_option,'sys_1')
     else
       updated_system_zones_map = {}
-      system_zones_map.each {|sname,zones| updated_system_zones_map["sys_1#{sname[5..]}"] = zones}
+      system_zones_map.each {|sname,zones| updated_system_zones_map["sys_1#{sname[5..-1]}"] = zones}
       system_zones_map = updated_system_zones_map
     end
     # Update system doas flags


### PR DESCRIPTION
Fixes issue #1295 by using older ruby syntax before version 2.6.

@ckirney @khaddad just making you aware of this fix I made to standards.  Please avoid using the newer endless range syntax in ruby if you can accomplish the same thing with older syntax. 