### PR TITLE
change prm boiler naming

### DIFF
--- a/lib/openstudio-standards/standards/Standards.BoilerHotWater.rb
+++ b/lib/openstudio-standards/standards/Standards.BoilerHotWater.rb
@@ -53,6 +53,24 @@ class Standard
     return capacity_w
   end
 
+  # Find design water flow rate in m^3/s
+  #
+  # @param boiler_hot_water [OpenStudio::Model::BoilerHotWater] hot water boiler object
+  # @return [Double] design water flow rate in m^3/s
+  def boiler_hot_water_find_design_water_flow_rate(boiler_hot_water)
+    design_water_flow_rate_m3_per_s = nil
+    if boiler_hot_water.designWaterFlowRate.is_initialized
+      design_water_flow_rate_m3_per_s = boiler_hot_water.designWaterFlowRate.get
+    elsif boiler_hot_water.autosizedDesignWaterFlowRate.is_initialized
+      design_water_flow_rate_m3_per_s = boiler_hot_water.autosizedDesignWaterFlowRate.get
+    else
+      OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.BoilerHotWater', "For #{boiler_hot_water.name} design water flow rate is not available.")
+      return false
+    end
+
+    return design_water_flow_rate_m3_per_s
+  end
+
   # Finds lookup object in standards and return minimum thermal efficiency
   #
   # @param boiler_hot_water [OpenStudio::Model::BoilerHotWater] hot water boiler object

--- a/lib/openstudio-standards/standards/Standards.PlantLoop.rb
+++ b/lib/openstudio-standards/standards/Standards.PlantLoop.rb
@@ -954,7 +954,9 @@ class Standard
       boiler.setSizingFactor(sizing_factor)
       boiler_capacity_autosized = boiler.isNominalCapacityAutosized
       capacity_w = boiler_hot_water_find_capacity(boiler)
-      boiler.setNominalCapacity(capacity_w * sizing_factor)
+      if capacity_w
+        boiler.setNominalCapacity(capacity_w * sizing_factor)
+      end
 
       boiler_flow_rate_autosized = boiler.isDesignWaterFlowRateAutosized
       unless boiler_flow_rate_autosized

--- a/lib/openstudio-standards/standards/Standards.PlantLoop.rb
+++ b/lib/openstudio-standards/standards/Standards.PlantLoop.rb
@@ -965,7 +965,7 @@ class Standard
       end
 
       # Reapply the standard efficiencies as the sizing change may have changed the efficiency lookup
-      boiler_hot_water_standard_minimum_thermal_efficiency(boiler_hot_water, rename = true)
+      boiler_hot_water_standard_minimum_thermal_efficiency(boiler, rename = true)
 
       # Reset back to autosized if the boiler capacity was initially autosized
       boiler.autosizeNominalCapacity if boiler_capacity_autosized

--- a/lib/openstudio-standards/standards/Standards.PlantLoop.rb
+++ b/lib/openstudio-standards/standards/Standards.PlantLoop.rb
@@ -945,30 +945,11 @@ class Standard
     final_boilers = [first_boiler, second_boiler]
     OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.PlantLoop', "For #{plant_loop.name}, added a second boiler.")
 
-    # Set the sizing factor for all boilers evenly and Rename the boilers
+    # Rename boilers and set the sizing factor
     sizing_factor = (1.0 / final_boilers.size).round(2)
     final_boilers.each_with_index do |boiler, i|
       boiler.setName("#{plant_loop.name} Boiler #{i + 1} of #{final_boilers.size}")
-      
-      # Set new sizing factor and new capacity (temporarily if autosized)
       boiler.setSizingFactor(sizing_factor)
-      boiler_capacity_autosized = boiler.isNominalCapacityAutosized
-      capacity_w = boiler_hot_water_find_capacity(boiler)
-      if capacity_w
-        boiler.setNominalCapacity(capacity_w * sizing_factor)
-      end
-
-      boiler_flow_rate_autosized = boiler.isDesignWaterFlowRateAutosized
-      unless boiler_flow_rate_autosized
-        design_water_flow_rate_m3_per_s = boiler_hot_water_find_design_water_flow_rate(boiler)
-        boiler.setDesignWaterFlowRate(design_water_flow_rate_m3_per_s * sizing_factor)
-      end
-
-      # Reapply the standard efficiencies as the sizing change may have changed the efficiency lookup
-      boiler_hot_water_standard_minimum_thermal_efficiency(boiler, rename = true)
-
-      # Reset back to autosized if the boiler capacity was initially autosized
-      boiler.autosizeNominalCapacity if boiler_capacity_autosized
     end
 
     # Set the equipment to stage sequentially

--- a/lib/openstudio-standards/standards/Standards.PlantLoop.rb
+++ b/lib/openstudio-standards/standards/Standards.PlantLoop.rb
@@ -948,8 +948,25 @@ class Standard
     # Set the sizing factor for all boilers evenly and Rename the boilers
     sizing_factor = (1.0 / final_boilers.size).round(2)
     final_boilers.each_with_index do |boiler, i|
+      boiler.setName("#{plant_loop.name} Boiler #{i + 1} of #{final_boilers.size}")
+      
+      # Set new sizing factor and new capacity (temporarily if autosized)
       boiler.setSizingFactor(sizing_factor)
-      boiler.setName("#{first_boiler.name} #{i + 1} of #{final_boilers.size}")
+      boiler_capacity_autosized = boiler.isNominalCapacityAutosized
+      capacity_w = boiler_hot_water_find_capacity(boiler)
+      boiler.setNominalCapacity(capacity_w * sizing_factor)
+
+      boiler_flow_rate_autosized = boiler.isDesignWaterFlowRateAutosized
+      unless boiler_flow_rate_autosized
+        design_water_flow_rate_m3_per_s = boiler_hot_water_find_design_water_flow_rate(boiler)
+        boiler.setDesignWaterFlowRate(design_water_flow_rate_m3_per_s * sizing_factor)
+      end
+
+      # Reapply the standard efficiencies as the sizing change may have changed the efficiency lookup
+      boiler_hot_water_standard_minimum_thermal_efficiency(boiler_hot_water, rename = true)
+
+      # Reset back to autosized if the boiler capacity was initially autosized
+      boiler.autosizeNominalCapacity if boiler_capacity_autosized
     end
 
     # Set the equipment to stage sequentially


### PR DESCRIPTION
- Fix #230
- Update to PRM method to have better naming for boilers
- Re-apply efficiency standard because multiple boilers with lower capacity may have different efficiency standards at the smaller size