### PR TITLE
always off schedule comstock small hotel elevator

### DIFF
--- a/lib/openstudio-standards/standards/ashrae_90_1/doe_ref_1980_2004/comstock_doe_ref_1980_2004/data/comstock_doe_ref_1980_2004.spc_typ.json
+++ b/lib/openstudio-standards/standards/ashrae_90_1/doe_ref_1980_2004/comstock_doe_ref_1980_2004/data/comstock_doe_ref_1980_2004.spc_typ.json
@@ -15572,7 +15572,7 @@
       "lpd_fraction_high_bay": 0.0,
       "lpd_fraction_specialty_lighting": 0.0437,
       "lpd_fraction_exit_lighting": 0.0229,
-      "lighting_schedule": null,
+      "lighting_schedule": "HotelSmall AlwaysOff",
       "compact_fluorescent_lighting_schedule": null,
       "high_bay_lighting_schedule": null,
       "specialty_lighting_schedule": null,

--- a/lib/openstudio-standards/standards/ashrae_90_1/doe_ref_pre_1980/comstock_doe_ref_pre_1980/data/comstock_doe_ref_pre_1980.spc_typ.json
+++ b/lib/openstudio-standards/standards/ashrae_90_1/doe_ref_pre_1980/comstock_doe_ref_pre_1980/data/comstock_doe_ref_pre_1980.spc_typ.json
@@ -15396,7 +15396,7 @@
       "lpd_fraction_high_bay": 0.0,
       "lpd_fraction_specialty_lighting": 0.0437,
       "lpd_fraction_exit_lighting": 0.0229,
-      "lighting_schedule": null,
+      "lighting_schedule": "HotelSmall AlwaysOff",
       "compact_fluorescent_lighting_schedule": null,
       "high_bay_lighting_schedule": null,
       "specialty_lighting_schedule": null,


### PR DESCRIPTION
pre 2004 vintages for small hotel elevator core didn't have a schedule set.  This adds the always off schedule, matching the other vintages.