### PR TITLE
Change heating type if using a hot water loop with a PSZ-AC system

### DIFF
--- a/lib/openstudio-standards/prototypes/common/objects/Prototype.hvac_systems.rb
+++ b/lib/openstudio-standards/prototypes/common/objects/Prototype.hvac_systems.rb
@@ -5931,6 +5931,7 @@ class Standard
         if air_loop_heating_type == 'Water'
           hot_water_loop = model_get_or_add_hot_water_loop(model, main_heat_fuel,
                                                            hot_water_loop_type: hot_water_loop_type)
+          heating_type = 'Water'
         else
           hot_water_loop = nil
         end


### PR DESCRIPTION
This fixes a bug where if a user enters 'Gas' or 'NaturalGas' for the main_heat_fuel argument in model_add_hvac_system for a 'PSZ-AC' system type, and does not change the default air_loop_heating_type: 'Water', the method will add an empty hot water loop to the model and construct the PSZ-AC system with gas coils.

Fixes issue #1306.