### PR TITLE
fix for Issue 1502

### DIFF
--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2019/ashrae_90_1_2019.AirLoopHVAC.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2019/ashrae_90_1_2019.AirLoopHVAC.rb
@@ -624,6 +624,7 @@ class ASHRAE9012019 < ASHRAE901
       max_oa_frac_sch_type = 'Schedule:Constant'
       oa_ctrl.setMaximumFractionofOutdoorAirSchedule(max_oa_frac_sch)
     else
+      max_oa_frac_sch = max_oa_frac_sch.get
       if max_oa_frac_sch.to_ScheduleRuleset.is_initialized
         max_oa_frac_sch = max_oa_frac_sch.to_ScheduleRuleset.get
         max_oa_frac_sch_type = 'Schedule:Year'


### PR DESCRIPTION
One way to verify the issue is to use 'bldg_2' from test/90_1_prm which has the required Maximum Fraction of Outdoor Air Schedule assigned to a multizone AHU. I wrote a simple unit test to show the method returning true, but not sure if it's needed.