### PR TITLE
Adding assert to handle model generating unsuccessfully case in the r…

### DIFF
--- a/test/90_1_prm/test_appendix_g_prm.rb
+++ b/test/90_1_prm/test_appendix_g_prm.rb
@@ -2794,6 +2794,7 @@ class AppendixGPRMTests < Minitest::Test
   # @param model [OpenStudio::model::Model] OpenStudio model object
   # @param arguments [Array] List of arguments
   def remove_transformer(model, arguments)
+    assert(model, 'Unsuccessfully generating the model')
     model.getElectricLoadCenterTransformers.each(&:remove)
     return model
   end


### PR DESCRIPTION
…emove_transfer function


Addressing the #1395  item number 3.
Adding assert to handle exception when the model generation is failed.