### PR TITLE
check PTHP cop coefficients

### DIFF
--- a/lib/openstudio-standards/standards/Standards.CoilHeatingDXSingleSpeed.rb
+++ b/lib/openstudio-standards/standards/Standards.CoilHeatingDXSingleSpeed.rb
@@ -129,7 +129,7 @@ class Standard
     end
 
     # If PTHP, use equations
-    if sub_category == 'PTHP'
+    if sub_category == 'PTHP' && !ac_props['pthp_cop_coefficient_1'].nil? && !ac_props['pthp_cop_coefficient_2'].nil
       pthp_cop_coeff_1 = ac_props['pthp_cop_coefficient_1']
       pthp_cop_coeff_2 = ac_props['pthp_cop_coefficient_2']
       # TABLE 6.8.1D

--- a/lib/openstudio-standards/standards/Standards.CoilHeatingDXSingleSpeed.rb
+++ b/lib/openstudio-standards/standards/Standards.CoilHeatingDXSingleSpeed.rb
@@ -129,7 +129,7 @@ class Standard
     end
 
     # If PTHP, use equations
-    if sub_category == 'PTHP' && !ac_props['pthp_cop_coefficient_1'].nil? && !ac_props['pthp_cop_coefficient_2'].nil
+    if sub_category == 'PTHP' && !ac_props['pthp_cop_coefficient_1'].nil? && !ac_props['pthp_cop_coefficient_2'].nil?
       pthp_cop_coeff_1 = ac_props['pthp_cop_coefficient_1']
       pthp_cop_coeff_2 = ac_props['pthp_cop_coefficient_2']
       # TABLE 6.8.1D

--- a/test/os_stds_methods/models/basic_pthp_model.osm
+++ b/test/os_stds_methods/models/basic_pthp_model.osm
@@ -1,0 +1,4139 @@
+
+OS:Version,
+  {4578f889-5f2a-465a-ae85-e573e2d290e1}, !- Handle
+  3.5.1,                                  !- Version Identifier
+  alpha;                                  !- Prerelease Identifier
+
+OS:Building,
+  {92940726-c2dd-49c5-9387-f2a903754def}, !- Handle
+  Building 1,                             !- Name
+  ,                                       !- Building Sector Type
+  0,                                      !- North Axis {deg}
+  ,                                       !- Nominal Floor to Floor Height {m}
+  ,                                       !- Space Type Name
+  {f0c3e122-ad83-48b1-a082-da84e06546af}, !- Default Construction Set Name
+  ,                                       !- Default Schedule Set Name
+  ,                                       !- Standards Number of Stories
+  ,                                       !- Standards Number of Above Ground Stories
+  90.1-2019,                              !- Standards Template
+  MidriseApartment;                       !- Standards Building Type
+
+OS:Facility,
+  {8b8ece4d-3100-4155-80b3-058660dc117a}; !- Handle
+
+OS:Site,
+  {28d24b73-afa3-4d6f-ab04-3312d983fa9d}, !- Handle
+  Site 1,                                 !- Name
+  ,                                       !- Latitude {deg}
+  ,                                       !- Longitude {deg}
+  ,                                       !- Time Zone {hr}
+  ,                                       !- Elevation {m}
+  City;                                   !- Terrain
+
+OS:SimulationControl,
+  {2967b6c0-7e37-452b-92c9-a1a1bc9d8d1e}, !- Handle
+  Yes,                                    !- Do Zone Sizing Calculation
+  Yes,                                    !- Do System Sizing Calculation
+  Yes,                                    !- Do Plant Sizing Calculation
+  No,                                     !- Run Simulation for Sizing Periods
+  Yes,                                    !- Run Simulation for Weather File Run Periods
+  ,                                       !- Loads Convergence Tolerance Value {W}
+  ,                                       !- Temperature Convergence Tolerance Value {deltaC}
+  FullExteriorWithReflections;            !- Solar Distribution
+
+OS:Sizing:Parameters,
+  {e5594d34-3aa7-46e0-8ada-e725b7af0268}, !- Handle
+  1.25,                                   !- Heating Sizing Factor
+  1.15;                                   !- Cooling Sizing Factor
+
+OS:Timestep,
+  {100131c3-55bb-49b8-ba18-728204e7ea14}, !- Handle
+  6;                                      !- Number of Timesteps per Hour
+
+OS:ShadowCalculation,
+  {e3cd92b7-05d7-4f7b-ba02-bbcf8a0aa2d9}, !- Handle
+  PolygonClipping,                        !- Shading Calculation Method
+  Periodic,                               !- Shading Calculation Update Frequency Method
+  30,                                     !- Shading Calculation Update Frequency
+  15000,                                  !- Maximum Figures in Shadow Overlap Calculations
+  ,                                       !- Polygon Clipping Algorithm
+  512,                                    !- Pixel Counting Resolution
+  ,                                       !- Sky Diffuse Modeling Algorithm
+  No,                                     !- Output External Shading Calculation Results
+  No,                                     !- Disable Self-Shading Within Shading Zone Groups
+  No;                                     !- Disable Self-Shading From Shading Zone Groups to Other Zones
+
+OS:HeatBalanceAlgorithm,
+  {b4c77b2e-7737-4a82-896d-216409664a4f}, !- Handle
+  ConductionTransferFunction,             !- Algorithm
+  200;                                    !- Surface Temperature Upper Limit {C}
+
+OS:RunPeriod,
+  {0dbc99f0-c664-41b1-b94a-65814c9f0089}, !- Handle
+  Run Period 1,                           !- Name
+  1,                                      !- Begin Month
+  1,                                      !- Begin Day of Month
+  12,                                     !- End Month
+  31,                                     !- End Day of Month
+  ,                                       !- Use Weather File Holidays and Special Days
+  ,                                       !- Use Weather File Daylight Saving Period
+  ,                                       !- Apply Weekend Holiday Rule
+  ,                                       !- Use Weather File Rain Indicators
+  ,                                       !- Use Weather File Snow Indicators
+  ;                                       !- Number of Times Runperiod to be Repeated
+
+OS:LifeCycleCost:Parameters,
+  {0075a268-ed9c-4a81-b1ec-40862b623f4b}, !- Handle
+  ,                                       !- Analysis Type
+  ,                                       !- Discounting Convention
+  ,                                       !- Inflation Approach
+  ,                                       !- Real Discount Rate
+  ,                                       !- Nominal Discount Rate
+  ,                                       !- Inflation
+  ,                                       !- Base Date Month
+  ,                                       !- Base Date Year
+  ,                                       !- Service Date Month
+  ,                                       !- Service Date Year
+  ;                                       !- Length of Study Period in Years
+
+OS:SizingPeriod:DesignDay,
+  {e106879a-eedf-486f-93a8-81c1431601ac}, !- Handle
+  White Plains Westchester Co A Ann Htg 99.6% Condns DB, !- Name
+  -13.5,                                  !- Maximum Dry-Bulb Temperature {C}
+  0,                                      !- Daily Dry-Bulb Temperature Range {deltaC}
+  99868,                                  !- Barometric Pressure {Pa}
+  4.9,                                    !- Wind Speed {m/s}
+  320,                                    !- Wind Direction {deg}
+  0,                                      !- Sky Clearness
+  ,                                       !- Rain Indicator
+  ,                                       !- Snow Indicator
+  21,                                     !- Day of Month
+  1,                                      !- Month
+  WinterDesignDay,                        !- Day Type
+  ,                                       !- Daylight Saving Time Indicator
+  Wetbulb,                                !- Humidity Condition Type
+  ,                                       !- Humidity Condition Day Schedule Name
+  -13.5,                                  !- Wetbulb or DewPoint at Maximum Dry-Bulb {C}
+  ,                                       !- Humidity Ratio at Maximum Dry-Bulb {kgWater/kgDryAir}
+  ,                                       !- Enthalpy at Maximum Dry-Bulb {J/kg}
+  ,                                       !- Dry-Bulb Temperature Range Modifier Type
+  ,                                       !- Dry-Bulb Temperature Range Modifier Day Schedule Name
+  ASHRAEClearSky;                         !- Solar Model Indicator
+
+OS:SizingPeriod:DesignDay,
+  {4505567f-f655-4531-94dc-f3afb0432188}, !- Handle
+  White Plains Westchester Co A Ann Hum_n 99.6% Condns DP=>MCDB, !- Name
+  -11.6,                                  !- Maximum Dry-Bulb Temperature {C}
+  0,                                      !- Daily Dry-Bulb Temperature Range {deltaC}
+  99868,                                  !- Barometric Pressure {Pa}
+  4.9,                                    !- Wind Speed {m/s}
+  320,                                    !- Wind Direction {deg}
+  0,                                      !- Sky Clearness
+  ,                                       !- Rain Indicator
+  ,                                       !- Snow Indicator
+  21,                                     !- Day of Month
+  1,                                      !- Month
+  WinterDesignDay,                        !- Day Type
+  ,                                       !- Daylight Saving Time Indicator
+  Dewpoint,                               !- Humidity Condition Type
+  ,                                       !- Humidity Condition Day Schedule Name
+  -22.1,                                  !- Wetbulb or DewPoint at Maximum Dry-Bulb {C}
+  ,                                       !- Humidity Ratio at Maximum Dry-Bulb {kgWater/kgDryAir}
+  ,                                       !- Enthalpy at Maximum Dry-Bulb {J/kg}
+  ,                                       !- Dry-Bulb Temperature Range Modifier Type
+  ,                                       !- Dry-Bulb Temperature Range Modifier Day Schedule Name
+  ASHRAEClearSky;                         !- Solar Model Indicator
+
+OS:SizingPeriod:DesignDay,
+  {dac9a898-9891-4505-b396-3ae82b40e3a7}, !- Handle
+  White Plains Westchester Co A Ann Htg Wind 99.6% Condns WS=>MCDB, !- Name
+  -5.3,                                   !- Maximum Dry-Bulb Temperature {C}
+  0,                                      !- Daily Dry-Bulb Temperature Range {deltaC}
+  99868,                                  !- Barometric Pressure {Pa}
+  11.4,                                   !- Wind Speed {m/s}
+  320,                                    !- Wind Direction {deg}
+  0,                                      !- Sky Clearness
+  ,                                       !- Rain Indicator
+  ,                                       !- Snow Indicator
+  21,                                     !- Day of Month
+  1,                                      !- Month
+  WinterDesignDay,                        !- Day Type
+  ,                                       !- Daylight Saving Time Indicator
+  Wetbulb,                                !- Humidity Condition Type
+  ,                                       !- Humidity Condition Day Schedule Name
+  -5.3,                                   !- Wetbulb or DewPoint at Maximum Dry-Bulb {C}
+  ,                                       !- Humidity Ratio at Maximum Dry-Bulb {kgWater/kgDryAir}
+  ,                                       !- Enthalpy at Maximum Dry-Bulb {J/kg}
+  ,                                       !- Dry-Bulb Temperature Range Modifier Type
+  ,                                       !- Dry-Bulb Temperature Range Modifier Day Schedule Name
+  ASHRAEClearSky;                         !- Solar Model Indicator
+
+OS:SizingPeriod:DesignDay,
+  {2eb8654f-270e-499e-b6a9-7461efe0c4a0}, !- Handle
+  White Plains Westchester Co A Ann Clg .4% Condns DB=>MWB, !- Name
+  32.2,                                   !- Maximum Dry-Bulb Temperature {C}
+  9.6,                                    !- Daily Dry-Bulb Temperature Range {deltaC}
+  99868,                                  !- Barometric Pressure {Pa}
+  3.8,                                    !- Wind Speed {m/s}
+  270,                                    !- Wind Direction {deg}
+  ,                                       !- Sky Clearness
+  ,                                       !- Rain Indicator
+  ,                                       !- Snow Indicator
+  21,                                     !- Day of Month
+  7,                                      !- Month
+  SummerDesignDay,                        !- Day Type
+  ,                                       !- Daylight Saving Time Indicator
+  Wetbulb,                                !- Humidity Condition Type
+  ,                                       !- Humidity Condition Day Schedule Name
+  23.4,                                   !- Wetbulb or DewPoint at Maximum Dry-Bulb {C}
+  ,                                       !- Humidity Ratio at Maximum Dry-Bulb {kgWater/kgDryAir}
+  ,                                       !- Enthalpy at Maximum Dry-Bulb {J/kg}
+  ,                                       !- Dry-Bulb Temperature Range Modifier Type
+  ,                                       !- Dry-Bulb Temperature Range Modifier Day Schedule Name
+  ASHRAETau,                              !- Solar Model Indicator
+  ,                                       !- Beam Solar Day Schedule Name
+  ,                                       !- Diffuse Solar Day Schedule Name
+  0.506,                                  !- ASHRAE Clear Sky Optical Depth for Beam Irradiance {dimensionless}
+  1.88;                                   !- ASHRAE Clear Sky Optical Depth for Diffuse Irradiance {dimensionless}
+
+OS:SizingPeriod:DesignDay,
+  {2afbdba8-c2ca-4550-8e13-f0c7457b758f}, !- Handle
+  White Plains Westchester Co A Ann Clg .4% Condns WB=>MDB, !- Name
+  29.7,                                   !- Maximum Dry-Bulb Temperature {C}
+  9.6,                                    !- Daily Dry-Bulb Temperature Range {deltaC}
+  99868,                                  !- Barometric Pressure {Pa}
+  3.8,                                    !- Wind Speed {m/s}
+  270,                                    !- Wind Direction {deg}
+  ,                                       !- Sky Clearness
+  ,                                       !- Rain Indicator
+  ,                                       !- Snow Indicator
+  21,                                     !- Day of Month
+  7,                                      !- Month
+  SummerDesignDay,                        !- Day Type
+  ,                                       !- Daylight Saving Time Indicator
+  Wetbulb,                                !- Humidity Condition Type
+  ,                                       !- Humidity Condition Day Schedule Name
+  24.8,                                   !- Wetbulb or DewPoint at Maximum Dry-Bulb {C}
+  ,                                       !- Humidity Ratio at Maximum Dry-Bulb {kgWater/kgDryAir}
+  ,                                       !- Enthalpy at Maximum Dry-Bulb {J/kg}
+  ,                                       !- Dry-Bulb Temperature Range Modifier Type
+  ,                                       !- Dry-Bulb Temperature Range Modifier Day Schedule Name
+  ASHRAETau,                              !- Solar Model Indicator
+  ,                                       !- Beam Solar Day Schedule Name
+  ,                                       !- Diffuse Solar Day Schedule Name
+  0.506,                                  !- ASHRAE Clear Sky Optical Depth for Beam Irradiance {dimensionless}
+  1.88;                                   !- ASHRAE Clear Sky Optical Depth for Diffuse Irradiance {dimensionless}
+
+OS:SizingPeriod:DesignDay,
+  {08897b48-96e7-4f3e-a8b1-5252d368877f}, !- Handle
+  White Plains Westchester Co A Ann Clg .4% Condns DP=>MDB, !- Name
+  26.5,                                   !- Maximum Dry-Bulb Temperature {C}
+  9.6,                                    !- Daily Dry-Bulb Temperature Range {deltaC}
+  99868,                                  !- Barometric Pressure {Pa}
+  3.8,                                    !- Wind Speed {m/s}
+  270,                                    !- Wind Direction {deg}
+  ,                                       !- Sky Clearness
+  ,                                       !- Rain Indicator
+  ,                                       !- Snow Indicator
+  21,                                     !- Day of Month
+  7,                                      !- Month
+  SummerDesignDay,                        !- Day Type
+  ,                                       !- Daylight Saving Time Indicator
+  Dewpoint,                               !- Humidity Condition Type
+  ,                                       !- Humidity Condition Day Schedule Name
+  23.1,                                   !- Wetbulb or DewPoint at Maximum Dry-Bulb {C}
+  ,                                       !- Humidity Ratio at Maximum Dry-Bulb {kgWater/kgDryAir}
+  ,                                       !- Enthalpy at Maximum Dry-Bulb {J/kg}
+  ,                                       !- Dry-Bulb Temperature Range Modifier Type
+  ,                                       !- Dry-Bulb Temperature Range Modifier Day Schedule Name
+  ASHRAETau,                              !- Solar Model Indicator
+  ,                                       !- Beam Solar Day Schedule Name
+  ,                                       !- Diffuse Solar Day Schedule Name
+  0.506,                                  !- ASHRAE Clear Sky Optical Depth for Beam Irradiance {dimensionless}
+  1.88;                                   !- ASHRAE Clear Sky Optical Depth for Diffuse Irradiance {dimensionless}
+
+OS:SizingPeriod:DesignDay,
+  {cff939c1-705c-45f9-9a1d-93e2d7792e43}, !- Handle
+  White Plains Westchester Co A Ann Clg .4% Condns Enth=>MDB, !- Name
+  29.7,                                   !- Maximum Dry-Bulb Temperature {C}
+  9.6,                                    !- Daily Dry-Bulb Temperature Range {deltaC}
+  99868,                                  !- Barometric Pressure {Pa}
+  3.8,                                    !- Wind Speed {m/s}
+  270,                                    !- Wind Direction {deg}
+  ,                                       !- Sky Clearness
+  ,                                       !- Rain Indicator
+  ,                                       !- Snow Indicator
+  21,                                     !- Day of Month
+  7,                                      !- Month
+  SummerDesignDay,                        !- Day Type
+  ,                                       !- Daylight Saving Time Indicator
+  Enthalpy,                               !- Humidity Condition Type
+  ,                                       !- Humidity Condition Day Schedule Name
+  23,                                     !- Wetbulb or DewPoint at Maximum Dry-Bulb {C}
+  ,                                       !- Humidity Ratio at Maximum Dry-Bulb {kgWater/kgDryAir}
+  75500,                                  !- Enthalpy at Maximum Dry-Bulb {J/kg}
+  ,                                       !- Dry-Bulb Temperature Range Modifier Type
+  ,                                       !- Dry-Bulb Temperature Range Modifier Day Schedule Name
+  ASHRAETau,                              !- Solar Model Indicator
+  ,                                       !- Beam Solar Day Schedule Name
+  ,                                       !- Diffuse Solar Day Schedule Name
+  0.506,                                  !- ASHRAE Clear Sky Optical Depth for Beam Irradiance {dimensionless}
+  1.88;                                   !- ASHRAE Clear Sky Optical Depth for Diffuse Irradiance {dimensionless}
+
+OS:Site:WaterMainsTemperature,
+  {65564de3-4823-448d-a35e-50ab8bafb3b9}, !- Handle
+  CorrelationFromWeatherFile;             !- Calculation Method
+
+OS:ClimateZones,
+  {5414a9af-7413-4b25-818a-52993803778e}, !- Handle
+  ASHRAE,                                 !- Climate Zone Institution Name 1
+  ANSI/ASHRAE Standard 169,               !- Climate Zone Document Name 1
+  2006,                                   !- Climate Zone Document Year 1
+  5A;                                     !- Climate Zone Value 1
+
+OS:Output:Variable,
+  {9a772321-84c8-4ead-8f73-25f517810a8f}, !- Handle
+  Output Variable 1,                      !- Name
+  ,                                       !- Key Value
+  Baseboard Electricity Energy,           !- Variable Name
+  Hourly;                                 !- Reporting Frequency
+
+OS:Output:Variable,
+  {b73fd2aa-555f-4ceb-a1e4-370b15860f1b}, !- Handle
+  Output Variable 2,                      !- Name
+  ,                                       !- Key Value
+  Boiler Electricity Energy,              !- Variable Name
+  Hourly;                                 !- Reporting Frequency
+
+OS:Output:Variable,
+  {0394fb4c-b21f-4167-9720-da138c2b9211}, !- Handle
+  Output Variable 3,                      !- Name
+  ,                                       !- Key Value
+  Boiler NaturalGas Energy,               !- Variable Name
+  Hourly;                                 !- Reporting Frequency
+
+OS:Output:Variable,
+  {a08ebc2b-7922-45b0-ac37-cdf5af41eefd}, !- Handle
+  Output Variable 4,                      !- Name
+  ,                                       !- Key Value
+  Chiller Electricity Energy,             !- Variable Name
+  Hourly;                                 !- Reporting Frequency
+
+OS:Output:Variable,
+  {235993b3-69f4-457c-be27-74e2211f478c}, !- Handle
+  Output Variable 5,                      !- Name
+  ,                                       !- Key Value
+  Chiller Heater System Cooling Electricity Energy, !- Variable Name
+  Hourly;                                 !- Reporting Frequency
+
+OS:Output:Variable,
+  {7fa6f3ea-378d-4568-b41f-1fff3da221ef}, !- Handle
+  Output Variable 6,                      !- Name
+  ,                                       !- Key Value
+  Chiller Heater System Heating Electricity Energy, !- Variable Name
+  Hourly;                                 !- Reporting Frequency
+
+OS:Output:Variable,
+  {ab0fe060-eb58-4462-ad6a-3a395166a26a}, !- Handle
+  Output Variable 7,                      !- Name
+  ,                                       !- Key Value
+  Cooling Coil Electricity Energy,        !- Variable Name
+  Hourly;                                 !- Reporting Frequency
+
+OS:Output:Variable,
+  {06e72356-3c2e-42c2-abaf-8c9f045e81e7}, !- Handle
+  Output Variable 8,                      !- Name
+  ,                                       !- Key Value
+  Cooling Coil Water Heating Electricity Energy, !- Variable Name
+  Hourly;                                 !- Reporting Frequency
+
+OS:Output:Variable,
+  {79c69e39-f7a7-49b3-872d-31eb3c784d89}, !- Handle
+  Output Variable 9,                      !- Name
+  ,                                       !- Key Value
+  Cooling Tower Fan Electricity Energy,   !- Variable Name
+  Hourly;                                 !- Reporting Frequency
+
+OS:Output:Variable,
+  {9581e35e-f2ad-4e7f-97a2-cf0e87ed5e0a}, !- Handle
+  Output Variable 10,                     !- Name
+  ,                                       !- Key Value
+  District Cooling Chilled Water Energy,  !- Variable Name
+  Hourly;                                 !- Reporting Frequency
+
+OS:Output:Variable,
+  {145dfab0-97b3-4861-8aad-a7d0e032aa62}, !- Handle
+  Output Variable 11,                     !- Name
+  ,                                       !- Key Value
+  District Heating Hot Water Energy,      !- Variable Name
+  Hourly;                                 !- Reporting Frequency
+
+OS:Output:Variable,
+  {22d8e72a-57d4-4317-a75a-4ba141c1d34b}, !- Handle
+  Output Variable 12,                     !- Name
+  ,                                       !- Key Value
+  Evaporative Cooler Electricity Energy,  !- Variable Name
+  Hourly;                                 !- Reporting Frequency
+
+OS:Output:Variable,
+  {35e377cf-3ebf-4dfa-9555-180a693cd824}, !- Handle
+  Output Variable 13,                     !- Name
+  ,                                       !- Key Value
+  Fan Electricity Energy,                 !- Variable Name
+  Hourly;                                 !- Reporting Frequency
+
+OS:Output:Variable,
+  {8480f80a-df63-45c5-9378-ec4282dc3cf8}, !- Handle
+  Output Variable 14,                     !- Name
+  ,                                       !- Key Value
+  Heating Coil Electricity Energy,        !- Variable Name
+  Hourly;                                 !- Reporting Frequency
+
+OS:Output:Variable,
+  {d10a6033-c288-4766-b89f-7863c905f7d3}, !- Handle
+  Output Variable 15,                     !- Name
+  ,                                       !- Key Value
+  Heating Coil NaturalGas Energy,         !- Variable Name
+  Hourly;                                 !- Reporting Frequency
+
+OS:Output:Variable,
+  {6e7e74d6-9b27-41d8-8300-85ba6e5ed447}, !- Handle
+  Output Variable 16,                     !- Name
+  ,                                       !- Key Value
+  Heating Coil Total Heating Energy,      !- Variable Name
+  Hourly;                                 !- Reporting Frequency
+
+OS:Output:Variable,
+  {14bd7a4f-7fd6-4c35-8369-cf7356530248}, !- Handle
+  Output Variable 17,                     !- Name
+  ,                                       !- Key Value
+  Hot_Water_Loop_Central_Air_Source_Heat_Pump Electricity Consumption, !- Variable Name
+  Hourly;                                 !- Reporting Frequency
+
+OS:Output:Variable,
+  {265d00b0-ee1e-4072-988d-b0f4cf9a8b3e}, !- Handle
+  Output Variable 18,                     !- Name
+  ,                                       !- Key Value
+  Humidifier Electricity Energy,          !- Variable Name
+  Hourly;                                 !- Reporting Frequency
+
+OS:Output:Variable,
+  {b11c6c33-9337-4b44-8b86-9174d6ebceae}, !- Handle
+  Output Variable 19,                     !- Name
+  ,                                       !- Key Value
+  Pump Electricity Energy,                !- Variable Name
+  Hourly;                                 !- Reporting Frequency
+
+OS:Output:Variable,
+  {b5d1c7e1-9e12-489f-bb6a-c543ef6ce7fc}, !- Handle
+  Output Variable 20,                     !- Name
+  ,                                       !- Key Value
+  VRF Heat Pump Cooling Electricity Energy, !- Variable Name
+  Hourly;                                 !- Reporting Frequency
+
+OS:Output:Variable,
+  {e0b71576-b2ac-4279-9f86-860f3d1b5bae}, !- Handle
+  Output Variable 21,                     !- Name
+  ,                                       !- Key Value
+  VRF Heat Pump Crankcase Heater Electricity Energy, !- Variable Name
+  Hourly;                                 !- Reporting Frequency
+
+OS:Output:Variable,
+  {c91f970a-9f2a-4f90-9832-d7efd8750a0d}, !- Handle
+  Output Variable 22,                     !- Name
+  ,                                       !- Key Value
+  VRF Heat Pump Defrost Electricity Energy, !- Variable Name
+  Hourly;                                 !- Reporting Frequency
+
+OS:Output:Variable,
+  {492fe12a-3606-4b85-afcc-b95cecc49a82}, !- Handle
+  Output Variable 23,                     !- Name
+  ,                                       !- Key Value
+  VRF Heat Pump Heating Electricity Energy, !- Variable Name
+  Hourly;                                 !- Reporting Frequency
+
+OS:Output:Variable,
+  {62ff672f-d60d-4977-8e65-0ec27c75925b}, !- Handle
+  Output Variable 24,                     !- Name
+  ,                                       !- Key Value
+  Water Heater Electricity Energy,        !- Variable Name
+  Hourly;                                 !- Reporting Frequency
+
+OS:Output:Variable,
+  {950d69c4-6268-406c-9f57-1c44caf6418c}, !- Handle
+  Output Variable 25,                     !- Name
+  ,                                       !- Key Value
+  Water Heater NaturalGas Energy,         !- Variable Name
+  Hourly;                                 !- Reporting Frequency
+
+OS:Output:Variable,
+  {f2fe8bab-0357-411a-bd5b-1a4586075f84}, !- Handle
+  Output Variable 26,                     !- Name
+  ,                                       !- Key Value
+  Water Use Equipment Heating Energy,     !- Variable Name
+  Hourly;                                 !- Reporting Frequency
+
+OS:Output:Variable,
+  {6b2344fe-4cdd-422c-a504-8d02705bafa3}, !- Handle
+  Output Variable 27,                     !- Name
+  ,                                       !- Key Value
+  Zone Electric Equipment Electricity Energy, !- Variable Name
+  Hourly;                                 !- Reporting Frequency
+
+OS:Output:Variable,
+  {7b2bcacc-b779-497b-9d19-1b5ef47e3c77}, !- Handle
+  Output Variable 28,                     !- Name
+  ,                                       !- Key Value
+  Zone Gas Equipment NaturalGas Energy,   !- Variable Name
+  Hourly;                                 !- Reporting Frequency
+
+OS:Output:Variable,
+  {719d42cc-4c82-4b2f-8f3d-4104037ff0de}, !- Handle
+  Output Variable 29,                     !- Name
+  ,                                       !- Key Value
+  Zone Ideal Loads Supply Air Total Cooling Energy, !- Variable Name
+  Hourly;                                 !- Reporting Frequency
+
+OS:Output:Variable,
+  {13d643bf-05d7-4ec9-b075-73226f178095}, !- Handle
+  Output Variable 30,                     !- Name
+  ,                                       !- Key Value
+  Zone Ideal Loads Supply Air Total Heating Energy, !- Variable Name
+  Hourly;                                 !- Reporting Frequency
+
+OS:Output:Variable,
+  {6e250650-3890-4024-a2dd-2287de2b24b7}, !- Handle
+  Output Variable 31,                     !- Name
+  ,                                       !- Key Value
+  Zone Lights Electricity Energy,         !- Variable Name
+  Hourly;                                 !- Reporting Frequency
+
+OS:Output:Variable,
+  {53362cbb-c460-4a31-8ff8-b5aaf1ca94a7}, !- Handle
+  Output Variable 32,                     !- Name
+  ,                                       !- Key Value
+  Zone Other Equipment Lost Heat Energy,  !- Variable Name
+  Hourly;                                 !- Reporting Frequency
+
+OS:Output:Variable,
+  {89201607-5fa2-4273-9f39-60fd6aaee52c}, !- Handle
+  Output Variable 33,                     !- Name
+  ,                                       !- Key Value
+  Zone Other Equipment Total Heating Energy, !- Variable Name
+  Hourly;                                 !- Reporting Frequency
+
+OS:Output:Variable,
+  {a9245044-f83a-45d3-9896-0ba03f3cc8f6}, !- Handle
+  Output Variable 34,                     !- Name
+  ,                                       !- Key Value
+  Zone VRF Air Terminal Cooling Electricity Energy, !- Variable Name
+  Hourly;                                 !- Reporting Frequency
+
+OS:Output:Variable,
+  {9b05042f-13ce-4c77-a412-049f0c40dd7a}, !- Handle
+  Output Variable 35,                     !- Name
+  ,                                       !- Key Value
+  Zone VRF Air Terminal Heating Electricity Energy, !- Variable Name
+  Hourly;                                 !- Reporting Frequency
+
+OS:Output:Variable,
+  {3a98c5da-c663-4db6-adf0-6fd7f9d78ade}, !- Handle
+  Output Variable 36,                     !- Name
+  ,                                       !- Key Value
+  Zone Ventilation Fan Electricity Energy, !- Variable Name
+  Hourly;                                 !- Reporting Frequency
+
+OS:Output:Table:SummaryReports,
+  {dacc9945-c3ca-40e0-8fd3-e601d7ffd5da}, !- Handle
+  AllSummary;                             !- Report Name 1
+
+OS:YearDescription,
+  {5fd8d844-bbdd-402f-b878-0ba364b6ffb1}, !- Handle
+  ,                                       !- Calendar Year
+  Sunday,                                 !- Day of Week for Start Day
+  No;                                     !- Is Leap Year
+
+OS:ScheduleTypeLimits,
+  {c8cfe707-c246-4b68-9e7e-d891a98b2357}, !- Handle
+  Temperature,                            !- Name
+  -273.15,                                !- Lower Limit Value
+  ,                                       !- Upper Limit Value
+  Continuous,                             !- Numeric Type
+  Temperature;                            !- Unit Type
+
+OS:ScheduleTypeLimits,
+  {2c86f4cd-9d00-4611-8205-b1e6971c61df}, !- Handle
+  Activity Level,                         !- Name
+  0,                                      !- Lower Limit Value
+  ,                                       !- Upper Limit Value
+  Continuous,                             !- Numeric Type
+  ActivityLevel;                          !- Unit Type
+
+OS:ScheduleTypeLimits,
+  {5ec29b47-2e16-4d0b-8501-22103961daaf}, !- Handle
+  Fractional,                             !- Name
+  0,                                      !- Lower Limit Value
+  1,                                      !- Upper Limit Value
+  Continuous,                             !- Numeric Type
+  Dimensionless;                          !- Unit Type
+
+OS:Schedule:Ruleset,
+  {6029af80-09e2-47e6-9788-93c6c4e7dfaa}, !- Handle
+  ApartmentMidRise HTGSETP_APT_SCH,       !- Name
+  {c8cfe707-c246-4b68-9e7e-d891a98b2357}, !- Schedule Type Limits Name
+  {767084bb-2ca5-4bbb-8a4d-6b0ef9761f1a}, !- Default Day Schedule Name
+  {a5391c12-4fa1-4cf9-9c6d-50a94cc0764d}, !- Summer Design Day Schedule Name
+  {79ac59f4-e994-4b2b-98a6-f13738a16aea}; !- Winter Design Day Schedule Name
+
+OS:Schedule:Day,
+  {767084bb-2ca5-4bbb-8a4d-6b0ef9761f1a}, !- Handle
+  ApartmentMidRise HTGSETP_APT_SCH_Default, !- Name
+  {c8cfe707-c246-4b68-9e7e-d891a98b2357}, !- Schedule Type Limits Name
+  ,                                       !- Interpolate to Timestep
+  24,                                     !- Hour 1
+  0,                                      !- Minute 1
+  21.7;                                   !- Value Until Time 1
+
+OS:Schedule:Day,
+  {a600404e-f1de-42b7-85eb-bf2c9bb0fe33}, !- Handle
+  ApartmentMidRise HTGSETP_APT_SCH_SmrDsn, !- Name
+  {c8cfe707-c246-4b68-9e7e-d891a98b2357}, !- Schedule Type Limits Name
+  ,                                       !- Interpolate to Timestep
+  24,                                     !- Hour 1
+  0,                                      !- Minute 1
+  21.7;                                   !- Value Until Time 1
+
+OS:Schedule:Day,
+  {ea08cbbd-a51b-45ca-b731-48173d7b57f2}, !- Handle
+  ApartmentMidRise HTGSETP_APT_SCH_WntrDsn, !- Name
+  {c8cfe707-c246-4b68-9e7e-d891a98b2357}, !- Schedule Type Limits Name
+  ,                                       !- Interpolate to Timestep
+  24,                                     !- Hour 1
+  0,                                      !- Minute 1
+  21.7;                                   !- Value Until Time 1
+
+OS:Schedule:Day,
+  {a5391c12-4fa1-4cf9-9c6d-50a94cc0764d}, !- Handle
+  ApartmentMidRise HTGSETP_APT_SCH_SmrDsn 1, !- Name
+  {c8cfe707-c246-4b68-9e7e-d891a98b2357}, !- Schedule Type Limits Name
+  ,                                       !- Interpolate to Timestep
+  24,                                     !- Hour 1
+  0,                                      !- Minute 1
+  21.7;                                   !- Value Until Time 1
+
+OS:Schedule:Day,
+  {79ac59f4-e994-4b2b-98a6-f13738a16aea}, !- Handle
+  ApartmentMidRise HTGSETP_APT_SCH_WntrDsn 1, !- Name
+  {c8cfe707-c246-4b68-9e7e-d891a98b2357}, !- Schedule Type Limits Name
+  ,                                       !- Interpolate to Timestep
+  24,                                     !- Hour 1
+  0,                                      !- Minute 1
+  21.7;                                   !- Value Until Time 1
+
+OS:Schedule:Ruleset,
+  {5ccc53e6-d989-4566-a468-10d0b79f9e4c}, !- Handle
+  ApartmentMidRise OCC_APT_SCH,           !- Name
+  {5ec29b47-2e16-4d0b-8501-22103961daaf}, !- Schedule Type Limits Name
+  {ffa74c57-4b13-41bb-b052-f26e01d1be32}, !- Default Day Schedule Name
+  {909ced8d-b6a9-4a01-9f4f-a4be42864bcb}, !- Summer Design Day Schedule Name
+  {ab2f0a6e-f5ca-45b2-845f-f1fea3539193}; !- Winter Design Day Schedule Name
+
+OS:Schedule:Day,
+  {ffa74c57-4b13-41bb-b052-f26e01d1be32}, !- Handle
+  ApartmentMidRise OCC_APT_SCH_Default,   !- Name
+  {5ec29b47-2e16-4d0b-8501-22103961daaf}, !- Schedule Type Limits Name
+  ,                                       !- Interpolate to Timestep
+  7,                                      !- Hour 1
+  0,                                      !- Minute 1
+  1,                                      !- Value Until Time 1
+  8,                                      !- Hour 2
+  0,                                      !- Minute 2
+  0.85,                                   !- Value Until Time 2
+  9,                                      !- Hour 3
+  0,                                      !- Minute 3
+  0.39,                                   !- Value Until Time 3
+  16,                                     !- Hour 4
+  0,                                      !- Minute 4
+  0.25,                                   !- Value Until Time 4
+  17,                                     !- Hour 5
+  0,                                      !- Minute 5
+  0.3,                                    !- Value Until Time 5
+  18,                                     !- Hour 6
+  0,                                      !- Minute 6
+  0.52,                                   !- Value Until Time 6
+  21,                                     !- Hour 7
+  0,                                      !- Minute 7
+  0.87,                                   !- Value Until Time 7
+  24,                                     !- Hour 8
+  0,                                      !- Minute 8
+  1;                                      !- Value Until Time 8
+
+OS:Schedule:Day,
+  {16e782c2-6095-4037-99fa-52e74744738f}, !- Handle
+  ApartmentMidRise OCC_APT_SCH_SmrDsn,    !- Name
+  {5ec29b47-2e16-4d0b-8501-22103961daaf}, !- Schedule Type Limits Name
+  ,                                       !- Interpolate to Timestep
+  7,                                      !- Hour 1
+  0,                                      !- Minute 1
+  1,                                      !- Value Until Time 1
+  8,                                      !- Hour 2
+  0,                                      !- Minute 2
+  0.85,                                   !- Value Until Time 2
+  9,                                      !- Hour 3
+  0,                                      !- Minute 3
+  0.39,                                   !- Value Until Time 3
+  16,                                     !- Hour 4
+  0,                                      !- Minute 4
+  0.25,                                   !- Value Until Time 4
+  17,                                     !- Hour 5
+  0,                                      !- Minute 5
+  0.3,                                    !- Value Until Time 5
+  18,                                     !- Hour 6
+  0,                                      !- Minute 6
+  0.52,                                   !- Value Until Time 6
+  21,                                     !- Hour 7
+  0,                                      !- Minute 7
+  0.87,                                   !- Value Until Time 7
+  24,                                     !- Hour 8
+  0,                                      !- Minute 8
+  1;                                      !- Value Until Time 8
+
+OS:Schedule:Day,
+  {b67b5d76-beb0-4fd1-b2ac-e210e086a71b}, !- Handle
+  ApartmentMidRise OCC_APT_SCH_WntrDsn,   !- Name
+  {5ec29b47-2e16-4d0b-8501-22103961daaf}, !- Schedule Type Limits Name
+  ,                                       !- Interpolate to Timestep
+  7,                                      !- Hour 1
+  0,                                      !- Minute 1
+  1,                                      !- Value Until Time 1
+  8,                                      !- Hour 2
+  0,                                      !- Minute 2
+  0.85,                                   !- Value Until Time 2
+  9,                                      !- Hour 3
+  0,                                      !- Minute 3
+  0.39,                                   !- Value Until Time 3
+  16,                                     !- Hour 4
+  0,                                      !- Minute 4
+  0.25,                                   !- Value Until Time 4
+  17,                                     !- Hour 5
+  0,                                      !- Minute 5
+  0.3,                                    !- Value Until Time 5
+  18,                                     !- Hour 6
+  0,                                      !- Minute 6
+  0.52,                                   !- Value Until Time 6
+  21,                                     !- Hour 7
+  0,                                      !- Minute 7
+  0.87,                                   !- Value Until Time 7
+  24,                                     !- Hour 8
+  0,                                      !- Minute 8
+  1;                                      !- Value Until Time 8
+
+OS:Schedule:Day,
+  {909ced8d-b6a9-4a01-9f4f-a4be42864bcb}, !- Handle
+  ApartmentMidRise OCC_APT_SCH_SmrDsn 1,  !- Name
+  {5ec29b47-2e16-4d0b-8501-22103961daaf}, !- Schedule Type Limits Name
+  ,                                       !- Interpolate to Timestep
+  7,                                      !- Hour 1
+  0,                                      !- Minute 1
+  1,                                      !- Value Until Time 1
+  8,                                      !- Hour 2
+  0,                                      !- Minute 2
+  0.85,                                   !- Value Until Time 2
+  9,                                      !- Hour 3
+  0,                                      !- Minute 3
+  0.39,                                   !- Value Until Time 3
+  16,                                     !- Hour 4
+  0,                                      !- Minute 4
+  0.25,                                   !- Value Until Time 4
+  17,                                     !- Hour 5
+  0,                                      !- Minute 5
+  0.3,                                    !- Value Until Time 5
+  18,                                     !- Hour 6
+  0,                                      !- Minute 6
+  0.52,                                   !- Value Until Time 6
+  21,                                     !- Hour 7
+  0,                                      !- Minute 7
+  0.87,                                   !- Value Until Time 7
+  24,                                     !- Hour 8
+  0,                                      !- Minute 8
+  1;                                      !- Value Until Time 8
+
+OS:Schedule:Day,
+  {ab2f0a6e-f5ca-45b2-845f-f1fea3539193}, !- Handle
+  ApartmentMidRise OCC_APT_SCH_WntrDsn 1, !- Name
+  {5ec29b47-2e16-4d0b-8501-22103961daaf}, !- Schedule Type Limits Name
+  ,                                       !- Interpolate to Timestep
+  7,                                      !- Hour 1
+  0,                                      !- Minute 1
+  1,                                      !- Value Until Time 1
+  8,                                      !- Hour 2
+  0,                                      !- Minute 2
+  0.85,                                   !- Value Until Time 2
+  9,                                      !- Hour 3
+  0,                                      !- Minute 3
+  0.39,                                   !- Value Until Time 3
+  16,                                     !- Hour 4
+  0,                                      !- Minute 4
+  0.25,                                   !- Value Until Time 4
+  17,                                     !- Hour 5
+  0,                                      !- Minute 5
+  0.3,                                    !- Value Until Time 5
+  18,                                     !- Hour 6
+  0,                                      !- Minute 6
+  0.52,                                   !- Value Until Time 6
+  21,                                     !- Hour 7
+  0,                                      !- Minute 7
+  0.87,                                   !- Value Until Time 7
+  24,                                     !- Hour 8
+  0,                                      !- Minute 8
+  1;                                      !- Value Until Time 8
+
+OS:Schedule:Ruleset,
+  {9a019e28-3764-426f-bde3-d7c95c5ffaa8}, !- Handle
+  ApartmentMidRise EQP_APT_SCH,           !- Name
+  {5ec29b47-2e16-4d0b-8501-22103961daaf}, !- Schedule Type Limits Name
+  {801511c8-92ab-4020-9350-c5eb4fb2bc52}, !- Default Day Schedule Name
+  {af50181f-7ae0-45c1-b8b7-1ebb9d973808}, !- Summer Design Day Schedule Name
+  {22c06050-dc67-408c-9d88-cd52d1bc3965}; !- Winter Design Day Schedule Name
+
+OS:Schedule:Day,
+  {801511c8-92ab-4020-9350-c5eb4fb2bc52}, !- Handle
+  ApartmentMidRise EQP_APT_SCH_Default,   !- Name
+  {5ec29b47-2e16-4d0b-8501-22103961daaf}, !- Schedule Type Limits Name
+  ,                                       !- Interpolate to Timestep
+  1,                                      !- Hour 1
+  0,                                      !- Minute 1
+  0.45,                                   !- Value Until Time 1
+  2,                                      !- Hour 2
+  0,                                      !- Minute 2
+  0.41,                                   !- Value Until Time 2
+  3,                                      !- Hour 3
+  0,                                      !- Minute 3
+  0.39,                                   !- Value Until Time 3
+  5,                                      !- Hour 4
+  0,                                      !- Minute 4
+  0.38,                                   !- Value Until Time 4
+  6,                                      !- Hour 5
+  0,                                      !- Minute 5
+  0.43,                                   !- Value Until Time 5
+  7,                                      !- Hour 6
+  0,                                      !- Minute 6
+  0.54,                                   !- Value Until Time 6
+  8,                                      !- Hour 7
+  0,                                      !- Minute 7
+  0.65,                                   !- Value Until Time 7
+  9,                                      !- Hour 8
+  0,                                      !- Minute 8
+  0.66,                                   !- Value Until Time 8
+  10,                                     !- Hour 9
+  0,                                      !- Minute 9
+  0.67,                                   !- Value Until Time 9
+  11,                                     !- Hour 10
+  0,                                      !- Minute 10
+  0.69,                                   !- Value Until Time 10
+  12,                                     !- Hour 11
+  0,                                      !- Minute 11
+  0.7,                                    !- Value Until Time 11
+  13,                                     !- Hour 12
+  0,                                      !- Minute 12
+  0.69,                                   !- Value Until Time 12
+  14,                                     !- Hour 13
+  0,                                      !- Minute 13
+  0.66,                                   !- Value Until Time 13
+  15,                                     !- Hour 14
+  0,                                      !- Minute 14
+  0.65,                                   !- Value Until Time 14
+  16,                                     !- Hour 15
+  0,                                      !- Minute 15
+  0.68,                                   !- Value Until Time 15
+  17,                                     !- Hour 16
+  0,                                      !- Minute 16
+  0.8,                                    !- Value Until Time 16
+  19,                                     !- Hour 17
+  0,                                      !- Minute 17
+  1,                                      !- Value Until Time 17
+  20,                                     !- Hour 18
+  0,                                      !- Minute 18
+  0.93,                                   !- Value Until Time 18
+  21,                                     !- Hour 19
+  0,                                      !- Minute 19
+  0.89,                                   !- Value Until Time 19
+  22,                                     !- Hour 20
+  0,                                      !- Minute 20
+  0.85,                                   !- Value Until Time 20
+  23,                                     !- Hour 21
+  0,                                      !- Minute 21
+  0.71,                                   !- Value Until Time 21
+  24,                                     !- Hour 22
+  0,                                      !- Minute 22
+  0.58;                                   !- Value Until Time 22
+
+OS:Schedule:Day,
+  {eb568436-89c4-48a8-ae55-c95101e17974}, !- Handle
+  ApartmentMidRise EQP_APT_SCH_SmrDsn,    !- Name
+  {5ec29b47-2e16-4d0b-8501-22103961daaf}, !- Schedule Type Limits Name
+  ,                                       !- Interpolate to Timestep
+  1,                                      !- Hour 1
+  0,                                      !- Minute 1
+  0.45,                                   !- Value Until Time 1
+  2,                                      !- Hour 2
+  0,                                      !- Minute 2
+  0.41,                                   !- Value Until Time 2
+  3,                                      !- Hour 3
+  0,                                      !- Minute 3
+  0.39,                                   !- Value Until Time 3
+  5,                                      !- Hour 4
+  0,                                      !- Minute 4
+  0.38,                                   !- Value Until Time 4
+  6,                                      !- Hour 5
+  0,                                      !- Minute 5
+  0.43,                                   !- Value Until Time 5
+  7,                                      !- Hour 6
+  0,                                      !- Minute 6
+  0.54,                                   !- Value Until Time 6
+  8,                                      !- Hour 7
+  0,                                      !- Minute 7
+  0.65,                                   !- Value Until Time 7
+  9,                                      !- Hour 8
+  0,                                      !- Minute 8
+  0.66,                                   !- Value Until Time 8
+  10,                                     !- Hour 9
+  0,                                      !- Minute 9
+  0.67,                                   !- Value Until Time 9
+  11,                                     !- Hour 10
+  0,                                      !- Minute 10
+  0.69,                                   !- Value Until Time 10
+  12,                                     !- Hour 11
+  0,                                      !- Minute 11
+  0.7,                                    !- Value Until Time 11
+  13,                                     !- Hour 12
+  0,                                      !- Minute 12
+  0.69,                                   !- Value Until Time 12
+  14,                                     !- Hour 13
+  0,                                      !- Minute 13
+  0.66,                                   !- Value Until Time 13
+  15,                                     !- Hour 14
+  0,                                      !- Minute 14
+  0.65,                                   !- Value Until Time 14
+  16,                                     !- Hour 15
+  0,                                      !- Minute 15
+  0.68,                                   !- Value Until Time 15
+  17,                                     !- Hour 16
+  0,                                      !- Minute 16
+  0.8,                                    !- Value Until Time 16
+  19,                                     !- Hour 17
+  0,                                      !- Minute 17
+  1,                                      !- Value Until Time 17
+  20,                                     !- Hour 18
+  0,                                      !- Minute 18
+  0.93,                                   !- Value Until Time 18
+  21,                                     !- Hour 19
+  0,                                      !- Minute 19
+  0.89,                                   !- Value Until Time 19
+  22,                                     !- Hour 20
+  0,                                      !- Minute 20
+  0.85,                                   !- Value Until Time 20
+  23,                                     !- Hour 21
+  0,                                      !- Minute 21
+  0.71,                                   !- Value Until Time 21
+  24,                                     !- Hour 22
+  0,                                      !- Minute 22
+  0.58;                                   !- Value Until Time 22
+
+OS:Schedule:Day,
+  {7d3c0461-8424-420c-af72-b59f484c71e7}, !- Handle
+  ApartmentMidRise EQP_APT_SCH_WntrDsn,   !- Name
+  {5ec29b47-2e16-4d0b-8501-22103961daaf}, !- Schedule Type Limits Name
+  ,                                       !- Interpolate to Timestep
+  1,                                      !- Hour 1
+  0,                                      !- Minute 1
+  0.45,                                   !- Value Until Time 1
+  2,                                      !- Hour 2
+  0,                                      !- Minute 2
+  0.41,                                   !- Value Until Time 2
+  3,                                      !- Hour 3
+  0,                                      !- Minute 3
+  0.39,                                   !- Value Until Time 3
+  5,                                      !- Hour 4
+  0,                                      !- Minute 4
+  0.38,                                   !- Value Until Time 4
+  6,                                      !- Hour 5
+  0,                                      !- Minute 5
+  0.43,                                   !- Value Until Time 5
+  7,                                      !- Hour 6
+  0,                                      !- Minute 6
+  0.54,                                   !- Value Until Time 6
+  8,                                      !- Hour 7
+  0,                                      !- Minute 7
+  0.65,                                   !- Value Until Time 7
+  9,                                      !- Hour 8
+  0,                                      !- Minute 8
+  0.66,                                   !- Value Until Time 8
+  10,                                     !- Hour 9
+  0,                                      !- Minute 9
+  0.67,                                   !- Value Until Time 9
+  11,                                     !- Hour 10
+  0,                                      !- Minute 10
+  0.69,                                   !- Value Until Time 10
+  12,                                     !- Hour 11
+  0,                                      !- Minute 11
+  0.7,                                    !- Value Until Time 11
+  13,                                     !- Hour 12
+  0,                                      !- Minute 12
+  0.69,                                   !- Value Until Time 12
+  14,                                     !- Hour 13
+  0,                                      !- Minute 13
+  0.66,                                   !- Value Until Time 13
+  15,                                     !- Hour 14
+  0,                                      !- Minute 14
+  0.65,                                   !- Value Until Time 14
+  16,                                     !- Hour 15
+  0,                                      !- Minute 15
+  0.68,                                   !- Value Until Time 15
+  17,                                     !- Hour 16
+  0,                                      !- Minute 16
+  0.8,                                    !- Value Until Time 16
+  19,                                     !- Hour 17
+  0,                                      !- Minute 17
+  1,                                      !- Value Until Time 17
+  20,                                     !- Hour 18
+  0,                                      !- Minute 18
+  0.93,                                   !- Value Until Time 18
+  21,                                     !- Hour 19
+  0,                                      !- Minute 19
+  0.89,                                   !- Value Until Time 19
+  22,                                     !- Hour 20
+  0,                                      !- Minute 20
+  0.85,                                   !- Value Until Time 20
+  23,                                     !- Hour 21
+  0,                                      !- Minute 21
+  0.71,                                   !- Value Until Time 21
+  24,                                     !- Hour 22
+  0,                                      !- Minute 22
+  0.58;                                   !- Value Until Time 22
+
+OS:Schedule:Day,
+  {af50181f-7ae0-45c1-b8b7-1ebb9d973808}, !- Handle
+  ApartmentMidRise EQP_APT_SCH_SmrDsn 1,  !- Name
+  {5ec29b47-2e16-4d0b-8501-22103961daaf}, !- Schedule Type Limits Name
+  ,                                       !- Interpolate to Timestep
+  1,                                      !- Hour 1
+  0,                                      !- Minute 1
+  0.45,                                   !- Value Until Time 1
+  2,                                      !- Hour 2
+  0,                                      !- Minute 2
+  0.41,                                   !- Value Until Time 2
+  3,                                      !- Hour 3
+  0,                                      !- Minute 3
+  0.39,                                   !- Value Until Time 3
+  5,                                      !- Hour 4
+  0,                                      !- Minute 4
+  0.38,                                   !- Value Until Time 4
+  6,                                      !- Hour 5
+  0,                                      !- Minute 5
+  0.43,                                   !- Value Until Time 5
+  7,                                      !- Hour 6
+  0,                                      !- Minute 6
+  0.54,                                   !- Value Until Time 6
+  8,                                      !- Hour 7
+  0,                                      !- Minute 7
+  0.65,                                   !- Value Until Time 7
+  9,                                      !- Hour 8
+  0,                                      !- Minute 8
+  0.66,                                   !- Value Until Time 8
+  10,                                     !- Hour 9
+  0,                                      !- Minute 9
+  0.67,                                   !- Value Until Time 9
+  11,                                     !- Hour 10
+  0,                                      !- Minute 10
+  0.69,                                   !- Value Until Time 10
+  12,                                     !- Hour 11
+  0,                                      !- Minute 11
+  0.7,                                    !- Value Until Time 11
+  13,                                     !- Hour 12
+  0,                                      !- Minute 12
+  0.69,                                   !- Value Until Time 12
+  14,                                     !- Hour 13
+  0,                                      !- Minute 13
+  0.66,                                   !- Value Until Time 13
+  15,                                     !- Hour 14
+  0,                                      !- Minute 14
+  0.65,                                   !- Value Until Time 14
+  16,                                     !- Hour 15
+  0,                                      !- Minute 15
+  0.68,                                   !- Value Until Time 15
+  17,                                     !- Hour 16
+  0,                                      !- Minute 16
+  0.8,                                    !- Value Until Time 16
+  19,                                     !- Hour 17
+  0,                                      !- Minute 17
+  1,                                      !- Value Until Time 17
+  20,                                     !- Hour 18
+  0,                                      !- Minute 18
+  0.93,                                   !- Value Until Time 18
+  21,                                     !- Hour 19
+  0,                                      !- Minute 19
+  0.89,                                   !- Value Until Time 19
+  22,                                     !- Hour 20
+  0,                                      !- Minute 20
+  0.85,                                   !- Value Until Time 20
+  23,                                     !- Hour 21
+  0,                                      !- Minute 21
+  0.71,                                   !- Value Until Time 21
+  24,                                     !- Hour 22
+  0,                                      !- Minute 22
+  0.58;                                   !- Value Until Time 22
+
+OS:Schedule:Day,
+  {22c06050-dc67-408c-9d88-cd52d1bc3965}, !- Handle
+  ApartmentMidRise EQP_APT_SCH_WntrDsn 1, !- Name
+  {5ec29b47-2e16-4d0b-8501-22103961daaf}, !- Schedule Type Limits Name
+  ,                                       !- Interpolate to Timestep
+  1,                                      !- Hour 1
+  0,                                      !- Minute 1
+  0.45,                                   !- Value Until Time 1
+  2,                                      !- Hour 2
+  0,                                      !- Minute 2
+  0.41,                                   !- Value Until Time 2
+  3,                                      !- Hour 3
+  0,                                      !- Minute 3
+  0.39,                                   !- Value Until Time 3
+  5,                                      !- Hour 4
+  0,                                      !- Minute 4
+  0.38,                                   !- Value Until Time 4
+  6,                                      !- Hour 5
+  0,                                      !- Minute 5
+  0.43,                                   !- Value Until Time 5
+  7,                                      !- Hour 6
+  0,                                      !- Minute 6
+  0.54,                                   !- Value Until Time 6
+  8,                                      !- Hour 7
+  0,                                      !- Minute 7
+  0.65,                                   !- Value Until Time 7
+  9,                                      !- Hour 8
+  0,                                      !- Minute 8
+  0.66,                                   !- Value Until Time 8
+  10,                                     !- Hour 9
+  0,                                      !- Minute 9
+  0.67,                                   !- Value Until Time 9
+  11,                                     !- Hour 10
+  0,                                      !- Minute 10
+  0.69,                                   !- Value Until Time 10
+  12,                                     !- Hour 11
+  0,                                      !- Minute 11
+  0.7,                                    !- Value Until Time 11
+  13,                                     !- Hour 12
+  0,                                      !- Minute 12
+  0.69,                                   !- Value Until Time 12
+  14,                                     !- Hour 13
+  0,                                      !- Minute 13
+  0.66,                                   !- Value Until Time 13
+  15,                                     !- Hour 14
+  0,                                      !- Minute 14
+  0.65,                                   !- Value Until Time 14
+  16,                                     !- Hour 15
+  0,                                      !- Minute 15
+  0.68,                                   !- Value Until Time 15
+  17,                                     !- Hour 16
+  0,                                      !- Minute 16
+  0.8,                                    !- Value Until Time 16
+  19,                                     !- Hour 17
+  0,                                      !- Minute 17
+  1,                                      !- Value Until Time 17
+  20,                                     !- Hour 18
+  0,                                      !- Minute 18
+  0.93,                                   !- Value Until Time 18
+  21,                                     !- Hour 19
+  0,                                      !- Minute 19
+  0.89,                                   !- Value Until Time 19
+  22,                                     !- Hour 20
+  0,                                      !- Minute 20
+  0.85,                                   !- Value Until Time 20
+  23,                                     !- Hour 21
+  0,                                      !- Minute 21
+  0.71,                                   !- Value Until Time 21
+  24,                                     !- Hour 22
+  0,                                      !- Minute 22
+  0.58;                                   !- Value Until Time 22
+
+OS:Schedule:Ruleset,
+  {307beed5-ee14-4064-be6b-a4e4e11921e5}, !- Handle
+  ApartmentMidRise INF_APT_SCH,           !- Name
+  {5ec29b47-2e16-4d0b-8501-22103961daaf}, !- Schedule Type Limits Name
+  {22d3d0c8-7cb5-414c-808f-4fb2670ad9f3}, !- Default Day Schedule Name
+  {2a2d9ede-3ca0-4596-bce8-51cf650bab1c}, !- Summer Design Day Schedule Name
+  {ca2a71f8-ccb9-4b47-ab0a-3da6acb6e22a}; !- Winter Design Day Schedule Name
+
+OS:Schedule:Day,
+  {22d3d0c8-7cb5-414c-808f-4fb2670ad9f3}, !- Handle
+  ApartmentMidRise INF_APT_SCH_Default,   !- Name
+  {5ec29b47-2e16-4d0b-8501-22103961daaf}, !- Schedule Type Limits Name
+  ,                                       !- Interpolate to Timestep
+  24,                                     !- Hour 1
+  0,                                      !- Minute 1
+  1;                                      !- Value Until Time 1
+
+OS:Schedule:Day,
+  {b7c7660d-f3bf-49b1-8ec6-df173573eeee}, !- Handle
+  ApartmentMidRise INF_APT_SCH_SmrDsn,    !- Name
+  ,                                       !- Schedule Type Limits Name
+  ,                                       !- Interpolate to Timestep
+  24,                                     !- Hour 1
+  0,                                      !- Minute 1
+  1;                                      !- Value Until Time 1
+
+OS:Schedule:Day,
+  {00981399-d5ed-4973-8db2-40a2b62198eb}, !- Handle
+  ApartmentMidRise INF_APT_SCH_WntrDsn,   !- Name
+  ,                                       !- Schedule Type Limits Name
+  ,                                       !- Interpolate to Timestep
+  24,                                     !- Hour 1
+  0,                                      !- Minute 1
+  1;                                      !- Value Until Time 1
+
+OS:Schedule:Day,
+  {2a2d9ede-3ca0-4596-bce8-51cf650bab1c}, !- Handle
+  ApartmentMidRise INF_APT_SCH_SmrDsn 1,  !- Name
+  {5ec29b47-2e16-4d0b-8501-22103961daaf}, !- Schedule Type Limits Name
+  ,                                       !- Interpolate to Timestep
+  24,                                     !- Hour 1
+  0,                                      !- Minute 1
+  1;                                      !- Value Until Time 1
+
+OS:Schedule:Day,
+  {ca2a71f8-ccb9-4b47-ab0a-3da6acb6e22a}, !- Handle
+  ApartmentMidRise INF_APT_SCH_WntrDsn 1, !- Name
+  {5ec29b47-2e16-4d0b-8501-22103961daaf}, !- Schedule Type Limits Name
+  ,                                       !- Interpolate to Timestep
+  24,                                     !- Hour 1
+  0,                                      !- Minute 1
+  1;                                      !- Value Until Time 1
+
+OS:Schedule:Ruleset,
+  {f0d42dde-dc4d-41c7-926f-0bead4710aa9}, !- Handle
+  ApartmentMidRise APT_DHW_SCH,           !- Name
+  {5ec29b47-2e16-4d0b-8501-22103961daaf}, !- Schedule Type Limits Name
+  {28265ebd-a261-4b3b-853b-fa9348e59832}, !- Default Day Schedule Name
+  {b6e9f2cb-360d-4402-a7a2-d4b59f008425}, !- Summer Design Day Schedule Name
+  {6a65ddfa-3df6-4f5b-bd1b-040265ceaf6a}; !- Winter Design Day Schedule Name
+
+OS:Schedule:Day,
+  {28265ebd-a261-4b3b-853b-fa9348e59832}, !- Handle
+  ApartmentMidRise APT_DHW_SCH_Default,   !- Name
+  {5ec29b47-2e16-4d0b-8501-22103961daaf}, !- Schedule Type Limits Name
+  ,                                       !- Interpolate to Timestep
+  1,                                      !- Hour 1
+  0,                                      !- Minute 1
+  0.08,                                   !- Value Until Time 1
+  2,                                      !- Hour 2
+  0,                                      !- Minute 2
+  0.04,                                   !- Value Until Time 2
+  4,                                      !- Hour 3
+  0,                                      !- Minute 3
+  0.01,                                   !- Value Until Time 3
+  5,                                      !- Hour 4
+  0,                                      !- Minute 4
+  0.04,                                   !- Value Until Time 4
+  6,                                      !- Hour 5
+  0,                                      !- Minute 5
+  0.27,                                   !- Value Until Time 5
+  7,                                      !- Hour 6
+  0,                                      !- Minute 6
+  0.94,                                   !- Value Until Time 6
+  8,                                      !- Hour 7
+  0,                                      !- Minute 7
+  1,                                      !- Value Until Time 7
+  9,                                      !- Hour 8
+  0,                                      !- Minute 8
+  0.96,                                   !- Value Until Time 8
+  10,                                     !- Hour 9
+  0,                                      !- Minute 9
+  0.84,                                   !- Value Until Time 9
+  11,                                     !- Hour 10
+  0,                                      !- Minute 10
+  0.76,                                   !- Value Until Time 10
+  12,                                     !- Hour 11
+  0,                                      !- Minute 11
+  0.61,                                   !- Value Until Time 11
+  13,                                     !- Hour 12
+  0,                                      !- Minute 12
+  0.53,                                   !- Value Until Time 12
+  14,                                     !- Hour 13
+  0,                                      !- Minute 13
+  0.47,                                   !- Value Until Time 13
+  15,                                     !- Hour 14
+  0,                                      !- Minute 14
+  0.41,                                   !- Value Until Time 14
+  16,                                     !- Hour 15
+  0,                                      !- Minute 15
+  0.47,                                   !- Value Until Time 15
+  17,                                     !- Hour 16
+  0,                                      !- Minute 16
+  0.55,                                   !- Value Until Time 16
+  18,                                     !- Hour 17
+  0,                                      !- Minute 17
+  0.73,                                   !- Value Until Time 17
+  19,                                     !- Hour 18
+  0,                                      !- Minute 18
+  0.86,                                   !- Value Until Time 18
+  20,                                     !- Hour 19
+  0,                                      !- Minute 19
+  0.82,                                   !- Value Until Time 19
+  21,                                     !- Hour 20
+  0,                                      !- Minute 20
+  0.75,                                   !- Value Until Time 20
+  22,                                     !- Hour 21
+  0,                                      !- Minute 21
+  0.61,                                   !- Value Until Time 21
+  23,                                     !- Hour 22
+  0,                                      !- Minute 22
+  0.53,                                   !- Value Until Time 22
+  24,                                     !- Hour 23
+  0,                                      !- Minute 23
+  0.29;                                   !- Value Until Time 23
+
+OS:Schedule:Day,
+  {0a6dcea5-2b48-4229-a265-a1e253fb7259}, !- Handle
+  ApartmentMidRise APT_DHW_SCH_SmrDsn,    !- Name
+  ,                                       !- Schedule Type Limits Name
+  ,                                       !- Interpolate to Timestep
+  1,                                      !- Hour 1
+  0,                                      !- Minute 1
+  0.08,                                   !- Value Until Time 1
+  2,                                      !- Hour 2
+  0,                                      !- Minute 2
+  0.04,                                   !- Value Until Time 2
+  4,                                      !- Hour 3
+  0,                                      !- Minute 3
+  0.01,                                   !- Value Until Time 3
+  5,                                      !- Hour 4
+  0,                                      !- Minute 4
+  0.04,                                   !- Value Until Time 4
+  6,                                      !- Hour 5
+  0,                                      !- Minute 5
+  0.27,                                   !- Value Until Time 5
+  7,                                      !- Hour 6
+  0,                                      !- Minute 6
+  0.94,                                   !- Value Until Time 6
+  8,                                      !- Hour 7
+  0,                                      !- Minute 7
+  1,                                      !- Value Until Time 7
+  9,                                      !- Hour 8
+  0,                                      !- Minute 8
+  0.96,                                   !- Value Until Time 8
+  10,                                     !- Hour 9
+  0,                                      !- Minute 9
+  0.84,                                   !- Value Until Time 9
+  11,                                     !- Hour 10
+  0,                                      !- Minute 10
+  0.76,                                   !- Value Until Time 10
+  12,                                     !- Hour 11
+  0,                                      !- Minute 11
+  0.61,                                   !- Value Until Time 11
+  13,                                     !- Hour 12
+  0,                                      !- Minute 12
+  0.53,                                   !- Value Until Time 12
+  14,                                     !- Hour 13
+  0,                                      !- Minute 13
+  0.47,                                   !- Value Until Time 13
+  15,                                     !- Hour 14
+  0,                                      !- Minute 14
+  0.41,                                   !- Value Until Time 14
+  16,                                     !- Hour 15
+  0,                                      !- Minute 15
+  0.47,                                   !- Value Until Time 15
+  17,                                     !- Hour 16
+  0,                                      !- Minute 16
+  0.55,                                   !- Value Until Time 16
+  18,                                     !- Hour 17
+  0,                                      !- Minute 17
+  0.73,                                   !- Value Until Time 17
+  19,                                     !- Hour 18
+  0,                                      !- Minute 18
+  0.86,                                   !- Value Until Time 18
+  20,                                     !- Hour 19
+  0,                                      !- Minute 19
+  0.82,                                   !- Value Until Time 19
+  21,                                     !- Hour 20
+  0,                                      !- Minute 20
+  0.75,                                   !- Value Until Time 20
+  22,                                     !- Hour 21
+  0,                                      !- Minute 21
+  0.61,                                   !- Value Until Time 21
+  23,                                     !- Hour 22
+  0,                                      !- Minute 22
+  0.53,                                   !- Value Until Time 22
+  24,                                     !- Hour 23
+  0,                                      !- Minute 23
+  0.29;                                   !- Value Until Time 23
+
+OS:Schedule:Day,
+  {4aed2175-d551-481e-a6d2-d66a5156c073}, !- Handle
+  ApartmentMidRise APT_DHW_SCH_WntrDsn,   !- Name
+  ,                                       !- Schedule Type Limits Name
+  ,                                       !- Interpolate to Timestep
+  1,                                      !- Hour 1
+  0,                                      !- Minute 1
+  0.08,                                   !- Value Until Time 1
+  2,                                      !- Hour 2
+  0,                                      !- Minute 2
+  0.04,                                   !- Value Until Time 2
+  4,                                      !- Hour 3
+  0,                                      !- Minute 3
+  0.01,                                   !- Value Until Time 3
+  5,                                      !- Hour 4
+  0,                                      !- Minute 4
+  0.04,                                   !- Value Until Time 4
+  6,                                      !- Hour 5
+  0,                                      !- Minute 5
+  0.27,                                   !- Value Until Time 5
+  7,                                      !- Hour 6
+  0,                                      !- Minute 6
+  0.94,                                   !- Value Until Time 6
+  8,                                      !- Hour 7
+  0,                                      !- Minute 7
+  1,                                      !- Value Until Time 7
+  9,                                      !- Hour 8
+  0,                                      !- Minute 8
+  0.96,                                   !- Value Until Time 8
+  10,                                     !- Hour 9
+  0,                                      !- Minute 9
+  0.84,                                   !- Value Until Time 9
+  11,                                     !- Hour 10
+  0,                                      !- Minute 10
+  0.76,                                   !- Value Until Time 10
+  12,                                     !- Hour 11
+  0,                                      !- Minute 11
+  0.61,                                   !- Value Until Time 11
+  13,                                     !- Hour 12
+  0,                                      !- Minute 12
+  0.53,                                   !- Value Until Time 12
+  14,                                     !- Hour 13
+  0,                                      !- Minute 13
+  0.47,                                   !- Value Until Time 13
+  15,                                     !- Hour 14
+  0,                                      !- Minute 14
+  0.41,                                   !- Value Until Time 14
+  16,                                     !- Hour 15
+  0,                                      !- Minute 15
+  0.47,                                   !- Value Until Time 15
+  17,                                     !- Hour 16
+  0,                                      !- Minute 16
+  0.55,                                   !- Value Until Time 16
+  18,                                     !- Hour 17
+  0,                                      !- Minute 17
+  0.73,                                   !- Value Until Time 17
+  19,                                     !- Hour 18
+  0,                                      !- Minute 18
+  0.86,                                   !- Value Until Time 18
+  20,                                     !- Hour 19
+  0,                                      !- Minute 19
+  0.82,                                   !- Value Until Time 19
+  21,                                     !- Hour 20
+  0,                                      !- Minute 20
+  0.75,                                   !- Value Until Time 20
+  22,                                     !- Hour 21
+  0,                                      !- Minute 21
+  0.61,                                   !- Value Until Time 21
+  23,                                     !- Hour 22
+  0,                                      !- Minute 22
+  0.53,                                   !- Value Until Time 22
+  24,                                     !- Hour 23
+  0,                                      !- Minute 23
+  0.29;                                   !- Value Until Time 23
+
+OS:Schedule:Day,
+  {b6e9f2cb-360d-4402-a7a2-d4b59f008425}, !- Handle
+  ApartmentMidRise APT_DHW_SCH_SmrDsn 1,  !- Name
+  {5ec29b47-2e16-4d0b-8501-22103961daaf}, !- Schedule Type Limits Name
+  ,                                       !- Interpolate to Timestep
+  1,                                      !- Hour 1
+  0,                                      !- Minute 1
+  0.08,                                   !- Value Until Time 1
+  2,                                      !- Hour 2
+  0,                                      !- Minute 2
+  0.04,                                   !- Value Until Time 2
+  4,                                      !- Hour 3
+  0,                                      !- Minute 3
+  0.01,                                   !- Value Until Time 3
+  5,                                      !- Hour 4
+  0,                                      !- Minute 4
+  0.04,                                   !- Value Until Time 4
+  6,                                      !- Hour 5
+  0,                                      !- Minute 5
+  0.27,                                   !- Value Until Time 5
+  7,                                      !- Hour 6
+  0,                                      !- Minute 6
+  0.94,                                   !- Value Until Time 6
+  8,                                      !- Hour 7
+  0,                                      !- Minute 7
+  1,                                      !- Value Until Time 7
+  9,                                      !- Hour 8
+  0,                                      !- Minute 8
+  0.96,                                   !- Value Until Time 8
+  10,                                     !- Hour 9
+  0,                                      !- Minute 9
+  0.84,                                   !- Value Until Time 9
+  11,                                     !- Hour 10
+  0,                                      !- Minute 10
+  0.76,                                   !- Value Until Time 10
+  12,                                     !- Hour 11
+  0,                                      !- Minute 11
+  0.61,                                   !- Value Until Time 11
+  13,                                     !- Hour 12
+  0,                                      !- Minute 12
+  0.53,                                   !- Value Until Time 12
+  14,                                     !- Hour 13
+  0,                                      !- Minute 13
+  0.47,                                   !- Value Until Time 13
+  15,                                     !- Hour 14
+  0,                                      !- Minute 14
+  0.41,                                   !- Value Until Time 14
+  16,                                     !- Hour 15
+  0,                                      !- Minute 15
+  0.47,                                   !- Value Until Time 15
+  17,                                     !- Hour 16
+  0,                                      !- Minute 16
+  0.55,                                   !- Value Until Time 16
+  18,                                     !- Hour 17
+  0,                                      !- Minute 17
+  0.73,                                   !- Value Until Time 17
+  19,                                     !- Hour 18
+  0,                                      !- Minute 18
+  0.86,                                   !- Value Until Time 18
+  20,                                     !- Hour 19
+  0,                                      !- Minute 19
+  0.82,                                   !- Value Until Time 19
+  21,                                     !- Hour 20
+  0,                                      !- Minute 20
+  0.75,                                   !- Value Until Time 20
+  22,                                     !- Hour 21
+  0,                                      !- Minute 21
+  0.61,                                   !- Value Until Time 21
+  23,                                     !- Hour 22
+  0,                                      !- Minute 22
+  0.53,                                   !- Value Until Time 22
+  24,                                     !- Hour 23
+  0,                                      !- Minute 23
+  0.29;                                   !- Value Until Time 23
+
+OS:Schedule:Day,
+  {6a65ddfa-3df6-4f5b-bd1b-040265ceaf6a}, !- Handle
+  ApartmentMidRise APT_DHW_SCH_WntrDsn 1, !- Name
+  {5ec29b47-2e16-4d0b-8501-22103961daaf}, !- Schedule Type Limits Name
+  ,                                       !- Interpolate to Timestep
+  1,                                      !- Hour 1
+  0,                                      !- Minute 1
+  0.08,                                   !- Value Until Time 1
+  2,                                      !- Hour 2
+  0,                                      !- Minute 2
+  0.04,                                   !- Value Until Time 2
+  4,                                      !- Hour 3
+  0,                                      !- Minute 3
+  0.01,                                   !- Value Until Time 3
+  5,                                      !- Hour 4
+  0,                                      !- Minute 4
+  0.04,                                   !- Value Until Time 4
+  6,                                      !- Hour 5
+  0,                                      !- Minute 5
+  0.27,                                   !- Value Until Time 5
+  7,                                      !- Hour 6
+  0,                                      !- Minute 6
+  0.94,                                   !- Value Until Time 6
+  8,                                      !- Hour 7
+  0,                                      !- Minute 7
+  1,                                      !- Value Until Time 7
+  9,                                      !- Hour 8
+  0,                                      !- Minute 8
+  0.96,                                   !- Value Until Time 8
+  10,                                     !- Hour 9
+  0,                                      !- Minute 9
+  0.84,                                   !- Value Until Time 9
+  11,                                     !- Hour 10
+  0,                                      !- Minute 10
+  0.76,                                   !- Value Until Time 10
+  12,                                     !- Hour 11
+  0,                                      !- Minute 11
+  0.61,                                   !- Value Until Time 11
+  13,                                     !- Hour 12
+  0,                                      !- Minute 12
+  0.53,                                   !- Value Until Time 12
+  14,                                     !- Hour 13
+  0,                                      !- Minute 13
+  0.47,                                   !- Value Until Time 13
+  15,                                     !- Hour 14
+  0,                                      !- Minute 14
+  0.41,                                   !- Value Until Time 14
+  16,                                     !- Hour 15
+  0,                                      !- Minute 15
+  0.47,                                   !- Value Until Time 15
+  17,                                     !- Hour 16
+  0,                                      !- Minute 16
+  0.55,                                   !- Value Until Time 16
+  18,                                     !- Hour 17
+  0,                                      !- Minute 17
+  0.73,                                   !- Value Until Time 17
+  19,                                     !- Hour 18
+  0,                                      !- Minute 18
+  0.86,                                   !- Value Until Time 18
+  20,                                     !- Hour 19
+  0,                                      !- Minute 19
+  0.82,                                   !- Value Until Time 19
+  21,                                     !- Hour 20
+  0,                                      !- Minute 20
+  0.75,                                   !- Value Until Time 20
+  22,                                     !- Hour 21
+  0,                                      !- Minute 21
+  0.61,                                   !- Value Until Time 21
+  23,                                     !- Hour 22
+  0,                                      !- Minute 22
+  0.53,                                   !- Value Until Time 22
+  24,                                     !- Hour 23
+  0,                                      !- Minute 23
+  0.29;                                   !- Value Until Time 23
+
+OS:Schedule:Ruleset,
+  {6dc866a4-6f32-4861-ad0e-36d0347ced31}, !- Handle
+  ApartmentMidRise CLGSETP_APT_SCH,       !- Name
+  {c8cfe707-c246-4b68-9e7e-d891a98b2357}, !- Schedule Type Limits Name
+  {50e6de05-30d5-4d1a-a86b-ee633736a395}, !- Default Day Schedule Name
+  {cc8a7812-6405-452c-a4fe-adc35713019d}, !- Summer Design Day Schedule Name
+  {652c72c9-409b-4bfc-97d0-237433e9e892}; !- Winter Design Day Schedule Name
+
+OS:Schedule:Day,
+  {50e6de05-30d5-4d1a-a86b-ee633736a395}, !- Handle
+  ApartmentMidRise CLGSETP_APT_SCH_Default, !- Name
+  {c8cfe707-c246-4b68-9e7e-d891a98b2357}, !- Schedule Type Limits Name
+  ,                                       !- Interpolate to Timestep
+  24,                                     !- Hour 1
+  0,                                      !- Minute 1
+  24.4;                                   !- Value Until Time 1
+
+OS:Schedule:Day,
+  {7ba85b25-3136-4ebb-9acf-2d55f6d509eb}, !- Handle
+  ApartmentMidRise CLGSETP_APT_SCH_SmrDsn, !- Name
+  {c8cfe707-c246-4b68-9e7e-d891a98b2357}, !- Schedule Type Limits Name
+  ,                                       !- Interpolate to Timestep
+  24,                                     !- Hour 1
+  0,                                      !- Minute 1
+  24.4;                                   !- Value Until Time 1
+
+OS:Schedule:Day,
+  {df998232-fec2-4e75-bdc1-7b65d1c5c843}, !- Handle
+  ApartmentMidRise CLGSETP_APT_SCH_WntrDsn, !- Name
+  {c8cfe707-c246-4b68-9e7e-d891a98b2357}, !- Schedule Type Limits Name
+  ,                                       !- Interpolate to Timestep
+  24,                                     !- Hour 1
+  0,                                      !- Minute 1
+  24.4;                                   !- Value Until Time 1
+
+OS:Schedule:Day,
+  {cc8a7812-6405-452c-a4fe-adc35713019d}, !- Handle
+  ApartmentMidRise CLGSETP_APT_SCH_SmrDsn 1, !- Name
+  {c8cfe707-c246-4b68-9e7e-d891a98b2357}, !- Schedule Type Limits Name
+  ,                                       !- Interpolate to Timestep
+  24,                                     !- Hour 1
+  0,                                      !- Minute 1
+  24.4;                                   !- Value Until Time 1
+
+OS:Schedule:Day,
+  {652c72c9-409b-4bfc-97d0-237433e9e892}, !- Handle
+  ApartmentMidRise CLGSETP_APT_SCH_WntrDsn 1, !- Name
+  {c8cfe707-c246-4b68-9e7e-d891a98b2357}, !- Schedule Type Limits Name
+  ,                                       !- Interpolate to Timestep
+  24,                                     !- Hour 1
+  0,                                      !- Minute 1
+  24.4;                                   !- Value Until Time 1
+
+OS:Schedule:Ruleset,
+  {95c125a0-3ff8-4863-8548-c71b1e88ad67}, !- Handle
+  ApartmentMidRise LTG_APT_SCH,           !- Name
+  {5ec29b47-2e16-4d0b-8501-22103961daaf}, !- Schedule Type Limits Name
+  {551f7991-25fd-4f78-9365-5d97e5b964a4}, !- Default Day Schedule Name
+  {015d1eff-4df5-4f71-a0ef-11134a06de97}, !- Summer Design Day Schedule Name
+  {f8ece71f-1dc8-434f-b5ab-ce170c389575}; !- Winter Design Day Schedule Name
+
+OS:Schedule:Day,
+  {551f7991-25fd-4f78-9365-5d97e5b964a4}, !- Handle
+  ApartmentMidRise LTG_APT_SCH_Default,   !- Name
+  {5ec29b47-2e16-4d0b-8501-22103961daaf}, !- Schedule Type Limits Name
+  ,                                       !- Interpolate to Timestep
+  4,                                      !- Hour 1
+  0,                                      !- Minute 1
+  0.011316031,                            !- Value Until Time 1
+  5,                                      !- Hour 2
+  0,                                      !- Minute 2
+  0.033948092,                            !- Value Until Time 2
+  6,                                      !- Hour 3
+  0,                                      !- Minute 3
+  0.0735542,                              !- Value Until Time 3
+  7,                                      !- Hour 4
+  0,                                      !- Minute 4
+  0.079212215,                            !- Value Until Time 4
+  8,                                      !- Hour 5
+  0,                                      !- Minute 5
+  0.0735542,                              !- Value Until Time 5
+  9,                                      !- Hour 6
+  0,                                      !- Minute 6
+  0.033948092,                            !- Value Until Time 6
+  15,                                     !- Hour 7
+  0,                                      !- Minute 7
+  0.022632061,                            !- Value Until Time 7
+  16,                                     !- Hour 8
+  0,                                      !- Minute 8
+  0.039606108,                            !- Value Until Time 8
+  17,                                     !- Hour 9
+  0,                                      !- Minute 9
+  0.079212215,                            !- Value Until Time 9
+  18,                                     !- Hour 10
+  0,                                      !- Minute 10
+  0.113160307,                            !- Value Until Time 10
+  19,                                     !- Hour 11
+  0,                                      !- Minute 11
+  0.152766415,                            !- Value Until Time 11
+  21,                                     !- Hour 12
+  0,                                      !- Minute 12
+  0.181056492,                            !- Value Until Time 12
+  22,                                     !- Hour 13
+  0,                                      !- Minute 13
+  0.124476338,                            !- Value Until Time 13
+  23,                                     !- Hour 14
+  0,                                      !- Minute 14
+  0.067896184,                            !- Value Until Time 14
+  24,                                     !- Hour 15
+  0,                                      !- Minute 15
+  0.028290077;                            !- Value Until Time 15
+
+OS:Schedule:Day,
+  {69b2e752-4fe4-438a-8a8a-2b2aaddffaef}, !- Handle
+  ApartmentMidRise LTG_APT_SCH_SmrDsn,    !- Name
+  ,                                       !- Schedule Type Limits Name
+  ,                                       !- Interpolate to Timestep
+  4,                                      !- Hour 1
+  0,                                      !- Minute 1
+  0.011316031,                            !- Value Until Time 1
+  5,                                      !- Hour 2
+  0,                                      !- Minute 2
+  0.033948092,                            !- Value Until Time 2
+  6,                                      !- Hour 3
+  0,                                      !- Minute 3
+  0.0735542,                              !- Value Until Time 3
+  7,                                      !- Hour 4
+  0,                                      !- Minute 4
+  0.079212215,                            !- Value Until Time 4
+  8,                                      !- Hour 5
+  0,                                      !- Minute 5
+  0.0735542,                              !- Value Until Time 5
+  9,                                      !- Hour 6
+  0,                                      !- Minute 6
+  0.033948092,                            !- Value Until Time 6
+  15,                                     !- Hour 7
+  0,                                      !- Minute 7
+  0.022632061,                            !- Value Until Time 7
+  16,                                     !- Hour 8
+  0,                                      !- Minute 8
+  0.039606108,                            !- Value Until Time 8
+  17,                                     !- Hour 9
+  0,                                      !- Minute 9
+  0.079212215,                            !- Value Until Time 9
+  18,                                     !- Hour 10
+  0,                                      !- Minute 10
+  0.113160307,                            !- Value Until Time 10
+  19,                                     !- Hour 11
+  0,                                      !- Minute 11
+  0.152766415,                            !- Value Until Time 11
+  21,                                     !- Hour 12
+  0,                                      !- Minute 12
+  0.181056492,                            !- Value Until Time 12
+  22,                                     !- Hour 13
+  0,                                      !- Minute 13
+  0.124476338,                            !- Value Until Time 13
+  23,                                     !- Hour 14
+  0,                                      !- Minute 14
+  0.067896184,                            !- Value Until Time 14
+  24,                                     !- Hour 15
+  0,                                      !- Minute 15
+  0.028290077;                            !- Value Until Time 15
+
+OS:Schedule:Day,
+  {66776821-4d57-478e-ac09-31468d352eab}, !- Handle
+  ApartmentMidRise LTG_APT_SCH_WntrDsn,   !- Name
+  ,                                       !- Schedule Type Limits Name
+  ,                                       !- Interpolate to Timestep
+  4,                                      !- Hour 1
+  0,                                      !- Minute 1
+  0.011316031,                            !- Value Until Time 1
+  5,                                      !- Hour 2
+  0,                                      !- Minute 2
+  0.033948092,                            !- Value Until Time 2
+  6,                                      !- Hour 3
+  0,                                      !- Minute 3
+  0.0735542,                              !- Value Until Time 3
+  7,                                      !- Hour 4
+  0,                                      !- Minute 4
+  0.079212215,                            !- Value Until Time 4
+  8,                                      !- Hour 5
+  0,                                      !- Minute 5
+  0.0735542,                              !- Value Until Time 5
+  9,                                      !- Hour 6
+  0,                                      !- Minute 6
+  0.033948092,                            !- Value Until Time 6
+  15,                                     !- Hour 7
+  0,                                      !- Minute 7
+  0.022632061,                            !- Value Until Time 7
+  16,                                     !- Hour 8
+  0,                                      !- Minute 8
+  0.039606108,                            !- Value Until Time 8
+  17,                                     !- Hour 9
+  0,                                      !- Minute 9
+  0.079212215,                            !- Value Until Time 9
+  18,                                     !- Hour 10
+  0,                                      !- Minute 10
+  0.113160307,                            !- Value Until Time 10
+  19,                                     !- Hour 11
+  0,                                      !- Minute 11
+  0.152766415,                            !- Value Until Time 11
+  21,                                     !- Hour 12
+  0,                                      !- Minute 12
+  0.181056492,                            !- Value Until Time 12
+  22,                                     !- Hour 13
+  0,                                      !- Minute 13
+  0.124476338,                            !- Value Until Time 13
+  23,                                     !- Hour 14
+  0,                                      !- Minute 14
+  0.067896184,                            !- Value Until Time 14
+  24,                                     !- Hour 15
+  0,                                      !- Minute 15
+  0.028290077;                            !- Value Until Time 15
+
+OS:Schedule:Day,
+  {015d1eff-4df5-4f71-a0ef-11134a06de97}, !- Handle
+  ApartmentMidRise LTG_APT_SCH_SmrDsn 1,  !- Name
+  {5ec29b47-2e16-4d0b-8501-22103961daaf}, !- Schedule Type Limits Name
+  ,                                       !- Interpolate to Timestep
+  4,                                      !- Hour 1
+  0,                                      !- Minute 1
+  0.011316031,                            !- Value Until Time 1
+  5,                                      !- Hour 2
+  0,                                      !- Minute 2
+  0.033948092,                            !- Value Until Time 2
+  6,                                      !- Hour 3
+  0,                                      !- Minute 3
+  0.0735542,                              !- Value Until Time 3
+  7,                                      !- Hour 4
+  0,                                      !- Minute 4
+  0.079212215,                            !- Value Until Time 4
+  8,                                      !- Hour 5
+  0,                                      !- Minute 5
+  0.0735542,                              !- Value Until Time 5
+  9,                                      !- Hour 6
+  0,                                      !- Minute 6
+  0.033948092,                            !- Value Until Time 6
+  15,                                     !- Hour 7
+  0,                                      !- Minute 7
+  0.022632061,                            !- Value Until Time 7
+  16,                                     !- Hour 8
+  0,                                      !- Minute 8
+  0.039606108,                            !- Value Until Time 8
+  17,                                     !- Hour 9
+  0,                                      !- Minute 9
+  0.079212215,                            !- Value Until Time 9
+  18,                                     !- Hour 10
+  0,                                      !- Minute 10
+  0.113160307,                            !- Value Until Time 10
+  19,                                     !- Hour 11
+  0,                                      !- Minute 11
+  0.152766415,                            !- Value Until Time 11
+  21,                                     !- Hour 12
+  0,                                      !- Minute 12
+  0.181056492,                            !- Value Until Time 12
+  22,                                     !- Hour 13
+  0,                                      !- Minute 13
+  0.124476338,                            !- Value Until Time 13
+  23,                                     !- Hour 14
+  0,                                      !- Minute 14
+  0.067896184,                            !- Value Until Time 14
+  24,                                     !- Hour 15
+  0,                                      !- Minute 15
+  0.028290077;                            !- Value Until Time 15
+
+OS:Schedule:Day,
+  {f8ece71f-1dc8-434f-b5ab-ce170c389575}, !- Handle
+  ApartmentMidRise LTG_APT_SCH_WntrDsn 1, !- Name
+  {5ec29b47-2e16-4d0b-8501-22103961daaf}, !- Schedule Type Limits Name
+  ,                                       !- Interpolate to Timestep
+  4,                                      !- Hour 1
+  0,                                      !- Minute 1
+  0.011316031,                            !- Value Until Time 1
+  5,                                      !- Hour 2
+  0,                                      !- Minute 2
+  0.033948092,                            !- Value Until Time 2
+  6,                                      !- Hour 3
+  0,                                      !- Minute 3
+  0.0735542,                              !- Value Until Time 3
+  7,                                      !- Hour 4
+  0,                                      !- Minute 4
+  0.079212215,                            !- Value Until Time 4
+  8,                                      !- Hour 5
+  0,                                      !- Minute 5
+  0.0735542,                              !- Value Until Time 5
+  9,                                      !- Hour 6
+  0,                                      !- Minute 6
+  0.033948092,                            !- Value Until Time 6
+  15,                                     !- Hour 7
+  0,                                      !- Minute 7
+  0.022632061,                            !- Value Until Time 7
+  16,                                     !- Hour 8
+  0,                                      !- Minute 8
+  0.039606108,                            !- Value Until Time 8
+  17,                                     !- Hour 9
+  0,                                      !- Minute 9
+  0.079212215,                            !- Value Until Time 9
+  18,                                     !- Hour 10
+  0,                                      !- Minute 10
+  0.113160307,                            !- Value Until Time 10
+  19,                                     !- Hour 11
+  0,                                      !- Minute 11
+  0.152766415,                            !- Value Until Time 11
+  21,                                     !- Hour 12
+  0,                                      !- Minute 12
+  0.181056492,                            !- Value Until Time 12
+  22,                                     !- Hour 13
+  0,                                      !- Minute 13
+  0.124476338,                            !- Value Until Time 13
+  23,                                     !- Hour 14
+  0,                                      !- Minute 14
+  0.067896184,                            !- Value Until Time 14
+  24,                                     !- Hour 15
+  0,                                      !- Minute 15
+  0.028290077;                            !- Value Until Time 15
+
+OS:Schedule:Ruleset,
+  {e21cea04-c68d-456b-9645-f7bdf9b83daf}, !- Handle
+  ApartmentMidRise Activity Schedule,     !- Name
+  {2c86f4cd-9d00-4611-8205-b1e6971c61df}, !- Schedule Type Limits Name
+  {757ae579-c69e-405d-bd6a-ba850517104a}, !- Default Day Schedule Name
+  {5c82f8ff-1a44-49aa-8eea-8f04831437dd}, !- Summer Design Day Schedule Name
+  {d631a0e2-275a-429a-b5ca-97fc68f538d3}; !- Winter Design Day Schedule Name
+
+OS:Schedule:Day,
+  {757ae579-c69e-405d-bd6a-ba850517104a}, !- Handle
+  ApartmentMidRise Activity Schedule_Default, !- Name
+  {2c86f4cd-9d00-4611-8205-b1e6971c61df}, !- Schedule Type Limits Name
+  ,                                       !- Interpolate to Timestep
+  24,                                     !- Hour 1
+  0,                                      !- Minute 1
+  95;                                     !- Value Until Time 1
+
+OS:Schedule:Day,
+  {f5e10210-7d8f-448a-aadc-b594b0a4b309}, !- Handle
+  ApartmentMidRise Activity Schedule_SmrDsn, !- Name
+  {2c86f4cd-9d00-4611-8205-b1e6971c61df}, !- Schedule Type Limits Name
+  ,                                       !- Interpolate to Timestep
+  24,                                     !- Hour 1
+  0,                                      !- Minute 1
+  95;                                     !- Value Until Time 1
+
+OS:Schedule:Day,
+  {2422c5a5-0aa3-44ac-80ad-55b2acc24630}, !- Handle
+  ApartmentMidRise Activity Schedule_WntrDsn, !- Name
+  {2c86f4cd-9d00-4611-8205-b1e6971c61df}, !- Schedule Type Limits Name
+  ,                                       !- Interpolate to Timestep
+  24,                                     !- Hour 1
+  0,                                      !- Minute 1
+  95;                                     !- Value Until Time 1
+
+OS:Schedule:Day,
+  {5c82f8ff-1a44-49aa-8eea-8f04831437dd}, !- Handle
+  ApartmentMidRise Activity Schedule_SmrDsn 1, !- Name
+  {2c86f4cd-9d00-4611-8205-b1e6971c61df}, !- Schedule Type Limits Name
+  ,                                       !- Interpolate to Timestep
+  24,                                     !- Hour 1
+  0,                                      !- Minute 1
+  95;                                     !- Value Until Time 1
+
+OS:Schedule:Day,
+  {d631a0e2-275a-429a-b5ca-97fc68f538d3}, !- Handle
+  ApartmentMidRise Activity Schedule_WntrDsn 1, !- Name
+  {2c86f4cd-9d00-4611-8205-b1e6971c61df}, !- Schedule Type Limits Name
+  ,                                       !- Interpolate to Timestep
+  24,                                     !- Hour 1
+  0,                                      !- Minute 1
+  95;                                     !- Value Until Time 1
+
+OS:Material:NoMass,
+  {f9b60d7d-a614-4796-bcbe-2e931ea3d6dd}, !- Handle
+  Typical Insulation-R4,                  !- Name
+  MediumSmooth,                           !- Roughness
+  0.704440735239539,                      !- Thermal Resistance {m2-K/W}
+  0.9,                                    !- Thermal Absorptance
+  0.7,                                    !- Solar Absorptance
+  0.7;                                    !- Visible Absorptance
+
+OS:WindowMaterial:SimpleGlazingSystem,
+  {41d6024d-e44c-4c26-bb57-5100a45bbbb9}, !- Handle
+  U 0.5 SHGC 0.4 Simple Glazing,          !- Name
+  2.839,                                  !- U-Factor {W/m2-K}
+  0.4,                                    !- Solar Heat Gain Coefficient
+  0.6;                                    !- Visible Transmittance
+
+OS:Material,
+  {62b88403-5f37-46b1-a4c2-093d2d2117b3}, !- Handle
+  Metal Roof Surface,                     !- Name
+  Smooth,                                 !- Roughness
+  0.000799999999999998,                   !- Thickness {m}
+  45.2497187436177,                       !- Conductivity {W/m-K}
+  7824.01788948971,                       !- Density {kg/m3}
+  499.67760800731,                        !- Specific Heat {J/kg-K}
+  0.9,                                    !- Thermal Absorptance
+  0.7,                                    !- Solar Absorptance
+  0.7;                                    !- Visible Absorptance
+
+OS:Material:NoMass,
+  {858aded2-f14a-464b-a2a4-39d720286336}, !- Handle
+  Typical Insulation-R7,                  !- Name
+  MediumSmooth,                           !- Roughness
+  1.23277128666919,                       !- Thermal Resistance {m2-K/W}
+  0.9,                                    !- Thermal Absorptance
+  0.7,                                    !- Solar Absorptance
+  0.7;                                    !- Visible Absorptance
+
+OS:Material:NoMass,
+  {c8de3886-4a1f-410d-884a-9354e068f598}, !- Handle
+  Typical Insulation-R24,                 !- Name
+  MediumSmooth,                           !- Roughness
+  4.22664441143724,                       !- Thermal Resistance {m2-K/W}
+  0.9,                                    !- Thermal Absorptance
+  0.7,                                    !- Solar Absorptance
+  0.7;                                    !- Visible Absorptance
+
+OS:Material,
+  {0f993def-aa98-45d0-bcb3-f91983081736}, !- Handle
+  F08 Metal surface,                      !- Name
+  Smooth,                                 !- Roughness
+  0.0008,                                 !- Thickness {m}
+  45.2497187436178,                       !- Conductivity {W/m-K}
+  7824.01788948971,                       !- Density {kg/m3}
+  499.677608007314,                       !- Specific Heat {J/kg-K}
+  0.9,                                    !- Thermal Absorptance
+  0.7,                                    !- Solar Absorptance
+  0.7;                                    !- Visible Absorptance
+
+OS:Material,
+  {1196e51c-0137-46dc-8925-dd7a54410bf6}, !- Handle
+  5/8 in. Gypsum Board,                   !- Name
+  MediumSmooth,                           !- Roughness
+  0.0159,                                 !- Thickness {m}
+  0.159892999094055,                      !- Conductivity {W/m-K}
+  800.001829191177,                       !- Density {kg/m3}
+  1089.29718545594,                       !- Specific Heat {J/kg-K}
+  0.9,                                    !- Thermal Absorptance
+  0.7,                                    !- Solar Absorptance
+  0.7;                                    !- Visible Absorptance
+
+OS:Material,
+  {daa2089f-c92f-4cf4-962d-2774878134ef}, !- Handle
+  25mm Stucco,                            !- Name
+  Smooth,                                 !- Roughness
+  0.0254,                                 !- Thickness {m}
+  0.71951849592325,                       !- Conductivity {W/m-K}
+  1856.00424372353,                       !- Density {kg/m3}
+  839.458381452284,                       !- Specific Heat {J/kg-K}
+  0.9,                                    !- Thermal Absorptance
+  0.7,                                    !- Solar Absorptance
+  0.7;                                    !- Visible Absorptance
+
+OS:Material:NoMass,
+  {a4450d11-937c-4937-8f3f-25cdc63a48de}, !- Handle
+  Typical Insulation-R31,                 !- Name
+  MediumSmooth,                           !- Roughness
+  5.45941569810643,                       !- Thermal Resistance {m2-K/W}
+  0.9,                                    !- Thermal Absorptance
+  0.7,                                    !- Solar Absorptance
+  0.7;                                    !- Visible Absorptance
+
+OS:WindowMaterial:SimpleGlazingSystem,
+  {cf5abe61-3efe-4772-8937-ba3966f003f2}, !- Handle
+  U 0.36 SHGC 0.38 Simple Glazing,        !- Name
+  2.04408,                                !- U-Factor {W/m2-K}
+  0.38,                                   !- Solar Heat Gain Coefficient
+  0.6;                                    !- Visible Transmittance
+
+OS:Material,
+  {ca7c25b9-dedf-413f-928c-616ab6565457}, !- Handle
+  8 in. Concrete Block Basement Wall,     !- Name
+  MediumRough,                            !- Roughness
+  0.2032,                                 !- Thickness {m}
+  1.32511322999199,                       !- Conductivity {W/m-K}
+  1842.00421171268,                       !- Density {kg/m3}
+  911.411957005339,                       !- Specific Heat {J/kg-K}
+  0.9,                                    !- Thermal Absorptance
+  0.7,                                    !- Solar Absorptance
+  0.7;                                    !- Visible Absorptance
+
+OS:WindowMaterial:Glazing,
+  {3fec2e8c-66e3-498c-817f-1484b11f2e28}, !- Handle
+  CLEAR 6MM,                              !- Name
+  SpectralAverage,                        !- Optical Data Type
+  ,                                       !- Window Glass Spectral Data Set Name
+  0.00599999999999998,                    !- Thickness {m}
+  0.775,                                  !- Solar Transmittance at Normal Incidence
+  0.071,                                  !- Front Side Solar Reflectance at Normal Incidence
+  0.071,                                  !- Back Side Solar Reflectance at Normal Incidence
+  0.881,                                  !- Visible Transmittance at Normal Incidence
+  0.08,                                   !- Front Side Visible Reflectance at Normal Incidence
+  0.08,                                   !- Back Side Visible Reflectance at Normal Incidence
+  0,                                      !- Infrared Transmittance at Normal Incidence
+  0.84,                                   !- Front Side Infrared Hemispherical Emissivity
+  0.84,                                   !- Back Side Infrared Hemispherical Emissivity
+  0.899398119904063,                      !- Conductivity {W/m-K}
+  1,                                      !- Dirt Correction Factor for Solar and Visible Transmittance
+  No;                                     !- Solar Diffusing
+
+OS:Material,
+  {290bb07c-a93d-4f66-93c8-87587a598143}, !- Handle
+  8 in. Normalweight Concrete Floor,      !- Name
+  MediumRough,                            !- Roughness
+  0.2032,                                 !- Thickness {m}
+  2.30845517442043,                       !- Conductivity {W/m-K}
+  2322.00530922738,                       !- Density {kg/m3}
+  831.463539724167,                       !- Specific Heat {J/kg-K}
+  0.9,                                    !- Thermal Absorptance
+  0.7,                                    !- Solar Absorptance
+  0.7;                                    !- Visible Absorptance
+
+OS:Material,
+  {f413b2b6-a2f5-4d84-9c2d-9e235b2fe267}, !- Handle
+  Roof Membrane,                          !- Name
+  VeryRough,                              !- Roughness
+  0.0095,                                 !- Thickness {m}
+  0.159892999094056,                      !- Conductivity {W/m-K}
+  1121.29256381722,                       !- Density {kg/m3}
+  1459.05861538136,                       !- Specific Heat {J/kg-K}
+  0.9,                                    !- Thermal Absorptance
+  0.7,                                    !- Solar Absorptance
+  0.7;                                    !- Visible Absorptance
+
+OS:Material:NoMass,
+  {cbfe28b1-441a-4ab5-bfce-10190c7e14a6}, !- Handle
+  Typical Insulation-R3,                  !- Name
+  MediumSmooth,                           !- Roughness
+  0.528330551429654,                      !- Thermal Resistance {m2-K/W}
+  0.9,                                    !- Thermal Absorptance
+  0.7,                                    !- Solar Absorptance
+  0.7;                                    !- Visible Absorptance
+
+OS:Material:NoMass,
+  {b78ab84d-d0ff-44b6-aebe-072d37080710}, !- Handle
+  Typical Insulation-R17,                 !- Name
+  MediumSmooth,                           !- Roughness
+  2.99387312476804,                       !- Thermal Resistance {m2-K/W}
+  0.9,                                    !- Thermal Absorptance
+  0.7,                                    !- Solar Absorptance
+  0.7;                                    !- Visible Absorptance
+
+OS:WindowMaterial:Glazing,
+  {e8dfd6d4-4cef-4ccc-a579-cf11dc26789f}, !- Handle
+  REF B CLEAR HI 6MM,                     !- Name
+  SpectralAverage,                        !- Optical Data Type
+  ,                                       !- Window Glass Spectral Data Set Name
+  0.00599999999999998,                    !- Thickness {m}
+  0.24,                                   !- Solar Transmittance at Normal Incidence
+  0.16,                                   !- Front Side Solar Reflectance at Normal Incidence
+  0.32,                                   !- Back Side Solar Reflectance at Normal Incidence
+  0.3,                                    !- Visible Transmittance at Normal Incidence
+  0.16,                                   !- Front Side Visible Reflectance at Normal Incidence
+  0.29,                                   !- Back Side Visible Reflectance at Normal Incidence
+  0,                                      !- Infrared Transmittance at Normal Incidence
+  0.84,                                   !- Front Side Infrared Hemispherical Emissivity
+  0.6,                                    !- Back Side Infrared Hemispherical Emissivity
+  0.899398119904063,                      !- Conductivity {W/m-K}
+  1,                                      !- Dirt Correction Factor for Solar and Visible Transmittance
+  No;                                     !- Solar Diffusing
+
+OS:Material:NoMass,
+  {4b4c61c9-209c-4925-a2a8-e873e128a989}, !- Handle
+  Typical Carpet Pad,                     !- Name
+  VeryRough,                              !- Roughness
+  0.2164799871521,                        !- Thermal Resistance {m2-K/W}
+  0.9,                                    !- Thermal Absorptance
+  0.7,                                    !- Solar Absorptance
+  0.8;                                    !- Visible Absorptance
+
+OS:WindowMaterial:Gas,
+  {84fdc873-b7bb-4762-85bc-c8fb36f09063}, !- Handle
+  AIR 13MM,                               !- Name
+  Air,                                    !- Gas Type
+  0.0127;                                 !- Thickness {m}
+
+OS:Construction,
+  {6f7e80b2-83df-4126-ac76-c92b41536612}, !- Handle
+  Typical Insulated Steel Framed Exterior Wall-R19, !- Name
+  ,                                       !- Surface Rendering Name
+  {daa2089f-c92f-4cf4-962d-2774878134ef}, !- Layer 1
+  {1196e51c-0137-46dc-8925-dd7a54410bf6}, !- Layer 2
+  {b78ab84d-d0ff-44b6-aebe-072d37080710}, !- Layer 3
+  {1196e51c-0137-46dc-8925-dd7a54410bf6}; !- Layer 4
+
+OS:Construction,
+  {685c5472-132a-45ce-8e1c-fed56b49af84}, !- Handle
+  Typical Insulated Metal Door-R3,        !- Name
+  ,                                       !- Surface Rendering Name
+  {0f993def-aa98-45d0-bcb3-f91983081736}, !- Layer 1
+  {cbfe28b1-441a-4ab5-bfce-10190c7e14a6}; !- Layer 2
+
+OS:Construction,
+  {3b85f31d-65a5-4943-88fd-2a49efcb4075}, !- Handle
+  U 0.5 SHGC 0.4 Simple Glazing Skylight, !- Name
+  ,                                       !- Surface Rendering Name
+  {41d6024d-e44c-4c26-bb57-5100a45bbbb9}; !- Layer 1
+
+OS:Construction,
+  {42678efa-3fe1-4282-aa26-c99b344fc865}, !- Handle
+  U 0.44 SHGC 0.26 Dbl Ref-B-H Clr 6mm/13mm Air, !- Name
+  ,                                       !- Surface Rendering Name
+  {e8dfd6d4-4cef-4ccc-a579-cf11dc26789f}, !- Layer 1
+  {84fdc873-b7bb-4762-85bc-c8fb36f09063}, !- Layer 2
+  {3fec2e8c-66e3-498c-817f-1484b11f2e28}; !- Layer 3
+
+OS:Construction,
+  {c5e553f3-8ec9-4a1b-a66b-545cccca81f3}, !- Handle
+  U 0.36 SHGC 0.38 Simple Glazing Window, !- Name
+  ,                                       !- Surface Rendering Name
+  {cf5abe61-3efe-4772-8937-ba3966f003f2}; !- Layer 1
+
+OS:Construction,
+  {8269ec73-c7a9-43c4-b3e7-6fd7bb3db0b5}, !- Handle
+  Typical Insulated Carpeted 8in Slab Floor-R5, !- Name
+  ,                                       !- Surface Rendering Name
+  {f9b60d7d-a614-4796-bcbe-2e931ea3d6dd}, !- Layer 1
+  {290bb07c-a93d-4f66-93c8-87587a598143}, !- Layer 2
+  {4b4c61c9-209c-4925-a2a8-e873e128a989}; !- Layer 3
+
+OS:Construction,
+  {e7e238e9-8103-4b28-9286-e34da2b74e8b}, !- Handle
+  Typical IEAD Roof-R32,                  !- Name
+  ,                                       !- Surface Rendering Name
+  {f413b2b6-a2f5-4d84-9c2d-9e235b2fe267}, !- Layer 1
+  {a4450d11-937c-4937-8f3f-25cdc63a48de}, !- Layer 2
+  {62b88403-5f37-46b1-a4c2-093d2d2117b3}; !- Layer 3
+
+OS:Construction,
+  {5a5bbd0a-4f1b-4bbd-bc1c-4aeaf7223bf4}, !- Handle
+  Typical Overhead Door-R4,               !- Name
+  ,                                       !- Surface Rendering Name
+  {f9b60d7d-a614-4796-bcbe-2e931ea3d6dd}; !- Layer 1
+
+OS:Construction,
+  {85ee19ad-9dfe-41b2-8c80-49b469775f59}, !- Handle
+  Typical Insulated Basement Mass Wall-R8, !- Name
+  ,                                       !- Surface Rendering Name
+  {858aded2-f14a-464b-a2a4-39d720286336}, !- Layer 1
+  {ca7c25b9-dedf-413f-928c-616ab6565457}; !- Layer 2
+
+OS:Construction,
+  {7072aab3-18fa-497f-8d94-f93e7f5c30c8}, !- Handle
+  Typical Insulated Steel Framed Exterior Floor-R27, !- Name
+  ,                                       !- Surface Rendering Name
+  {daa2089f-c92f-4cf4-962d-2774878134ef}, !- Layer 1
+  {1196e51c-0137-46dc-8925-dd7a54410bf6}, !- Layer 2
+  {c8de3886-4a1f-410d-884a-9354e068f598}, !- Layer 3
+  {1196e51c-0137-46dc-8925-dd7a54410bf6}, !- Layer 4
+  {4b4c61c9-209c-4925-a2a8-e873e128a989}; !- Layer 5
+
+OS:DefaultConstructionSet,
+  {784c7e91-22dd-4362-b8ec-061ea4f8064a}, !- Handle
+  2019::ClimateZone5::SteelFramed,        !- Name
+  {ac721e24-0212-4ad6-a591-10c5cf050504}, !- Default Exterior Surface Constructions Name
+  {37266f95-e94b-44ee-bd53-9269ecddaffa}, !- Default Interior Surface Constructions Name
+  {e6a2be13-0157-4154-8a36-41e27f54103e}, !- Default Ground Contact Surface Constructions Name
+  {1060e52e-ffe8-4fc7-b37c-4bc9161a4103}, !- Default Exterior SubSurface Constructions Name
+  {579c3c1a-b9a4-4883-a6b9-95f3373df2bf}, !- Default Interior SubSurface Constructions Name
+  ,                                       !- Interior Partition Construction Name
+  ,                                       !- Space Shading Construction Name
+  ,                                       !- Building Shading Construction Name
+  ,                                       !- Site Shading Construction Name
+  ;                                       !- Adiabatic Surface Construction Name
+
+OS:DefaultSurfaceConstructions,
+  {37266f95-e94b-44ee-bd53-9269ecddaffa}, !- Handle
+  Default Surface Constructions 1,        !- Name
+  ,                                       !- Floor Construction Name
+  ,                                       !- Wall Construction Name
+  ;                                       !- Roof Ceiling Construction Name
+
+OS:DefaultSurfaceConstructions,
+  {ac721e24-0212-4ad6-a591-10c5cf050504}, !- Handle
+  Default Surface Constructions 2,        !- Name
+  {7072aab3-18fa-497f-8d94-f93e7f5c30c8}, !- Floor Construction Name
+  {6f7e80b2-83df-4126-ac76-c92b41536612}, !- Wall Construction Name
+  {e7e238e9-8103-4b28-9286-e34da2b74e8b}; !- Roof Ceiling Construction Name
+
+OS:DefaultSurfaceConstructions,
+  {e6a2be13-0157-4154-8a36-41e27f54103e}, !- Handle
+  Default Surface Constructions 3,        !- Name
+  {8269ec73-c7a9-43c4-b3e7-6fd7bb3db0b5}, !- Floor Construction Name
+  {85ee19ad-9dfe-41b2-8c80-49b469775f59}, !- Wall Construction Name
+  ;                                       !- Roof Ceiling Construction Name
+
+OS:DefaultSubSurfaceConstructions,
+  {579c3c1a-b9a4-4883-a6b9-95f3373df2bf}, !- Handle
+  Default Sub Surface Constructions 1,    !- Name
+  ,                                       !- Fixed Window Construction Name
+  ,                                       !- Operable Window Construction Name
+  ,                                       !- Door Construction Name
+  ,                                       !- Glass Door Construction Name
+  ,                                       !- Overhead Door Construction Name
+  ,                                       !- Skylight Construction Name
+  ,                                       !- Tubular Daylight Dome Construction Name
+  ;                                       !- Tubular Daylight Diffuser Construction Name
+
+OS:DefaultSubSurfaceConstructions,
+  {1060e52e-ffe8-4fc7-b37c-4bc9161a4103}, !- Handle
+  Default Sub Surface Constructions 2,    !- Name
+  {c5e553f3-8ec9-4a1b-a66b-545cccca81f3}, !- Fixed Window Construction Name
+  {c5e553f3-8ec9-4a1b-a66b-545cccca81f3}, !- Operable Window Construction Name
+  {685c5472-132a-45ce-8e1c-fed56b49af84}, !- Door Construction Name
+  {42678efa-3fe1-4282-aa26-c99b344fc865}, !- Glass Door Construction Name
+  {5a5bbd0a-4f1b-4bbd-bc1c-4aeaf7223bf4}, !- Overhead Door Construction Name
+  {3b85f31d-65a5-4943-88fd-2a49efcb4075}, !- Skylight Construction Name
+  ,                                       !- Tubular Daylight Dome Construction Name
+  ;                                       !- Tubular Daylight Diffuser Construction Name
+
+OS:StandardsInformation:Construction,
+  {3ae86e44-605e-4ba1-8733-b888f11dd1d0}, !- Handle
+  {c5e553f3-8ec9-4a1b-a66b-545cccca81f3}, !- Construction Name
+  ExteriorWindow,                         !- Intended Surface Type
+  ,                                       !- Standards Construction Type
+  ,                                       !- Perturbable Layer
+  ,                                       !- Perturbable Layer Type
+  ,                                       !- Other Perturbable Layer Type
+  ,                                       !- Construction Standard
+  ,                                       !- Construction Standard Source
+  Fixed Window,                           !- Fenestration Type
+  ,                                       !- Fenestration Assembly Context
+  ,                                       !- Fenestration Number of Panes
+  Metal Framing with Thermal Break;       !- Fenestration Frame Type
+
+OS:StandardsInformation:Construction,
+  {52b76e97-e6a1-4993-b408-ea49be6de99c}, !- Handle
+  {3b85f31d-65a5-4943-88fd-2a49efcb4075}, !- Construction Name
+  Skylight,                               !- Intended Surface Type
+  ,                                       !- Standards Construction Type
+  ,                                       !- Perturbable Layer
+  ,                                       !- Perturbable Layer Type
+  ,                                       !- Other Perturbable Layer Type
+  ,                                       !- Construction Standard
+  ,                                       !- Construction Standard Source
+  Fixed Window,                           !- Fenestration Type
+  ,                                       !- Fenestration Assembly Context
+  ,                                       !- Fenestration Number of Panes
+  Metal Framing with Thermal Break;       !- Fenestration Frame Type
+
+OS:StandardsInformation:Construction,
+  {f0e65286-5503-4b1c-b00f-b0d11350e71b}, !- Handle
+  {685c5472-132a-45ce-8e1c-fed56b49af84}, !- Construction Name
+  ExteriorDoor;                           !- Intended Surface Type
+
+OS:StandardsInformation:Construction,
+  {824973fa-7821-442a-ad51-04de45e5741e}, !- Handle
+  {5a5bbd0a-4f1b-4bbd-bc1c-4aeaf7223bf4}, !- Construction Name
+  OverheadDoor;                           !- Intended Surface Type
+
+OS:StandardsInformation:Construction,
+  {c1284098-8ede-498f-8661-c52ea4ce825e}, !- Handle
+  {42678efa-3fe1-4282-aa26-c99b344fc865}, !- Construction Name
+  GlassDoor,                              !- Intended Surface Type
+  ,                                       !- Standards Construction Type
+  ,                                       !- Perturbable Layer
+  ,                                       !- Perturbable Layer Type
+  ,                                       !- Other Perturbable Layer Type
+  ,                                       !- Construction Standard
+  ,                                       !- Construction Standard Source
+  Glazed Door,                            !- Fenestration Type
+  ,                                       !- Fenestration Assembly Context
+  ,                                       !- Fenestration Number of Panes
+  Metal Framing with Thermal Break;       !- Fenestration Frame Type
+
+OS:SpaceType,
+  {291fe1c2-9bb0-443e-8d59-ed767308bbf1}, !- Handle
+  2019::MidriseApartment::Apartment,      !- Name
+  ,                                       !- Default Construction Set Name
+  ,                                       !- Default Schedule Set Name
+  ,                                       !- Group Rendering Name
+  {8039c09c-e999-4cab-baa3-bf6f85bc9904}, !- Design Specification Outdoor Air Object Name
+  ,                                       !- Standards Template
+  ,                                       !- Standards Building Type
+  Apartment;                              !- Standards Space Type
+
+OS:People:Definition,
+  {5421900a-98a5-4f70-bcc6-d25bb60a26be}, !- Handle
+  2019::MidriseApartment::Apartment_People, !- Name
+  People/Area,                            !- Number of People Calculation Method
+  ,                                       !- Number of People {people}
+  0.0283090965846098,                     !- People per Space Floor Area {person/m2}
+  ,                                       !- Space Floor Area per Person {m2/person}
+  0.3,                                    !- Fraction Radiant
+  Autocalculate;                          !- Sensible Heat Fraction
+
+OS:People,
+  {f880d1de-6377-4b53-85a6-e539106e6814}, !- Handle
+  2019::MidriseApartment::Apartment_People, !- Name
+  {5421900a-98a5-4f70-bcc6-d25bb60a26be}, !- People Definition Name
+  {291fe1c2-9bb0-443e-8d59-ed767308bbf1}, !- Space or SpaceType Name
+  {5ccc53e6-d989-4566-a468-10d0b79f9e4c}, !- Number of People Schedule Name
+  {e21cea04-c68d-456b-9645-f7bdf9b83daf}, !- Activity Level Schedule Name
+  ,                                       !- Surface Name/Angle Factor List Name
+  ,                                       !- Work Efficiency Schedule Name
+  ,                                       !- Clothing Insulation Schedule Name
+  ,                                       !- Air Velocity Schedule Name
+  1;                                      !- Multiplier
+
+OS:Lights:Definition,
+  {614d424b-48b7-4953-9c55-c5d02871e31d}, !- Handle
+  2019::MidriseApartment::Apartment_Lighting, !- Name
+  Watts/Area,                             !- Design Level Calculation Method
+  ,                                       !- Lighting Level {W}
+  6.45834,                                !- Watts per Space Floor Area {W/m2}
+  ,                                       !- Watts per Person {W/person}
+  0.6,                                    !- Fraction Radiant
+  0.2,                                    !- Fraction Visible
+  0;                                      !- Return Air Fraction
+
+OS:Lights,
+  {13b5fb2e-23ef-455c-a045-fe1b91650363}, !- Handle
+  2019::MidriseApartment::Apartment_Lighting, !- Name
+  {614d424b-48b7-4953-9c55-c5d02871e31d}, !- Lights Definition Name
+  {291fe1c2-9bb0-443e-8d59-ed767308bbf1}, !- Space or SpaceType Name
+  {95c125a0-3ff8-4863-8548-c71b1e88ad67}, !- Schedule Name
+  1,                                      !- Fraction Replaceable
+  ,                                       !- Multiplier
+  General;                                !- End-Use Subcategory
+
+OS:ElectricEquipment:Definition,
+  {1e7a645d-f47b-455e-92f7-25fa48564279}, !- Handle
+  2019::MidriseApartment::Apartment_Electric, !- Name
+  Watts/Area,                             !- Design Level Calculation Method
+  ,                                       !- Design Level {W}
+  6.66999354514752,                       !- Watts per Space Floor Area {W/m2}
+  ,                                       !- Watts per Person {W/person}
+  0,                                      !- Fraction Latent
+  0.5,                                    !- Fraction Radiant
+  0;                                      !- Fraction Lost
+
+OS:ElectricEquipment,
+  {b52a051e-a7c5-43ed-9140-06d165ff5278}, !- Handle
+  2019::MidriseApartment::Apartment_Electric, !- Name
+  {1e7a645d-f47b-455e-92f7-25fa48564279}, !- Electric Equipment Definition Name
+  {291fe1c2-9bb0-443e-8d59-ed767308bbf1}, !- Space or SpaceType Name
+  {9a019e28-3764-426f-bde3-d7c95c5ffaa8}, !- Schedule Name
+  ,                                       !- Multiplier
+  Electric Equipment;                     !- End-Use Subcategory
+
+OS:SpaceInfiltration:DesignFlowRate,
+  {739d6fff-b7bf-44a1-9b44-306d1707dfef}, !- Handle
+  2019::MidriseApartment::Apartment_Infiltration, !- Name
+  {291fe1c2-9bb0-443e-8d59-ed767308bbf1}, !- Space or SpaceType Name
+  {307beed5-ee14-4064-be6b-a4e4e11921e5}, !- Schedule Name
+  Flow/ExteriorArea,                      !- Design Flow Rate Calculation Method
+  ,                                       !- Design Flow Rate {m3/s}
+  ,                                       !- Flow per Space Floor Area {m3/s-m2}
+  0.00056896,                             !- Flow per Exterior Surface Area {m3/s-m2}
+  ,                                       !- Air Changes per Hour {1/hr}
+  1,                                      !- Constant Term Coefficient
+  0,                                      !- Temperature Term Coefficient
+  0,                                      !- Velocity Term Coefficient
+  ;                                       !- Velocity Squared Term Coefficient
+
+OS:DesignSpecification:OutdoorAir,
+  {8039c09c-e999-4cab-baa3-bf6f85bc9904}, !- Handle
+  2019::MidriseApartment::Apartment_Ventilation, !- Name
+  ,                                       !- Outdoor Air Method
+  ,                                       !- Outdoor Air Flow per Person {m3/s-person}
+  ,                                       !- Outdoor Air Flow per Floor Area {m3/s-m2}
+  0,                                      !- Outdoor Air Flow Rate {m3/s}
+  0.35,                                   !- Outdoor Air Flow Air Changes per Hour {1/hr}
+  ;                                       !- Outdoor Air Flow Rate Fraction Schedule Name
+
+OS:Material,
+  {d659728c-b880-4b12-8b8d-8dd64d87dff6}, !- Handle
+  Generic Roof Membrane,                  !- Name
+  MediumRough,                            !- Roughness
+  0.01,                                   !- Thickness {m}
+  0.16,                                   !- Conductivity {W/m-K}
+  1120,                                   !- Density {kg/m3}
+  1460,                                   !- Specific Heat {J/kg-K}
+  0.9,                                    !- Thermal Absorptance
+  0.65,                                   !- Solar Absorptance
+  0.65;                                   !- Visible Absorptance
+
+OS:Material,
+  {3eafa05e-5e2f-4323-8987-58c8189f6810}, !- Handle
+  Generic Acoustic Tile,                  !- Name
+  MediumSmooth,                           !- Roughness
+  0.02,                                   !- Thickness {m}
+  0.06,                                   !- Conductivity {W/m-K}
+  368,                                    !- Density {kg/m3}
+  590,                                    !- Specific Heat {J/kg-K}
+  0.9,                                    !- Thermal Absorptance
+  0.2,                                    !- Solar Absorptance
+  0.2;                                    !- Visible Absorptance
+
+OS:Material,
+  {c9ec46ff-a3bc-4666-ac75-e6184e4d834c}, !- Handle
+  Generic 25mm Wood,                      !- Name
+  MediumSmooth,                           !- Roughness
+  0.0254,                                 !- Thickness {m}
+  0.15,                                   !- Conductivity {W/m-K}
+  608,                                    !- Density {kg/m3}
+  1630,                                   !- Specific Heat {J/kg-K}
+  0.9,                                    !- Thermal Absorptance
+  0.5,                                    !- Solar Absorptance
+  0.5;                                    !- Visible Absorptance
+
+OS:Material,
+  {eb80ec8b-0a7e-4dcb-83b1-2b599532f34f}, !- Handle
+  Generic HW Concrete,                    !- Name
+  MediumRough,                            !- Roughness
+  0.2,                                    !- Thickness {m}
+  1.95,                                   !- Conductivity {W/m-K}
+  2240,                                   !- Density {kg/m3}
+  900,                                    !- Specific Heat {J/kg-K}
+  0.9,                                    !- Thermal Absorptance
+  0.8,                                    !- Solar Absorptance
+  0.8;                                    !- Visible Absorptance
+
+OS:WindowMaterial:Gas,
+  {ac1f6a1b-99d0-43f1-9c79-7bd1e9520708}, !- Handle
+  Generic Window Air Gap,                 !- Name
+  Air,                                    !- Gas Type
+  0.0127;                                 !- Thickness {m}
+
+OS:WindowMaterial:Gas,
+  {d2514a73-d524-494d-94cc-5a86a32db95c}, !- Handle
+  Generic Window Argon Gap,               !- Name
+  Argon,                                  !- Gas Type
+  0.0127;                                 !- Thickness {m}
+
+OS:Material,
+  {4c84fe8b-bba4-4fb4-853e-7faaf574cfa7}, !- Handle
+  Generic Gypsum Board,                   !- Name
+  MediumSmooth,                           !- Roughness
+  0.0127,                                 !- Thickness {m}
+  0.16,                                   !- Conductivity {W/m-K}
+  800,                                    !- Density {kg/m3}
+  1090,                                   !- Specific Heat {J/kg-K}
+  0.9,                                    !- Thermal Absorptance
+  0.5,                                    !- Solar Absorptance
+  0.5;                                    !- Visible Absorptance
+
+OS:Material,
+  {31fb3ab0-18a1-4918-8a43-87965196bf1c}, !- Handle
+  Generic Wall Air Gap,                   !- Name
+  Smooth,                                 !- Roughness
+  0.1,                                    !- Thickness {m}
+  0.667,                                  !- Conductivity {W/m-K}
+  1.28,                                   !- Density {kg/m3}
+  1000,                                   !- Specific Heat {J/kg-K}
+  0.9,                                    !- Thermal Absorptance
+  0.7,                                    !- Solar Absorptance
+  0.7;                                    !- Visible Absorptance
+
+OS:Material,
+  {129748d9-400a-435a-9dcd-3752822bef53}, !- Handle
+  Generic Ceiling Air Gap,                !- Name
+  Smooth,                                 !- Roughness
+  0.1,                                    !- Thickness {m}
+  0.556,                                  !- Conductivity {W/m-K}
+  1.28,                                   !- Density {kg/m3}
+  1000,                                   !- Specific Heat {J/kg-K}
+  0.9,                                    !- Thermal Absorptance
+  0.7,                                    !- Solar Absorptance
+  0.7;                                    !- Visible Absorptance
+
+OS:Material,
+  {a4267591-4792-4b73-bf6a-275fe19f6554}, !- Handle
+  Generic Brick,                          !- Name
+  MediumRough,                            !- Roughness
+  0.1,                                    !- Thickness {m}
+  0.9,                                    !- Conductivity {W/m-K}
+  1920,                                   !- Density {kg/m3}
+  790,                                    !- Specific Heat {J/kg-K}
+  0.9,                                    !- Thermal Absorptance
+  0.65,                                   !- Solar Absorptance
+  0.65;                                   !- Visible Absorptance
+
+OS:Material,
+  {46e679af-c5d3-47c5-bd04-e26a7da95afd}, !- Handle
+  Generic 50mm Insulation,                !- Name
+  MediumRough,                            !- Roughness
+  0.05,                                   !- Thickness {m}
+  0.03,                                   !- Conductivity {W/m-K}
+  43,                                     !- Density {kg/m3}
+  1210,                                   !- Specific Heat {J/kg-K}
+  0.9,                                    !- Thermal Absorptance
+  0.7,                                    !- Solar Absorptance
+  0.7;                                    !- Visible Absorptance
+
+OS:WindowMaterial:Glazing,
+  {e91747de-f0da-454c-a427-596faa04efa0}, !- Handle
+  Generic Low-e Glass,                    !- Name
+  SpectralAverage,                        !- Optical Data Type
+  ,                                       !- Window Glass Spectral Data Set Name
+  0.006,                                  !- Thickness {m}
+  0.45,                                   !- Solar Transmittance at Normal Incidence
+  0.36,                                   !- Front Side Solar Reflectance at Normal Incidence
+  0.36,                                   !- Back Side Solar Reflectance at Normal Incidence
+  0.71,                                   !- Visible Transmittance at Normal Incidence
+  0.21,                                   !- Front Side Visible Reflectance at Normal Incidence
+  0.21,                                   !- Back Side Visible Reflectance at Normal Incidence
+  0,                                      !- Infrared Transmittance at Normal Incidence
+  0.84,                                   !- Front Side Infrared Hemispherical Emissivity
+  0.047,                                  !- Back Side Infrared Hemispherical Emissivity
+  1,                                      !- Conductivity {W/m-K}
+  1,                                      !- Dirt Correction Factor for Solar and Visible Transmittance
+  No;                                     !- Solar Diffusing
+
+OS:Material,
+  {5c4af044-dfd5-4cd5-b6f8-0fa552226c1a}, !- Handle
+  Generic Painted Metal,                  !- Name
+  Smooth,                                 !- Roughness
+  0.0015,                                 !- Thickness {m}
+  45,                                     !- Conductivity {W/m-K}
+  7690,                                   !- Density {kg/m3}
+  410,                                    !- Specific Heat {J/kg-K}
+  0.9,                                    !- Thermal Absorptance
+  0.5,                                    !- Solar Absorptance
+  0.5;                                    !- Visible Absorptance
+
+OS:Material,
+  {20b4dd3e-99bb-4d24-8dc2-bf06c8080dec}, !- Handle
+  Generic LW Concrete,                    !- Name
+  MediumRough,                            !- Roughness
+  0.1,                                    !- Thickness {m}
+  0.53,                                   !- Conductivity {W/m-K}
+  1280,                                   !- Density {kg/m3}
+  840,                                    !- Specific Heat {J/kg-K}
+  0.9,                                    !- Thermal Absorptance
+  0.8,                                    !- Solar Absorptance
+  0.8;                                    !- Visible Absorptance
+
+OS:Material,
+  {e70dcb53-b828-4b86-a5b3-7ef3b36b02d9}, !- Handle
+  Generic 25mm Insulation,                !- Name
+  MediumRough,                            !- Roughness
+  0.025,                                  !- Thickness {m}
+  0.03,                                   !- Conductivity {W/m-K}
+  43,                                     !- Density {kg/m3}
+  1210,                                   !- Specific Heat {J/kg-K}
+  0.9,                                    !- Thermal Absorptance
+  0.7,                                    !- Solar Absorptance
+  0.7;                                    !- Visible Absorptance
+
+OS:WindowMaterial:Glazing,
+  {3efdb386-90c8-4638-ac58-7b49441af7c2}, !- Handle
+  Generic Clear Glass,                    !- Name
+  SpectralAverage,                        !- Optical Data Type
+  ,                                       !- Window Glass Spectral Data Set Name
+  0.006,                                  !- Thickness {m}
+  0.77,                                   !- Solar Transmittance at Normal Incidence
+  0.07,                                   !- Front Side Solar Reflectance at Normal Incidence
+  0.07,                                   !- Back Side Solar Reflectance at Normal Incidence
+  0.88,                                   !- Visible Transmittance at Normal Incidence
+  0.08,                                   !- Front Side Visible Reflectance at Normal Incidence
+  0.08,                                   !- Back Side Visible Reflectance at Normal Incidence
+  0,                                      !- Infrared Transmittance at Normal Incidence
+  0.84,                                   !- Front Side Infrared Hemispherical Emissivity
+  0.84,                                   !- Back Side Infrared Hemispherical Emissivity
+  1,                                      !- Conductivity {W/m-K}
+  1,                                      !- Dirt Correction Factor for Solar and Visible Transmittance
+  No;                                     !- Solar Diffusing
+
+OS:Construction,
+  {494388bc-a09f-42c2-b003-edc1337c041e}, !- Handle
+  Generic Interior Door,                  !- Name
+  ,                                       !- Surface Rendering Name
+  {c9ec46ff-a3bc-4666-ac75-e6184e4d834c}; !- Layer 1
+
+OS:Construction,
+  {c7aaaea5-4d1f-40df-b59e-d317dc991b0c}, !- Handle
+  Generic Single Pane,                    !- Name
+  ,                                       !- Surface Rendering Name
+  {3efdb386-90c8-4638-ac58-7b49441af7c2}; !- Layer 1
+
+OS:Construction,
+  {cddf4cb7-a7ab-4522-a761-b59465e5ee03}, !- Handle
+  Generic Shade,                          !- Name
+  ,                                       !- Surface Rendering Name
+  {89f4c27b-b1e1-4a0d-b8a4-7e3f5b72dcc0}; !- Layer 1
+
+OS:Material,
+  {89f4c27b-b1e1-4a0d-b8a4-7e3f5b72dcc0}, !- Handle
+  Material 1,                             !- Name
+  Smooth,                                 !- Roughness
+  0.1,                                    !- Thickness {m}
+  0.1,                                    !- Conductivity {W/m-K}
+  0.1,                                    !- Density {kg/m3}
+  100,                                    !- Specific Heat {J/kg-K}
+  ,                                       !- Thermal Absorptance
+  0.65,                                   !- Solar Absorptance
+  0.65;                                   !- Visible Absorptance
+
+OS:Construction,
+  {26b5c50a-4d09-43fc-a8ae-bf8b992a39b8}, !- Handle
+  Generic Context,                        !- Name
+  ,                                       !- Surface Rendering Name
+  {729f2c8c-0bc8-45e0-9302-e57ea4750a17}; !- Layer 1
+
+OS:Material,
+  {729f2c8c-0bc8-45e0-9302-e57ea4750a17}, !- Handle
+  Material 2,                             !- Name
+  Smooth,                                 !- Roughness
+  0.1,                                    !- Thickness {m}
+  0.1,                                    !- Conductivity {W/m-K}
+  0.1,                                    !- Density {kg/m3}
+  100,                                    !- Specific Heat {J/kg-K}
+  ,                                       !- Thermal Absorptance
+  0.8,                                    !- Solar Absorptance
+  0.8;                                    !- Visible Absorptance
+
+OS:Construction,
+  {863e135f-d0e2-4a7e-be13-5cd98430e41e}, !- Handle
+  Generic Interior Ceiling,               !- Name
+  ,                                       !- Surface Rendering Name
+  {20b4dd3e-99bb-4d24-8dc2-bf06c8080dec}, !- Layer 1
+  {129748d9-400a-435a-9dcd-3752822bef53}, !- Layer 2
+  {3eafa05e-5e2f-4323-8987-58c8189f6810}; !- Layer 3
+
+OS:Construction,
+  {55d76e36-d782-4878-8ff9-6c9ee1e65eb0}, !- Handle
+  Generic Interior Wall,                  !- Name
+  ,                                       !- Surface Rendering Name
+  {4c84fe8b-bba4-4fb4-853e-7faaf574cfa7}, !- Layer 1
+  {31fb3ab0-18a1-4918-8a43-87965196bf1c}, !- Layer 2
+  {4c84fe8b-bba4-4fb4-853e-7faaf574cfa7}; !- Layer 3
+
+OS:Construction,
+  {161ae28f-7a25-4c81-af20-a04f4b96d12b}, !- Handle
+  Generic Exposed Floor,                  !- Name
+  ,                                       !- Surface Rendering Name
+  {5c4af044-dfd5-4cd5-b6f8-0fa552226c1a}, !- Layer 1
+  {129748d9-400a-435a-9dcd-3752822bef53}, !- Layer 2
+  {46e679af-c5d3-47c5-bd04-e26a7da95afd}, !- Layer 3
+  {20b4dd3e-99bb-4d24-8dc2-bf06c8080dec}; !- Layer 4
+
+OS:Construction,
+  {ab09f565-3ba6-4ebd-80a6-5122ba6eeded}, !- Handle
+  Generic Interior Floor,                 !- Name
+  ,                                       !- Surface Rendering Name
+  {3eafa05e-5e2f-4323-8987-58c8189f6810}, !- Layer 1
+  {129748d9-400a-435a-9dcd-3752822bef53}, !- Layer 2
+  {20b4dd3e-99bb-4d24-8dc2-bf06c8080dec}; !- Layer 3
+
+OS:Construction,
+  {ab5d9226-4373-4f92-ad6a-418bf2bcb559}, !- Handle
+  Generic Ground Slab,                    !- Name
+  ,                                       !- Surface Rendering Name
+  {46e679af-c5d3-47c5-bd04-e26a7da95afd}, !- Layer 1
+  {eb80ec8b-0a7e-4dcb-83b1-2b599532f34f}; !- Layer 2
+
+OS:Construction,
+  {f0061ef5-7da2-4789-9863-fbe019e7cc67}, !- Handle
+  Generic Roof,                           !- Name
+  ,                                       !- Surface Rendering Name
+  {d659728c-b880-4b12-8b8d-8dd64d87dff6}, !- Layer 1
+  {46e679af-c5d3-47c5-bd04-e26a7da95afd}, !- Layer 2
+  {20b4dd3e-99bb-4d24-8dc2-bf06c8080dec}, !- Layer 3
+  {129748d9-400a-435a-9dcd-3752822bef53}, !- Layer 4
+  {3eafa05e-5e2f-4323-8987-58c8189f6810}; !- Layer 5
+
+OS:Construction,
+  {2a5a99e7-f7a3-4ecc-a98b-3ce813bf88df}, !- Handle
+  Generic Exterior Wall,                  !- Name
+  ,                                       !- Surface Rendering Name
+  {a4267591-4792-4b73-bf6a-275fe19f6554}, !- Layer 1
+  {20b4dd3e-99bb-4d24-8dc2-bf06c8080dec}, !- Layer 2
+  {46e679af-c5d3-47c5-bd04-e26a7da95afd}, !- Layer 3
+  {31fb3ab0-18a1-4918-8a43-87965196bf1c}, !- Layer 4
+  {4c84fe8b-bba4-4fb4-853e-7faaf574cfa7}; !- Layer 5
+
+OS:Construction,
+  {955006cb-bfab-4cdc-9930-8b7b2a745658}, !- Handle
+  Generic Underground Wall,               !- Name
+  ,                                       !- Surface Rendering Name
+  {46e679af-c5d3-47c5-bd04-e26a7da95afd}, !- Layer 1
+  {eb80ec8b-0a7e-4dcb-83b1-2b599532f34f}, !- Layer 2
+  {31fb3ab0-18a1-4918-8a43-87965196bf1c}, !- Layer 3
+  {4c84fe8b-bba4-4fb4-853e-7faaf574cfa7}; !- Layer 4
+
+OS:Construction:AirBoundary,
+  {37045f82-c35e-4e03-be4c-61ba8bae8f8d}, !- Handle
+  Generic Air Boundary,                   !- Name
+  None,                                   !- Air Exchange Method
+  0;                                      !- Simple Mixing Air Changes per Hour {1/hr}
+
+OS:Construction,
+  {3dfd97e7-29bf-4200-9251-1b65fe1092b2}, !- Handle
+  Generic Underground Roof,               !- Name
+  ,                                       !- Surface Rendering Name
+  {46e679af-c5d3-47c5-bd04-e26a7da95afd}, !- Layer 1
+  {eb80ec8b-0a7e-4dcb-83b1-2b599532f34f}, !- Layer 2
+  {129748d9-400a-435a-9dcd-3752822bef53}, !- Layer 3
+  {3eafa05e-5e2f-4323-8987-58c8189f6810}; !- Layer 4
+
+OS:Construction,
+  {5bd54441-373e-4bf1-83df-dc2e0c14a4f0}, !- Handle
+  Generic Double Pane,                    !- Name
+  ,                                       !- Surface Rendering Name
+  {e91747de-f0da-454c-a427-596faa04efa0}, !- Layer 1
+  {ac1f6a1b-99d0-43f1-9c79-7bd1e9520708}, !- Layer 2
+  {3efdb386-90c8-4638-ac58-7b49441af7c2}; !- Layer 3
+
+OS:Construction,
+  {d8f7dbdb-1630-4ac0-a98c-45b5a48c124d}, !- Handle
+  Generic Exterior Door,                  !- Name
+  ,                                       !- Surface Rendering Name
+  {5c4af044-dfd5-4cd5-b6f8-0fa552226c1a}, !- Layer 1
+  {e70dcb53-b828-4b86-a5b3-7ef3b36b02d9}, !- Layer 2
+  {5c4af044-dfd5-4cd5-b6f8-0fa552226c1a}; !- Layer 3
+
+OS:DefaultConstructionSet,
+  {f0c3e122-ad83-48b1-a082-da84e06546af}, !- Handle
+  Default Generic Construction Set,       !- Name
+  {0df47767-a98c-4062-9a23-d125c3271352}, !- Default Exterior Surface Constructions Name
+  {80c76a23-e590-4fcd-ae37-c2e09d75ae2f}, !- Default Interior Surface Constructions Name
+  {74f9e400-5606-40f5-b40c-07dc42f32ad5}, !- Default Ground Contact Surface Constructions Name
+  {c68fb8d0-177e-40de-bbd3-347cba0f7010}, !- Default Exterior SubSurface Constructions Name
+  {fd54a493-084d-4a95-a19f-1f5d45a4d02a}, !- Default Interior SubSurface Constructions Name
+  {37045f82-c35e-4e03-be4c-61ba8bae8f8d}, !- Interior Partition Construction Name
+  {cddf4cb7-a7ab-4522-a761-b59465e5ee03}, !- Space Shading Construction Name
+  ,                                       !- Building Shading Construction Name
+  ,                                       !- Site Shading Construction Name
+  {55d76e36-d782-4878-8ff9-6c9ee1e65eb0}; !- Adiabatic Surface Construction Name
+
+OS:DefaultSurfaceConstructions,
+  {80c76a23-e590-4fcd-ae37-c2e09d75ae2f}, !- Handle
+  Default Surface Constructions 4,        !- Name
+  {ab09f565-3ba6-4ebd-80a6-5122ba6eeded}, !- Floor Construction Name
+  {55d76e36-d782-4878-8ff9-6c9ee1e65eb0}, !- Wall Construction Name
+  {863e135f-d0e2-4a7e-be13-5cd98430e41e}; !- Roof Ceiling Construction Name
+
+OS:DefaultSurfaceConstructions,
+  {0df47767-a98c-4062-9a23-d125c3271352}, !- Handle
+  Default Surface Constructions 5,        !- Name
+  {161ae28f-7a25-4c81-af20-a04f4b96d12b}, !- Floor Construction Name
+  {2a5a99e7-f7a3-4ecc-a98b-3ce813bf88df}, !- Wall Construction Name
+  {f0061ef5-7da2-4789-9863-fbe019e7cc67}; !- Roof Ceiling Construction Name
+
+OS:DefaultSurfaceConstructions,
+  {74f9e400-5606-40f5-b40c-07dc42f32ad5}, !- Handle
+  Default Surface Constructions 6,        !- Name
+  {ab5d9226-4373-4f92-ad6a-418bf2bcb559}, !- Floor Construction Name
+  {955006cb-bfab-4cdc-9930-8b7b2a745658}, !- Wall Construction Name
+  {3dfd97e7-29bf-4200-9251-1b65fe1092b2}; !- Roof Ceiling Construction Name
+
+OS:DefaultSubSurfaceConstructions,
+  {fd54a493-084d-4a95-a19f-1f5d45a4d02a}, !- Handle
+  Default Sub Surface Constructions 3,    !- Name
+  {c7aaaea5-4d1f-40df-b59e-d317dc991b0c}, !- Fixed Window Construction Name
+  {c7aaaea5-4d1f-40df-b59e-d317dc991b0c}, !- Operable Window Construction Name
+  {494388bc-a09f-42c2-b003-edc1337c041e}, !- Door Construction Name
+  {c7aaaea5-4d1f-40df-b59e-d317dc991b0c}, !- Glass Door Construction Name
+  ,                                       !- Overhead Door Construction Name
+  ,                                       !- Skylight Construction Name
+  ,                                       !- Tubular Daylight Dome Construction Name
+  ;                                       !- Tubular Daylight Diffuser Construction Name
+
+OS:DefaultSubSurfaceConstructions,
+  {c68fb8d0-177e-40de-bbd3-347cba0f7010}, !- Handle
+  Default Sub Surface Constructions 4,    !- Name
+  {5bd54441-373e-4bf1-83df-dc2e0c14a4f0}, !- Fixed Window Construction Name
+  {5bd54441-373e-4bf1-83df-dc2e0c14a4f0}, !- Operable Window Construction Name
+  {d8f7dbdb-1630-4ac0-a98c-45b5a48c124d}, !- Door Construction Name
+  {5bd54441-373e-4bf1-83df-dc2e0c14a4f0}, !- Glass Door Construction Name
+  {d8f7dbdb-1630-4ac0-a98c-45b5a48c124d}, !- Overhead Door Construction Name
+  {5bd54441-373e-4bf1-83df-dc2e0c14a4f0}, !- Skylight Construction Name
+  ,                                       !- Tubular Daylight Dome Construction Name
+  ;                                       !- Tubular Daylight Diffuser Construction Name
+
+OS:StandardsInformation:Construction,
+  {e832576c-4e14-4743-8155-7408260a6d73}, !- Handle
+  {5bd54441-373e-4bf1-83df-dc2e0c14a4f0}, !- Construction Name
+  ExteriorWindow,                         !- Intended Surface Type
+  ,                                       !- Standards Construction Type
+  ,                                       !- Perturbable Layer
+  ,                                       !- Perturbable Layer Type
+  ,                                       !- Other Perturbable Layer Type
+  ,                                       !- Construction Standard
+  ,                                       !- Construction Standard Source
+  Fixed Window,                           !- Fenestration Type
+  ,                                       !- Fenestration Assembly Context
+  ,                                       !- Fenestration Number of Panes
+  Metal Framing with Thermal Break;       !- Fenestration Frame Type
+
+OS:StandardsInformation:Construction,
+  {2b31f1ea-f2c1-4d06-a6e0-6bcee3b18cf5}, !- Handle
+  {d8f7dbdb-1630-4ac0-a98c-45b5a48c124d}, !- Construction Name
+  ExteriorDoor;                           !- Intended Surface Type
+
+OS:Schedule:Ruleset,
+  {623ebef8-3ec3-49a3-b8d5-2a23b1a88c83}, !- Handle
+  Always On,                              !- Name
+  {5ec29b47-2e16-4d0b-8501-22103961daaf}, !- Schedule Type Limits Name
+  {f79379c2-f04a-4e3c-8666-5ceab6427481}; !- Default Day Schedule Name
+
+OS:Schedule:Day,
+  {f79379c2-f04a-4e3c-8666-5ceab6427481}, !- Handle
+  Always On_Day Schedule,                 !- Name
+  {5ec29b47-2e16-4d0b-8501-22103961daaf}, !- Schedule Type Limits Name
+  ,                                       !- Interpolate to Timestep
+  24,                                     !- Hour 1
+  0,                                      !- Minute 1
+  1;                                      !- Value Until Time 1
+
+OS:Space,
+  {011920c9-f207-4c91-a3b9-f8621dfaf568}, !- Handle
+  OfficeShoeBox_34d12885_Space,           !- Name
+  {291fe1c2-9bb0-443e-8d59-ed767308bbf1}, !- Space Type Name
+  {784c7e91-22dd-4362-b8ec-061ea4f8064a}, !- Default Construction Set Name
+  ,                                       !- Default Schedule Set Name
+  ,                                       !- Direction of Relative North {deg}
+  ,                                       !- X Origin {m}
+  ,                                       !- Y Origin {m}
+  ,                                       !- Z Origin {m}
+  {39921f27-8961-4974-ae3e-d408d1bffdca}, !- Building Story Name
+  {ee8b5988-e308-4da9-9ea0-dc3a34abfed1}; !- Thermal Zone Name
+
+OS:ThermalZone,
+  {ee8b5988-e308-4da9-9ea0-dc3a34abfed1}, !- Handle
+  OfficeShoeBox_34d12885,                 !- Name
+  ,                                       !- Multiplier
+  3,                                      !- Ceiling Height {m}
+  150,                                    !- Volume {m3}
+  ,                                       !- Floor Area {m2}
+  ,                                       !- Zone Inside Convection Algorithm
+  ,                                       !- Zone Outside Convection Algorithm
+  ,                                       !- Zone Conditioning Equipment List Name
+  {3923b073-9d99-4c5c-8544-c5cd276a2fb2}, !- Zone Air Inlet Port List
+  {fc1c6843-d237-42c7-9095-e73fcc545341}, !- Zone Air Exhaust Port List
+  {9f91ea42-7503-4629-b049-f3a4c4448098}, !- Zone Air Node Name
+  {3463604b-94a8-4b92-808d-fae2bd66af64}, !- Zone Return Air Port List
+  ,                                       !- Primary Daylighting Control Name
+  ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
+  ,                                       !- Secondary Daylighting Control Name
+  ,                                       !- Fraction of Zone Controlled by Secondary Daylighting Control
+  ,                                       !- Illuminance Map Name
+  ,                                       !- Group Rendering Name
+  {2ffee654-88e6-4650-92d9-f3301ab813e4}, !- Thermostat Name
+  No;                                     !- Use Ideal Air Loads
+
+OS:Node,
+  {ba2fa6a8-ffc7-4d9f-af67-bea5d51c8a34}, !- Handle
+  OfficeShoeBox_34d12885 Zone Air Node,   !- Name
+  {9f91ea42-7503-4629-b049-f3a4c4448098}, !- Inlet Port
+  ;                                       !- Outlet Port
+
+OS:Connection,
+  {9f91ea42-7503-4629-b049-f3a4c4448098}, !- Handle
+  {ee8b5988-e308-4da9-9ea0-dc3a34abfed1}, !- Source Object
+  11,                                     !- Outlet Port
+  {ba2fa6a8-ffc7-4d9f-af67-bea5d51c8a34}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:PortList,
+  {3923b073-9d99-4c5c-8544-c5cd276a2fb2}, !- Handle
+  {ee8b5988-e308-4da9-9ea0-dc3a34abfed1}, !- HVAC Component
+  {03b578be-69f9-4b0e-bebd-cdc5b86f498c}; !- Port 1
+
+OS:PortList,
+  {fc1c6843-d237-42c7-9095-e73fcc545341}, !- Handle
+  {ee8b5988-e308-4da9-9ea0-dc3a34abfed1}, !- HVAC Component
+  {3b8fa3a7-12cc-4d60-ae72-14539f4c861d}; !- Port 1
+
+OS:PortList,
+  {3463604b-94a8-4b92-808d-fae2bd66af64}, !- Handle
+  {ee8b5988-e308-4da9-9ea0-dc3a34abfed1}; !- HVAC Component
+
+OS:Sizing:Zone,
+  {0a4d25a9-d3ec-4d50-95cb-2b6ba83607db}, !- Handle
+  {ee8b5988-e308-4da9-9ea0-dc3a34abfed1}, !- Zone or ZoneList Name
+  SupplyAirTemperature,                   !- Zone Cooling Design Supply Air Temperature Input Method
+  13.8888888888889,                       !- Zone Cooling Design Supply Air Temperature {C}
+  11.11,                                  !- Zone Cooling Design Supply Air Temperature Difference {deltaC}
+  SupplyAirTemperature,                   !- Zone Heating Design Supply Air Temperature Input Method
+  50.0000000000001,                       !- Zone Heating Design Supply Air Temperature {C}
+  11.11,                                  !- Zone Heating Design Supply Air Temperature Difference {deltaC}
+  0.008,                                  !- Zone Cooling Design Supply Air Humidity Ratio {kg-H2O/kg-air}
+  0.008,                                  !- Zone Heating Design Supply Air Humidity Ratio {kg-H2O/kg-air}
+  ,                                       !- Zone Heating Sizing Factor
+  ,                                       !- Zone Cooling Sizing Factor
+  DesignDay,                              !- Cooling Design Air Flow Method
+  ,                                       !- Cooling Design Air Flow Rate {m3/s}
+  ,                                       !- Cooling Minimum Air Flow per Zone Floor Area {m3/s-m2}
+  ,                                       !- Cooling Minimum Air Flow {m3/s}
+  ,                                       !- Cooling Minimum Air Flow Fraction
+  DesignDay,                              !- Heating Design Air Flow Method
+  ,                                       !- Heating Design Air Flow Rate {m3/s}
+  ,                                       !- Heating Maximum Air Flow per Zone Floor Area {m3/s-m2}
+  ,                                       !- Heating Maximum Air Flow {m3/s}
+  ,                                       !- Heating Maximum Air Flow Fraction
+  No,                                     !- Account for Dedicated Outdoor Air System
+  NeutralSupplyAir,                       !- Dedicated Outdoor Air System Control Strategy
+  autosize,                               !- Dedicated Outdoor Air Low Setpoint Temperature for Design {C}
+  autosize,                               !- Dedicated Outdoor Air High Setpoint Temperature for Design {C}
+  Sensible Load Only No Latent Load,      !- Zone Load Sizing Method
+  HumidityRatioDifference,                !- Zone Latent Cooling Design Supply Air Humidity Ratio Input Method
+  ,                                       !- Zone Dehumidification Design Supply Air Humidity Ratio {kgWater/kgDryAir}
+  0.005,                                  !- Zone Cooling Design Supply Air Humidity Ratio Difference {kgWater/kgDryAir}
+  HumidityRatioDifference,                !- Zone Latent Heating Design Supply Air Humidity Ratio Input Method
+  ,                                       !- Zone Humidification Design Supply Air Humidity Ratio {kgWater/kgDryAir}
+  0.005;                                  !- Zone Humidification Design Supply Air Humidity Ratio Difference {kgWater/kgDryAir}
+
+OS:ZoneHVAC:EquipmentList,
+  {24d012c5-8afe-4321-b9df-4b84fc7c7e44}, !- Handle
+  OfficeShoeBox_34d12885 Zone HVAC Equipment List, !- Name
+  {ee8b5988-e308-4da9-9ea0-dc3a34abfed1}, !- Thermal Zone
+  ,                                       !- Load Distribution Scheme
+  {b7901e2b-cfca-436e-baae-dcb3cc2965b2}, !- Zone Equipment 1
+  1,                                      !- Zone Equipment Cooling Sequence 1
+  1,                                      !- Zone Equipment Heating or No-Load Sequence 1
+  ,                                       !- Zone Equipment Sequential Cooling Fraction Schedule Name 1
+  ;                                       !- Zone Equipment Sequential Heating Fraction Schedule Name 1
+
+OS:AdditionalProperties,
+  {d4b38ad2-36e0-4dd2-a01f-23da6b13f118}, !- Handle
+  {011920c9-f207-4c91-a3b9-f8621dfaf568}, !- Object Name
+  displayName,                            !- Feature Name 1
+  String,                                 !- Feature Data Type 1
+  Office Shoe Box;                        !- Feature Value 1
+
+OS:AdditionalProperties,
+  {73b813a6-0f36-4e64-8c2f-283a9c5b1d72}, !- Handle
+  {ee8b5988-e308-4da9-9ea0-dc3a34abfed1}, !- Object Name
+  displayName,                            !- Feature Name 1
+  String,                                 !- Feature Data Type 1
+  Office Shoe Box;                        !- Feature Value 1
+
+OS:BuildingStory,
+  {39921f27-8961-4974-ae3e-d408d1bffdca}, !- Handle
+  Floor1,                                 !- Name
+  ,                                       !- Nominal Z Coordinate {m}
+  ,                                       !- Nominal Floor to Floor Height {m}
+  ,                                       !- Default Construction Set Name
+  ,                                       !- Default Schedule Set Name
+  ;                                       !- Group Rendering Name
+
+OS:Surface,
+  {834fcec9-fd10-4b10-948d-8c5c2341ad44}, !- Handle
+  Face_04ecc819_0,                        !- Name
+  Wall,                                   !- Surface Type
+  ,                                       !- Construction Name
+  {011920c9-f207-4c91-a3b9-f8621dfaf568}, !- Space Name
+  Adiabatic,                              !- Outside Boundary Condition
+  ,                                       !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  5, 0, 3,                                !- X,Y,Z Vertex 1 {m}
+  5, 0, 0,                                !- X,Y,Z Vertex 2 {m}
+  5, 10, 0,                               !- X,Y,Z Vertex 3 {m}
+  5, 10, 3;                               !- X,Y,Z Vertex 4 {m}
+
+OS:AdditionalProperties,
+  {c88d7c31-9e76-4e18-b2da-117e9613f04d}, !- Handle
+  {834fcec9-fd10-4b10-948d-8c5c2341ad44}, !- Object Name
+  displayName,                            !- Feature Name 1
+  String,                                 !- Feature Data Type 1
+  Face_04ecc819;                          !- Feature Value 1
+
+OS:Surface,
+  {b0c15315-ad80-461e-a479-62abfc53b4d0}, !- Handle
+  Face_04ecc819_1,                        !- Name
+  Wall,                                   !- Surface Type
+  ,                                       !- Construction Name
+  {011920c9-f207-4c91-a3b9-f8621dfaf568}, !- Space Name
+  Adiabatic,                              !- Outside Boundary Condition
+  ,                                       !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  0, 10, 3,                               !- X,Y,Z Vertex 1 {m}
+  0, 10, 0,                               !- X,Y,Z Vertex 2 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
+  0, 0, 3;                                !- X,Y,Z Vertex 4 {m}
+
+OS:AdditionalProperties,
+  {40b45cd9-4115-4a9e-9565-9ce7a37f80be}, !- Handle
+  {b0c15315-ad80-461e-a479-62abfc53b4d0}, !- Object Name
+  displayName,                            !- Feature Name 1
+  String,                                 !- Feature Data Type 1
+  Face_04ecc819;                          !- Feature Value 1
+
+OS:Surface,
+  {97d19a03-debd-4772-8fb4-a1b8ba00683f}, !- Handle
+  Face_04ecc819_2,                        !- Name
+  Floor,                                  !- Surface Type
+  {ab09f565-3ba6-4ebd-80a6-5122ba6eeded}, !- Construction Name
+  {011920c9-f207-4c91-a3b9-f8621dfaf568}, !- Space Name
+  Adiabatic,                              !- Outside Boundary Condition
+  ,                                       !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  5, 10, 0,                               !- X,Y,Z Vertex 1 {m}
+  5, 0, 0,                                !- X,Y,Z Vertex 2 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 3 {m}
+  0, 10, 0;                               !- X,Y,Z Vertex 4 {m}
+
+OS:AdditionalProperties,
+  {0fce2a67-666e-46cd-8ac2-2eef2aa92abb}, !- Handle
+  {97d19a03-debd-4772-8fb4-a1b8ba00683f}, !- Object Name
+  displayName,                            !- Feature Name 1
+  String,                                 !- Feature Data Type 1
+  Face_04ecc819;                          !- Feature Value 1
+
+OS:Surface,
+  {93170f6c-2f18-4e50-b08e-beb5a9b730d0}, !- Handle
+  Face_04ecc819_3,                        !- Name
+  RoofCeiling,                            !- Surface Type
+  {863e135f-d0e2-4a7e-be13-5cd98430e41e}, !- Construction Name
+  {011920c9-f207-4c91-a3b9-f8621dfaf568}, !- Space Name
+  Adiabatic,                              !- Outside Boundary Condition
+  ,                                       !- Outside Boundary Condition Object
+  NoSun,                                  !- Sun Exposure
+  NoWind,                                 !- Wind Exposure
+  ,                                       !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  0, 10, 3,                               !- X,Y,Z Vertex 1 {m}
+  0, 0, 3,                                !- X,Y,Z Vertex 2 {m}
+  5, 0, 3,                                !- X,Y,Z Vertex 3 {m}
+  5, 10, 3;                               !- X,Y,Z Vertex 4 {m}
+
+OS:AdditionalProperties,
+  {35932b78-d102-4819-a558-67c4a5ea96af}, !- Handle
+  {93170f6c-2f18-4e50-b08e-beb5a9b730d0}, !- Object Name
+  displayName,                            !- Feature Name 1
+  String,                                 !- Feature Data Type 1
+  Face_04ecc819;                          !- Feature Value 1
+
+OS:Surface,
+  {f1047ae5-d001-426a-acf0-5e597bcdf8e1}, !- Handle
+  Face_e33d7dbf,                          !- Name
+  Wall,                                   !- Surface Type
+  ,                                       !- Construction Name
+  {011920c9-f207-4c91-a3b9-f8621dfaf568}, !- Space Name
+  Outdoors,                               !- Outside Boundary Condition
+  ,                                       !- Outside Boundary Condition Object
+  SunExposed,                             !- Sun Exposure
+  WindExposed,                            !- Wind Exposure
+  Autocalculate,                          !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  0, 0, 3,                                !- X,Y,Z Vertex 1 {m}
+  0, 0, 0,                                !- X,Y,Z Vertex 2 {m}
+  5, 0, 0,                                !- X,Y,Z Vertex 3 {m}
+  5, 0, 3;                                !- X,Y,Z Vertex 4 {m}
+
+OS:AdditionalProperties,
+  {7ad12901-261e-47d8-aa8e-26ebcbe66ed0}, !- Handle
+  {f1047ae5-d001-426a-acf0-5e597bcdf8e1}, !- Object Name
+  displayName,                            !- Feature Name 1
+  String,                                 !- Feature Data Type 1
+  Face_e33d7dbf;                          !- Feature Value 1
+
+OS:SubSurface,
+  {e96d6afd-f3d4-4d53-91ce-5bf161af2447}, !- Handle
+  Face_e33d7dbf_Glz0,                     !- Name
+  FixedWindow,                            !- Sub Surface Type
+  ,                                       !- Construction Name
+  {f1047ae5-d001-426a-acf0-5e597bcdf8e1}, !- Surface Name
+  ,                                       !- Outside Boundary Condition Object
+  ,                                       !- View Factor to Ground
+  ,                                       !- Frame and Divider Name
+  ,                                       !- Multiplier
+  ,                                       !- Number of Vertices
+  1.0625, 0, 2.8,                         !- X,Y,Z Vertex 1 {m}
+  1.0625, 0, 0.8,                         !- X,Y,Z Vertex 2 {m}
+  1.4375, 0, 0.8,                         !- X,Y,Z Vertex 3 {m}
+  1.4375, 0, 2.8;                         !- X,Y,Z Vertex 4 {m}
+
+OS:SubSurface,
+  {97ddf8e6-b90d-4700-b132-70513fe5cfc5}, !- Handle
+  Face_e33d7dbf_Glz1,                     !- Name
+  FixedWindow,                            !- Sub Surface Type
+  ,                                       !- Construction Name
+  {f1047ae5-d001-426a-acf0-5e597bcdf8e1}, !- Surface Name
+  ,                                       !- Outside Boundary Condition Object
+  ,                                       !- View Factor to Ground
+  ,                                       !- Frame and Divider Name
+  ,                                       !- Multiplier
+  ,                                       !- Number of Vertices
+  3.5625, 0, 2.8,                         !- X,Y,Z Vertex 1 {m}
+  3.5625, 0, 0.8,                         !- X,Y,Z Vertex 2 {m}
+  3.9375, 0, 0.8,                         !- X,Y,Z Vertex 3 {m}
+  3.9375, 0, 2.8;                         !- X,Y,Z Vertex 4 {m}
+
+OS:Surface,
+  {a2ba32c3-e5e1-477f-ab20-c122568df928}, !- Handle
+  Face_a5381b87,                          !- Name
+  Wall,                                   !- Surface Type
+  ,                                       !- Construction Name
+  {011920c9-f207-4c91-a3b9-f8621dfaf568}, !- Space Name
+  Outdoors,                               !- Outside Boundary Condition
+  ,                                       !- Outside Boundary Condition Object
+  SunExposed,                             !- Sun Exposure
+  WindExposed,                            !- Wind Exposure
+  Autocalculate,                          !- View Factor to Ground
+  ,                                       !- Number of Vertices
+  5, 10, 3,                               !- X,Y,Z Vertex 1 {m}
+  5, 10, 0,                               !- X,Y,Z Vertex 2 {m}
+  0, 10, 0,                               !- X,Y,Z Vertex 3 {m}
+  0, 10, 3;                               !- X,Y,Z Vertex 4 {m}
+
+OS:AdditionalProperties,
+  {c1bc4059-2858-4d70-a8f3-92f7384f6eae}, !- Handle
+  {a2ba32c3-e5e1-477f-ab20-c122568df928}, !- Object Name
+  displayName,                            !- Feature Name 1
+  String,                                 !- Feature Data Type 1
+  Face_a5381b87;                          !- Feature Value 1
+
+OS:SubSurface,
+  {015199c1-b8d5-49b9-8d8a-5d3f69edfa24}, !- Handle
+  Face_a5381b87_Glz0,                     !- Name
+  FixedWindow,                            !- Sub Surface Type
+  ,                                       !- Construction Name
+  {a2ba32c3-e5e1-477f-ab20-c122568df928}, !- Surface Name
+  ,                                       !- Outside Boundary Condition Object
+  ,                                       !- View Factor to Ground
+  ,                                       !- Frame and Divider Name
+  ,                                       !- Multiplier
+  ,                                       !- Number of Vertices
+  3.9375, 10, 2.8,                        !- X,Y,Z Vertex 1 {m}
+  3.9375, 10, 0.8,                        !- X,Y,Z Vertex 2 {m}
+  3.5625, 10, 0.8,                        !- X,Y,Z Vertex 3 {m}
+  3.5625, 10, 2.8;                        !- X,Y,Z Vertex 4 {m}
+
+OS:SubSurface,
+  {e36856ec-ac2d-4934-bb46-a75c0ff54247}, !- Handle
+  Face_a5381b87_Glz1,                     !- Name
+  FixedWindow,                            !- Sub Surface Type
+  ,                                       !- Construction Name
+  {a2ba32c3-e5e1-477f-ab20-c122568df928}, !- Surface Name
+  ,                                       !- Outside Boundary Condition Object
+  ,                                       !- View Factor to Ground
+  ,                                       !- Frame and Divider Name
+  ,                                       !- Multiplier
+  ,                                       !- Number of Vertices
+  1.4375, 10, 2.8,                        !- X,Y,Z Vertex 1 {m}
+  1.4375, 10, 0.8,                        !- X,Y,Z Vertex 2 {m}
+  1.0625, 10, 0.8,                        !- X,Y,Z Vertex 3 {m}
+  1.0625, 10, 2.8;                        !- X,Y,Z Vertex 4 {m}
+
+OS:WaterUse:Equipment:Definition,
+  {6984b36c-eb46-4528-849f-d76de0e06fc7}, !- Handle
+  2019::MidriseApartment::Apartment_SHW..OfficeShoeBox_34d12885, !- Name
+  General,                                !- End-Use Subcategory
+  2.07303192997349e-06,                   !- Peak Flow Rate {m3/s}
+  {035675c1-6af8-4966-a2f2-1f3ea9b013df}, !- Target Temperature Schedule Name
+  {8d0f8d4b-8154-4555-a176-db4f2893ffcd}, !- Sensible Fraction Schedule Name
+  {09dc3de7-c142-48a3-9ffa-c40eb5728616}; !- Latent Fraction Schedule Name
+
+OS:WaterUse:Equipment,
+  {d7d6c209-89d1-4b0b-a242-ab903e3b3b72}, !- Handle
+  2019::MidriseApartment::Apartment_SHW..OfficeShoeBox_34d12885, !- Name
+  {6984b36c-eb46-4528-849f-d76de0e06fc7}, !- Water Use Equipment Definition Name
+  {011920c9-f207-4c91-a3b9-f8621dfaf568}, !- Space Name
+  {f0d42dde-dc4d-41c7-926f-0bead4710aa9}; !- Flow Rate Fraction Schedule Name
+
+OS:Schedule:Constant,
+  {6a4eaffb-70a5-473e-bad1-76c997dd1fb6}, !- Handle
+  Always On Discrete,                     !- Name
+  {6414e080-a9d8-49c1-8579-0e383ac0359b}, !- Schedule Type Limits Name
+  1;                                      !- Value
+
+OS:ScheduleTypeLimits,
+  {6414e080-a9d8-49c1-8579-0e383ac0359b}, !- Handle
+  OnOff,                                  !- Name
+  0,                                      !- Lower Limit Value
+  1,                                      !- Upper Limit Value
+  Discrete,                               !- Numeric Type
+  Availability;                           !- Unit Type
+
+OS:Schedule:Ruleset,
+  {035675c1-6af8-4966-a2f2-1f3ea9b013df}, !- Handle
+  60.0C Hot Water,                        !- Name
+  {1376f755-75d2-47b9-8ade-d6c159a0c345}, !- Schedule Type Limits Name
+  {50d736b6-dc64-42a4-9942-4434862e0fa2}; !- Default Day Schedule Name
+
+OS:Schedule:Day,
+  {50d736b6-dc64-42a4-9942-4434862e0fa2}, !- Handle
+  Schedule Day 1,                         !- Name
+  {1376f755-75d2-47b9-8ade-d6c159a0c345}, !- Schedule Type Limits Name
+  ,                                       !- Interpolate to Timestep
+  24,                                     !- Hour 1
+  0,                                      !- Minute 1
+  60;                                     !- Value Until Time 1
+
+OS:WaterUse:Connections,
+  {880bfce8-e5ac-4255-aaba-709789d4b1b5}, !- Handle
+  Water Use Connections 1,                !- Name
+  {55a61653-8901-48d4-8d39-db9488962524}, !- Inlet Node Name
+  {500f8842-a92c-4431-a10e-d75d79acaa39}, !- Outlet Node Name
+  ,                                       !- Supply Water Storage Tank Name
+  ,                                       !- Reclamation Water Storage Tank Name
+  {035675c1-6af8-4966-a2f2-1f3ea9b013df}, !- Hot Water Supply Temperature Schedule Name
+  ,                                       !- Cold Water Supply Temperature Schedule Name
+  None,                                   !- Drain Water Heat Exchanger Type
+  Plant,                                  !- Drain Water Heat Exchanger Destination
+  ,                                       !- Drain Water Heat Exchanger U-Factor Times Area {W/K}
+  {d7d6c209-89d1-4b0b-a242-ab903e3b3b72}; !- Water Use Equipment Name 1
+
+OS:ScheduleTypeLimits,
+  {1376f755-75d2-47b9-8ade-d6c159a0c345}, !- Handle
+  Temperature 1,                          !- Name
+  ,                                       !- Lower Limit Value
+  ,                                       !- Upper Limit Value
+  Continuous,                             !- Numeric Type
+  Temperature;                            !- Unit Type
+
+OS:Schedule:Ruleset,
+  {8d0f8d4b-8154-4555-a176-db4f2893ffcd}, !- Handle
+  0.2 Hot Water Sensible Fraction,        !- Name
+  ,                                       !- Schedule Type Limits Name
+  {2bff7a72-ebbc-4d2f-b762-89576256205b}; !- Default Day Schedule Name
+
+OS:Schedule:Day,
+  {2bff7a72-ebbc-4d2f-b762-89576256205b}, !- Handle
+  Schedule Day 2,                         !- Name
+  ,                                       !- Schedule Type Limits Name
+  ,                                       !- Interpolate to Timestep
+  24,                                     !- Hour 1
+  0,                                      !- Minute 1
+  0.2;                                    !- Value Until Time 1
+
+OS:Schedule:Ruleset,
+  {09dc3de7-c142-48a3-9ffa-c40eb5728616}, !- Handle
+  0.05 Hot Water Latent Fraction,         !- Name
+  ,                                       !- Schedule Type Limits Name
+  {4d353213-f344-4349-9581-c9b92b6dec02}; !- Default Day Schedule Name
+
+OS:Schedule:Day,
+  {4d353213-f344-4349-9581-c9b92b6dec02}, !- Handle
+  Schedule Day 3,                         !- Name
+  ,                                       !- Schedule Type Limits Name
+  ,                                       !- Interpolate to Timestep
+  24,                                     !- Hour 1
+  0,                                      !- Minute 1
+  0.05;                                   !- Value Until Time 1
+
+OS:ThermostatSetpoint:DualSetpoint,
+  {2ffee654-88e6-4650-92d9-f3301ab813e4}, !- Handle
+  2019::MidriseApartment::Apartment_Setpoint, !- Name
+  {6029af80-09e2-47e6-9788-93c6c4e7dfaa}, !- Heating Setpoint Temperature Schedule Name
+  {6dc866a4-6f32-4861-ad0e-36d0347ced31}; !- Cooling Setpoint Temperature Schedule Name
+
+OS:Fan:OnOff,
+  {ed55dd33-cd6d-49a0-8f82-7cda27dac0b5}, !- Handle
+  OfficeShoeBox_34d12885 PTHP Fan,        !- Name
+  {6a4eaffb-70a5-473e-bad1-76c997dd1fb6}, !- Availability Schedule Name
+  0.52,                                   !- Fan Total Efficiency
+  331.2882503,                            !- Pressure Rise {Pa}
+  autosize,                               !- Maximum Flow Rate {m3/s}
+  0.8,                                    !- Motor Efficiency
+  1,                                      !- Motor In Airstream Fraction
+  ,                                       !- Air Inlet Node Name
+  ,                                       !- Air Outlet Node Name
+  {ac8cf370-bd01-4ba5-9024-14082328a93e}, !- Fan Power Ratio Function of Speed Ratio Curve Name
+  {d4dda1ee-9223-46b8-82dc-5ccd3a17efd4}, !- Fan Efficiency Ratio Function of Speed Ratio Curve Name
+  ;                                       !- End-Use Subcategory
+
+OS:Curve:Exponent,
+  {ac8cf370-bd01-4ba5-9024-14082328a93e}, !- Handle
+  Fan On Off Power Curve,                 !- Name
+  1,                                      !- Coefficient1 Constant
+  0,                                      !- Coefficient2 Constant
+  0,                                      !- Coefficient3 Constant
+  0,                                      !- Minimum Value of x
+  1,                                      !- Maximum Value of x
+  ,                                       !- Minimum Curve Output
+  ,                                       !- Maximum Curve Output
+  ,                                       !- Input Unit Type for X
+  ;                                       !- Output Unit Type
+
+OS:Curve:Cubic,
+  {d4dda1ee-9223-46b8-82dc-5ccd3a17efd4}, !- Handle
+  Fan On Off Efficiency Curve,            !- Name
+  1,                                      !- Coefficient1 Constant
+  0,                                      !- Coefficient2 x
+  0,                                      !- Coefficient3 x**2
+  0,                                      !- Coefficient4 x**3
+  0,                                      !- Minimum Value of x
+  1;                                      !- Maximum Value of x
+
+OS:Coil:Heating:DX:SingleSpeed,
+  {6af17f7e-fcbe-480e-895c-d4284661cdf4}, !- Handle
+  OfficeShoeBox_34d12885 PTHP Htg Coil,   !- Name
+  {6a4eaffb-70a5-473e-bad1-76c997dd1fb6}, !- Availability Schedule Name
+  Autosize,                               !- Rated Total Heating Capacity {W}
+  3.3,                                    !- Rated COP {W/W}
+  Autosize,                               !- Rated Air Flow Rate {m3/s}
+  773.3,                                  !- Rated Supply Fan Power Per Volume Flow Rate 2017 {W/(m3/s)}
+  934.4,                                  !- Rated Supply Fan Power Per Volume Flow Rate 2023 {W/(m3/s)}
+  ,                                       !- Air Inlet Node Name
+  ,                                       !- Air Outlet Node Name
+  {16d5a1c0-5df5-4101-ba67-d3b22847a5f9}, !- Total Heating Capacity Function of Temperature Curve Name
+  {5d33e732-5298-41fd-8c4c-b23a73198e0c}, !- Total Heating Capacity Function of Flow Fraction Curve Name
+  {576fd49a-fd69-4810-b11e-5ddcb8e6254d}, !- Energy Input Ratio Function of Temperature Curve Name
+  {33135fb4-6cf7-4ec2-b3e3-8b7862280844}, !- Energy Input Ratio Function of Flow Fraction Curve Name
+  {c36f53f6-1941-430c-89d6-ba5701e3508c}, !- Part Load Fraction Correlation Curve Name
+  {deb6cd17-41f1-4eca-8c7c-d22edaec0524}, !- Defrost Energy Input Ratio Function of Temperature Curve Name
+  ,                                       !- Minimum Outdoor Dry-Bulb Temperature for Compressor Operation {C}
+  ,                                       !- Maximum Outdoor Dry-Bulb Temperature for Defrost Operation {C}
+  ,                                       !- Crankcase Heater Capacity {W}
+  ,                                       !- Maximum Outdoor Dry-Bulb Temperature for Crankcase Heater Operation {C}
+  ReverseCycle,                           !- Defrost Strategy
+  OnDemand,                               !- Defrost Control
+  0.166667,                               !- Defrost Time Period Fraction
+  2000;                                   !- Resistive Defrost Heater Capacity {W}
+
+OS:Curve:Cubic,
+  {b217ae8a-1ab5-44b8-b2bb-0d9958aad5f1}, !- Handle
+  Curve Cubic 1,                          !- Name
+  0.758746,                               !- Coefficient1 Constant
+  0.027626,                               !- Coefficient2 x
+  0.000148716,                            !- Coefficient3 x**2
+  3.4992e-06,                             !- Coefficient4 x**3
+  -20,                                    !- Minimum Value of x
+  20;                                     !- Maximum Value of x
+
+OS:Curve:Cubic,
+  {3bb7031a-aee4-459f-9d53-bae0ad61f137}, !- Handle
+  Curve Cubic 2,                          !- Name
+  0.84,                                   !- Coefficient1 Constant
+  0.16,                                   !- Coefficient2 x
+  0,                                      !- Coefficient3 x**2
+  0,                                      !- Coefficient4 x**3
+  0.5,                                    !- Minimum Value of x
+  1.5;                                    !- Maximum Value of x
+
+OS:Curve:Cubic,
+  {3d93c3f4-e4b0-4fc2-a394-8325bd1fb66a}, !- Handle
+  Curve Cubic 3,                          !- Name
+  1.19248,                                !- Coefficient1 Constant
+  -0.0300438,                             !- Coefficient2 x
+  0.00103745,                             !- Coefficient3 x**2
+  -2.3328e-05,                            !- Coefficient4 x**3
+  -20,                                    !- Minimum Value of x
+  20;                                     !- Maximum Value of x
+
+OS:Curve:Quadratic,
+  {b9eab8b4-5ff0-448d-b6a1-b112cac9e285}, !- Handle
+  Curve Quadratic 1,                      !- Name
+  1.3824,                                 !- Coefficient1 Constant
+  -0.4336,                                !- Coefficient2 x
+  0.0512,                                 !- Coefficient3 x**2
+  0,                                      !- Minimum Value of x
+  1;                                      !- Maximum Value of x
+
+OS:Curve:Quadratic,
+  {4f2b0b62-043b-4923-911d-99fab632a3cd}, !- Handle
+  Curve Quadratic 2,                      !- Name
+  0.75,                                   !- Coefficient1 Constant
+  0.25,                                   !- Coefficient2 x
+  0,                                      !- Coefficient3 x**2
+  0,                                      !- Minimum Value of x
+  1;                                      !- Maximum Value of x
+
+OS:Curve:Cubic,
+  {16d5a1c0-5df5-4101-ba67-d3b22847a5f9}, !- Handle
+  OfficeShoeBox_34d12885 PTHP Htg Coil Htg Cap Func of Temp Curve, !- Name
+  0.758746,                               !- Coefficient1 Constant
+  0.027626,                               !- Coefficient2 x
+  0.000148716,                            !- Coefficient3 x**2
+  3.4992e-06,                             !- Coefficient4 x**3
+  -20,                                    !- Minimum Value of x
+  20;                                     !- Maximum Value of x
+
+OS:Curve:Cubic,
+  {5d33e732-5298-41fd-8c4c-b23a73198e0c}, !- Handle
+  OfficeShoeBox_34d12885 PTHP Htg Coil Htg Cap Func of Flow Frac Curve, !- Name
+  0.84,                                   !- Coefficient1 Constant
+  0.16,                                   !- Coefficient2 x
+  0,                                      !- Coefficient3 x**2
+  0,                                      !- Coefficient4 x**3
+  0.5,                                    !- Minimum Value of x
+  1.5;                                    !- Maximum Value of x
+
+OS:Curve:Cubic,
+  {576fd49a-fd69-4810-b11e-5ddcb8e6254d}, !- Handle
+  OfficeShoeBox_34d12885 PTHP Htg Coil EIR Func of Temp Curve, !- Name
+  1.19248,                                !- Coefficient1 Constant
+  -0.0300438,                             !- Coefficient2 x
+  0.00103745,                             !- Coefficient3 x**2
+  -2.3328e-05,                            !- Coefficient4 x**3
+  -20,                                    !- Minimum Value of x
+  20;                                     !- Maximum Value of x
+
+OS:Curve:Quadratic,
+  {33135fb4-6cf7-4ec2-b3e3-8b7862280844}, !- Handle
+  OfficeShoeBox_34d12885 PTHP Htg Coil EIR Func of Flow Frac Curve, !- Name
+  1.3824,                                 !- Coefficient1 Constant
+  -0.4336,                                !- Coefficient2 x
+  0.0512,                                 !- Coefficient3 x**2
+  0,                                      !- Minimum Value of x
+  1;                                      !- Maximum Value of x
+
+OS:Curve:Quadratic,
+  {c36f53f6-1941-430c-89d6-ba5701e3508c}, !- Handle
+  OfficeShoeBox_34d12885 PTHP Htg Coil PLR Correlation Curve, !- Name
+  0.85,                                   !- Coefficient1 Constant
+  0.15,                                   !- Coefficient2 x
+  0,                                      !- Coefficient3 x**2
+  0,                                      !- Minimum Value of x
+  1;                                      !- Maximum Value of x
+
+OS:Curve:Biquadratic,
+  {deb6cd17-41f1-4eca-8c7c-d22edaec0524}, !- Handle
+  OfficeShoeBox_34d12885 PTHP Htg Coil Defrost EIR Func of Temp Curve, !- Name
+  0.297145,                               !- Coefficient1 Constant
+  0.0430933,                              !- Coefficient2 x
+  -0.000748766,                           !- Coefficient3 x**2
+  0.00597727,                             !- Coefficient4 y
+  0.000482112,                            !- Coefficient5 y**2
+  -0.000956448,                           !- Coefficient6 x*y
+  -23.33333,                              !- Minimum Value of x
+  29.44444,                               !- Maximum Value of x
+  -23.33333,                              !- Minimum Value of y
+  29.44444;                               !- Maximum Value of y
+
+OS:Coil:Cooling:DX:SingleSpeed,
+  {58f5e442-a3a4-4bf6-9cfe-6109f4d5335b}, !- Handle
+  OfficeShoeBox_34d12885 PTHP Clg Coil,   !- Name
+  {6a4eaffb-70a5-473e-bad1-76c997dd1fb6}, !- Availability Schedule Name
+  autosize,                               !- Rated Total Cooling Capacity {W}
+  autosize,                               !- Rated Sensible Heat Ratio
+  3,                                      !- Rated COP {W/W}
+  autosize,                               !- Rated Air Flow Rate {m3/s}
+  773.3,                                  !- Rated Evaporator Fan Power Per Volume Flow Rate 2017 {W/(m3/s)}
+  934.4,                                  !- Rated Evaporator Fan Power Per Volume Flow Rate 2023 {W/(m3/s)}
+  ,                                       !- Air Inlet Node Name
+  ,                                       !- Air Outlet Node Name
+  {40745877-a5fe-4605-b870-e054c9a32542}, !- Total Cooling Capacity Function of Temperature Curve Name
+  {5e7ebefe-5df9-4da7-84d1-cf82a492d205}, !- Total Cooling Capacity Function of Flow Fraction Curve Name
+  {66a261bd-191f-4834-876b-ef6e3bc4cbd2}, !- Energy Input Ratio Function of Temperature Curve Name
+  {1d8ba8ee-ba36-4b29-8919-a380f1ff7d7d}, !- Energy Input Ratio Function of Flow Fraction Curve Name
+  {57af4351-45b6-4539-8fc6-dbde97e63ce6}, !- Part Load Fraction Correlation Curve Name
+  -25,                                    !- Minimum Outdoor Dry-Bulb Temperature for Compressor Operation {C}
+  0,                                      !- Nominal Time for Condensate Removal to Begin {s}
+  0,                                      !- Ratio of Initial Moisture Evaporation Rate and Steady State Latent Capacity {dimensionless}
+  0,                                      !- Maximum Cycling Rate {cycles/hr}
+  0,                                      !- Latent Capacity Time Constant {s}
+  ,                                       !- Condenser Air Inlet Node Name
+  AirCooled,                              !- Condenser Type
+  0.9,                                    !- Evaporative Condenser Effectiveness {dimensionless}
+  autosize,                               !- Evaporative Condenser Air Flow Rate {m3/s}
+  autosize,                               !- Evaporative Condenser Pump Rated Power Consumption {W}
+  0,                                      !- Crankcase Heater Capacity {W}
+  10,                                     !- Maximum Outdoor Dry-Bulb Temperature for Crankcase Heater Operation {C}
+  ,                                       !- Supply Water Storage Tank Name
+  ,                                       !- Condensate Collection Water Storage Tank Name
+  0,                                      !- Basin Heater Capacity {W/K}
+  2;                                      !- Basin Heater Setpoint Temperature {C}
+
+OS:Curve:Biquadratic,
+  {205b3602-3d47-4788-9904-1018615afceb}, !- Handle
+  Curve Biquadratic 1,                    !- Name
+  0.942587793,                            !- Coefficient1 Constant
+  0.009543347,                            !- Coefficient2 x
+  0.00068377,                             !- Coefficient3 x**2
+  -0.011042676,                           !- Coefficient4 y
+  5.249e-06,                              !- Coefficient5 y**2
+  -9.72e-06,                              !- Coefficient6 x*y
+  17,                                     !- Minimum Value of x
+  22,                                     !- Maximum Value of x
+  13,                                     !- Minimum Value of y
+  46;                                     !- Maximum Value of y
+
+OS:Curve:Quadratic,
+  {bf073ed0-abbd-4020-a3a1-b384b6f77647}, !- Handle
+  Curve Quadratic 3,                      !- Name
+  0.8,                                    !- Coefficient1 Constant
+  0.2,                                    !- Coefficient2 x
+  0,                                      !- Coefficient3 x**2
+  0.5,                                    !- Minimum Value of x
+  1.5;                                    !- Maximum Value of x
+
+OS:Curve:Biquadratic,
+  {dae5169e-35ed-4af9-807c-d106a8ab6fbd}, !- Handle
+  Curve Biquadratic 2,                    !- Name
+  0.342414409,                            !- Coefficient1 Constant
+  0.034885008,                            !- Coefficient2 x
+  -0.0006237,                             !- Coefficient3 x**2
+  0.004977216,                            !- Coefficient4 y
+  0.000437951,                            !- Coefficient5 y**2
+  -0.000728028,                           !- Coefficient6 x*y
+  17,                                     !- Minimum Value of x
+  22,                                     !- Maximum Value of x
+  13,                                     !- Minimum Value of y
+  46;                                     !- Maximum Value of y
+
+OS:Curve:Quadratic,
+  {f562f4a9-6d3a-420d-962a-1948d658b127}, !- Handle
+  Curve Quadratic 4,                      !- Name
+  1.1552,                                 !- Coefficient1 Constant
+  -0.1808,                                !- Coefficient2 x
+  0.0256,                                 !- Coefficient3 x**2
+  0.5,                                    !- Minimum Value of x
+  1.5;                                    !- Maximum Value of x
+
+OS:Curve:Quadratic,
+  {3f76bd99-789d-43b4-b1e9-e89179b00bcb}, !- Handle
+  Curve Quadratic 5,                      !- Name
+  0.85,                                   !- Coefficient1 Constant
+  0.15,                                   !- Coefficient2 x
+  0,                                      !- Coefficient3 x**2
+  0,                                      !- Minimum Value of x
+  1;                                      !- Maximum Value of x
+
+OS:Curve:Biquadratic,
+  {40745877-a5fe-4605-b870-e054c9a32542}, !- Handle
+  Curve Biquadratic 3,                    !- Name
+  0.766956,                               !- Coefficient1 Constant
+  0.0107756,                              !- Coefficient2 x
+  -4.14703e-05,                           !- Coefficient3 x**2
+  0.00134961,                             !- Coefficient4 y
+  -0.000261144,                           !- Coefficient5 y**2
+  0.000457488,                            !- Coefficient6 x*y
+  12.78,                                  !- Minimum Value of x
+  23.89,                                  !- Maximum Value of x
+  21.1,                                   !- Minimum Value of y
+  46.1;                                   !- Maximum Value of y
+
+OS:Curve:Quadratic,
+  {5e7ebefe-5df9-4da7-84d1-cf82a492d205}, !- Handle
+  Curve Quadratic 6,                      !- Name
+  0.8,                                    !- Coefficient1 Constant
+  0.2,                                    !- Coefficient2 x
+  0,                                      !- Coefficient3 x**2
+  0.5,                                    !- Minimum Value of x
+  1.5;                                    !- Maximum Value of x
+
+OS:Curve:Biquadratic,
+  {66a261bd-191f-4834-876b-ef6e3bc4cbd2}, !- Handle
+  Curve Biquadratic 4,                    !- Name
+  0.297145,                               !- Coefficient1 Constant
+  0.0430933,                              !- Coefficient2 x
+  -0.000748766,                           !- Coefficient3 x**2
+  0.00597727,                             !- Coefficient4 y
+  0.000482112,                            !- Coefficient5 y**2
+  -0.000956448,                           !- Coefficient6 x*y
+  12.78,                                  !- Minimum Value of x
+  23.89,                                  !- Maximum Value of x
+  21.1,                                   !- Minimum Value of y
+  46.1;                                   !- Maximum Value of y
+
+OS:Curve:Quadratic,
+  {1d8ba8ee-ba36-4b29-8919-a380f1ff7d7d}, !- Handle
+  Curve Quadratic 7,                      !- Name
+  1.156,                                  !- Coefficient1 Constant
+  -0.1816,                                !- Coefficient2 x
+  0.0256,                                 !- Coefficient3 x**2
+  0.5,                                    !- Minimum Value of x
+  1.5;                                    !- Maximum Value of x
+
+OS:Curve:Quadratic,
+  {57af4351-45b6-4539-8fc6-dbde97e63ce6}, !- Handle
+  Curve Quadratic 8,                      !- Name
+  0.85,                                   !- Coefficient1 Constant
+  0.15,                                   !- Coefficient2 x
+  0,                                      !- Coefficient3 x**2
+  0,                                      !- Minimum Value of x
+  1;                                      !- Maximum Value of x
+
+OS:Coil:Heating:Electric,
+  {8726ec1f-fa7a-4ad4-a03d-79369855011a}, !- Handle
+  OfficeShoeBox_34d12885 PTHP Supplemental Htg Coil, !- Name
+  {6a4eaffb-70a5-473e-bad1-76c997dd1fb6}, !- Availability Schedule Name
+  1,                                      !- Efficiency
+  ,                                       !- Nominal Capacity {W}
+  ,                                       !- Air Inlet Node Name
+  ;                                       !- Air Outlet Node Name
+
+OS:ZoneHVAC:PackagedTerminalHeatPump,
+  {b7901e2b-cfca-436e-baae-dcb3cc2965b2}, !- Handle
+  OfficeShoeBox_34d12885 PTHP,            !- Name
+  {6a4eaffb-70a5-473e-bad1-76c997dd1fb6}, !- Availability Schedule Name
+  {58fe757b-b81c-4b29-8640-df367adff2b1}, !- Air Inlet Node Name
+  {8936c15d-8055-4c33-aea3-388706ddc237}, !- Air Outlet Node Name
+  OutdoorAir:Mixer,                       !- Outdoor Air Mixer Object Type
+  ,                                       !- Outdoor Air Mixer Name
+  Autosize,                               !- Supply Air Flow Rate During Cooling Operation {m3/s}
+  Autosize,                               !- Supply Air Flow Rate During Heating Operation {m3/s}
+  Autosize,                               !- Supply Air Flow Rate When No Cooling or Heating is Needed {m3/s}
+  Autosize,                               !- Outdoor Air Flow Rate During Cooling Operation {m3/s}
+  Autosize,                               !- Outdoor Air Flow Rate During Heating Operation {m3/s}
+  Autosize,                               !- Outdoor Air Flow Rate When No Cooling or Heating is Needed {m3/s}
+  {ed55dd33-cd6d-49a0-8f82-7cda27dac0b5}, !- Supply Air Fan Name
+  {6af17f7e-fcbe-480e-895c-d4284661cdf4}, !- Heating Coil Name
+  ,                                       !- Heating Convergence Tolerance {dimensionless}
+  ,                                       !- Minimum Outdoor Dry-Bulb Temperature for Compressor Operation {C}
+  {58f5e442-a3a4-4bf6-9cfe-6109f4d5335b}, !- Cooling Coil Name
+  ,                                       !- Cooling Convergence Tolerance {dimensionless}
+  {8726ec1f-fa7a-4ad4-a03d-79369855011a}, !- Supplemental Heating Coil Name
+  Autosize,                               !- Maximum Supply Air Temperature from Supplemental Heater {C}
+  ,                                       !- Maximum Outdoor Dry-Bulb Temperature for Supplemental Heater Operation {C}
+  DrawThrough,                            !- Fan Placement
+  {4d36947c-0c74-4bcb-bbdc-14f9ff78e14b}; !- Supply Air Fan Operating Mode Schedule Name
+
+OS:Schedule:Constant,
+  {4d36947c-0c74-4bcb-bbdc-14f9ff78e14b}, !- Handle
+  Always Off Discrete,                    !- Name
+  {3340effd-b297-45e3-99b1-37fc53d8f938}, !- Schedule Type Limits Name
+  0;                                      !- Value
+
+OS:ScheduleTypeLimits,
+  {3340effd-b297-45e3-99b1-37fc53d8f938}, !- Handle
+  OnOff 1,                                !- Name
+  0,                                      !- Lower Limit Value
+  1,                                      !- Upper Limit Value
+  Discrete,                               !- Numeric Type
+  Availability;                           !- Unit Type
+
+OS:Node,
+  {918f3381-c1c8-47fa-b2e1-621a80ce3b44}, !- Handle
+  OfficeShoeBox_34d12885 PTHP Inlet Air Node, !- Name
+  {3b8fa3a7-12cc-4d60-ae72-14539f4c861d}, !- Inlet Port
+  {58fe757b-b81c-4b29-8640-df367adff2b1}; !- Outlet Port
+
+OS:Connection,
+  {3b8fa3a7-12cc-4d60-ae72-14539f4c861d}, !- Handle
+  {fc1c6843-d237-42c7-9095-e73fcc545341}, !- Source Object
+  2,                                      !- Outlet Port
+  {918f3381-c1c8-47fa-b2e1-621a80ce3b44}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {58fe757b-b81c-4b29-8640-df367adff2b1}, !- Handle
+  {918f3381-c1c8-47fa-b2e1-621a80ce3b44}, !- Source Object
+  3,                                      !- Outlet Port
+  {b7901e2b-cfca-436e-baae-dcb3cc2965b2}, !- Target Object
+  3;                                      !- Inlet Port
+
+OS:Node,
+  {99ea59e5-356b-4b43-bd5a-77ada8835f76}, !- Handle
+  OfficeShoeBox_34d12885 PTHP Outlet Air Node, !- Name
+  {8936c15d-8055-4c33-aea3-388706ddc237}, !- Inlet Port
+  {03b578be-69f9-4b0e-bebd-cdc5b86f498c}; !- Outlet Port
+
+OS:Connection,
+  {03b578be-69f9-4b0e-bebd-cdc5b86f498c}, !- Handle
+  {99ea59e5-356b-4b43-bd5a-77ada8835f76}, !- Source Object
+  3,                                      !- Outlet Port
+  {3923b073-9d99-4c5c-8544-c5cd276a2fb2}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {8936c15d-8055-4c33-aea3-388706ddc237}, !- Handle
+  {b7901e2b-cfca-436e-baae-dcb3cc2965b2}, !- Source Object
+  4,                                      !- Outlet Port
+  {99ea59e5-356b-4b43-bd5a-77ada8835f76}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:PlantLoop,
+  {3e8ffd96-c2d0-4658-a32b-85f86925762e}, !- Handle
+  SHW Loop default_district_shw,          !- Name
+  ,                                       !- Fluid Type
+  0,                                      !- Glycol Concentration
+  ,                                       !- User Defined Fluid Type
+  ,                                       !- Plant Equipment Operation Heating Load
+  ,                                       !- Plant Equipment Operation Cooling Load
+  ,                                       !- Primary Plant Equipment Operation Scheme
+  {0ba08e78-4256-4c94-9c8f-0685e74c93a0}, !- Loop Temperature Setpoint Node Name
+  60,                                     !- Maximum Loop Temperature {C}
+  10,                                     !- Minimum Loop Temperature {C}
+  ,                                       !- Maximum Loop Flow Rate {m3/s}
+  ,                                       !- Minimum Loop Flow Rate {m3/s}
+  Autocalculate,                          !- Plant Loop Volume {m3}
+  {ab9c72c3-47b3-4d5d-9405-0925da366ad0}, !- Plant Side Inlet Node Name
+  {5d300791-8c3a-4502-90e2-7d92f287bbec}, !- Plant Side Outlet Node Name
+  ,                                       !- Plant Side Branch List Name
+  {f58a55f1-9fd4-4a8e-a848-cb84b9663cb9}, !- Demand Side Inlet Node Name
+  {2304a820-05a3-4ef3-b02e-6f2ee9a83322}, !- Demand Side Outlet Node Name
+  ,                                       !- Demand Side Branch List Name
+  ,                                       !- Demand Side Connector List Name
+  Optimal,                                !- Load Distribution Scheme
+  {02cf9f3a-7c91-48d8-8cc7-45599b8ff3ab}, !- Availability Manager List Name
+  ,                                       !- Plant Loop Demand Calculation Scheme
+  ,                                       !- Common Pipe Simulation
+  ,                                       !- Pressure Simulation Type
+  ,                                       !- Plant Equipment Operation Heating Load Schedule
+  ,                                       !- Plant Equipment Operation Cooling Load Schedule
+  ,                                       !- Primary Plant Equipment Operation Scheme Schedule
+  ,                                       !- Component Setpoint Operation Scheme Schedule
+  {455d9b6f-4416-4b2f-a62d-78f72613296e}, !- Demand Mixer Name
+  {30c2d394-4523-4943-9d3f-5a07bbe4174b}, !- Demand Splitter Name
+  {880dcd1f-e8e7-45da-9879-56bf69db5853}, !- Supply Mixer Name
+  {2420518c-a0e9-453a-aaab-9f96cb290b34}; !- Supply Splitter Name
+
+OS:Node,
+  {ae3bfa4b-f44d-4278-952c-833dd45036e5}, !- Handle
+  Node 1,                                 !- Name
+  {ab9c72c3-47b3-4d5d-9405-0925da366ad0}, !- Inlet Port
+  {d284b77c-24ef-4d26-b58c-dd0ddbf9d2a0}; !- Outlet Port
+
+OS:Node,
+  {0ba08e78-4256-4c94-9c8f-0685e74c93a0}, !- Handle
+  Node 2,                                 !- Name
+  {bf6a44ba-4a82-46b7-8e32-b325f0c9c3d4}, !- Inlet Port
+  {5d300791-8c3a-4502-90e2-7d92f287bbec}; !- Outlet Port
+
+OS:Node,
+  {ddc46b3f-7bd4-4aad-8f85-221354edb0ed}, !- Handle
+  Node 3,                                 !- Name
+  {f9c3937e-2e2a-4f16-b0db-41bac37973e7}, !- Inlet Port
+  {43750636-e009-4fc1-92dc-8ad8518fc6cf}; !- Outlet Port
+
+OS:Connector:Mixer,
+  {880dcd1f-e8e7-45da-9879-56bf69db5853}, !- Handle
+  Connector Mixer 1,                      !- Name
+  {bf6a44ba-4a82-46b7-8e32-b325f0c9c3d4}, !- Outlet Branch Name
+  {506f4eff-9881-49f2-83e4-25dadda44ef3}; !- Inlet Branch Name 1
+
+OS:Connector:Splitter,
+  {2420518c-a0e9-453a-aaab-9f96cb290b34}, !- Handle
+  Connector Splitter 1,                   !- Name
+  {3636f982-db0f-46fb-80d5-39b7afc9e214}, !- Inlet Branch Name
+  {f9c3937e-2e2a-4f16-b0db-41bac37973e7}; !- Outlet Branch Name 1
+
+OS:Connection,
+  {ab9c72c3-47b3-4d5d-9405-0925da366ad0}, !- Handle
+  {3e8ffd96-c2d0-4658-a32b-85f86925762e}, !- Source Object
+  14,                                     !- Outlet Port
+  {ae3bfa4b-f44d-4278-952c-833dd45036e5}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {f9c3937e-2e2a-4f16-b0db-41bac37973e7}, !- Handle
+  {2420518c-a0e9-453a-aaab-9f96cb290b34}, !- Source Object
+  3,                                      !- Outlet Port
+  {ddc46b3f-7bd4-4aad-8f85-221354edb0ed}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {bf6a44ba-4a82-46b7-8e32-b325f0c9c3d4}, !- Handle
+  {880dcd1f-e8e7-45da-9879-56bf69db5853}, !- Source Object
+  2,                                      !- Outlet Port
+  {0ba08e78-4256-4c94-9c8f-0685e74c93a0}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {5d300791-8c3a-4502-90e2-7d92f287bbec}, !- Handle
+  {0ba08e78-4256-4c94-9c8f-0685e74c93a0}, !- Source Object
+  3,                                      !- Outlet Port
+  {3e8ffd96-c2d0-4658-a32b-85f86925762e}, !- Target Object
+  15;                                     !- Inlet Port
+
+OS:Node,
+  {aafa383d-2de1-466f-aa66-445c0788def1}, !- Handle
+  Node 4,                                 !- Name
+  {f58a55f1-9fd4-4a8e-a848-cb84b9663cb9}, !- Inlet Port
+  {a474bd19-556c-495d-91b6-1e2200ebe8fa}; !- Outlet Port
+
+OS:Node,
+  {46afc4c2-6d1c-4bf4-8af6-e18c455f5883}, !- Handle
+  Node 5,                                 !- Name
+  {cf78de8d-8309-41e1-962e-a63eb07a107c}, !- Inlet Port
+  {2304a820-05a3-4ef3-b02e-6f2ee9a83322}; !- Outlet Port
+
+OS:Node,
+  {113b0592-a60b-4053-b0d4-6c1be976a6aa}, !- Handle
+  Node 6,                                 !- Name
+  {18554121-1ffb-460d-87dd-dd5ae8fc6822}, !- Inlet Port
+  {55a61653-8901-48d4-8d39-db9488962524}; !- Outlet Port
+
+OS:Connector:Mixer,
+  {455d9b6f-4416-4b2f-a62d-78f72613296e}, !- Handle
+  Connector Mixer 2,                      !- Name
+  {cf78de8d-8309-41e1-962e-a63eb07a107c}, !- Outlet Branch Name
+  {9ef655d1-386d-4ea2-8ecc-59fc07364ad8}; !- Inlet Branch Name 1
+
+OS:Connector:Splitter,
+  {30c2d394-4523-4943-9d3f-5a07bbe4174b}, !- Handle
+  Connector Splitter 2,                   !- Name
+  {a474bd19-556c-495d-91b6-1e2200ebe8fa}, !- Inlet Branch Name
+  {18554121-1ffb-460d-87dd-dd5ae8fc6822}; !- Outlet Branch Name 1
+
+OS:Connection,
+  {f58a55f1-9fd4-4a8e-a848-cb84b9663cb9}, !- Handle
+  {3e8ffd96-c2d0-4658-a32b-85f86925762e}, !- Source Object
+  17,                                     !- Outlet Port
+  {aafa383d-2de1-466f-aa66-445c0788def1}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {a474bd19-556c-495d-91b6-1e2200ebe8fa}, !- Handle
+  {aafa383d-2de1-466f-aa66-445c0788def1}, !- Source Object
+  3,                                      !- Outlet Port
+  {30c2d394-4523-4943-9d3f-5a07bbe4174b}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {18554121-1ffb-460d-87dd-dd5ae8fc6822}, !- Handle
+  {30c2d394-4523-4943-9d3f-5a07bbe4174b}, !- Source Object
+  3,                                      !- Outlet Port
+  {113b0592-a60b-4053-b0d4-6c1be976a6aa}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {cf78de8d-8309-41e1-962e-a63eb07a107c}, !- Handle
+  {455d9b6f-4416-4b2f-a62d-78f72613296e}, !- Source Object
+  2,                                      !- Outlet Port
+  {46afc4c2-6d1c-4bf4-8af6-e18c455f5883}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {2304a820-05a3-4ef3-b02e-6f2ee9a83322}, !- Handle
+  {46afc4c2-6d1c-4bf4-8af6-e18c455f5883}, !- Source Object
+  3,                                      !- Outlet Port
+  {3e8ffd96-c2d0-4658-a32b-85f86925762e}, !- Target Object
+  18;                                     !- Inlet Port
+
+OS:Sizing:Plant,
+  {4b8412b9-1db8-47a6-8e08-151af4f7bcc3}, !- Handle
+  {3e8ffd96-c2d0-4658-a32b-85f86925762e}, !- Plant or Condenser Loop Name
+  Heating,                                !- Loop Type
+  60,                                     !- Design Loop Exit Temperature {C}
+  5,                                      !- Loop Design Temperature Difference {deltaC}
+  NonCoincident,                          !- Sizing Option
+  1,                                      !- Zone Timesteps in Averaging Window
+  None;                                   !- Coincident Sizing Factor Mode
+
+OS:AvailabilityManagerAssignmentList,
+  {02cf9f3a-7c91-48d8-8cc7-45599b8ff3ab}, !- Handle
+  Plant Loop 1 AvailabilityManagerAssignmentList; !- Name
+
+OS:Schedule:Ruleset,
+  {0643d519-7b6a-4ab3-bed0-0b7461d6eb3a}, !- Handle
+  60C Hot Water,                          !- Name
+  {1376f755-75d2-47b9-8ade-d6c159a0c345}, !- Schedule Type Limits Name
+  {ad6785ab-b726-4868-935a-1d81df984577}; !- Default Day Schedule Name
+
+OS:Schedule:Day,
+  {ad6785ab-b726-4868-935a-1d81df984577}, !- Handle
+  Schedule Day 4,                         !- Name
+  {1376f755-75d2-47b9-8ade-d6c159a0c345}, !- Schedule Type Limits Name
+  ,                                       !- Interpolate to Timestep
+  24,                                     !- Hour 1
+  0,                                      !- Minute 1
+  60;                                     !- Value Until Time 1
+
+OS:SetpointManager:Scheduled,
+  {5939b4b1-98b0-42a4-85bd-011bf8fa5870}, !- Handle
+  Setpoint Manager Scheduled 1,           !- Name
+  Temperature,                            !- Control Variable
+  {0643d519-7b6a-4ab3-bed0-0b7461d6eb3a}, !- Schedule Name
+  {0ba08e78-4256-4c94-9c8f-0685e74c93a0}; !- Setpoint Node or NodeList Name
+
+OS:Pump:ConstantSpeed,
+  {b6dd133d-89ed-47b6-a078-31e3fc40f16f}, !- Handle
+  SHW Pump1,                              !- Name
+  {d284b77c-24ef-4d26-b58c-dd0ddbf9d2a0}, !- Inlet Node Name
+  {7726632f-0167-49b4-8121-b1c635bbb627}, !- Outlet Node Name
+  autosize,                               !- Rated Flow Rate {m3/s}
+  29891,                                  !- Rated Pump Head {Pa}
+  autosize,                               !- Rated Power Consumption {W}
+  0.9,                                    !- Motor Efficiency
+  0,                                      !- Fraction of Motor Inefficiencies to Fluid Stream
+  Intermittent,                           !- Pump Control Type
+  ,                                       !- Pump Flow Rate Schedule
+  ,                                       !- Pump Curve
+  ,                                       !- Impeller Diameter {m}
+  ,                                       !- Rotational Speed {rev/min}
+  ,                                       !- Zone
+  ,                                       !- Skin Loss Radiative Fraction
+  PowerPerFlowPerPressure,                !- Design Power Sizing Method
+  348701.1,                               !- Design Electric Power per Unit Flow Rate {W/(m3/s)}
+  1.282051282,                            !- Design Shaft Power per Unit Flow Rate per Unit Head {W-s/m3-Pa}
+  Water Systems;                          !- End-Use Subcategory
+
+OS:Node,
+  {0c0b9c39-92e8-40d9-8e3e-ad21b3b702a7}, !- Handle
+  Node 7,                                 !- Name
+  {7726632f-0167-49b4-8121-b1c635bbb627}, !- Inlet Port
+  {3636f982-db0f-46fb-80d5-39b7afc9e214}; !- Outlet Port
+
+OS:Connection,
+  {d284b77c-24ef-4d26-b58c-dd0ddbf9d2a0}, !- Handle
+  {ae3bfa4b-f44d-4278-952c-833dd45036e5}, !- Source Object
+  3,                                      !- Outlet Port
+  {b6dd133d-89ed-47b6-a078-31e3fc40f16f}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {7726632f-0167-49b4-8121-b1c635bbb627}, !- Handle
+  {b6dd133d-89ed-47b6-a078-31e3fc40f16f}, !- Source Object
+  3,                                      !- Outlet Port
+  {0c0b9c39-92e8-40d9-8e3e-ad21b3b702a7}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {3636f982-db0f-46fb-80d5-39b7afc9e214}, !- Handle
+  {0c0b9c39-92e8-40d9-8e3e-ad21b3b702a7}, !- Source Object
+  3,                                      !- Outlet Port
+  {2420518c-a0e9-453a-aaab-9f96cb290b34}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:WaterHeater:Mixed,
+  {4642336c-a4fd-49ef-aa62-b04b1c82e769}, !- Handle
+  Ideal Service Hot Water Heater,         !- Name
+  0,                                      !- Tank Volume {m3}
+  {acd72dbe-b359-415e-86e6-22f7760a1af1}, !- Setpoint Temperature Schedule Name
+  2,                                      !- Deadband Temperature Difference {deltaC}
+  82.22,                                  !- Maximum Temperature Limit {C}
+  Modulate,                               !- Heater Control Type
+  1000000,                                !- Heater Maximum Capacity {W}
+  ,                                       !- Heater Minimum Capacity {W}
+  ,                                       !- Heater Ignition Minimum Flow Rate {m3/s}
+  ,                                       !- Heater Ignition Delay {s}
+  DistrictHeating,                        !- Heater Fuel Type
+  1,                                      !- Heater Thermal Efficiency
+  ,                                       !- Part Load Factor Curve Name
+  20,                                     !- Off Cycle Parasitic Fuel Consumption Rate {W}
+  DistrictHeating,                        !- Off Cycle Parasitic Fuel Type
+  0.8,                                    !- Off Cycle Parasitic Heat Fraction to Tank
+  ,                                       !- On Cycle Parasitic Fuel Consumption Rate {W}
+  DistrictHeating,                        !- On Cycle Parasitic Fuel Type
+  ,                                       !- On Cycle Parasitic Heat Fraction to Tank
+  Schedule,                               !- Ambient Temperature Indicator
+  {5fafb7cd-68c6-4469-9d16-b1e385419f5b}, !- Ambient Temperature Schedule Name
+  ,                                       !- Ambient Temperature Thermal Zone Name
+  ,                                       !- Ambient Temperature Outdoor Air Node Name
+  0,                                      !- Off Cycle Loss Coefficient to Ambient Temperature {W/K}
+  ,                                       !- Off Cycle Loss Fraction to Thermal Zone
+  0,                                      !- On Cycle Loss Coefficient to Ambient Temperature {W/K}
+  ,                                       !- On Cycle Loss Fraction to Thermal Zone
+  ,                                       !- Peak Use Flow Rate {m3/s}
+  ,                                       !- Use Flow Rate Fraction Schedule Name
+  ,                                       !- Cold Water Supply Temperature Schedule Name
+  {43750636-e009-4fc1-92dc-8ad8518fc6cf}, !- Use Side Inlet Node Name
+  {b3bba757-9b32-46c3-b61f-29e62deb121a}, !- Use Side Outlet Node Name
+  1,                                      !- Use Side Effectiveness
+  ,                                       !- Source Side Inlet Node Name
+  ,                                       !- Source Side Outlet Node Name
+  1,                                      !- Source Side Effectiveness
+  autosize,                               !- Use Side Design Flow Rate {m3/s}
+  autosize,                               !- Source Side Design Flow Rate {m3/s}
+  1.5,                                    !- Indirect Water Heating Recovery Time {hr}
+  IndirectHeatPrimarySetpoint,            !- Source Side Flow Control Mode
+  ,                                       !- Indirect Alternate Setpoint Temperature Schedule Name
+  General;                                !- End-Use Subcategory
+
+OS:Schedule:Ruleset,
+  {4db0358f-30bd-495a-92fa-cd6d806a894a}, !- Handle
+  Schedule Ruleset 1,                     !- Name
+  {1376f755-75d2-47b9-8ade-d6c159a0c345}, !- Schedule Type Limits Name
+  {7d7af4b8-338e-42c7-ad99-2f404e63b8d9}; !- Default Day Schedule Name
+
+OS:Schedule:Day,
+  {7d7af4b8-338e-42c7-ad99-2f404e63b8d9}, !- Handle
+  Schedule Day 5,                         !- Name
+  {1376f755-75d2-47b9-8ade-d6c159a0c345}, !- Schedule Type Limits Name
+  ,                                       !- Interpolate to Timestep
+  24,                                     !- Hour 1
+  0,                                      !- Minute 1
+  22;                                     !- Value Until Time 1
+
+OS:Schedule:Ruleset,
+  {acd72dbe-b359-415e-86e6-22f7760a1af1}, !- Handle
+  Schedule Ruleset 2,                     !- Name
+  {1376f755-75d2-47b9-8ade-d6c159a0c345}, !- Schedule Type Limits Name
+  {e8c05245-3c4e-45cd-b151-b8eab46d5dd1}; !- Default Day Schedule Name
+
+OS:Schedule:Day,
+  {e8c05245-3c4e-45cd-b151-b8eab46d5dd1}, !- Handle
+  Schedule Day 6,                         !- Name
+  {1376f755-75d2-47b9-8ade-d6c159a0c345}, !- Schedule Type Limits Name
+  ,                                       !- Interpolate to Timestep
+  24,                                     !- Hour 1
+  0,                                      !- Minute 1
+  60;                                     !- Value Until Time 1
+
+OS:WaterHeater:Sizing,
+  {86c769a0-9235-4682-97f6-1cc618dd275b}, !- Handle
+  {4642336c-a4fd-49ef-aa62-b04b1c82e769}, !- WaterHeater Name
+  PeakDraw,                               !- Design Mode
+  0.538503,                               !- Time Storage Can Meet Peak Draw {hr}
+  0,                                      !- Time for Tank Recovery {hr}
+  1;                                      !- Nominal Tank Volume for Autosizing Plant Connections {m3}
+
+OS:Schedule:Ruleset,
+  {5fafb7cd-68c6-4469-9d16-b1e385419f5b}, !- Handle
+  22C Ambient Condition,                  !- Name
+  {1376f755-75d2-47b9-8ade-d6c159a0c345}, !- Schedule Type Limits Name
+  {78d71204-9da9-4e38-acf1-41e8220842cd}; !- Default Day Schedule Name
+
+OS:Schedule:Day,
+  {78d71204-9da9-4e38-acf1-41e8220842cd}, !- Handle
+  Schedule Day 7,                         !- Name
+  {1376f755-75d2-47b9-8ade-d6c159a0c345}, !- Schedule Type Limits Name
+  ,                                       !- Interpolate to Timestep
+  24,                                     !- Hour 1
+  0,                                      !- Minute 1
+  22;                                     !- Value Until Time 1
+
+OS:Node,
+  {0656e665-fc42-4580-bd58-19c4864816f5}, !- Handle
+  Node 8,                                 !- Name
+  {b3bba757-9b32-46c3-b61f-29e62deb121a}, !- Inlet Port
+  {506f4eff-9881-49f2-83e4-25dadda44ef3}; !- Outlet Port
+
+OS:Connection,
+  {43750636-e009-4fc1-92dc-8ad8518fc6cf}, !- Handle
+  {ddc46b3f-7bd4-4aad-8f85-221354edb0ed}, !- Source Object
+  3,                                      !- Outlet Port
+  {4642336c-a4fd-49ef-aa62-b04b1c82e769}, !- Target Object
+  31;                                     !- Inlet Port
+
+OS:Connection,
+  {b3bba757-9b32-46c3-b61f-29e62deb121a}, !- Handle
+  {4642336c-a4fd-49ef-aa62-b04b1c82e769}, !- Source Object
+  32,                                     !- Outlet Port
+  {0656e665-fc42-4580-bd58-19c4864816f5}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {506f4eff-9881-49f2-83e4-25dadda44ef3}, !- Handle
+  {0656e665-fc42-4580-bd58-19c4864816f5}, !- Source Object
+  3,                                      !- Outlet Port
+  {880dcd1f-e8e7-45da-9879-56bf69db5853}, !- Target Object
+  3;                                      !- Inlet Port
+
+OS:Node,
+  {cb801bc7-5e20-4b47-be8f-a42c79095b01}, !- Handle
+  Node 9,                                 !- Name
+  {500f8842-a92c-4431-a10e-d75d79acaa39}, !- Inlet Port
+  {9ef655d1-386d-4ea2-8ecc-59fc07364ad8}; !- Outlet Port
+
+OS:Connection,
+  {55a61653-8901-48d4-8d39-db9488962524}, !- Handle
+  {113b0592-a60b-4053-b0d4-6c1be976a6aa}, !- Source Object
+  3,                                      !- Outlet Port
+  {880bfce8-e5ac-4255-aaba-709789d4b1b5}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {500f8842-a92c-4431-a10e-d75d79acaa39}, !- Handle
+  {880bfce8-e5ac-4255-aaba-709789d4b1b5}, !- Source Object
+  3,                                      !- Outlet Port
+  {cb801bc7-5e20-4b47-be8f-a42c79095b01}, !- Target Object
+  2;                                      !- Inlet Port
+
+OS:Connection,
+  {9ef655d1-386d-4ea2-8ecc-59fc07364ad8}, !- Handle
+  {cb801bc7-5e20-4b47-be8f-a42c79095b01}, !- Source Object
+  3,                                      !- Outlet Port
+  {455d9b6f-4416-4b2f-a62d-78f72613296e}, !- Target Object
+  3;                                      !- Inlet Port
+

--- a/test/os_stds_methods/test_apply_hvac_efficiency_standard.rb
+++ b/test/os_stds_methods/test_apply_hvac_efficiency_standard.rb
@@ -1,0 +1,52 @@
+require_relative '../helpers/minitest_helper'
+
+class TestApplyHVACEfficiencyStandard < Minitest::Test
+  def test_pthp_90_1_2019
+    test_name = 'test_pthp_90_1_2019'
+    # Load model
+    std = Standard.build('90.1-2019')
+    model = std.safe_load_model("#{File.dirname(__FILE__)}/models/basic_pthp_model.osm")
+    building = model.getBuilding
+    std.model_add_design_days_and_weather_file(model, 'ASHRAE 169-2013-4A')
+
+    # Set the heating and cooling sizing parameters
+    std.model_apply_prm_sizing_parameters(model)
+    # Perform a sizing run
+    if std.model_run_sizing_run(model, "output/#{test_name}/SR1") == false
+      return false
+    end
+    # If there are any multizone systems, reset damper positions
+    # to achieve a 60% ventilation effectiveness minimum for the system
+    # following the ventilation rate procedure from 62.1
+    std.model_apply_multizone_vav_outdoor_air_sizing(model)
+    # get the climate zone  
+    climate_zone_obj = model.getClimateZones.getClimateZone('ASHRAE', 2006)
+    if climate_zone_obj.empty
+      climate_zone_obj = model.getClimateZones.getClimateZone('ASHRAE', 2013)
+    end
+    climate_zone = climate_zone_obj.value
+    # get the building type
+    bldg_type = nil
+    unless building.standardsBuildingType.empty?
+      bldg_type = building.standardsBuildingType.get
+    end
+    # Apply the prototype HVAC assumptions
+    std.model_apply_prototype_hvac_assumptions(model, bldg_type, climate_zone)
+
+    model.getCoilHeatingDXSingleSpeeds.each do |coil|
+      # find ac properties
+      search_criteria = std.coil_dx_find_search_criteria(coil, true)
+      sub_category = search_criteria['subcategory']
+      suppl_heating_type = search_criteria['heating_type']
+      capacity_w = std.coil_heating_dx_single_speed_find_capacity(coil, true)
+      capacity_btu_per_hr = OpenStudio.convert(capacity_w, 'W', 'Btu/hr').get
+      capacity_kbtu_per_hr = OpenStudio.convert(capacity_w, 'W', 'kBtu/hr').get
+      ac_props = std.model_find_object(std.standards_data['heat_pumps_heating'], search_criteria, capacity_btu_per_hr, Date.today)
+      # puts "#{coil.name} #{capacity_btu_per_hr}"
+      # puts ac_props
+    end
+
+    # Apply the HVAC efficiency standard
+    std.model_apply_hvac_efficiency_standard(model, climate_zone)
+  end
+end


### PR DESCRIPTION
90.1-2016 and 90.1-2019 PTHP systems don't use the pthp_cop_coefficient_1, pthp_cop_coefficient_2 coefficients as earlier versions.  Add a check that they are present for earlier standards.