### PR TITLE
Add assert to check for building type and climate zone to rule out La…

### DIFF
--- a/test/90_1_prm/test_appendix_g_prm.rb
+++ b/test/90_1_prm/test_appendix_g_prm.rb
@@ -32,6 +32,10 @@ class AppendixGPRMTests < Minitest::Test
       # mod is an array of method intended to modify the model
       building_type, template, climate_zone, user_data_dir, mod = prototype
 
+      climate_zone_code = climate_zone.split('-')[-1]
+      assert(building_type != 'LargeOffice' || ['0A', '0B', '1A', '1B', '2A', '2B'].include?(climate_zone_code), "Baseline model cannot be generated for #{building_type} in climate zone: #{climate_zone}. Use climate zone 0, 1 or 2 instead")
+
+
       # Concatenate modifier functions and arguments
       mod_str = mod.flatten.join('_') unless mod.empty?
 

--- a/test/90_1_prm/test_appendix_g_prm.rb
+++ b/test/90_1_prm/test_appendix_g_prm.rb
@@ -33,7 +33,7 @@ class AppendixGPRMTests < Minitest::Test
       building_type, template, climate_zone, user_data_dir, mod = prototype
 
       climate_zone_code = climate_zone.split('-')[-1]
-      assert(building_type != 'LargeOffice' || ['0A', '0B', '1A', '1B', '2A', '2B'].include?(climate_zone_code), "Baseline model cannot be generated for #{building_type} in climate zone: #{climate_zone}. Use climate zone 0, 1 or 2 instead")
+      assert(building_type != 'LargeOffice' || ['0A', '0B', '1A', '1B', '2A', '2B'].include?(climate_zone_code), "Baseline model cannot be generated for #{building_type} in climate zone: #{climate_zone}. Due to a known problem with sizing of heating system for data center (which has zero heating load), the large office model fails in mild to cold climates (CZ 3 and higher). Use climate zone 0, 1 or 2 instead")
 
 
       # Concatenate modifier functions and arguments


### PR DESCRIPTION
…rgeOffice + climate zone above 3 failure

I added an assertion at prototype generation method to stop the execution when there is LargeOffice at CZ3+ occurs.

The stop point will halt all simulations and return the error message to the CI or client, so there won't be waste time waiting for the results.

Not sure if this is what we wanted for the exception handling?