### PR TITLE
Lookup model standards template for model_find_target_eui(model)

### DIFF
--- a/lib/openstudio-standards/prototypes/common/objects/Prototype.Model.rb
+++ b/lib/openstudio-standards/prototypes/common/objects/Prototype.Model.rb
@@ -1794,7 +1794,7 @@ Standard.class_eval do
   #
   # @param model [OpenStudio::Model::Model] the model
   def model_apply_prototype_hvac_efficiency_adjustments(model)
-    building_data = model_get_building_climate_zone_and_building_type(model)
+    building_data = model_get_building_properties(model)
     building_type = building_data['building_type']
     climate_zone = building_data['climate_zone']
 

--- a/lib/openstudio-standards/standards/Standards.Model.rb
+++ b/lib/openstudio-standards/standards/Standards.Model.rb
@@ -2971,11 +2971,12 @@ class Standard
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param building_type [String] the building type
   # @param run_type [String] design day is dd-only, otherwise annual run
+  # @param lkp_template [String] The standards template, e.g.'90.1-2013'
   # @return [Hash] a hash of results for each fuel, where the keys are in the form 'End Use|Fuel Type',
   #   e.g. Heating|Electricity, Exterior Equipment|Water.  All end use/fuel type combos are present,
   #   with values of 0.0 if none of this end use/fuel type combo was used by the simulation.
   #   Returns nil if the legacy results couldn't be found.
-  def model_legacy_results_by_end_use_and_fuel_type(model, climate_zone, building_type, run_type)
+  def model_legacy_results_by_end_use_and_fuel_type(model, climate_zone, building_type, run_type, lkp_template:nil)
     # Load the legacy idf results CSV file into a ruby hash
     top_dir = File.expand_path('../../..', File.dirname(__FILE__))
     standards_data_dir = "#{top_dir}/data/standards"
@@ -2999,10 +3000,14 @@ class Standard
     legacy_idf_csv = CSV.new(temp, headers: true, converters: :all)
     legacy_idf_results = legacy_idf_csv.to_a.map(&:to_hash)
 
+    if lkp_template.nil?
+      lkp_template = template
+    end
+
     # Get the results for this building
     search_criteria = {
       'Building Type' => building_type,
-      'Template' => template,
+      'Template' => lkp_template,
       'Climate Zone' => climate_zone
     }
     energy_values = model_find_object(legacy_idf_results, search_criteria)
@@ -3019,9 +3024,10 @@ class Standard
   # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param building_type [String] the building type
+  # @param lkp_template [String] The standards template, e.g.'90.1-2013'
   # @return [Hash] Returns a hash with data presented in various bins.
   #   Returns nil if no search results
-  def model_process_results_for_datapoint(model, climate_zone, building_type)
+  def model_process_results_for_datapoint(model, climate_zone, building_type, lkp_template: nil)
     # Hash to store the legacy results by fuel and by end use
     legacy_results_hash = {}
     legacy_results_hash['total_legacy_energy_val'] = 0
@@ -3030,7 +3036,7 @@ class Standard
     legacy_results_hash['total_energy_by_end_use'] = {}
 
     # Get the legacy simulation results
-    legacy_values = model_legacy_results_by_end_use_and_fuel_type(model, climate_zone, building_type, 'annual')
+    legacy_values = model_legacy_results_by_end_use_and_fuel_type(model, climate_zone, building_type, 'annual', lkp_template)
     if legacy_values.nil?
       OpenStudio.logFree(OpenStudio::Error, 'openstudio.standards.Model', "Could not find legacy idf results for #{search_criteria}")
       return legacy_results_hash
@@ -3159,8 +3165,8 @@ class Standard
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @param remap_office [bool] re-map small office or leave it alone
-  # @return [hash] key for climate zone and building type, both values are strings
-  def model_get_building_climate_zone_and_building_type(model, remap_office = true)
+  # @return [hash] key for climate zone, building type, and standards template.  All values are strings.
+  def model_get_building_properties(model, remap_office = true)
     # get climate zone from model
     climate_zone = model_standards_climate_zone(model)
 
@@ -3176,12 +3182,20 @@ class Standard
       building_type = model_remap_office(model, open_studio_area)
     end
 
+    # get standards template
+    if model.getBuilding.standardsTemplate.is_initialized
+      standards_template = model.getBuilding.standardsTemplate.get
+    end
+
     results = {}
     results['climate_zone'] = climate_zone
     results['building_type'] = building_type
+    results['standards_template'] = standards_template
 
     return results
   end
+
+
 
   # remap office to one of the prototype buildings
   #
@@ -3210,12 +3224,13 @@ class Standard
   # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @return [Double] EUI (MJ/m^2) for target template for given OSM. Returns nil if can't calculate EUI
   def model_find_target_eui(model)
-    building_data = model_get_building_climate_zone_and_building_type(model)
+    building_data = model_get_building_properties(model)
     climate_zone = building_data['climate_zone']
     building_type = building_data['building_type']
+    building_template = building_data['standards_template']
 
     # look up results
-    target_consumption = model_process_results_for_datapoint(model, climate_zone, building_type)
+    target_consumption = model_process_results_for_datapoint(model, climate_zone, building_type, lkp_template: building_template)
 
     # lookup target floor area for prototype buildings
     target_floor_area = model_find_prototype_floor_area(model, building_type)
@@ -3243,12 +3258,13 @@ class Standard
   # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @return [Hash] EUI (MJ/m^2) This will return a hash of end uses. key is end use, value is eui
   def model_find_target_eui_by_end_use(model)
-    building_data = model_get_building_climate_zone_and_building_type(model)
+    building_data = model_get_building_properties(model)
     climate_zone = building_data['climate_zone']
     building_type = building_data['building_type']
+    building_template = building_data['standards_template']
 
     # look up results
-    target_consumption = model_process_results_for_datapoint(model, climate_zone, building_type)
+    target_consumption = model_process_results_for_datapoint(model, climate_zone, building_type, lkp_template: building_template)
 
     # lookup target floor area for prototype buildings
     target_floor_area = model_find_prototype_floor_area(model, building_type)
@@ -3603,7 +3619,7 @@ class Standard
   # @return [Hash] hash of construction properties
   def model_get_construction_properties(model, intended_surface_type, standards_construction_type, building_category, climate_zone = nil)
     # get climate_zone_set
-    climate_zone = model_get_building_climate_zone_and_building_type(model)['climate_zone'] if climate_zone.nil?
+    climate_zone = model_get_building_properties(model)['climate_zone'] if climate_zone.nil?
     climate_zone_set = model_find_climate_zone_set(model, climate_zone)
 
     # populate search hash
@@ -4098,7 +4114,7 @@ class Standard
     # @todo for types not in table use standards area normalized swh values
 
     # get building type
-    building_data = model_get_building_climate_zone_and_building_type(model)
+    building_data = model_get_building_properties(model)
     building_type = building_data['building_type']
 
     result = []
@@ -4770,7 +4786,7 @@ class Standard
   # @param model [OpenStudio::Model::Model] the model
   # @return [String] the ventilation method, either Sum or Maximum
   def model_ventilation_method(model)
-    building_data = model_get_building_climate_zone_and_building_type(model)
+    building_data = model_get_building_properties(model)
     building_type = building_data['building_type']
     if building_type != 'Laboratory' # Laboratory has multiple criteria on ventilation, pick the greatest
       ventilation_method = 'Sum'

--- a/lib/openstudio-standards/standards/Standards.Model.rb
+++ b/lib/openstudio-standards/standards/Standards.Model.rb
@@ -3036,7 +3036,7 @@ class Standard
     legacy_results_hash['total_energy_by_end_use'] = {}
 
     # Get the legacy simulation results
-    legacy_values = model_legacy_results_by_end_use_and_fuel_type(model, climate_zone, building_type, 'annual', lkp_template)
+    legacy_values = model_legacy_results_by_end_use_and_fuel_type(model, climate_zone, building_type, 'annual', lkp_template: lkp_template)
     if legacy_values.nil?
       OpenStudio.logFree(OpenStudio::Error, 'openstudio.standards.Model', "Could not find legacy idf results for #{search_criteria}")
       return legacy_results_hash

--- a/lib/openstudio-standards/standards/Standards.SpaceType.rb
+++ b/lib/openstudio-standards/standards/Standards.SpaceType.rb
@@ -584,7 +584,7 @@ class Standard
                         end
 
     # get climate_zone_set
-    climate_zone = model_get_building_climate_zone_and_building_type(space_type.model)['climate_zone']
+    climate_zone = model_get_building_properties(space_type.model)['climate_zone']
     climate_zone_set = model_find_climate_zone_set(space_type.model, climate_zone)
 
     # populate search hash

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2019/ashrae_90_1_2019.AirLoopHVAC.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2019/ashrae_90_1_2019.AirLoopHVAC.rb
@@ -464,7 +464,7 @@ class ASHRAE9012019 < ASHRAE901
       # Check if air loop serves a non-transient dwelling unit,
       # currently non-transient dwelling units are residential
       # spaces in the apartment prototypes
-      building_data = model_get_building_climate_zone_and_building_type(air_loop_hvac.model)
+      building_data = model_get_building_properties(air_loop_hvac.model)
       building_type = building_data['building_type']
       nontrans_dwel = false
       if building_type == 'MidriseApartment' || building_type == 'HighriseApartment'

--- a/test/90_1_general/test_get_building_climate_zone_and_building_type.rb
+++ b/test/90_1_general/test_get_building_climate_zone_and_building_type.rb
@@ -20,7 +20,7 @@ class TestFindSpaceTypeStandardsData < Minitest::Test
     model.getClimateZones.setClimateZone("ASHRAE",climate_zones.first)
 
     # get climate zone
-    data = standard.model_get_building_climate_zone_and_building_type(model, remap_office = true)
+    data = standard.model_get_building_properties(model, remap_office = true)
     building_type = data[:building_type]
     climate_zone = data[:climate_zone]
 


### PR DESCRIPTION
Changes the model_get_building_climate_zone_and_building_type(model) method to model_get_building_properties(model) and returns the standards template as well if available.  Edit the model_find_target_eui(model) method tree to use the model template if available instead of the template used to build the Standards object.