### PR TITLE
Check user and baseline model(s) UMLH

### DIFF
--- a/lib/openstudio-standards/standards/Standards.ThermalZone.rb
+++ b/lib/openstudio-standards/standards/Standards.ThermalZone.rb
@@ -2077,4 +2077,32 @@ class Standard
   def thermal_zone_prm_lab_delta_t(thermal_zone)
     return nil
   end
+
+  # Determine the number of unmet load hours during occupancy for a thermal zone
+  #
+  # @param thermal_zone [OpenStudio::Model::ThermalZone] OpenStudio ThermalZone object
+  # @param umlh_type [String] Type of unmet load hours, either 'Cooling' or 'Heating'
+  def thermal_zone_get_unmet_load_hours(thermal_zone, umlh_type)
+    umlh = OpenStudio::OptionalDouble.new
+    sql = thermal_zone.model.sqlFile
+    if sql.is_initialized
+      sql = sql.get
+      query = "SELECT Value
+              FROM tabulardatawithstrings
+              WHERE ReportName='SystemSummary'
+              AND ReportForString='Entire Facility'
+              AND TableName='Time Setpoint Not Met'
+              AND ColumnName='During Occupied #{umlh_type.capitalize}'
+              AND RowName='#{thermal_zone.name.to_s.upcase}'
+              AND Units='hr'"
+      val = sql.execAndReturnFirstDouble(query)
+      if val.is_initialized
+        umlh = OpenStudio::OptionalDouble.new(val.get)
+      end
+    else
+      OpenStudio.logFree(OpenStudio::Error, 'openstudio.model.Model', 'Model has no sql file containing results, cannot lookup data.')
+    end
+
+    return umlh.to_f
+  end
 end

--- a/lib/openstudio-standards/standards/ashrae_90_1_prm/docs/unmet_load_hours.md
+++ b/lib/openstudio-standards/standards/ashrae_90_1_prm/docs/unmet_load_hours.md
@@ -1,0 +1,20 @@
+Unmet Load Hours (UMLH)
+
+# ASHRAE 90.1-2019
+Unmet load hours for the proposed design or baseline building design shall not exceed 300 (of the 8760 hours simulated). Alternatively, unmet load hours exceeding these limits shall be permitted to be accepted upon approval of the rating authority, provided that sufficient justification is given indicating that the accuracy of the simulation is not significantly compromised by these unmet loads. 
+
+# ASHRAE 90.1-2019 PRM Reference Manual
+If the automatic oversizing percentage is not sufficient to meet demands, then UMLH are evaluated at the building level by looking at the UMLH for each thermal zone being modeled. The first step would be to determine if the UMLH are high (>300) for the proposed building design as well as the baseline building. If that is the case, the issue is usually related to fan operation, HVAC availability, and occupancy schedules where the HVAC system has an incorrectly specified schedule that makes it unavailable during occupied hours. Optimal start controls, if a part of the building design, can also help eliminate UMLH during startup times. Since the same schedules are used for the baseline design, UMLH are seen in the baseline building as well. Other user inputs that could cause UMLH include incorrectly specified zone minimum airflows, which could result in unmet heating load hours. In this case, the software should notify the user and ask the user to verify schedules of operation. If a space is being conditioned via transfer air, it might be that the temperature of the transfer air is not sufficient to meet space conditioning requirements. 
+* If this is not the case and UMLH are seen only with the baseline design, the user or software tool is required to incrementally increase system airflows and equipment capacities, following the steps outlined below.
+  * In the case where UMLH for cooling are a bigger problem, the equipment in the baseline building model is resized by first increasing the design airflow of all zones with significant UMLH (greater than 150 for an individual zone) by 10%, increasing the design airflow of all zones with some UMLH (between 50 and 150) by 5%. Then, the equipment capacity for the system(s) serving the affected zones is increased to handle the increased zone loads. For the central plant, the chiller(s) and towers are resized proportionally to handle the increased system loads.
+  * In the case where UMLH for heating are a bigger problem, the same procedure is followed, with zone airflows resized first, then heating secondary equipment capacity and then boiler capacity as necessary. The capacity of the boiler or furnace shall be increased in proportion to capacities of coils required to meet the increased airflows at the baseline supply air. For heat pumps, the capacity of the coil is increased so that the additional load is not met by auxiliary heat.
+
+# Implementation
+The user model unmet load hours are checked as the first step of the baseline generation process. If the number is greater than 300, an error is published and the process is stopped. This requires the user to address the UMLH in the user/proposed model prior to generating the baseline model(s) which can be take some time.
+
+At the end of the process, each baseline model's UMLH are checked. if the number is greater than 300, the process go through each zone and adjust the zone sizing factor by either increasing it by 5% or 10% for zones having respectively UMLH between 50 and 150 and greater than 150. Then, the model is re-ran and the check/adjustments are performed again until the number of UMLH is below 300. 
+
+# Key Ruby Methods 
+## New
+* `model_get_unmet_load_hours`: get the total unmet load hours during occupancy of a model that has been simulated
+* `thermal_zone_get_unmet_load_hours`: determine the number of unmet load hours during occupancy for a thermal zone

--- a/test/90_1_prm/data/prototype_list.json
+++ b/test/90_1_prm/data/prototype_list.json
@@ -148,5 +148,8 @@
     "return_air_type": [
         ["LargeOffice", "90.1-2004", "ASHRAE 169-2013-2A", "userdata_default_test",[["remove_transformer", []]]],
         ["PrimarySchool", "90.1-2013", "ASHRAE 169-2013-4A", "userdata_default_test", [["remove_transformer", []]]]
+    ],
+    "unmet_load_hours": [
+        ["SmallOffice", "90.1-2004", "ASHRAE 169-2013-2A", "userdata_default_test",[["unmet_load_hours", []]]]
     ]
 }

--- a/test/90_1_prm/test_appendix_g_prm.rb
+++ b/test/90_1_prm/test_appendix_g_prm.rb
@@ -179,12 +179,14 @@ class AppendixGPRMTests < Minitest::Test
         hvac_building_type = @bldg_type_alt[id_prototype_mapping[id]]
       end
 
+      unmet_load_hours = (mod_str == 'unmet_load_hours') ? true : false
+
       # Create baseline model
       model_baseline = @prototype_creator.model_create_prm_stable_baseline_building(model, building_type, climate_zone,
                                                                                     @@hvac_building_types[hvac_building_type],
                                                                                     @@wwr_building_types[building_type],
                                                                                     @@swh_building_types[building_type],
-                                                                                    nil, run_dir_baseline, false, false)
+                                                                                    nil, run_dir_baseline, false, unmet_load_hours, false)
 
       # Check if baseline could be created
       assert(model_baseline, "Baseline model could not be generated for #{building_type}, #{template}, #{climate_zone}.")
@@ -1342,7 +1344,8 @@ class AppendixGPRMTests < Minitest::Test
   end
 
   # Check the model's secondary flow fraction
-  # @param model [OpenStudio::Model::AirTerminalSingleDuctParallelPIUReheat] Parallel PIU terminal
+  # @param terminal [OpenStudio::Model::AirTerminalSingleDuctParallelPIUReheat] Parallel PIU terminal
+  # @param mod_str [String] Run description
   def check_secondary_flow_fraction(terminal, mod_str)
     if terminal.maximumSecondaryAirFlowRate.is_initialized
       secondary_flow = terminal.maximumSecondaryAirFlowRate.get.to_f
@@ -2059,6 +2062,27 @@ class AppendixGPRMTests < Minitest::Test
     end
   end
 
+  # Check model unmet load hours
+  #
+  # @param prototypes_base [Hash] Baseline prototypes
+  def check_unmet_load_hours(prototypes_base)
+    standard = Standard.build('90.1-PRM-2019')
+    prototypes_base.each do |prototype, model|
+      building_type, template, climate_zone, mod = prototype
+
+      assert(standard.model_get_unmet_load_hours(model) < 300, "The #{building_type} prototype building model has more than 300 unmet load hours.")
+    end
+  end
+
+  # Placeholder method to indicate that we want to check unmet
+  # load hours
+  #
+  # @param model [OpenStudio::model::Model] OpenStudio model object
+  # @param arguments [Array] Not used
+  def unmet_load_hours(model, arguments)
+    return model
+  end
+
   # Add a AirLoopHVACDedicatedOutdoorAirSystem in the model
   #
   # @param model [OpenStudio::model::Model] OpenStudio model object
@@ -2546,6 +2570,7 @@ class AppendixGPRMTests < Minitest::Test
       'multi_bldg_handling',
       'economizer_exception',
       'building_rotation_check',
+      'unmet_load_hours',
     ]
 
     # Get list of unique prototypes
@@ -2585,5 +2610,6 @@ class AppendixGPRMTests < Minitest::Test
     check_f_c_factors(prototypes_base['f_c_factors']) if tests.include? 'f_c_factors'
     check_fan_power_credits(prototypes_base['fan_power_credits']) if tests.include? 'fan_power_credits'
     check_return_air_type(prototypes_base['return_air_type']) if tests.include? 'return_air_type'
+    check_unmet_load_hours(prototypes_base['unmet_load_hours']) if tests.include? 'unmet_load_hours'
   end
 end


### PR DESCRIPTION
The proposed changes add a set of verification to make sure that both the user and baseline model(s) meet section G3.1.2.3 of ASHRAE 90.1 Appendix G. Adjustments are made to the baseline model if the first version of the model ends up having unmet load hours (UMLH). The adjustment follow the recommendation from the ASHRAE 90.1-2019 PRM Reference Manual.