### PR TITLE
fix schedule method for heatingSetpointTemperatureSchedule

### DIFF
--- a/lib/openstudio-standards/standards/Standards.ThermalZone.rb
+++ b/lib/openstudio-standards/standards/Standards.ThermalZone.rb
@@ -980,7 +980,7 @@ class Standard
         end
       elsif equip.to_ZoneHVACLowTemperatureRadiantElectric.is_initialized
         equip = equip.to_ZoneHVACLowTemperatureRadiantElectric.get
-        htg_sch = equip.heatingSetpointTemperatureSchedule.get
+        htg_sch = equip.heatingSetpointTemperatureSchedule
       elsif equip.to_ZoneHVACLowTempRadiantConstFlow.is_initialized
         equip = equip.to_ZoneHVACLowTempRadiantConstFlow.get
         htg_coil = equip.heatingCoil


### PR DESCRIPTION
The heatingSetpointTemperatureSchedule method for the ZoneHVACLowTemperatureRadiantElectric object returns a Schedule object, not an optional Schedule object.  Fixes #1338 