### PR TITLE
fix typo and delete extra methods

### DIFF
--- a/lib/openstudio-standards/btap/btap.model.rb
+++ b/lib/openstudio-standards/btap/btap.model.rb
@@ -8,7 +8,7 @@ class OpenStudio::Model::Construction
   #insulation layer.
   #@author Phylroy A. Lopez <plopez@nrcan.gc.ca>
   #@return OpenStudio::Model::Material insulation_material_layer
-  def self.find_and_set_insulaton_layer()
+  def self.find_and_set_insulation_layer()
       insulation_material_layer = nil
       #return if there is already a defined insulation layer.
       return self.insulation unless self.insulation.empty?
@@ -77,7 +77,7 @@ class OpenStudio::Model::Construction
 
     if  conductance.kind_of?(Float)
       #re-find insulation layer
-      find_and_set_insulaton_layer(self.model,new_construction)
+      find_and_set_insulation_layer(self.model,new_construction)
 
       #Determine how low the resistance can be set. Subtract existing insulation
       #Values from the total resistance to see how low we can go.

--- a/lib/openstudio-standards/btap/btap.model.rb
+++ b/lib/openstudio-standards/btap/btap.model.rb
@@ -2,45 +2,6 @@ require "#{File.dirname(__FILE__)}/btap"
 
 
 class OpenStudio::Model::Construction
-  #This method will search through the layers and find the layer with the
-  #lowest conductance and set that as the insulation layer. Note: Concrete walls
-  #or slabs with no insulation layer but with a carper will see the carpet as the
-  #insulation layer.
-  #@author Phylroy A. Lopez <plopez@nrcan.gc.ca>
-  #@return OpenStudio::Model::Material insulation_material_layer
-  def self.find_and_set_insulaton_layer()
-      insulation_material_layer = nil
-      #return if there is already a defined insulation layer.
-      return self.insulation unless self.insulation.empty?
-      #set minimum conductance to 100.0
-      min_conductance = 100.0
-      #loop through Layers
-      self.layers.each do |layer|
-        #try casting the layer to an OpaqueMaterial.
-        material = nil
-        material = layer.to_OpaqueMaterial.get unless layer.to_OpaqueMaterial.empty?
-        material = layer.to_FenestrationMaterial.get unless layer.to_FenestrationMaterial.empty?
-        #check if the cast was successful, then find the insulation layer.
-        unless nil == material
-          if BTAP::Resources::Envelope::Materials::get_conductance(material) < min_conductance
-            #Keep track of the highest thermal resistance value.
-            min_conductance = BTAP::Resources::Envelope::Materials::get_conductance(material)
-            insulation_material_layer = material
-            unless material.to_OpaqueMaterial.empty?
-              self.setInsulation(material)
-            end
-          end
-        end
-      end
-      if self.insulation.empty? and self.isOpaque
-        raise ("construction #{self.name.get.to_s} insulation layer could not be set!. This occurs when a insulation layer is duplicated in the construction.")
-      end
-      return insulation_material_layer
-  end
-
-
-
-
   #This method will create a new construction based on self and a new conductance value.
   #It will check to see if a similar construction has already been created by this method
   #if so it will return the existing construction. If you wish to keep some of the properties, enter the
@@ -77,7 +38,7 @@ class OpenStudio::Model::Construction
 
     if  conductance.kind_of?(Float)
       #re-find insulation layer
-      find_and_set_insulaton_layer(self.model,new_construction)
+      find_and_set_insulation_layer(self.model,new_construction)
 
       #Determine how low the resistance can be set. Subtract existing insulation
       #Values from the total resistance to see how low we can go.

--- a/lib/openstudio-standards/btap/btap.model.rb
+++ b/lib/openstudio-standards/btap/btap.model.rb
@@ -2,6 +2,45 @@ require "#{File.dirname(__FILE__)}/btap"
 
 
 class OpenStudio::Model::Construction
+  #This method will search through the layers and find the layer with the
+  #lowest conductance and set that as the insulation layer. Note: Concrete walls
+  #or slabs with no insulation layer but with a carper will see the carpet as the
+  #insulation layer.
+  #@author Phylroy A. Lopez <plopez@nrcan.gc.ca>
+  #@return OpenStudio::Model::Material insulation_material_layer
+  def self.find_and_set_insulaton_layer()
+      insulation_material_layer = nil
+      #return if there is already a defined insulation layer.
+      return self.insulation unless self.insulation.empty?
+      #set minimum conductance to 100.0
+      min_conductance = 100.0
+      #loop through Layers
+      self.layers.each do |layer|
+        #try casting the layer to an OpaqueMaterial.
+        material = nil
+        material = layer.to_OpaqueMaterial.get unless layer.to_OpaqueMaterial.empty?
+        material = layer.to_FenestrationMaterial.get unless layer.to_FenestrationMaterial.empty?
+        #check if the cast was successful, then find the insulation layer.
+        unless nil == material
+          if BTAP::Resources::Envelope::Materials::get_conductance(material) < min_conductance
+            #Keep track of the highest thermal resistance value.
+            min_conductance = BTAP::Resources::Envelope::Materials::get_conductance(material)
+            insulation_material_layer = material
+            unless material.to_OpaqueMaterial.empty?
+              self.setInsulation(material)
+            end
+          end
+        end
+      end
+      if self.insulation.empty? and self.isOpaque
+        raise ("construction #{self.name.get.to_s} insulation layer could not be set!. This occurs when a insulation layer is duplicated in the construction.")
+      end
+      return insulation_material_layer
+  end
+
+
+
+
   #This method will create a new construction based on self and a new conductance value.
   #It will check to see if a similar construction has already been created by this method
   #if so it will return the existing construction. If you wish to keep some of the properties, enter the
@@ -38,7 +77,7 @@ class OpenStudio::Model::Construction
 
     if  conductance.kind_of?(Float)
       #re-find insulation layer
-      find_and_set_insulation_layer(self.model,new_construction)
+      find_and_set_insulaton_layer(self.model,new_construction)
 
       #Determine how low the resistance can be set. Subtract existing insulation
       #Values from the total resistance to see how low we can go.

--- a/lib/openstudio-standards/btap/envelope.rb
+++ b/lib/openstudio-standards/btap/envelope.rb
@@ -504,13 +504,13 @@ module BTAP
 
             #This method will test find and set insulation layer.
             # @author Phylroy A. Lopez <plopez@nrcan.gc.ca>
-            def test_find_and_set_insulaton_layer()
+            def test_find_and_set_insulation_layer()
               construction = BTAP::Resources::Envelope::Constructions::create_construction(@model, "test construction", [@opaque, @air_gap, @insulation, @massless, @opaque])
 
               #check insulation was not set.
               assert((construction.insulation().empty?))
               #now set it.
-              BTAP::Resources::Envelope::Constructions::find_and_set_insulaton_layer(@model, [construction])
+              BTAP::Resources::Envelope::Constructions::find_and_set_insulation_layer(@model, [construction])
               #Now check that it found the insulation  value.
               assert(construction.insulation().get == @insulation)
             end
@@ -544,7 +544,7 @@ module BTAP
         #@param model [OpenStudio::Model::Model]
         #@param constructions_array [BTAP::Common::validate_array]
         #@return <String> insulating_layers
-        def self.find_and_set_insulaton_layer(model, constructions_array)
+        def self.find_and_set_insulation_layer(model, constructions_array)
           constructions_array = BTAP::Common::validate_array(model, constructions_array, "Construction")
           insulating_layers = Array.new()
           constructions_array.each do |construction|
@@ -619,7 +619,7 @@ module BTAP
 
           if conductance.kind_of?(Float)
             #re-find insulation layer
-            find_and_set_insulaton_layer(model, new_construction)
+            find_and_set_insulation_layer(model, new_construction)
 
             #Determine how low the resistance can be set. Subtract exisiting insulation
             #Values from the total resistance to see how low we can go.

--- a/lib/openstudio-standards/btap/envelope.rb
+++ b/lib/openstudio-standards/btap/envelope.rb
@@ -502,19 +502,6 @@ module BTAP
               assert(construction.insulation().get == @insulation)
             end
 
-            #This method will test find and set insulation layer.
-            # @author Phylroy A. Lopez <plopez@nrcan.gc.ca>
-            def test_find_and_set_insulaton_layer()
-              construction = BTAP::Resources::Envelope::Constructions::create_construction(@model, "test construction", [@opaque, @air_gap, @insulation, @massless, @opaque])
-
-              #check insulation was not set.
-              assert((construction.insulation().empty?))
-              #now set it.
-              BTAP::Resources::Envelope::Constructions::find_and_set_insulaton_layer(@model, [construction])
-              #Now check that it found the insulation  value.
-              assert(construction.insulation().get == @insulation)
-            end
-
             #This method will test creation of fenestration construction.
             #@author Phylroy A. Lopez <plopez@nrcan.gc.ca>
             def test_create_fenestration_construction()
@@ -535,53 +522,6 @@ module BTAP
             end
           end
         end # End Test Constructions
-
-        #This method will search through the layers and find the layer with the
-        #lowest conductance and set that as the insulation layer. Note: Concrete walls
-        #or slabs with no insulation layer but with a carper will see the carpet as the
-        #insulation layer.
-        #@author Phylroy A. Lopez <plopez@nrcan.gc.ca>
-        #@param model [OpenStudio::Model::Model]
-        #@param constructions_array [BTAP::Common::validate_array]
-        #@return <String> insulating_layers
-        def self.find_and_set_insulaton_layer(model, constructions_array)
-          constructions_array = BTAP::Common::validate_array(model, constructions_array, "Construction")
-          insulating_layers = Array.new()
-          constructions_array.each do |construction|
-            return_material = ""
-            #skip if already has an insulation layer set.
-            next unless construction.insulation.empty?
-            #set insulation layer.
-            #find insulation layer
-            min_conductance = 100.0
-            #loop through Layers
-            construction.layers.each do |layer|
-              #try casting the layer to an OpaqueMaterial.
-              material = nil
-              material = layer.to_OpaqueMaterial.get unless layer.to_OpaqueMaterial.empty?
-              material = layer.to_FenestrationMaterial.get unless layer.to_FenestrationMaterial.empty?
-              #check if the cast was successful, then find the insulation layer.
-              unless nil == material
-
-                if BTAP::Resources::Envelope::Materials::get_conductance(material) < min_conductance
-                  #Keep track of the highest thermal resistance value.
-                  min_conductance = BTAP::Resources::Envelope::Materials::get_conductance(material)
-                  return_material = material
-                  unless material.to_OpaqueMaterial.empty?
-                    construction.setInsulation(material)
-                  end
-                end
-              end
-            end
-            if construction.insulation.empty? and construction.isOpaque
-              raise ("construction #{construction.name.get.to_s} insulation layer could not be set!. This occurs when a insulation layer is duplicated in the construction.")
-            end
-
-            insulating_layers << return_material
-          end
-
-          return insulating_layers
-        end
 
         #This method will create a new construction based on self and a new conductance value.
         #It will check to see if a similar construction has already been created by this method
@@ -619,7 +559,7 @@ module BTAP
 
           if conductance.kind_of?(Float)
             #re-find insulation layer
-            find_and_set_insulaton_layer(model, new_construction)
+            find_and_set_insulation_layer(model, new_construction)
 
             #Determine how low the resistance can be set. Subtract exisiting insulation
             #Values from the total resistance to see how low we can go.

--- a/lib/openstudio-standards/standards/Standards.Construction.rb
+++ b/lib/openstudio-standards/standards/Standards.Construction.rb
@@ -31,7 +31,7 @@ class Standard
     if insulation_layer_name.nil? && target_u_value_ip == 0.0
       # Do nothing if the construction already doesn't have an insulation layer
     elsif insulation_layer_name.nil?
-      insulation_layer_name = find_and_set_insulaton_layer(construction).name
+      insulation_layer_name = find_and_set_insulation_layer(construction).name
     end
 
     # Remove the insulation layer if the specified U-value is zero.

--- a/lib/openstudio-standards/standards/Standards.Construction.rb
+++ b/lib/openstudio-standards/standards/Standards.Construction.rb
@@ -31,7 +31,7 @@ class Standard
     if insulation_layer_name.nil? && target_u_value_ip == 0.0
       # Do nothing if the construction already doesn't have an insulation layer
     elsif insulation_layer_name.nil?
-      insulation_layer_name = find_and_set_insulation_layer(construction).name
+      insulation_layer_name = find_and_set_insulaton_layer(construction).name
     end
 
     # Remove the insulation layer if the specified U-value is zero.


### PR DESCRIPTION
change methods to use find_and_set_insulation_layer instead of find_and_set_insulaton_layer (misspelled), and delete all instances  of find_and_set_insulaton_layer (misspelled)