### PR TITLE
update chiller staging method

### DIFF
--- a/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.PlantLoop.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.PlantLoop.rb
@@ -157,7 +157,8 @@ class ASHRAE901PRM < Standard
     chiller_compressor_type = nil
 
     # Set the equipment to stage sequentially
-    plant_loop.setLoadDistributionScheme('SequentialLoad')
+    #plant_loop.setLoadDistributionScheme('SequentialLoad')
+    plant_loop.setLoadDistributionScheme('SequentialUniformPLR')
 
     # Determine the capacity of the loop
     cap_w = plant_loop_total_cooling_capacity(plant_loop, sizing_run_dir)

--- a/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.PlantLoop.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.PlantLoop.rb
@@ -157,7 +157,6 @@ class ASHRAE901PRM < Standard
     chiller_compressor_type = nil
 
     # Set the equipment to stage sequentially
-    #plant_loop.setLoadDistributionScheme('SequentialLoad')
     plant_loop.setLoadDistributionScheme('SequentialUniformPLR')
 
     # Determine the capacity of the loop


### PR DESCRIPTION
From PRM-RM:
Software shall bring the first boiler to 100% capacity prior to the staging of the next boiler.
When more than one chiller is required in the baseline design, each chiller shall run to full capacity prior to staging of the next chiller. When more than one chiller is operational, then the load shall be shared equally among all the chillers.

The current boiler's setting is correct and the chiller's setting is updated from 'SequentialLoad' into 'SequentialUniformPLR'.