### PR TITLE
check and remove baseline piping losses

### DIFF
--- a/lib/openstudio-standards/standards/Standards.Model.rb
+++ b/lib/openstudio-standards/standards/Standards.Model.rb
@@ -242,12 +242,12 @@ class Standard
       # Remove all EMS objects from the model
       model_remove_prm_ems_objects(model)
 
-      if /prm/i !~ template
+      # if /prm/i !~ template
 
         # Modify the service water heating loops per the baseline rules
         OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.Model', '*** Cleaning up Service Water Heating Loops ***')
         model_apply_baseline_swh_loops(model, building_type)
-      end
+      # end
 
       # Determine the baseline HVAC system type for each of the groups of zones and add that system type.
       OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.Model', '*** Adding Baseline HVAC Systems ***')

--- a/test/90_1_prm/data/prototype_list.json
+++ b/test/90_1_prm/data/prototype_list.json
@@ -1,7 +1,6 @@
 {
     "wwr": [
-        ["SmallOffice", "90.1-2013", "ASHRAE 169-2013-2A", "no_user_data", []],
-        ["MidriseApartment", "90.1-2013", "ASHRAE 169-2013-2A", "no_user_data", [["remove_transformer", []]]]
+        ["MidriseApartment", "90.1-2019", "ASHRAE 169-2013-2A", "no_user_data", [["add_piping_insulation", []]]]
     ],
     "srr": [
         ["RetailStandalone", "90.1-2010", "ASHRAE 169-2013-2A", "no_user_data", [["increase_skylight_size", [10]]]]

--- a/test/90_1_prm/test_appendix_g_prm.rb
+++ b/test/90_1_prm/test_appendix_g_prm.rb
@@ -2214,6 +2214,19 @@ class AppendixGPRMTests < Minitest::Test
     return model
   end
 
+  # Add piping insulation to service heating water systems
+
+  def add_piping_insulation(model, arguments)
+    std = Standard.build('90.1-PRM-2019')
+    model.getPlantLoops.each do |plantloop|
+      if std.plant_loop_swh_loop?(plantloop)
+        std.model_add_piping_losses_to_swh_system(model, plantloop, true)
+      end
+    end
+
+    return model
+  end
+
   # Run test suite for the ASHRAE 90.1 appendix G Performance
   # Rating Method (PRM) baseline automation implementation
   # in openstudio-standards.


### PR DESCRIPTION
The prototype model was created with piping losses and the prm baseline automation process can  automatically remove the piping losses  for ASHRAE 90.1-2019 prm baseline models. 