### PR TITLE
Typo in OS_AirLoopHVAC_UnitarySystem in Siz.HeatingCoolingFuels

### DIFF
--- a/lib/openstudio-standards/hvac_sizing/Siz.HeatingCoolingFuels.rb
+++ b/lib/openstudio-standards/hvac_sizing/Siz.HeatingCoolingFuels.rb
@@ -9,7 +9,7 @@
 ###### IMPORTANT NOTE ######
 
 class OpenStudio::Model::Model
-  
+
   # Get the heating fuel type of a plant loop
   # @todo If no heating equipment is found, check if there's a heat exchanger,
   # or a WaterHeater:Mixed or stratified that is connected to a heating source on the demand side
@@ -24,11 +24,11 @@ class OpenStudio::Model::Model
       when 'OS_Boiler_HotWater'
         component = component.to_BoilerHotWater.get
         fuels << component.fuelType
-      when 'OS_Boiler_Steam' 
+      when 'OS_Boiler_Steam'
         component = component.to_BoilerHotWater.get
         fuels << component.fuelType
       when 'OS_DistrictHeating'
-        fuels << 'DistrictHeating' 
+        fuels << 'DistrictHeating'
       when 'OS_HeatPump_WaterToWater_EquationFit_Heating'
         fuels << 'Electricity'
       when 'OS_SolarCollector_FlatPlate_PhotovoltaicThermal'
@@ -38,7 +38,7 @@ class OpenStudio::Model::Model
       when 'OS_SolarCollector_IntegralCollectorStorage'
         fuels << 'SolarEnergy'
       when 'OS_WaterHeater_HeatPump'
-        fuels << 'Electricity'     
+        fuels << 'Electricity'
       when 'OS_WaterHeater_Mixed'
         component = component.to_WaterHeaterMixed.get
 
@@ -79,9 +79,9 @@ class OpenStudio::Model::Model
         #OpenStudio::logFree(OpenStudio::Debug, 'openstudio.sizing.Model', "No heating fuel types found for #{obj_type}")
       end
     end
-    
+
     return fuels.uniq.sort
- 
+
   end
 
   # Get the cooling fuel type of a plant loop
@@ -94,7 +94,7 @@ class OpenStudio::Model::Model
     plant_loop.supplyComponents.each do |component|
        # Get the object type
       obj_type = component.iddObjectType.valueName.to_s
-      case obj_type  
+      case obj_type
       when 'OS_Chiller_Absorption'
         fuels << 'NaturalGas'
         OpenStudio::logFree(OpenStudio::Warn, 'openstudio.sizing.Model', "Assuming NaturalGas as fuel for absorption chiller.")
@@ -120,14 +120,14 @@ class OpenStudio::Model::Model
       when 'OS_FluidCooler_TwoSpeed'
         fuels << 'Electricity'
       when 'OS_Node', 'OS_Pump_ConstantSpeed', 'OS_Pump_VariableSpeed', 'OS_Connector_Splitter', 'OS_Connector_Mixer', 'OS_Pipe_Adiabatic'
-        # To avoid extraneous debug messages  
+        # To avoid extraneous debug messages
       else
         #OpenStudio::logFree(OpenStudio::Debug, 'openstudio.sizing.Model', "No cooling fuel types found for #{obj_type}")
       end
     end
-    
+
     return fuels.uniq.sort
-    
+
   end
 
   # Get the heating fuel type of a heating coil
@@ -161,7 +161,7 @@ class OpenStudio::Model::Model
       heating_coil = heating_coil.to_CoilHeatingWaterBaseboardRadiant.get
         if heating_coil.plantLoop.is_initialized
         fuels += self.plant_loop_heating_fuels(heating_coil.plantLoop.get)
-      end  
+      end
     when 'OS_Coil_Heating_WaterToAirHeatPump_EquationFit'
       fuels << 'Electricity'
       heating_coil = heating_coil.to_CoilHeatingWaterToAirHeatPumpEquationFit.get
@@ -192,13 +192,13 @@ class OpenStudio::Model::Model
       OpenStudio::logFree(OpenStudio::Debug, 'openstudio.sizing.Model', "No heating fuel types found for #{obj_type}")
     end
 
-    return fuels.uniq.sort 
+    return fuels.uniq.sort
 
   end
 
   # Get type of heat for coil for Appendix G system type selections
-  # 
-  # @param heating_coil [object] 
+  #
+  # @param heating_coil [object]
   # @return string description of heat type: Fuel, Electric, District, HeatPump, Solar, Mixed
   def coil_heat_type(heating_coil)
     fuels = []
@@ -231,7 +231,7 @@ class OpenStudio::Model::Model
       heating_coil = heating_coil.to_CoilHeatingWaterBaseboardRadiant.get
         if heating_coil.plantLoop.is_initialized
         fuels += self.plant_loop_heating_fuels(heating_coil.plantLoop.get)
-      end  
+      end
     when 'OS_Coil_Heating_WaterToAirHeatPump_EquationFit'
       fuels << 'Electricity'
       heating_coil = heating_coil.to_CoilHeatingWaterToAirHeatPumpEquationFit.get
@@ -283,7 +283,7 @@ class OpenStudio::Model::Model
         end
       end
     end
-    
+
     # Choose only one heat type, or Mixed if there are multiple
     if heat_type == ''
       if has_fuel == true
@@ -323,8 +323,8 @@ class OpenStudio::Model::Model
   end
 
   # Get primary type of heat for one air loop for Appendix G system type selections
-  # 
-  # @param air_loop [object] 
+  #
+  # @param air_loop [object]
   # @return string description of heat type: Fuel, Electric, District, HeatPump, Solar, Mixed
   def airloop_primary_heat_type(air_loop)
 
@@ -362,7 +362,7 @@ class OpenStudio::Model::Model
       when 'OS_Coil_Heating_Gas_MultiStage'
         heat_types << self.coil_heat_type(component)
       when 'OS_Coil_Heating_Water'
-        heat_types << self.coil_heat_type(component)  
+        heat_types << self.coil_heat_type(component)
       when 'OS_Coil_Heating_WaterToAirHeatPump_EquationFit'
         heat_types << self.coil_heat_type(component)
       when 'OS_Coil_Heating_WaterToAirHeatPump_VariableSpeed_EquationFit'
@@ -372,11 +372,11 @@ class OpenStudio::Model::Model
       when 'OS_Coil_WaterHeating_Desuperheater'
         heat_types << self.coil_heat_type(component)
       when 'OS_Node', 'OS_Fan_ConstantVolume', 'OS_Fan_VariableVolume', 'OS_AirLoopHVAC_OutdoorAirSystem'
-        # To avoid extraneous debug messages  
+        # To avoid extraneous debug messages
       else
         #OpenStudio::logFree(OpenStudio::Debug, 'openstudio.sizing.Model', "No heating fuel types found for #{obj_type}")
       end
-    end    
+    end
 
     has_electric = false
     has_fuel = false
@@ -448,8 +448,8 @@ class OpenStudio::Model::Model
   end
 
   # Get primary type of heat for one air loop for Appendix G system type selections
-  # 
-  # @param air_loop [object] 
+  #
+  # @param air_loop [object]
   # @return string description of heat type: Fuel, Electric, District, HeatPump, Solar, Mixed
   def zone_equipment_heat_type(zone)
     fuels = []
@@ -464,44 +464,44 @@ class OpenStudio::Model::Model
         heat_type = self.coil_heat_type(equipment.heatingCoil)
       when 'OS_AirTerminal_SingleDuct_ConstantVolume_Reheat'
         equipment = equipment.to_AirTerminalSingleDuctConstantVolumeReheat.get
-        heat_type = self.coil_heat_type(equipment.reheatCoil)  
+        heat_type = self.coil_heat_type(equipment.reheatCoil)
       when 'OS_AirTerminal_SingleDuct_InletSideMixer'
         # TODO
       when 'OS_AirTerminal_SingleDuct_ParallelPIU_Reheat'
         equipment = equipment.to_AirTerminalSingleDuctParallelPIUReheat.get
-        heat_type = self.coil_heat_type(equipment.reheatCoil) 
+        heat_type = self.coil_heat_type(equipment.reheatCoil)
       when 'OS_AirTerminal_SingleDuct_SeriesPIU_Reheat'
         equipment = equipment.to_AirTerminalSingleDuctSeriesPIUReheat.get
-        heat_type = self.coil_heat_type(equipment.reheatCoil) 
+        heat_type = self.coil_heat_type(equipment.reheatCoil)
       when 'OS_AirTerminal_SingleDuct_VAVHeatAndCool_Reheat'
         equipment = equipment.to_AirTerminalSingleDuctVAVHeatAndCoolReheat.get
-        heat_type = self.coil_heat_type(equipment.reheatCoil) 
+        heat_type = self.coil_heat_type(equipment.reheatCoil)
       when 'OS_AirTerminal_SingleDuct_VAV_Reheat'
         equipment = equipment.to_AirTerminalSingleDuctVAVReheat.get
         heat_type = self.coil_heat_type(equipment.reheatCoil)
       when 'OS_ZoneHVAC_Baseboard_Convective_Water'
         equipment = equipment.to_ZoneHVACBaseboardConvectiveWater.get
-        heat_type = self.coil_heat_type(equipment.heatingCoil) 
+        heat_type = self.coil_heat_type(equipment.heatingCoil)
       when 'OS_ZoneHVAC_Baseboard_RadiantConvective_Water'
         equipment = equipment.to_ZoneHVACBaseboardRadiantConvectiveWater.get
-        heat_type = self.coil_heat_type(equipment.heatingCoil) 
+        heat_type = self.coil_heat_type(equipment.heatingCoil)
       when 'OS_ZoneHVAC_FourPipeFanCoil'
         equipment = equipment.to_ZoneHVACFourPipeFanCoil.get
-        heat_type = self.coil_heat_type(equipment.heatingCoil) 
+        heat_type = self.coil_heat_type(equipment.heatingCoil)
       when 'OS_ZoneHVAC_LowTemperatureRadiant_ConstantFlow'
         equipment = equipment.to_ZoneHVACLowTempRadiantConstFlow.get
-        heat_type = self.coil_heat_type(equipment.heatingCoil) 
+        heat_type = self.coil_heat_type(equipment.heatingCoil)
       when 'OS_ZoneHVAC_LowTemperatureRadiant_VariableFlow'
         equipment = equipment.to_ZoneHVACLowTempRadiantVarFlow.get
-        heat_type = self.coil_heat_type(equipment.heatingCoil) 
+        heat_type = self.coil_heat_type(equipment.heatingCoil)
       when 'OS_ZoneHVAC_UnitHeater'
         equipment = equipment.to_ZoneHVACUnitHeater.get
-        heat_type = self.coil_heat_type(equipment.heatingCoil) 
+        heat_type = self.coil_heat_type(equipment.heatingCoil)
       when 'OS_ZoneHVAC_UnitVentilator'
         equipment = equipment.to_ZoneHVACUnitVentilator.get
         if equipment.heatingCoil.is_initialized
-          heat_type = self.coil_heat_type(equipment.heatingCoil.get) 
-        end 
+          heat_type = self.coil_heat_type(equipment.heatingCoil.get)
+        end
       when 'OS_ZoneHVAC_Baseboard_Convective_Electric'
         heat_type = 'Electric'
       when 'OS_ZoneHVAC_Baseboard_RadiantConvective_Electric'
@@ -542,9 +542,9 @@ class OpenStudio::Model::Model
       else
         OpenStudio::logFree(OpenStudio::Debug, 'openstudio.sizing.Model', "No heat type found for #{obj_type}")      end
     end
-    
+
     return heat_type
-    
+
   end
 
 
@@ -593,17 +593,17 @@ class OpenStudio::Model::Model
       if cooling_coil.plantLoop.is_initialized
         fuels += self.plant_loop_cooling_fuels(cooling_coil.plantLoop.get)
       end
-    when 'OS_Coil_Cooling_Water'  
+    when 'OS_Coil_Cooling_Water'
       cooling_coil = cooling_coil.to_CoilCoolingWater.get
       if cooling_coil.plantLoop.is_initialized
         fuels += self.plant_loop_cooling_fuels(cooling_coil.plantLoop.get)
-      end    
+      end
     else
       OpenStudio::logFree(OpenStudio::Debug, 'openstudio.sizing.Model', "No cooling fuel types found for #{obj_type}")
     end
 
     return fuels.uniq.sort
-    
+
   end
 
   # Get the heating fuels for a zone
@@ -615,7 +615,7 @@ class OpenStudio::Model::Model
       # Get the object type
       obj_type = equipment.iddObjectType.valueName.to_s
       case obj_type
-      when 'OS_AirLooHVAC_UnitarySystem'
+      when 'OS_AirLoopHVAC_UnitarySystem'
         equipment = equipment.to_AirLoopHVACUnitarySystem.get
         if equipment.heatingCoil.is_initialized
           fuels += self.coil_heating_fuels(equipment.heatingCoil.get)
@@ -625,33 +625,33 @@ class OpenStudio::Model::Model
         fuels += self.coil_heating_fuels(equipment.heatingCoil)
       when 'OS_AirTerminal_SingleDuct_ConstantVolume_Reheat'
         equipment = equipment.to_AirTerminalSingleDuctConstantVolumeReheat.get
-        fuels += self.coil_heating_fuels(equipment.reheatCoil)  
+        fuels += self.coil_heating_fuels(equipment.reheatCoil)
       when 'OS_AirTerminal_SingleDuct_InletSideMixer'
         # @todo complete method
       when 'OS_AirTerminal_SingleDuct_ParallelPIU_Reheat'
         equipment = equipment.to_AirTerminalSingleDuctParallelPIUReheat.get
-        fuels += self.coil_heating_fuels(equipment.reheatCoil) 
+        fuels += self.coil_heating_fuels(equipment.reheatCoil)
       when 'OS_AirTerminal_SingleDuct_SeriesPIU_Reheat'
         equipment = equipment.to_AirTerminalSingleDuctSeriesPIUReheat.get
-        fuels += self.coil_heating_fuels(equipment.reheatCoil) 
+        fuels += self.coil_heating_fuels(equipment.reheatCoil)
       when 'OS_AirTerminal_SingleDuct_VAVHeatAndCool_Reheat'
         equipment = equipment.to_AirTerminalSingleDuctVAVHeatAndCoolReheat.get
-        fuels += self.coil_heating_fuels(equipment.reheatCoil) 
+        fuels += self.coil_heating_fuels(equipment.reheatCoil)
       when 'OS_AirTerminal_SingleDuct_VAV_Reheat'
         equipment = equipment.to_AirTerminalSingleDuctVAVReheat.get
         fuels += self.coil_heating_fuels(equipment.reheatCoil)
       when 'OS_ZoneHVAC_Baseboard_Convective_Water'
         equipment = equipment.to_ZoneHVACBaseboardConvectiveWater.get
-        fuels += self.coil_heating_fuels(equipment.heatingCoil) 
+        fuels += self.coil_heating_fuels(equipment.heatingCoil)
       when 'OS_ZoneHVAC_Baseboard_RadiantConvective_Water'
         equipment = equipment.to_ZoneHVACBaseboardRadiantConvectiveWater.get
-        fuels += self.coil_heating_fuels(equipment.heatingCoil) 
+        fuels += self.coil_heating_fuels(equipment.heatingCoil)
       when 'OS_ZoneHVAC_FourPipeFanCoil'
         equipment = equipment.to_ZoneHVACFourPipeFanCoil.get
-        fuels += self.coil_heating_fuels(equipment.heatingCoil) 
+        fuels += self.coil_heating_fuels(equipment.heatingCoil)
       when 'OS_ZoneHVAC_LowTemperatureRadiant_ConstantFlow'
         equipment = equipment.to_ZoneHVACLowTempRadiantConstFlow.get
-        fuels += self.coil_heating_fuels(equipment.heatingCoil) 
+        fuels += self.coil_heating_fuels(equipment.heatingCoil)
       when 'OS_ZoneHVAC_LowTemperatureRadiant_VariableFlow'
         equipment = equipment.to_ZoneHVACLowTempRadiantVarFlow.get
         if equipment.model.version < OpenStudio::VersionString.new('3.2.0')
@@ -663,12 +663,12 @@ class OpenStudio::Model::Model
         end
       when 'OS_ZoneHVAC_UnitHeater'
         equipment = equipment.to_ZoneHVACUnitHeater.get
-        fuels += self.coil_heating_fuels(equipment.heatingCoil) 
+        fuels += self.coil_heating_fuels(equipment.heatingCoil)
       when 'OS_ZoneHVAC_UnitVentilator'
         equipment = equipment.to_ZoneHVACUnitVentilator.get
         if equipment.heatingCoil.is_initialized
-          fuels += self.coil_heating_fuels(equipment.heatingCoil.get) 
-        end 
+          fuels += self.coil_heating_fuels(equipment.heatingCoil.get)
+        end
       when 'OS_ZoneHVAC_Baseboard_Convective_Electric'
         fuels << 'Electricity'
       when 'OS_ZoneHVAC_Baseboard_RadiantConvective_Electric'
@@ -695,9 +695,9 @@ class OpenStudio::Model::Model
         OpenStudio::logFree(OpenStudio::Debug, 'openstudio.sizing.Model', "No heating fuel types found for #{obj_type}")
       end
     end
-    
+
     return fuels.uniq.sort
-    
+
   end
 
   # Get the cooling fuels for a zone
@@ -716,10 +716,10 @@ class OpenStudio::Model::Model
       when 'OS_AirTerminal_SingleDuct_ConstantVolume_CooledBeam'
         equipment = equipment.to_AirTerminalSingleDuctConstantVolumeCooledBeam.get
         fuels += self.coil_cooling_fuels(equipment.coilCoolingCooledBeam)
-      when 'OS_AirTerminal_SingleDuct_ConstantVolume_FourPipeInduction'      
+      when 'OS_AirTerminal_SingleDuct_ConstantVolume_FourPipeInduction'
         equipment = equipment.to_AirTerminalSingleDuctConstantVolumeFourPipeInduction.get
         if equipment.coolingCoil.is_initialized
-          fuels += self.coil_cooling_fuels(equipment.coolingCoil.get) 
+          fuels += self.coil_cooling_fuels(equipment.coolingCoil.get)
         end
       when 'OS_ZoneHVAC_FourPipeFanCoil'
         equipment = equipment.to_ZoneHVACFourPipeFanCoil.get
@@ -752,7 +752,7 @@ class OpenStudio::Model::Model
     end
 
     return fuels.uniq.sort
-    
+
   end
 
   # Get the heating fuels for a zones airloop
@@ -764,7 +764,7 @@ class OpenStudio::Model::Model
       return fuels
     end
     air_loop = air_loop.get
-    
+
     # Find fuel types of all equipment
     # on the supply side of this airloop.
     air_loop.supplyComponents.each do |component|
@@ -800,7 +800,7 @@ class OpenStudio::Model::Model
       when 'OS_Coil_Heating_Gas_MultiStage'
         fuels += self.coil_heating_fuels(component)
       when 'OS_Coil_Heating_Water'
-        fuels += self.coil_heating_fuels(component)  
+        fuels += self.coil_heating_fuels(component)
       when 'OS_Coil_Heating_WaterToAirHeatPump_EquationFit'
         fuels += self.coil_heating_fuels(component)
       when 'OS_Coil_Heating_WaterToAirHeatPump_VariableSpeed_EquationFit'
@@ -810,14 +810,14 @@ class OpenStudio::Model::Model
       when 'OS_Coil_WaterHeating_Desuperheater'
         fuels += self.coil_heating_fuels(component)
       when 'OS_Node', 'OS_Fan_ConstantVolume', 'OS_Fan_VariableVolume', 'OS_AirLoopHVAC_OutdoorAirSystem'
-        # To avoid extraneous debug messages  
+        # To avoid extraneous debug messages
       else
         #OpenStudio::logFree(OpenStudio::Debug, 'openstudio.sizing.Model', "No heating fuel types found for #{obj_type}")
       end
-    end    
- 
+    end
+
     return fuels.uniq.sort
-    
+
   end
 
   # Get the cooling fuels for a zones airloop
@@ -829,7 +829,7 @@ class OpenStudio::Model::Model
       return fuels
     end
     air_loop = air_loop.get
-    
+
     # Find fuel types of all equipment
     # on the supply side of this airloop.
     air_loop.supplyComponents.each do |component|
@@ -853,7 +853,7 @@ class OpenStudio::Model::Model
       when 'OS_EvaporativeCooler_Direct_ResearchSpecial'
         fuels << 'Electricity'
       when 'OS_EvaporativeCooler_Indirect_ResearchSpecial'
-        fuels << 'Electricity'  
+        fuels << 'Electricity'
       when 'OS_Coil_Cooling_DX_MultiSpeed'
         fuels += self.coil_cooling_fuels(component)
       when 'OS_Coil_Cooling_DX_SingleSpeed'
@@ -874,19 +874,19 @@ class OpenStudio::Model::Model
         fuels += self.coil_cooling_fuels(component)
       when 'OS_CoilSystem_Cooling_Water_HeatExchangerAssisted'
         fuels += self.coil_cooling_fuels(component)
-      when 'OS_Coil_Cooling_Water'      
-        fuels += self.coil_cooling_fuels(component)  
+      when 'OS_Coil_Cooling_Water'
+        fuels += self.coil_cooling_fuels(component)
       when 'OS_HeatPump_WaterToWater_EquationFit_Cooling'
         fuels += self.coil_cooling_fuels(component)
       when 'OS_Node', 'OS_Fan_ConstantVolume', 'OS_Fan_VariableVolume', 'OS_AirLoopHVAC_OutdoorAirSystem'
-        # To avoid extraneous debug messages  
+        # To avoid extraneous debug messages
       else
         #OpenStudio::logFree(OpenStudio::Debug, 'openstudio.sizing.Model', "No heating fuel types found for #{obj_type}")
       end
-    end    
- 
+    end
+
     return fuels.uniq.sort
-    
-  end     
-  
+
+  end
+
 end


### PR DESCRIPTION
```diff
-OS_AirLooHVAC_UnitarySystem
+OS_AirLoopHVAC_UnitarySystem
```

View without whitespace changes: https://github.com/NREL/openstudio-standards/pull/1418/files?w=1