### PR TITLE
Fixes #1372 by updating VentilationRateProcedure enumerations

### DIFF
--- a/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2004/ashrae_90_1_2004.AirTerminalSingleDuctVAVReheat.rb
+++ b/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2004/ashrae_90_1_2004.AirTerminalSingleDuctVAVReheat.rb
@@ -7,12 +7,9 @@ class ASHRAE9012004 < ASHRAE901
   # @param air_terminal_single_duct_vav_reheat [OpenStudio::Model::AirTerminalSingleDuctVAVReheat] the air terminal object
   # @param zone_oa_per_area [Double] the zone outdoor air per area in m^3/s*m^2
   # @return [Bool] returns true if successful, false if not
-  def air_terminal_single_duct_vav_reheat_apply_initial_prototype_damper_position(air_terminal_single_duct_vav_reheat, zone_oa_per_area)
+  def air_terminal_single_duct_vav_reheat_initial_prototype_damper_position(air_terminal_single_duct_vav_reheat, zone_oa_per_area)
     min_damper_position = 0.3
 
-    # Set the minimum flow fraction
-    air_terminal_single_duct_vav_reheat.setConstantMinimumAirFlowFraction(min_damper_position)
-
-    return true
+    return min_damper_position
   end
 end

--- a/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2007/ashrae_90_1_2007.AirTerminalSingleDuctVAVReheat.rb
+++ b/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2007/ashrae_90_1_2007.AirTerminalSingleDuctVAVReheat.rb
@@ -7,12 +7,9 @@ class ASHRAE9012007 < ASHRAE901
   # @param air_terminal_single_duct_vav_reheat [OpenStudio::Model::AirTerminalSingleDuctVAVReheat] the air terminal object
   # @param zone_oa_per_area [Double] the zone outdoor air per area in m^3/s*m^2
   # @return [Bool] returns true if successful, false if not
-  def air_terminal_single_duct_vav_reheat_apply_initial_prototype_damper_position(air_terminal_single_duct_vav_reheat, zone_oa_per_area)
+  def air_terminal_single_duct_vav_reheat_initial_prototype_damper_position(air_terminal_single_duct_vav_reheat, zone_oa_per_area)
     min_damper_position = 0.3
 
-    # Set the minimum flow fraction
-    air_terminal_single_duct_vav_reheat.setConstantMinimumAirFlowFraction(min_damper_position)
-
-    return true
+    return min_damper_position
   end
 end

--- a/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2010/ashrae_90_1_2010.AirTerminalSingleDuctVAVReheat.rb
+++ b/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2010/ashrae_90_1_2010.AirTerminalSingleDuctVAVReheat.rb
@@ -7,7 +7,7 @@ class ASHRAE9012010 < ASHRAE901
   # @param air_terminal_single_duct_vav_reheat [OpenStudio::Model::AirTerminalSingleDuctVAVReheat] the air terminal object
   # @param zone_oa_per_area [Double] the zone outdoor air per area in m^3/s*m^2
   # @return [Bool] returns true if successful, false if not
-  def air_terminal_single_duct_vav_reheat_apply_initial_prototype_damper_position(air_terminal_single_duct_vav_reheat, zone_oa_per_area)
+  def air_terminal_single_duct_vav_reheat_initial_prototype_damper_position(air_terminal_single_duct_vav_reheat, zone_oa_per_area)
     min_damper_position = case air_terminal_single_duct_vav_reheat_reheat_type(air_terminal_single_duct_vav_reheat)
                           when 'HotWater'
                             0.2
@@ -15,9 +15,6 @@ class ASHRAE9012010 < ASHRAE901
                             0.3
                           end
 
-    # Set the minimum flow fraction
-    air_terminal_single_duct_vav_reheat.setConstantMinimumAirFlowFraction(min_damper_position)
-
-    return true
+    return min_damper_position
   end
 end

--- a/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2013/ashrae_90_1_2013.AirTerminalSingleDuctVAVReheat.rb
+++ b/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2013/ashrae_90_1_2013.AirTerminalSingleDuctVAVReheat.rb
@@ -7,7 +7,7 @@ class ASHRAE9012013 < ASHRAE901
   # @param air_terminal_single_duct_vav_reheat [OpenStudio::Model::AirTerminalSingleDuctVAVReheat] the air terminal object
   # @param zone_oa_per_area [Double] the zone outdoor air per area in m^3/s*m^2
   # @return [Bool] returns true if successful, false if not
-  def air_terminal_single_duct_vav_reheat_apply_initial_prototype_damper_position(air_terminal_single_duct_vav_reheat, zone_oa_per_area)
+  def air_terminal_single_duct_vav_reheat_initial_prototype_damper_position(air_terminal_single_duct_vav_reheat, zone_oa_per_area)
     min_damper_position = case air_terminal_single_duct_vav_reheat_reheat_type(air_terminal_single_duct_vav_reheat)
                           when 'HotWater'
                             0.2
@@ -17,9 +17,6 @@ class ASHRAE9012013 < ASHRAE901
                             0.2
                           end
 
-    # Set the minimum flow fraction
-    air_terminal_single_duct_vav_reheat.setConstantMinimumAirFlowFraction(min_damper_position)
-
-    return true
+    return min_damper_position
   end
 end

--- a/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2016/ashrae_90_1_2016.AirTerminalSingleDuctVAVReheat.rb
+++ b/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2016/ashrae_90_1_2016.AirTerminalSingleDuctVAVReheat.rb
@@ -7,7 +7,7 @@ class ASHRAE9012016 < ASHRAE901
   # @param air_terminal_single_duct_vav_reheat [OpenStudio::Model::AirTerminalSingleDuctVAVReheat] the air terminal object
   # @param zone_oa_per_area [Double] the zone outdoor air per area in m^3/s*m^2
   # @return [Bool] returns true if successful, false if not
-  def air_terminal_single_duct_vav_reheat_apply_initial_prototype_damper_position(air_terminal_single_duct_vav_reheat, zone_oa_per_area)
+  def air_terminal_single_duct_vav_reheat_initial_prototype_damper_position(air_terminal_single_duct_vav_reheat, zone_oa_per_area)
     min_damper_position = case air_terminal_single_duct_vav_reheat_reheat_type(air_terminal_single_duct_vav_reheat)
                           when 'HotWater'
                             0.2
@@ -17,9 +17,6 @@ class ASHRAE9012016 < ASHRAE901
                             0.2
                           end
 
-    # Set the minimum flow fraction
-    air_terminal_single_duct_vav_reheat.setConstantMinimumAirFlowFraction(min_damper_position)
-
-    return true
+    return min_damper_position
   end
 end

--- a/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2019/ashrae_90_1_2019.AirTerminalSingleDuctVAVReheat.rb
+++ b/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2019/ashrae_90_1_2019.AirTerminalSingleDuctVAVReheat.rb
@@ -7,7 +7,7 @@ class ASHRAE9012019 < ASHRAE901
   # @param air_terminal_single_duct_vav_reheat [OpenStudio::Model::AirTerminalSingleDuctVAVReheat] the air terminal object
   # @param zone_oa_per_area [Double] the zone outdoor air per area in m^3/s*m^2
   # @return [Bool] returns true if successful, false if not
-  def air_terminal_single_duct_vav_reheat_apply_initial_prototype_damper_position(air_terminal_single_duct_vav_reheat, zone_oa_per_area)
+  def air_terminal_single_duct_vav_reheat_initial_prototype_damper_position(air_terminal_single_duct_vav_reheat, zone_oa_per_area)
     min_damper_position = case air_terminal_single_duct_vav_reheat_reheat_type(air_terminal_single_duct_vav_reheat)
                           when 'HotWater'
                             0.2
@@ -17,9 +17,6 @@ class ASHRAE9012019 < ASHRAE901
                             0.2
                           end
 
-    # Set the minimum flow fraction
-    air_terminal_single_duct_vav_reheat.setConstantMinimumAirFlowFraction(min_damper_position)
-
-    return true
+    return min_damper_position
   end
 end

--- a/lib/openstudio-standards/prototypes/ashrae_90_1/doe_ref_1980_2004/doe_ref_1980_2004.AirTerminalSingleDuctVAVReheat.rb
+++ b/lib/openstudio-standards/prototypes/ashrae_90_1/doe_ref_1980_2004/doe_ref_1980_2004.AirTerminalSingleDuctVAVReheat.rb
@@ -7,11 +7,10 @@ class DOERef1980to2004 < ASHRAE901
   # @param air_terminal_single_duct_vav_reheat [OpenStudio::Model::AirTerminalSingleDuctVAVReheat] the air terminal object
   # @param zone_oa_per_area [Double] the zone outdoor air per area in m^3/s*m^2
   # @return [Bool] returns true if successful, false if not
-  def air_terminal_single_duct_vav_reheat_apply_initial_prototype_damper_position(air_terminal_single_duct_vav_reheat, zone_oa_per_area)
+  def air_terminal_single_duct_vav_reheat_initial_prototype_damper_position(air_terminal_single_duct_vav_reheat, zone_oa_per_area)
     # Set the minimum flow fraction
     min_damper_position = 0.3
-    air_terminal_single_duct_vav_reheat.setConstantMinimumAirFlowFraction(min_damper_position)
 
-    return true
+    return min_damper_position
   end
 end

--- a/lib/openstudio-standards/prototypes/ashrae_90_1/doe_ref_pre_1980/doe_ref_pre_1980.AirTerminalSingleDuctVAVReheat.rb
+++ b/lib/openstudio-standards/prototypes/ashrae_90_1/doe_ref_pre_1980/doe_ref_pre_1980.AirTerminalSingleDuctVAVReheat.rb
@@ -7,11 +7,10 @@ class DOERefPre1980 < ASHRAE901
   # @param air_terminal_single_duct_vav_reheat [OpenStudio::Model::AirTerminalSingleDuctVAVReheat] the air terminal object
   # @param zone_oa_per_area [Double] the zone outdoor air per area in m^3/s*m^2
   # @return [Bool] returns true if successful, false if not
-  def air_terminal_single_duct_vav_reheat_apply_initial_prototype_damper_position(air_terminal_single_duct_vav_reheat, zone_oa_per_area)
+  def air_terminal_single_duct_vav_reheat_initial_prototype_damper_position(air_terminal_single_duct_vav_reheat, zone_oa_per_area)
     # Set the minimum flow fraction
     min_damper_position = 0.3
-    air_terminal_single_duct_vav_reheat.setConstantMinimumAirFlowFraction(min_damper_position)
 
-    return true
+    return min_damper_position
   end
 end

--- a/lib/openstudio-standards/prototypes/ashrae_90_1/nrel_nze_ready_2017/nrel_zne_ready_2017.AirTerminalSingleDuctVAVReheat.rb
+++ b/lib/openstudio-standards/prototypes/ashrae_90_1/nrel_nze_ready_2017/nrel_zne_ready_2017.AirTerminalSingleDuctVAVReheat.rb
@@ -7,7 +7,7 @@ class NRELZNEReady2017 < ASHRAE901
   # @param air_terminal_single_duct_vav_reheat [OpenStudio::Model::AirTerminalSingleDuctVAVReheat] the air terminal object
   # @param zone_oa_per_area [Double] the zone outdoor air per area in m^3/s*m^2
   # @return [Bool] returns true if successful, false if not
-  def air_terminal_single_duct_vav_reheat_apply_initial_prototype_damper_position(air_terminal_single_duct_vav_reheat, zone_oa_per_area)
+  def air_terminal_single_duct_vav_reheat_initial_prototype_damper_position(air_terminal_single_duct_vav_reheat, zone_oa_per_area)
     min_damper_position = case air_terminal_single_duct_vav_reheat_reheat_type(air_terminal_single_duct_vav_reheat)
                           when 'HotWater'
                             0.2
@@ -15,9 +15,6 @@ class NRELZNEReady2017 < ASHRAE901
                             0.3
                           end
 
-    # Set the minimum flow fraction
-    air_terminal_single_duct_vav_reheat.setConstantMinimumAirFlowFraction(min_damper_position)
-
-    return true
+    return min_damper_position
   end
 end

--- a/lib/openstudio-standards/prototypes/ashrae_90_1/ze_aedg_multifamily/ze_aedg_multifamily.AirTerminalSingleDuctVAVReheat.rb
+++ b/lib/openstudio-standards/prototypes/ashrae_90_1/ze_aedg_multifamily/ze_aedg_multifamily.AirTerminalSingleDuctVAVReheat.rb
@@ -7,7 +7,7 @@ class ZEAEDGMultifamily < ASHRAE901
   # @param air_terminal_single_duct_vav_reheat [OpenStudio::Model::AirTerminalSingleDuctVAVReheat] the air terminal object
   # @param zone_oa_per_area [Double] the zone outdoor air per area in m^3/s*m^2
   # @return [Bool] returns true if successful, false if not
-  def air_terminal_single_duct_vav_reheat_apply_initial_prototype_damper_position(air_terminal_single_duct_vav_reheat, zone_oa_per_area)
+  def air_terminal_single_duct_vav_reheat_initial_prototype_damper_position(air_terminal_single_duct_vav_reheat, zone_oa_per_area)
     min_damper_position = case air_terminal_single_duct_vav_reheat_reheat_type(air_terminal_single_duct_vav_reheat)
                           when 'HotWater'
                             0.2
@@ -15,9 +15,6 @@ class ZEAEDGMultifamily < ASHRAE901
                             0.3
                           end
 
-    # Set the minimum flow fraction
-    air_terminal_single_duct_vav_reheat.setConstantMinimumAirFlowFraction(min_damper_position)
-
-    return true
+    return min_damper_position
   end
 end

--- a/lib/openstudio-standards/prototypes/common/buildings/Prototype.Hospital.rb
+++ b/lib/openstudio-standards/prototypes/common/buildings/Prototype.Hospital.rb
@@ -404,13 +404,10 @@ module Hospital
   # @param air_terminal_single_duct_vav_reheat [OpenStudio::Model::AirTerminalSingleDuctVAVReheat] the air terminal object
   # @param zone_oa_per_area [Double] the zone outdoor air per area in m^3/s*m^2
   # @return [Bool] returns true if successful, false if not
-  def air_terminal_single_duct_vav_reheat_apply_initial_prototype_damper_position(air_terminal_single_duct_vav_reheat, zone_oa_per_area)
+  def air_terminal_single_duct_vav_reheat_initial_prototype_damper_position(air_terminal_single_duct_vav_reheat, zone_oa_per_area)
     min_damper_position = template == '90.1-2010' || template == '90.1-2013' || template == '90.1-2016' || template == '90.1-2019' ? 0.2 : 0.3
 
-    # Set the minimum flow fraction
-    air_terminal_single_duct_vav_reheat.setConstantMinimumAirFlowFraction(min_damper_position)
-
-    return true
+    return min_damper_position
   end
 
   # Type of SAT reset for this building type

--- a/lib/openstudio-standards/prototypes/common/buildings/Prototype.LargeHotel.rb
+++ b/lib/openstudio-standards/prototypes/common/buildings/Prototype.LargeHotel.rb
@@ -254,13 +254,10 @@ module LargeHotel
   # @param air_terminal_single_duct_vav_reheat [OpenStudio::Model::AirTerminalSingleDuctVAVReheat] the air terminal object
   # @param zone_oa_per_area [Double] the zone outdoor air per area in m^3/s*m^2
   # @return [Bool] returns true if successful, false if not
-  def air_terminal_single_duct_vav_reheat_apply_initial_prototype_damper_position(air_terminal_single_duct_vav_reheat, zone_oa_per_area)
+  def air_terminal_single_duct_vav_reheat_initial_prototype_damper_position(air_terminal_single_duct_vav_reheat, zone_oa_per_area)
     min_damper_position = template == '90.1-2010' || template == '90.1-2013' || template == '90.1-2016' || template == '90.1-2019' ? 0.2 : 0.3
 
-    # Set the minimum flow fraction
-    air_terminal_single_duct_vav_reheat.setConstantMinimumAirFlowFraction(min_damper_position)
-
-    return true
+    return min_damper_position
   end
 
   # Type of SAT reset for this building type

--- a/lib/openstudio-standards/prototypes/common/buildings/Prototype.LargeOffice.rb
+++ b/lib/openstudio-standards/prototypes/common/buildings/Prototype.LargeOffice.rb
@@ -146,13 +146,10 @@ module LargeOffice
   # @param air_terminal_single_duct_vav_reheat [OpenStudio::Model::AirTerminalSingleDuctVAVReheat] the air terminal object
   # @param zone_oa_per_area [Double] the zone outdoor air per area in m^3/s*m^2
   # @return [Bool] returns true if successful, false if not
-  def air_terminal_single_duct_vav_reheat_apply_initial_prototype_damper_position(air_terminal_single_duct_vav_reheat, zone_oa_per_area)
+  def air_terminal_single_duct_vav_reheat_initial_prototype_damper_position(air_terminal_single_duct_vav_reheat, zone_oa_per_area)
     min_damper_position = template == '90.1-2010' || template == '90.1-2013' || template == '90.1-2016' || template == '90.1-2019' ? 0.2 : 0.3
 
-    # Set the minimum flow fraction
-    air_terminal_single_duct_vav_reheat.setConstantMinimumAirFlowFraction(min_damper_position)
-
-    return true
+    return min_damper_position
   end
 
   # Type of SAT reset for this building type

--- a/lib/openstudio-standards/prototypes/common/buildings/Prototype.LargeOfficeDetailed.rb
+++ b/lib/openstudio-standards/prototypes/common/buildings/Prototype.LargeOfficeDetailed.rb
@@ -148,12 +148,9 @@ module LargeOfficeDetailed
   # @param air_terminal_single_duct_vav_reheat [OpenStudio::Model::AirTerminalSingleDuctVAVReheat] the air terminal object
   # @param zone_oa_per_area [Double] the zone outdoor air per area in m^3/s*m^2
   # @return [Bool] returns true if successful, false if not
-  def air_terminal_single_duct_vav_reheat_apply_initial_prototype_damper_position(air_terminal_single_duct_vav_reheat, zone_oa_per_area)
+  def air_terminal_single_duct_vav_reheat_initial_prototype_damper_position(air_terminal_single_duct_vav_reheat, zone_oa_per_area)
     min_damper_position = template == '90.1-2010' || template == '90.1-2013' || template == '90.1-2016' || template == '90.1-2019' ? 0.2 : 0.3
 
-    # Set the minimum flow fraction
-    air_terminal_single_duct_vav_reheat.setConstantMinimumAirFlowFraction(min_damper_position)
-
-    return true
+    return min_damper_position
   end
 end

--- a/lib/openstudio-standards/prototypes/common/buildings/Prototype.MediumOffice.rb
+++ b/lib/openstudio-standards/prototypes/common/buildings/Prototype.MediumOffice.rb
@@ -164,13 +164,10 @@ module MediumOffice
   # @param air_terminal_single_duct_vav_reheat [OpenStudio::Model::AirTerminalSingleDuctVAVReheat] the air terminal object
   # @param zone_oa_per_area [Double] the zone outdoor air per area in m^3/s*m^2
   # @return [Bool] returns true if successful, false if not
-  def air_terminal_single_duct_vav_reheat_apply_initial_prototype_damper_position(air_terminal_single_duct_vav_reheat, zone_oa_per_area)
+  def air_terminal_single_duct_vav_reheat_initial_prototype_damper_position(air_terminal_single_duct_vav_reheat, zone_oa_per_area)
     min_damper_position = template == '90.1-2010' || template == '90.1-2013' || template == '90.1-2016' || template == '90.1-2019' ? 0.2 : 0.3
 
-    # Set the minimum flow fraction
-    air_terminal_single_duct_vav_reheat.setConstantMinimumAirFlowFraction(min_damper_position)
-
-    return true
+    return min_damper_position
   end
 
   # Type of SAT reset for this building type

--- a/lib/openstudio-standards/prototypes/common/buildings/Prototype.MediumOfficeDetailed.rb
+++ b/lib/openstudio-standards/prototypes/common/buildings/Prototype.MediumOfficeDetailed.rb
@@ -174,12 +174,9 @@ module MediumOfficeDetailed
   # @param air_terminal_single_duct_vav_reheat [OpenStudio::Model::AirTerminalSingleDuctVAVReheat] the air terminal object
   # @param zone_oa_per_area [Double] the zone outdoor air per area in m^3/s*m^2
   # @return [Bool] returns true if successful, false if not
-  def air_terminal_single_duct_vav_reheat_apply_initial_prototype_damper_position(air_terminal_single_duct_vav_reheat, zone_oa_per_area)
+  def air_terminal_single_duct_vav_reheat_initial_prototype_damper_position(air_terminal_single_duct_vav_reheat, zone_oa_per_area)
     min_damper_position = template == '90.1-2010' || template == '90.1-2013' || template == '90.1-2016' || template == '90.1-2019' ? 0.2 : 0.3
 
-    # Set the minimum flow fraction
-    air_terminal_single_duct_vav_reheat.setConstantMinimumAirFlowFraction(min_damper_position)
-
-    return true
+    return min_damper_position
   end
 end

--- a/lib/openstudio-standards/prototypes/common/buildings/Prototype.Outpatient.rb
+++ b/lib/openstudio-standards/prototypes/common/buildings/Prototype.Outpatient.rb
@@ -516,7 +516,7 @@ module Outpatient
   # @param air_terminal_single_duct_vav_reheat [OpenStudio::Model::AirTerminalSingleDuctVAVReheat] the air terminal object
   # @param zone_oa_per_area [Double] the zone outdoor air per area in m^3/s*m^2
   # @return [Bool] returns true if successful, false if not
-  def air_terminal_single_duct_vav_reheat_apply_initial_prototype_damper_position(air_terminal_single_duct_vav_reheat, zone_oa_per_area)
+  def air_terminal_single_duct_vav_reheat_initial_prototype_damper_position(air_terminal_single_duct_vav_reheat, zone_oa_per_area)
     # Minimum damper position
     # Based on AIA 2001 ventilation requirements
     # See Section 5.2.2.16 in Thornton et al. 2010
@@ -580,10 +580,7 @@ module Outpatient
       min_damper_position = 0.3
     end
 
-    # Set the minimum flow fraction
-    air_terminal_single_duct_vav_reheat.setConstantMinimumAirFlowFraction(min_damper_position)
-
-    return true
+    return min_damper_position
   end
 
   # Type of SAT reset for this building type

--- a/lib/openstudio-standards/prototypes/common/buildings/Prototype.PrimarySchool.rb
+++ b/lib/openstudio-standards/prototypes/common/buildings/Prototype.PrimarySchool.rb
@@ -126,13 +126,10 @@ module PrimarySchool
   # @param air_terminal_single_duct_vav_reheat [OpenStudio::Model::AirTerminalSingleDuctVAVReheat] the air terminal object
   # @param zone_oa_per_area [Double] the zone outdoor air per area in m^3/s*m^2
   # @return [Bool] returns true if successful, false if not
-  def air_terminal_single_duct_vav_reheat_apply_initial_prototype_damper_position(air_terminal_single_duct_vav_reheat, zone_oa_per_area)
+  def air_terminal_single_duct_vav_reheat_initial_prototype_damper_position(air_terminal_single_duct_vav_reheat, zone_oa_per_area)
     min_damper_position = template == '90.1-2010' || template == '90.1-2013' || template == '90.1-2016' || template == '90.1-2019' ? 0.2 : 0.3
 
-    # Set the minimum flow fraction
-    air_terminal_single_duct_vav_reheat.setConstantMinimumAirFlowFraction(min_damper_position)
-
-    return true
+    return min_damper_position
   end
 
   # Type of SAT reset for this building type

--- a/lib/openstudio-standards/prototypes/common/buildings/Prototype.SecondarySchool.rb
+++ b/lib/openstudio-standards/prototypes/common/buildings/Prototype.SecondarySchool.rb
@@ -168,13 +168,10 @@ module SecondarySchool
   # @param air_terminal_single_duct_vav_reheat [OpenStudio::Model::AirTerminalSingleDuctVAVReheat] the air terminal object
   # @param zone_oa_per_area [Double] the zone outdoor air per area in m^3/s*m^2
   # @return [Bool] returns true if successful, false if not
-  def air_terminal_single_duct_vav_reheat_apply_initial_prototype_damper_position(air_terminal_single_duct_vav_reheat, zone_oa_per_area)
+  def air_terminal_single_duct_vav_reheat_initial_prototype_damper_position(air_terminal_single_duct_vav_reheat, zone_oa_per_area)
     min_damper_position = template == '90.1-2010' || template == '90.1-2013' || template == '90.1-2016' || template == '90.1-2019' ? 0.2 : 0.3
 
-    # Set the minimum flow fraction
-    air_terminal_single_duct_vav_reheat.setConstantMinimumAirFlowFraction(min_damper_position)
-
-    return true
+    return min_damper_position
   end
 
   # Type of SAT reset for this building type

--- a/lib/openstudio-standards/prototypes/common/objects/Prototype.AirTerminalSingleDuctVAVReheat.rb
+++ b/lib/openstudio-standards/prototypes/common/objects/Prototype.AirTerminalSingleDuctVAVReheat.rb
@@ -8,12 +8,9 @@ class Standard
   # @param air_terminal_single_duct_vav_reheat [OpenStudio::Model::AirTerminalSingleDuctVAVReheat] the air terminal object
   # @param zone_oa_per_area [Double] the zone outdoor air per area in m^3/s*m^2
   # @return [Bool] returns true if successful, false if not
-  def air_terminal_single_duct_vav_reheat_apply_initial_prototype_damper_position(air_terminal_single_duct_vav_reheat, zone_oa_per_area)
+  def air_terminal_single_duct_vav_reheat_initial_prototype_damper_position(air_terminal_single_duct_vav_reheat, zone_oa_per_area)
     min_damper_position = 0.3
 
-    # Set the minimum flow fraction
-    air_terminal_single_duct_vav_reheat.setConstantMinimumAirFlowFraction(min_damper_position)
-
-    return true
+    return min_damper_position
   end
 end

--- a/lib/openstudio-standards/prototypes/common/objects/Prototype.SizingSystem.rb
+++ b/lib/openstudio-standards/prototypes/common/objects/Prototype.SizingSystem.rb
@@ -57,7 +57,11 @@ class Standard
     end
 
     sizing_system = air_loop_hvac.sizingSystem
-    sizing_system.setSystemOutdoorAirMethod('VentilationRateProcedure')
+    if air_loop_hvac.model.version < OpenStudio::VersionString.new('3.3.0')
+      sizing_system.setSystemOutdoorAirMethod('VentilationRateProcedure')
+    else
+      sizing_system.setSystemOutdoorAirMethod('Standard62.1VentilationRateProcedure')
+    end
     # Set the minimum zone ventilation efficiency to be 0.6
     air_loop_hvac.thermalZones.sort.each do |zone|
       sizing_zone = zone.sizingZone

--- a/lib/openstudio-standards/prototypes/common/objects/Prototype.SizingSystem.rb
+++ b/lib/openstudio-standards/prototypes/common/objects/Prototype.SizingSystem.rb
@@ -62,15 +62,6 @@ class Standard
     else
       sizing_system.setSystemOutdoorAirMethod('Standard62.1VentilationRateProcedure')
     end
-    # Set the minimum zone ventilation efficiency to be 0.6
-    air_loop_hvac.thermalZones.sort.each do |zone|
-      sizing_zone = zone.sizingZone
-      if air_loop_hvac.model.version < OpenStudio::VersionString.new('3.0.0')
-        OpenStudio.logFree(OpenStudio::Warn, 'openstudio.prototype.SizingSystem', "The design minimum zone ventilation efficiency cannot be set for #{sizing_system.name.to_s}. It can only be set OpenStudio 3.0.0 and later.")
-      else
-        sizing_zone.setDesignMinimumZoneVentilationEfficiency(0.6)
-      end
-    end
 
     return true
   end

--- a/lib/openstudio-standards/prototypes/common/objects/Prototype.hvac_systems.rb
+++ b/lib/openstudio-standards/prototypes/common/objects/Prototype.hvac_systems.rb
@@ -1763,7 +1763,15 @@ class Standard
         terminal.setMaximumFlowFractionDuringReheat(0.5)
         terminal.setMaximumReheatAirTemperature(dsgn_temps['zn_htg_dsgn_sup_air_temp_c'])
         air_loop.multiAddBranchForZone(zone, terminal.to_HVACComponent.get)
-        air_terminal_single_duct_vav_reheat_apply_initial_prototype_damper_position(terminal, thermal_zone_outdoor_airflow_rate_per_area(zone))
+        mdp = air_terminal_single_duct_vav_reheat_initial_prototype_damper_position(terminal, thermal_zone_outdoor_airflow_rate_per_area(zone))
+        if zone.model.version < OpenStudio::VersionString.new('3.1.0')
+          # Hard size minimum damper position
+          terminal.setConstantMinimumAirFlowFraction(mdp)
+        else
+          # Allow EnergyPlus to autosize minimum damper position with lower limit
+          zone.sizingZone.setCoolingMinimumAirFlowFraction(mdp)
+          terminal.autosizeConstantMinimumAirFlowFraction
+        end
 
         # zone sizing
         sizing_zone = zone.sizingZone
@@ -1782,7 +1790,15 @@ class Standard
           terminal.setZoneMinimumAirFlowInputMethod('Constant')
         end
         air_loop.multiAddBranchForZone(zone, terminal.to_HVACComponent.get)
-        air_terminal_single_duct_vav_reheat_apply_initial_prototype_damper_position(terminal, thermal_zone_outdoor_airflow_rate_per_area(zone))
+        mdp = air_terminal_single_duct_vav_reheat_initial_prototype_damper_position(terminal, thermal_zone_outdoor_airflow_rate_per_area(zone))
+        if zone.model.version < OpenStudio::VersionString.new('3.1.0')
+          # Hard size minimum damper position
+          terminal.setConstantMinimumAirFlowFraction(mdp)
+        else
+          # Allow EnergyPlus to autosize minimum damper position with lower limit
+          zone.sizingZone.setCoolingMinimumAirFlowFraction(mdp)
+          terminal.autosizeConstantMinimumAirFlowFraction
+        end
 
         # zone sizing
         sizing_zone = zone.sizingZone
@@ -2103,7 +2119,15 @@ class Standard
       end
       terminal.setMaximumReheatAirTemperature(dsgn_temps['zn_htg_dsgn_sup_air_temp_c'])
       air_loop.multiAddBranchForZone(zone, terminal.to_HVACComponent.get)
-      air_terminal_single_duct_vav_reheat_apply_initial_prototype_damper_position(terminal, thermal_zone_outdoor_airflow_rate_per_area(zone))
+      mdp = air_terminal_single_duct_vav_reheat_initial_prototype_damper_position(terminal, thermal_zone_outdoor_airflow_rate_per_area(zone))
+      if zone.model.version < OpenStudio::VersionString.new('3.1.0')
+        # Hard size minimum damper position
+        terminal.setConstantMinimumAirFlowFraction(mdp)
+      else
+        # Allow EnergyPlus to autosize minimum damper position with lower limit
+        zone.sizingZone.setCoolingMinimumAirFlowFraction(mdp)
+        terminal.autosizeConstantMinimumAirFlowFraction
+      end
 
       unless return_plenum.nil?
         zone.setReturnPlenum(return_plenum)
@@ -2410,7 +2434,15 @@ class Standard
       terminal.setMaximumFlowFractionDuringReheat(0.5)
       terminal.setMaximumReheatAirTemperature(dsgn_temps['zn_htg_dsgn_sup_air_temp_c'])
       air_loop.multiAddBranchForZone(zone, terminal.to_HVACComponent.get)
-      air_terminal_single_duct_vav_reheat_apply_initial_prototype_damper_position(terminal, thermal_zone_outdoor_airflow_rate_per_area(zone))
+      mdp = air_terminal_single_duct_vav_reheat_initial_prototype_damper_position(terminal, thermal_zone_outdoor_airflow_rate_per_area(zone))
+      if zone.model.version < OpenStudio::VersionString.new('3.1.0')
+        # Hard size minimum damper position
+        terminal.setConstantMinimumAirFlowFraction(mdp)
+      else
+        # Allow EnergyPlus to autosize minimum damper position with lower limit
+        zone.sizingZone.setCoolingMinimumAirFlowFraction(mdp)
+        terminal.autosizeConstantMinimumAirFlowFraction
+      end
 
       # zone sizing
       sizing_zone = zone.sizingZone
@@ -4415,7 +4447,7 @@ class Standard
   # @param model_occ_hr_end [Double] (Optional) Only applies if control_strategy is 'proportional_control'.
   #   Ending hour of building occupancy.
   # @param control_strategy [String] name of control strategy.  Options are 'proportional_control' and 'none'.
-  #   If control strategy is 'proportional_control', the method will apply the CBE radiant control sequences 
+  #   If control strategy is 'proportional_control', the method will apply the CBE radiant control sequences
   #   detailed in Raftery et al. (2017), “A new control strategy for high thermal mass radiant systems”.
   #   Otherwise no control strategy will be applied and the radiant system will assume the EnergyPlus default controls.
   # @param proportional_gain [Double] (Optional) Only applies if control_strategy is 'proportional_control'.

--- a/lib/openstudio-standards/standards/Standards.AirLoopHVAC.rb
+++ b/lib/openstudio-standards/standards/Standards.AirLoopHVAC.rb
@@ -1811,7 +1811,7 @@ class Standard
         controller_mv.setSystemOutdoorAirMethod('Standard62.1VentilationRateProcedureWithLimit')
       end
         # Change the min flow rate in the controller outdoor air
-      controller_oa.setMinimumOutdoorAirFlowRate(0.0)
+      # controller_oa.setMinimumOutdoorAirFlowRate(0.0)
     else
       OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.AirLoopHVAC', "For #{air_loop_hvac.name}, cannot enable multizone vav optimization because the system has no OA intake.")
       return false
@@ -1850,7 +1850,7 @@ class Standard
         if equip.to_AirTerminalSingleDuctVAVReheat.is_initialized
           zone_oa = thermal_zone_outdoor_airflow_rate(zone)
           vav_terminal = equip.to_AirTerminalSingleDuctVAVReheat.get
-          air_terminal_single_duct_vav_reheat_apply_minimum_damper_position(vav_terminal, zone_oa, has_ddc)
+          air_terminal_single_duct_vav_reheat_apply_minimum_damper_position(vav_terminal, zone, zone_oa, has_ddc)
         end
       end
     end
@@ -2292,7 +2292,7 @@ class Standard
     end
 
     # Change the min flow rate in the controller outdoor air
-    controller_oa.setMinimumOutdoorAirFlowRate(0.0)
+    # controller_oa.setMinimumOutdoorAirFlowRate(0.0)
 
     # Enable DCV in the controller mechanical ventilation
     controller_mv.setDemandControlledVentilation(true)

--- a/lib/openstudio-standards/standards/Standards.AirLoopHVAC.rb
+++ b/lib/openstudio-standards/standards/Standards.AirLoopHVAC.rb
@@ -1808,7 +1808,7 @@ class Standard
       if air_loop_hvac.model.version < OpenStudio::VersionString.new('3.3.0')
         controller_mv.setSystemOutdoorAirMethod('VentilationRateProcedure')
       else
-        controller_mv.setSystemOutdoorAirMethod('Standard62.1VentilationRateProcedure')
+        controller_mv.setSystemOutdoorAirMethod('Standard62.1VentilationRateProcedureWithLimit')
       end
         # Change the min flow rate in the controller outdoor air
       controller_oa.setMinimumOutdoorAirFlowRate(0.0)

--- a/lib/openstudio-standards/standards/Standards.AirLoopHVAC.rb
+++ b/lib/openstudio-standards/standards/Standards.AirLoopHVAC.rb
@@ -1877,6 +1877,21 @@ class Standard
       return true
     end
 
+    # Set the minimum zone ventilation efficiency to be 0.6
+
+    # Use the built-in EnergyPlus method when available
+    if air_loop_hvac.model.version > OpenStudio::VersionString.new('3.0.0')
+      air_loop_hvac.thermalZones.sort.each do |zone|
+        sizing_zone = zone.sizingZone
+        sizing_zone.setDesignMinimumZoneVentilationEfficiency(0.6)
+      end
+      OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.AirLoopHVAC', "For #{air_loop_hvac.name}: the multizone outdoor air calculation method was applied, and a minimum zone ventilation efficiency of 0.6 was specified using the EnergyPlus algorithm.")
+
+      return true
+    end
+
+    # Use the manual method otherwise
+
     # Total uncorrected outdoor airflow rate
     v_ou = 0.0
     air_loop_hvac.thermalZones.each do |zone|

--- a/lib/openstudio-standards/standards/Standards.AirLoopHVAC.rb
+++ b/lib/openstudio-standards/standards/Standards.AirLoopHVAC.rb
@@ -1805,8 +1805,12 @@ class Standard
       oa_system = air_loop_hvac.airLoopHVACOutdoorAirSystem.get
       controller_oa = oa_system.getControllerOutdoorAir
       controller_mv = controller_oa.controllerMechanicalVentilation
-      controller_mv.setSystemOutdoorAirMethod('VentilationRateProcedure')
-      # Change the min flow rate in the controller outdoor air
+      if air_loop_hvac.model.version < OpenStudio::VersionString.new('3.3.0')
+        controller_mv.setSystemOutdoorAirMethod('VentilationRateProcedure')
+      else
+        controller_mv.setSystemOutdoorAirMethod('Standard62.1VentilationRateProcedure')
+      end
+        # Change the min flow rate in the controller outdoor air
       controller_oa.setMinimumOutdoorAirFlowRate(0.0)
     else
       OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.AirLoopHVAC', "For #{air_loop_hvac.name}, cannot enable multizone vav optimization because the system has no OA intake.")

--- a/lib/openstudio-standards/standards/Standards.AirTerminalSingleDuctVAVReheat.rb
+++ b/lib/openstudio-standards/standards/Standards.AirTerminalSingleDuctVAVReheat.rb
@@ -13,10 +13,18 @@ class Standard
   #   which impacts the minimum damper position requirement.
   # @return [Bool] returns true if successful, false if not
   # @todo remove exception where older vintages don't have minimum positions adjusted.
-  def air_terminal_single_duct_vav_reheat_apply_minimum_damper_position(air_terminal_single_duct_vav_reheat, zone_min_oa = nil, has_ddc = true)
+  def air_terminal_single_duct_vav_reheat_apply_minimum_damper_position(air_terminal_single_duct_vav_reheat, zone, zone_min_oa = nil, has_ddc = true)
     # Minimum damper position
     min_damper_position = air_terminal_single_duct_vav_reheat_minimum_damper_position(air_terminal_single_duct_vav_reheat, has_ddc)
-    air_terminal_single_duct_vav_reheat.setConstantMinimumAirFlowFraction(min_damper_position)
+    if air_loop_hvac.model.version < OpenStudio::VersionString.new('3.1.0')
+      # Hard size minimum damper position
+      air_terminal_single_duct_vav_reheat.setConstantMinimumAirFlowFraction(min_damper_position)
+    else
+      # Allow EnergyPlus to autosize minimum damper position with lower limit
+      zone.sizingZone.setCoolingMinimumAirFlowFraction(min_damper_position)
+      air_terminal_single_duct_vav_reheat.autosizeConstantMinimumAirFlowFraction
+    end
+
     OpenStudio.logFree(OpenStudio::Debug, 'openstudio.standards.AirTerminalSingleDuctVAVReheat', "For #{air_terminal_single_duct_vav_reheat.name}: set minimum damper position to #{min_damper_position}.")
 
     # Minimum OA flow rate

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2019/ashrae_90_1_2019.AirLoopHVAC.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2019/ashrae_90_1_2019.AirLoopHVAC.rb
@@ -540,6 +540,21 @@ class ASHRAE9012019 < ASHRAE901
       return true
     end
 
+    # Set the minimum zone ventilation efficiency to be 0.6
+
+    # Use the built-in EnergyPlus method when available
+    if air_loop_hvac.model.version > OpenStudio::VersionString.new('3.0.0')
+      air_loop_hvac.thermalZones.sort.each do |zone|
+        sizing_zone = zone.sizingZone
+        sizing_zone.setDesignMinimumZoneVentilationEfficiency(0.6)
+      end
+      OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.AirLoopHVAC', "For #{air_loop_hvac.name}: the multizone outdoor air calculation method was applied, and a minimum zone ventilation efficiency of 0.6 was specified using the EnergyPlus algorithm.")
+
+      return true
+    end
+
+    # Use the manual method otherwise
+
     # Total uncorrected outdoor airflow rate
     v_ou = 0.0
     air_loop_hvac.thermalZones.each do |zone|


### PR DESCRIPTION
In OpenStudio 3.3.0/EnergyPlus 9.6, the enumerations in the Sizing:System and Controller:MechanicalVentilation objects changed from VentilationRateProcedure to Standard62.1VentilationRateProcedure. When this change is not handled, the setter methods will not change the value, and the default ZoneSum method will be used. This method significantly underestimates the minimum outdoor air requirements for multizone systems, which in turn impacts energy consumption.

The fix is to modify the code to be version-dependent.