### PR TITLE
Appendix g dev debug user directory error

### DIFF
--- a/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.Model.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.Model.rb
@@ -780,6 +780,8 @@ class ASHRAE901PRM < Standard
   def model_add_prm_elevators(model)
     # Load elevator data from userdata csv files
     user_elevators = @standards_data.key?('userdata_electric_equipment') ? @standards_data['userdata_electric_equipment'] : nil
+    return false if user_elevators.nil?
+
     user_elevators.each do |user_elevator|
       num_lifts = user_elevator['elevator_number_of_lifts'].to_i
       next if num_lifts == 0

--- a/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.rb
@@ -24,7 +24,8 @@ class ASHRAE901PRM < Standard
     stds_dir = __dir__
     src_csv_dir = "#{stds_dir}/userdata_csv/*.csv"
     json_objs = {}
-    Dir.glob(src_csv_dir) do |csv_full_name|
+
+    Dir.glob(src_csv_dir).each do |csv_full_name|
       json_rows = []
       csv_file_name = File.basename(csv_full_name, File.extname(csv_full_name))
       json_objs[csv_file_name] = json_rows
@@ -33,7 +34,7 @@ class ASHRAE901PRM < Standard
     # Read all valid files in user_data_folder and load into json array
     unless user_data_path == ''
       user_data_validation_outcome = true
-      Dir.glob("#{user_data_path}/*.csv") do |csv_full_name|
+      Dir.glob("#{user_data_path}/*.csv").each do |csv_full_name|
         csv_file_name = File.basename(csv_full_name, File.extname(csv_full_name))
         if json_objs.key?(csv_file_name)
           # Load csv file into array of hashes

--- a/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.rb
@@ -30,7 +30,6 @@ class ASHRAE901PRM < Standard
       csv_file_name = File.basename(csv_full_name, File.extname(csv_full_name))
       json_objs[csv_file_name] = json_rows
     end
-
     
     # Read all valid files in user_data_folder and load into json array
     unless user_data_path == ''

--- a/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.rb
@@ -31,6 +31,7 @@ class ASHRAE901PRM < Standard
       json_objs[csv_file_name] = json_rows
     end
 
+    
     # Read all valid files in user_data_folder and load into json array
     unless user_data_path == ''
       user_data_validation_outcome = true

--- a/test/90_1_prm/test_appendix_g_prm.rb
+++ b/test/90_1_prm/test_appendix_g_prm.rb
@@ -2794,6 +2794,7 @@ class AppendixGPRMTests < Minitest::Test
   # @param model [OpenStudio::model::Model] OpenStudio model object
   # @param arguments [Array] List of arguments
   def remove_transformer(model, arguments)
+    assert(model, 'Unsuccessfully generating the model')
     model.getElectricLoadCenterTransformers.each(&:remove)
     return model
   end

--- a/test/90_1_prm/test_appendix_g_prm.rb
+++ b/test/90_1_prm/test_appendix_g_prm.rb
@@ -2794,7 +2794,6 @@ class AppendixGPRMTests < Minitest::Test
   # @param model [OpenStudio::model::Model] OpenStudio model object
   # @param arguments [Array] List of arguments
   def remove_transformer(model, arguments)
-    assert(model, 'Unsuccessfully generating the model')
     model.getElectricLoadCenterTransformers.each(&:remove)
     return model
   end


### PR DESCRIPTION
The command line interface is failing when calling create PRM method.
Failing message indicates the directory for user data files are arrays instead of strings.

Fix the issue in the convert_user_data_to_json function, and verified the workflow in the command line.