### PR TITLE
check vav part load curve

### DIFF
--- a/test/90_1_prm/data/prototype_list.json
+++ b/test/90_1_prm/data/prototype_list.json
@@ -29,13 +29,9 @@
         ["Warehouse", "90.1-2013", "ASHRAE 169-2013-2A", "no_user_data",[]]
     ],
     "vav_fan_curve": [
-        ["Outpatient", "90.1-2013", "ASHRAE 169-2013-2A", "no_user_data",[]],
         ["MediumOffice", "90.1-2013", "ASHRAE 169-2013-2A", "no_user_data",[["remove_transformer", []]]],
-        ["LargeHotel", "90.1-2013", "ASHRAE 169-2013-2A", "no_user_data",[["remove_transformer", []]]],
-        ["Hospital", "90.1-2013", "ASHRAE 169-2013-2A", "no_user_data",[["remove_transformer", []]]],
-        ["LargeOffice", "90.1-2013", "ASHRAE 169-2013-2A", "no_user_data",[["remove_transformer", []]]],
-        ["PrimarySchool", "90.1-2013", "ASHRAE 169-2013-2A", "no_user_data",[["remove_transformer", []]]],
-        ["SecondarySchool", "90.1-2013", "ASHRAE 169-2013-2A", "no_user_data",[["remove_transformer", []]]]     
+        ["MediumOffice", "90.1-2013", "ASHRAE 169-2013-4A", "no_user_data",[["remove_transformer", []]]],
+        ["SecondarySchool", "90.1-2013", "ASHRAE 169-2013-4A", "no_user_data",[["remove_transformer", []]]]     
     ],
     "hvac_baseline": [
         ["MediumOffice", "90.1-2013", "ASHRAE 169-2013-2A", "no_user_data",[["remove_transformer", []], ["return_relief_fan", []]]],

--- a/test/90_1_prm/data/prototype_list.json
+++ b/test/90_1_prm/data/prototype_list.json
@@ -29,13 +29,13 @@
         ["Warehouse", "90.1-2013", "ASHRAE 169-2013-2A", "no_user_data",[]]
     ],
     "vav_fan_curve": [
-        ["Outpatient", "90.1-2013", "ASHRAE 169-2013-4C", []],
-        ["MediumOffice", "90.1-2013", "ASHRAE 169-2013-4A", [["remove_transformer", []]]],
-        ["LargeHotel", "90.1-2013", "ASHRAE 169-2013-4A", [["remove_transformer", []]]],
-        ["Hospital", "90.1-2013", "ASHRAE 169-2013-4A", [["remove_transformer", []]]],
-        ["LargeOffice", "90.1-2013", "ASHRAE 169-2013-4A", [["remove_transformer", []]]],
-        ["PrimarySchool", "90.1-2013", "ASHRAE 169-2013-4A", [["remove_transformer", []]]],
-        ["SecondarySchool", "90.1-2013", "ASHRAE 169-2013-4A", [["remove_transformer", []]]]     
+        ["Outpatient", "90.1-2013", "ASHRAE 169-2013-4C", "no_user_data",[]],
+        ["MediumOffice", "90.1-2013", "ASHRAE 169-2013-4A", "no_user_data",[["remove_transformer", []]]],
+        ["LargeHotel", "90.1-2013", "ASHRAE 169-2013-4A", "no_user_data",[["remove_transformer", []]]],
+        ["Hospital", "90.1-2013", "ASHRAE 169-2013-4A", "no_user_data",[["remove_transformer", []]]],
+        ["LargeOffice", "90.1-2013", "ASHRAE 169-2013-4A", "no_user_data",[["remove_transformer", []]]],
+        ["PrimarySchool", "90.1-2013", "ASHRAE 169-2013-4A", "no_user_data",[["remove_transformer", []]]],
+        ["SecondarySchool", "90.1-2013", "ASHRAE 169-2013-4A", "no_user_data",[["remove_transformer", []]]]     
     ],
     "hvac_baseline": [
         ["MediumOffice", "90.1-2013", "ASHRAE 169-2013-2A", "no_user_data",[["remove_transformer", []], ["return_relief_fan", []]]],

--- a/test/90_1_prm/data/prototype_list.json
+++ b/test/90_1_prm/data/prototype_list.json
@@ -29,13 +29,13 @@
         ["Warehouse", "90.1-2013", "ASHRAE 169-2013-2A", "no_user_data",[]]
     ],
     "vav_fan_curve": [
-        ["Outpatient", "90.1-2013", "ASHRAE 169-2013-4C", "no_user_data",[]],
-        ["MediumOffice", "90.1-2013", "ASHRAE 169-2013-4A", "no_user_data",[["remove_transformer", []]]],
-        ["LargeHotel", "90.1-2013", "ASHRAE 169-2013-4A", "no_user_data",[["remove_transformer", []]]],
-        ["Hospital", "90.1-2013", "ASHRAE 169-2013-4A", "no_user_data",[["remove_transformer", []]]],
-        ["LargeOffice", "90.1-2013", "ASHRAE 169-2013-4A", "no_user_data",[["remove_transformer", []]]],
-        ["PrimarySchool", "90.1-2013", "ASHRAE 169-2013-4A", "no_user_data",[["remove_transformer", []]]],
-        ["SecondarySchool", "90.1-2013", "ASHRAE 169-2013-4A", "no_user_data",[["remove_transformer", []]]]     
+        ["Outpatient", "90.1-2013", "ASHRAE 169-2013-2A", "no_user_data",[]],
+        ["MediumOffice", "90.1-2013", "ASHRAE 169-2013-2A", "no_user_data",[["remove_transformer", []]]],
+        ["LargeHotel", "90.1-2013", "ASHRAE 169-2013-2A", "no_user_data",[["remove_transformer", []]]],
+        ["Hospital", "90.1-2013", "ASHRAE 169-2013-2A", "no_user_data",[["remove_transformer", []]]],
+        ["LargeOffice", "90.1-2013", "ASHRAE 169-2013-2A", "no_user_data",[["remove_transformer", []]]],
+        ["PrimarySchool", "90.1-2013", "ASHRAE 169-2013-2A", "no_user_data",[["remove_transformer", []]]],
+        ["SecondarySchool", "90.1-2013", "ASHRAE 169-2013-2A", "no_user_data",[["remove_transformer", []]]]     
     ],
     "hvac_baseline": [
         ["MediumOffice", "90.1-2013", "ASHRAE 169-2013-2A", "no_user_data",[["remove_transformer", []], ["return_relief_fan", []]]],

--- a/test/90_1_prm/data/prototype_list.json
+++ b/test/90_1_prm/data/prototype_list.json
@@ -28,6 +28,15 @@
         ["SmallOffice", "90.1-2013", "ASHRAE 169-2013-2A", "no_user_data",[]],
         ["Warehouse", "90.1-2013", "ASHRAE 169-2013-2A", "no_user_data",[]]
     ],
+    "vav_fan_curve": [
+        ["Outpatient", "90.1-2013", "ASHRAE 169-2013-4C", []],
+        ["MediumOffice", "90.1-2013", "ASHRAE 169-2013-4A", [["remove_transformer", []]]],
+        ["LargeHotel", "90.1-2013", "ASHRAE 169-2013-4A", [["remove_transformer", []]]],
+        ["Hospital", "90.1-2013", "ASHRAE 169-2013-4A", [["remove_transformer", []]]],
+        ["LargeOffice", "90.1-2013", "ASHRAE 169-2013-4A", [["remove_transformer", []]]],
+        ["PrimarySchool", "90.1-2013", "ASHRAE 169-2013-4A", [["remove_transformer", []]]],
+        ["SecondarySchool", "90.1-2013", "ASHRAE 169-2013-4A", [["remove_transformer", []]]]     
+    ],
     "hvac_baseline": [
         ["MediumOffice", "90.1-2013", "ASHRAE 169-2013-2A", "no_user_data",[["remove_transformer", []], ["return_relief_fan", []]]],
         ["Warehouse", "90.1-2004", "ASHRAE 169-2013-2A", "no_user_data",[["remove_cooling_coils", []]]],

--- a/test/90_1_prm/test_appendix_g_prm.rb
+++ b/test/90_1_prm/test_appendix_g_prm.rb
@@ -1717,31 +1717,31 @@ class AppendixGPRMTests < Minitest::Test
         if supply_fan.fanPowerCoefficient1.is_initialized
           expected_coefficient = 0.0013
           coefficient = supply_fan.fanPowerCoefficient1.get
-          assert((coefficient - expected_coefficient).abs < 0.01, "Expected Coefficient 1 for #{supply_fan_name} to be equal to #{expected_coefficient}; found #{coefficient} instead")
+          assert((coefficient - expected_coefficient).abs < 0.0001, "Expected Coefficient 1 for #{supply_fan_name} to be equal to #{expected_coefficient}; found #{coefficient} instead")
         end
         # coefficient 2
         if supply_fan.fanPowerCoefficient2.is_initialized
           expected_coefficient = 0.1470
           coefficient = supply_fan.fanPowerCoefficient2.get
-          assert((coefficient - expected_coefficient).abs < 0.01, "Expected Coefficient 1 for #{supply_fan_name} to be equal to #{expected_coefficient}; found #{coefficient} instead")
+          assert((coefficient - expected_coefficient).abs < 0.0001, "Expected Coefficient 1 for #{supply_fan_name} to be equal to #{expected_coefficient}; found #{coefficient} instead")
         end
         # coefficient 3
         if supply_fan.fanPowerCoefficient4.is_initialized
           expected_coefficient = 0.9506
           coefficient = supply_fan.fanPowerCoefficient3.get
-          assert((coefficient - expected_coefficient).abs < 0.01, "Expected Coefficient 1 for #{supply_fan_name} to be equal to #{expected_coefficient}; found #{coefficient} instead")
+          assert((coefficient - expected_coefficient).abs < 0.0001, "Expected Coefficient 1 for #{supply_fan_name} to be equal to #{expected_coefficient}; found #{coefficient} instead")
         end
         # coefficient 4
         if supply_fan.fanPowerCoefficient4.is_initialized
           expected_coefficient = -0.0998
           coefficient = supply_fan.fanPowerCoefficient4.get
-          assert((coefficient - expected_coefficient).abs < 0.01, "Expected Coefficient 1 for #{supply_fan_name} to be equal to #{expected_coefficient}; found #{coefficient} instead")
+          assert((coefficient - expected_coefficient).abs < 0.0001, "Expected Coefficient 1 for #{supply_fan_name} to be equal to #{expected_coefficient}; found #{coefficient} instead")
         end
         # coefficient 5
         if supply_fan.fanPowerCoefficient5.is_initialized
           expected_coefficient = 0
           coefficient = supply_fan.fanPowerCoefficient5.get
-          assert((coefficient - expected_coefficient).abs < 0.01, "Expected Coefficient 1 for #{supply_fan_name} to be equal to #{expected_coefficient}; found #{coefficient} instead")
+          assert((coefficient - expected_coefficient).abs < 0.0001, "Expected Coefficient 1 for #{supply_fan_name} to be equal to #{expected_coefficient}; found #{coefficient} instead")
         end
       end  
     end

--- a/test/90_1_prm/test_appendix_g_prm.rb
+++ b/test/90_1_prm/test_appendix_g_prm.rb
@@ -1701,6 +1701,54 @@ class AppendixGPRMTests < Minitest::Test
     end
   end
 
+
+  
+ # Check if coefficients of part-load power curve is correct per G3.1.3.15
+  def check_variable_speed_fan_power(prototypes_base)
+    prototypes_base.each do |prototype, model|
+      model.getFanVariableVolumes.each do |supply_fan|
+        supply_fan_name = supply_fan.name.get.to_s
+
+      
+        # check fan curves
+        # Skip single-zone VAV fans
+        next if supply_fan.airLoopHVAC.get.thermalZones.size == 1
+        # coefficient 1
+        if supply_fan.fanPowerCoefficient1.is_initialized
+          expected_coefficient = 0.0013
+          coefficient = supply_fan.fanPowerCoefficient1.get
+          assert((coefficient - expected_coefficient).abs < 0.01, "Expected Coefficient 1 for #{supply_fan_name} to be equal to #{expected_coefficient}; found #{coefficient} instead")
+        end
+        # coefficient 2
+        if supply_fan.fanPowerCoefficient2.is_initialized
+          expected_coefficient = 0.1470
+          coefficient = supply_fan.fanPowerCoefficient2.get
+          assert((coefficient - expected_coefficient).abs < 0.01, "Expected Coefficient 1 for #{supply_fan_name} to be equal to #{expected_coefficient}; found #{coefficient} instead")
+        end
+        # coefficient 3
+        if supply_fan.fanPowerCoefficient4.is_initialized
+          expected_coefficient = 0.9506
+          coefficient = supply_fan.fanPowerCoefficient3.get
+          assert((coefficient - expected_coefficient).abs < 0.01, "Expected Coefficient 1 for #{supply_fan_name} to be equal to #{expected_coefficient}; found #{coefficient} instead")
+        end
+        # coefficient 4
+        if supply_fan.fanPowerCoefficient4.is_initialized
+          expected_coefficient = -0.0998
+          coefficient = supply_fan.fanPowerCoefficient4.get
+          assert((coefficient - expected_coefficient).abs < 0.01, "Expected Coefficient 1 for #{supply_fan_name} to be equal to #{expected_coefficient}; found #{coefficient} instead")
+        end
+        # coefficient 5
+        if supply_fan.fanPowerCoefficient5.is_initialized
+          expected_coefficient = 0
+          coefficient = supply_fan.fanPowerCoefficient5.get
+          assert((coefficient - expected_coefficient).abs < 0.01, "Expected Coefficient 1 for #{supply_fan_name} to be equal to #{expected_coefficient}; found #{coefficient} instead")
+        end
+      end  
+    end
+  end
+
+
+
   # Set ZoneMultiplier to passed value for all zones
 
   # @param model, arguments[]
@@ -2068,6 +2116,7 @@ class AppendixGPRMTests < Minitest::Test
       'daylighting_control',
       'light_occ_sensor',
       'infiltration',
+      'vav_fan_curve',
       'hvac_baseline',
       'hvac_psz_split_from_mz',
       'plant_temp_reset_ctrl',
@@ -2100,6 +2149,7 @@ class AppendixGPRMTests < Minitest::Test
     check_lpd(prototypes_base['lpd']) if tests.include? 'lpd'
     check_light_occ_sensor(prototypes['light_occ_sensor'], prototypes_base['light_occ_sensor']) if tests.include? 'light_occ_sensor'
     check_infiltration(prototypes['infiltration'], prototypes_base['infiltration']) if tests.include? 'infiltration'
+    check_variable_speed_fan_power(prototypes_base['vav_fan_curve']) if tests.include? 'vav_fan_curve'
     check_hvac(prototypes_base['hvac_baseline']) if tests.include? 'hvac_baseline'
     check_sat_ctrl(prototypes_base['sat_ctrl']) if tests.include? 'sat_ctrl'
     check_number_of_boilers(prototypes_base['number_of_boilers']) if tests.include? 'number_of_boilers'

--- a/test/90_1_prm/test_appendix_g_prm.rb
+++ b/test/90_1_prm/test_appendix_g_prm.rb
@@ -1717,31 +1717,31 @@ class AppendixGPRMTests < Minitest::Test
         if supply_fan.fanPowerCoefficient1.is_initialized
           expected_coefficient = 0.0013
           coefficient = supply_fan.fanPowerCoefficient1.get
-          assert((coefficient - expected_coefficient).abs < 0.0001, "Expected Coefficient 1 for #{supply_fan_name} to be equal to #{expected_coefficient}; found #{coefficient} instead")
+          assert(((coefficient - expected_coefficient)/expected_coefficient).abs < 0.01, "Expected Coefficient 1 for #{supply_fan_name} to be equal to #{expected_coefficient}; found #{coefficient} instead")
         end
         # coefficient 2
         if supply_fan.fanPowerCoefficient2.is_initialized
           expected_coefficient = 0.1470
           coefficient = supply_fan.fanPowerCoefficient2.get
-          assert((coefficient - expected_coefficient).abs < 0.0001, "Expected Coefficient 1 for #{supply_fan_name} to be equal to #{expected_coefficient}; found #{coefficient} instead")
+          assert(((coefficient - expected_coefficient)/expected_coefficient).abs < 0.01, "Expected Coefficient 1 for #{supply_fan_name} to be equal to #{expected_coefficient}; found #{coefficient} instead")
         end
         # coefficient 3
         if supply_fan.fanPowerCoefficient4.is_initialized
           expected_coefficient = 0.9506
           coefficient = supply_fan.fanPowerCoefficient3.get
-          assert((coefficient - expected_coefficient).abs < 0.0001, "Expected Coefficient 1 for #{supply_fan_name} to be equal to #{expected_coefficient}; found #{coefficient} instead")
+          assert(((coefficient - expected_coefficient)/expected_coefficient).abs < 0.01, "Expected Coefficient 1 for #{supply_fan_name} to be equal to #{expected_coefficient}; found #{coefficient} instead")
         end
         # coefficient 4
         if supply_fan.fanPowerCoefficient4.is_initialized
           expected_coefficient = -0.0998
           coefficient = supply_fan.fanPowerCoefficient4.get
-          assert((coefficient - expected_coefficient).abs < 0.0001, "Expected Coefficient 1 for #{supply_fan_name} to be equal to #{expected_coefficient}; found #{coefficient} instead")
+          assert(((coefficient - expected_coefficient)/expected_coefficient).abs < 0.01, "Expected Coefficient 1 for #{supply_fan_name} to be equal to #{expected_coefficient}; found #{coefficient} instead")
         end
         # coefficient 5
         if supply_fan.fanPowerCoefficient5.is_initialized
           expected_coefficient = 0
           coefficient = supply_fan.fanPowerCoefficient5.get
-          assert((coefficient - expected_coefficient).abs < 0.0001, "Expected Coefficient 1 for #{supply_fan_name} to be equal to #{expected_coefficient}; found #{coefficient} instead")
+          assert((coefficient - expected_coefficient).abs < 0.01, "Expected Coefficient 1 for #{supply_fan_name} to be equal to #{expected_coefficient}; found #{coefficient} instead")
         end
       end  
     end


### PR DESCRIPTION
Check if correct  VAV fan part load curves from appendix g Table G3.1.3.15 is applied to baseline.
