### PR TITLE
Logging and test update

### DIFF
--- a/data/openstudio_standards_data/applications/database_maintenance.py
+++ b/data/openstudio_standards_data/applications/database_maintenance.py
@@ -1,4 +1,5 @@
 import sqlite3
+import logging
 
 import database_tables as tables
 from database_engine.database_util import read_csv_to_list_dict, read_json_to_list_dict
@@ -12,8 +13,8 @@ def create_openstudio_standards_database_from_csv(conn: sqlite3.Connection):
             datatable.create_a_table(conn)
             data = read_csv_to_list_dict(f"{datatable.initial_data_directory}.csv")
             for record in data:
-                print(record)
-                print(datatable.add_a_record(conn, record))
+                logging.info(record)
+                logging.info(datatable.add_a_record(conn, record))
 
 
 def create_openstudio_standards_database_from_json(conn: sqlite3.Connection):
@@ -24,8 +25,8 @@ def create_openstudio_standards_database_from_json(conn: sqlite3.Connection):
             datatable.create_a_table(conn)
             data = read_json_to_list_dict(f"{datatable.initial_data_directory}.json")
             for record in data:
-                print(record)
-                print(datatable.add_a_record(conn, record))
+                logging.info(record)
+                logging.info(datatable.add_a_record(conn, record))
 
 
 def export_openstudio_standards_database_to_csv(conn: sqlite3.Connection, save_dir=""):

--- a/data/openstudio_standards_data/database_engine/database.py
+++ b/data/openstudio_standards_data/database_engine/database.py
@@ -2,6 +2,7 @@ import sqlite3
 from sqlite3 import Error
 import csv
 import json
+import logging
 
 DB_FILE = "openstudio_standards_database.db"
 
@@ -18,7 +19,7 @@ def create_connect(db_file):
         # enable foreign keys execution
         conn.execute("PRAGMA foreign_keys = 1")
     except Error as e:
-        print(e)
+        logging.error(e)
     return conn
 
 
@@ -40,7 +41,7 @@ class DBOperation:
         :param connection:
         :return:
         """
-        print(f"creating table: {self.data_table_name}")
+        logging.info(f"creating table: {self.data_table_name}")
         connection.execute(self._get_create_table_query())
         return True
 

--- a/data/openstudio_standards_data/test/test_database.py
+++ b/data/openstudio_standards_data/test/test_database.py
@@ -2,12 +2,18 @@ from unittest import TestCase
 from unittest import mock
 import os
 import sqlite3
+import difflib
+import glob
+import shutil
 from applications.database_maintenance import (
     create_openstudio_standards_database_from_csv,
+    create_openstudio_standards_database_from_json,
+    export_openstudio_standards_database_to_csv,
+    export_openstudio_standards_database_to_json,
 )
 
 
-class TestDatabaseQuries(TestCase):
+class TestDatabaseQueries(TestCase):
     """
     Test database - unfinished
     """
@@ -27,13 +33,23 @@ class TestDatabaseQuries(TestCase):
         pass
 
 
-def test_create_database():
-    # Create DB
-    db_name = "openstudio_standards_data"
+def create_db(db_name, from_type=""):
+    # Delete DB if already exists
     if os.path.isfile(f"{db_name}.db"):
         os.remove(f"{db_name}.db")
     conn = sqlite3.connect(f"{db_name}.db")
-    create_openstudio_standards_database_from_csv(conn)
+    # Create DB
+    if from_type == "json":
+        create_openstudio_standards_database_from_json(conn)
+    else:
+        create_openstudio_standards_database_from_csv(conn)
+    return conn
+
+
+def test_create_export_database():
+    # Create DB from JSON file
+    db_name = "openstudio_standards_data"
+    conn = create_db(db_name=db_name, from_type="json")
 
     # Check that DB exists
     assert os.path.isfile(f"{db_name}.db")
@@ -44,5 +60,47 @@ def test_create_database():
     res = cur.fetchall()
     assert len(res) == 0, f"Foreign key issue: {res}"
 
-    # Close DB
+    # Create a copy of original JSON files
+    if os.path.isdir("./original_database_files"):
+        shutil.rmtree("./original_database_files", ignore_errors=True)
+    shutil.copytree("./database_files", "./original_database_files")
+
+    # Export data to JSON and CSV files
+    export_openstudio_standards_database_to_json(conn, save_dir="./database_files/")
+    export_openstudio_standards_database_to_csv(conn, save_dir="./database_files/")
     conn.close()
+
+    # Regenerate DB from JSON and CSV files
+    db_name = "openstudio_standards_data_from_csv"
+    conn_csv = create_db(db_name=db_name, from_type="csv")
+    db_name = "openstudio_standards_data_from_json"
+    conn_json = create_db(db_name=db_name, from_type="json")
+
+    # Export both DB to JSON files
+    if not os.path.isdir("./test/database_files_from_json"):
+        os.mkdir("./test/database_files_from_json")
+    if not os.path.isdir("./test/database_files_from_csv"):
+        os.mkdir("./test/database_files_from_csv")
+    export_openstudio_standards_database_to_json(
+        conn_json, save_dir="./test/database_files_from_json/"
+    )
+    export_openstudio_standards_database_to_json(
+        conn_csv, save_dir="./test/database_files_from_csv/"
+    )
+    conn.close()
+
+    # Compare original JSON files with the ones generated from both DB
+    # There should be no difference between the JSON files originating
+    # from a DB generated from JSON or CSV files
+    filenames = glob.glob("./test/database_files_from_json/*.json")
+    filenames = [f.split("\\")[-1] for f in filenames]
+    for f in filenames:
+        with open(f"./test/database_files_from_json/{f}") as f_from_json:
+            fc_from_json = f_from_json.readlines()
+        with open(f"./test/database_files_from_csv/{f}") as f_from_csv:
+            fc_from_csv = f_from_csv.readlines()
+        with open(f"./original_database_files/{f}") as f_org:
+            fc_org = f_org.readlines()
+            assert (
+                fc_from_json == fc_from_csv == fc_org
+            ), f"Content is different in {f}.json files"

--- a/data/openstudio_standards_data/test/test_template.py
+++ b/data/openstudio_standards_data/test/test_template.py
@@ -6,12 +6,6 @@ from applications.database_maintenance import (
 )
 
 db_name = "openstudio_standards_data"
-if os.path.isfile(f"{db_name}.db"):
-    os.remove(f"{db_name}.db")
-conn = sqlite3.connect(f"{db_name}.db")
-create_openstudio_standards_database_from_csv(conn)
-conn.close()
-assert os.path.isfile(f"{db_name}.db")
 
 
 def test_get_template_data__true():


### PR DESCRIPTION
Use logging instead or `print()` and expand a bit on the tests to make sure that JSON generated from a database created using either CSV of JSON files has the same content.