### PR TITLE
Fixes VRP enumerations for newer E+ versions and makes Evz template-dependent

### DIFF
--- a/lib/openstudio-standards/prototypes/common/objects/Prototype.SizingSystem.rb
+++ b/lib/openstudio-standards/prototypes/common/objects/Prototype.SizingSystem.rb
@@ -57,14 +57,20 @@ class Standard
     end
 
     sizing_system = air_loop_hvac.sizingSystem
-    sizing_system.setSystemOutdoorAirMethod('VentilationRateProcedure')
-    # Set the minimum zone ventilation efficiency to be 0.6
+    if air_loop_hvac.model.version < OpenStudio::VersionString.new('3.3.0')
+      sizing_system.setSystemOutdoorAirMethod('VentilationRateProcedure')
+    else
+      sizing_system.setSystemOutdoorAirMethod('Standard62.1VentilationRateProcedure')
+    end
+
+    # Set the minimum zone ventilation efficiency
+    min_ventilation_efficiency = air_loop_hvac_minimum_zone_ventilation_efficiency(air_loop_hvac)
     air_loop_hvac.thermalZones.sort.each do |zone|
       sizing_zone = zone.sizingZone
       if air_loop_hvac.model.version < OpenStudio::VersionString.new('3.0.0')
         OpenStudio.logFree(OpenStudio::Warn, 'openstudio.prototype.SizingSystem', "The design minimum zone ventilation efficiency cannot be set for #{sizing_system.name}. It can only be set OpenStudio 3.0.0 and later.")
       else
-        sizing_zone.setDesignMinimumZoneVentilationEfficiency(0.6)
+        sizing_zone.setDesignMinimumZoneVentilationEfficiency(min_ventilation_efficiency)
       end
     end
 

--- a/lib/openstudio-standards/standards/ashrae_90_1/doe_ref_1980_2004/doe_ref_1980_2004.AirLoopHVAC.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/doe_ref_1980_2004/doe_ref_1980_2004.AirLoopHVAC.rb
@@ -47,4 +47,15 @@ class DOERef1980to2004 < ASHRAE901
     damper_action = 'Single Maximum'
     return damper_action
   end
+
+  # Determine minimum ventilation efficiency for zones.
+  # For DOE Ref 1980-2004, assume that VAV system designers did not
+  # care about decreasing system OA flow rates and therefore did not
+  # adjust minimum damper positions to achieve any specific
+  # ventilation efficiency.
+  def air_loop_hvac_minimum_zone_ventilation_efficiency(air_loop_hvac)
+    min_ventilation_efficiency = 0
+
+    return min_ventilation_efficiency
+  end
 end

--- a/lib/openstudio-standards/standards/ashrae_90_1/doe_ref_pre_1980/doe_ref_pre_1980.AirLoopHVAC.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/doe_ref_pre_1980/doe_ref_pre_1980.AirLoopHVAC.rb
@@ -47,4 +47,15 @@ class DOERefPre1980 < ASHRAE901
     damper_action = 'Single Maximum'
     return damper_action
   end
+
+  # Determine minimum ventilation efficiency for zones.
+  # For DOE Ref Pre-1980, assume that VAV system designers did not
+  # care about decreasing system OA flow rates and therefore did not
+  # adjust minimum damper positions to achieve any specific
+  # ventilation efficiency.
+  def air_loop_hvac_minimum_zone_ventilation_efficiency(air_loop_hvac)
+    min_ventilation_efficiency = 0
+
+    return min_ventilation_efficiency
+  end
 end


### PR DESCRIPTION
Fixes VRP enumerations for newer E+ versions and makes Evz template-dependent. Fixes #1372 using the method suggested by @lymereJ. Opened a separate feature request issue #1391 to someday use EnergyPlus to autosize minimum damper position.