### PR TITLE
Wx bug fix fenestration expansion missing construction name

### DIFF
--- a/lib/openstudio-standards.rb
+++ b/lib/openstudio-standards.rb
@@ -25,6 +25,7 @@ module OpenstudioStandards
   require_relative 'openstudio-standards/utilities/schedule_translator'
   require_relative 'openstudio-standards/utilities/array'
   require_relative 'openstudio-standards/utilities/object_info'
+  require_relative 'openstudio-standards/utilities/assertion'
 
   stds = 'openstudio-standards/standards'
   proto = 'openstudio-standards/prototypes'

--- a/lib/openstudio-standards/standards/Standards.Model.rb
+++ b/lib/openstudio-standards/standards/Standards.Model.rb
@@ -83,7 +83,7 @@ class Standard
     # User data process
     # bldg_type_hvac_zone_hash could be an empty hash if all zones in the models are unconditioned
     bldg_type_hvac_zone_hash = {}
-    handle_user_input_data(user_model, climate_zone, hvac_building_type, wwr_building_type, swh_building_type, bldg_type_hvac_zone_hash)
+    handle_user_input_data(user_model, climate_zone, sizing_run_dir, hvac_building_type, wwr_building_type, swh_building_type, bldg_type_hvac_zone_hash)
     # Define different orientation from original orientation
     # for each individual baseline models
     # Need to run proposed model sizing simulation if no sql data is available
@@ -6950,12 +6950,13 @@ class Standard
   # 2. data from measure and OpenStudio interface
   # @param [OpenStudio:model:Model] model
   # @param [String] climate_zone
+  # @param [String] sizing_run_dir
   # @param [String] default_hvac_building_type
   # @param [String] default_wwr_building_type
   # @param [String] default_swh_building_type
   # @param [Hash] bldg_type_hvac_zone_hash A hash maps building type for hvac to a list of thermal zones
   # @return True
-  def handle_user_input_data(model, climate_zone, default_hvac_building_type, default_wwr_building_type, default_swh_building_type, bldg_type_hvac_zone_hash)
+  def handle_user_input_data(model, climate_zone, sizing_run_dir, default_hvac_building_type, default_wwr_building_type, default_swh_building_type, bldg_type_hvac_zone_hash)
     return true
   end
 

--- a/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.Model.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.Model.rb
@@ -1487,19 +1487,17 @@ class ASHRAE901PRM < Standard
         user_airloops.each do |user_airloop|
           if air_loop_name == user_airloop['name']
             # gas phase air cleaning is system base - add proposed hvac system name to zones
-            if user_airloop.key?('economizer_exception_for_gas_phase_air_cleaning') && !user_airloop['economizer_exception_for_gas_phase_air_cleaning'].nil?
-              if user_airloop['economizer_exception_for_gas_phase_air_cleaning'].downcase == 'yes'
-                air_loop.thermalZones.each do |thermal_zone|
-                  thermal_zone.additionalProperties.setFeature('economizer_exception_for_gas_phase_air_cleaning', air_loop_name)
-                end
+            economizer_exception_for_gas_phase_air_cleaning = prm_read_user_data(user_airloop, 'economizer_exception_for_gas_phase_air_cleaning', 'no')
+            if economizer_exception_for_gas_phase_air_cleaning.downcase == 'yes'
+              air_loop.thermalZones.each do |thermal_zone|
+                thermal_zone.additionalProperties.setFeature('economizer_exception_for_gas_phase_air_cleaning', air_loop_name)
               end
             end
+            economizer_exception_for_open_refrigerated_cases = prm_read_user_data(user_airloop, 'economizer_exception_for_open_refrigerated_cases', 'no')
             # Open refrigerated cases is zone based - add yes or no to zones
-            if user_airloop.key?('economizer_exception_for_open_refrigerated_cases') && !user_airloop['economizer_exception_for_open_refrigerated_cases'].nil?
-              if user_airloop['economizer_exception_for_open_refrigerated_cases'].downcase == 'yes'
-                air_loop.thermalZones.each do |thermal_zone|
-                  thermal_zone.additionalProperties.setFeature('economizer_exception_for_open_refrigerated_cases', 'yes')
-                end
+            if economizer_exception_for_open_refrigerated_cases.downcase == 'yes'
+              air_loop.thermalZones.each do |thermal_zone|
+                thermal_zone.additionalProperties.setFeature('economizer_exception_for_open_refrigerated_cases', 'yes')
               end
             end
             # Fan power credits, exhaust air energy recovery

--- a/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.Model.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.Model.rb
@@ -1461,7 +1461,9 @@ class ASHRAE901PRM < Standard
   # @param [String] default_swh_building_type
   # @param [Hash] bldg_type_hvac_zone_hash A hash maps building type for hvac to a list of thermal zones
   # @return True
-  def handle_user_input_data(model, climate_zone, default_hvac_building_type, default_wwr_building_type, default_swh_building_type, bldg_type_hvac_zone_hash)
+  def handle_user_input_data(model, climate_zone, sizing_run_dir, default_hvac_building_type, default_wwr_building_type, default_swh_building_type, bldg_type_hvac_zone_hash)
+    # Set sizing run directory
+    @sizing_run_dir = sizing_run_dir
     # load the multiple building area types from user data
     handle_multi_building_area_types(model, climate_zone, default_hvac_building_type, default_wwr_building_type, default_swh_building_type, bldg_type_hvac_zone_hash)
     # load user data from proposed model

--- a/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.PlanarSurface.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.PlanarSurface.rb
@@ -54,10 +54,10 @@ class ASHRAE901PRM < Standard
         cons_set = space.model.building.get.defaultConstructionSet.get
         construction = get_default_surface_cons_from_surface_type(surface_category, surface_type, cons_set)
       end
-      OpenStudio.logFree(OpenStudio::Debug, 'prm.log', "Search for #{planar_surface.name.get} defaultConstructionSet, find #{construction ? construction.name.get: "Nil"}")
-      raise "No defaultConstructionSet defined for space #{space.name.get}, failed to find default construction for surface #{planar_surface.name.get}" unless construction
-
-      return previous_construction_map if construction.nil?
+      prm_raise(construction,
+                @sizing_run_dir,
+                "Surface #{planar_surface.name.get} does not have a construction. Failed to find defaultConstructionSet for #{planar_surface.name.get}. Add a construction for the surface or add a defaultConstructionSet to Space #{space.name.get} or SpaceType #{space_type.name.get}.",
+                "Failed to find defaultConstructionSet for #{planar_surface.name.get}. Check inputs.")
     end
 
     # Determine if residential or nonresidential

--- a/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.PlanarSurface.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.PlanarSurface.rb
@@ -54,6 +54,8 @@ class ASHRAE901PRM < Standard
         cons_set = space.model.building.get.defaultConstructionSet.get
         construction = get_default_surface_cons_from_surface_type(surface_category, surface_type, cons_set)
       end
+      OpenStudio.logFree(OpenStudio::Debug, 'prm.log', "Search for #{planar_surface.name.get} defaultConstructionSet, find #{construction ? construction.name.get: "Nil"}")
+      raise "No defaultConstructionSet defined for space #{space.name.get}, failed to find default construction for surface #{planar_surface.name.get}" unless construction
 
       return previous_construction_map if construction.nil?
     end

--- a/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.Surface.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.Surface.rb
@@ -26,7 +26,6 @@ class ASHRAE901PRM < Standard
       end
       # Save doors to a temp list
       door_list = []
-      fenestration_construction = ''
       surface.subSurfaces.sort.each do |sub|
         if sub.subSurfaceType == 'Door'
           door = {}
@@ -34,8 +33,6 @@ class ASHRAE901PRM < Standard
           door['vertices'] = sub.vertices
           door['construction'] = sub.construction.get
           door_list << door
-        else
-          fenestration_construction = sub.construction.get
         end
       end
       # remove all existing windows and set the window to wall ratio to the calculated new WWR
@@ -43,11 +40,6 @@ class ASHRAE901PRM < Standard
       surface.subSurfaces.sort.each(&:remove)
       # Apply default construction to the subsurface - the standard construction will be applied later.
       surface.setWindowToWallRatio(wwr_adjusted, 0.6, true)
-      # Need to assign at least one construction so that the
-      # baseline construction material can be added to the new surface
-      surface.subSurfaces.each do |sub|
-        sub.setConstruction(fenestration_construction)
-      end
       # add door back.
       unless door_list.empty?
         door_list.each do |door|

--- a/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.Surface.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.Surface.rb
@@ -26,6 +26,7 @@ class ASHRAE901PRM < Standard
       end
       # Save doors to a temp list
       door_list = []
+      fenestration_construction = ''
       surface.subSurfaces.sort.each do |sub|
         if sub.subSurfaceType == 'Door'
           door = {}
@@ -33,6 +34,8 @@ class ASHRAE901PRM < Standard
           door['vertices'] = sub.vertices
           door['construction'] = sub.construction.get
           door_list << door
+        else
+          fenestration_construction = sub.construction.get
         end
       end
       # remove all existing windows and set the window to wall ratio to the calculated new WWR
@@ -40,6 +43,11 @@ class ASHRAE901PRM < Standard
       surface.subSurfaces.sort.each(&:remove)
       # Apply default construction to the subsurface - the standard construction will be applied later.
       surface.setWindowToWallRatio(wwr_adjusted, 0.6, true)
+      # Need to assign at least one construction so that the
+      # baseline construction material can be added to the new surface
+      surface.subSurfaces.each do |sub|
+        sub.setConstruction(fenestration_construction)
+      end
       # add door back.
       unless door_list.empty?
         door_list.each do |door|

--- a/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.rb
@@ -7,6 +7,7 @@ require 'csv'
 class ASHRAE901PRM < Standard
   def initialize
     load_standards_database
+    @sizing_run_dir = Dir.pwd
   end
 
   def load_standards_database(data_directories = [])

--- a/lib/openstudio-standards/utilities/assertion.rb
+++ b/lib/openstudio-standards/utilities/assertion.rb
@@ -17,3 +17,12 @@ def prm_raise(bool, log_dir, log_msg, err_msg)
     raise PRMError, err_msg
   end
 end
+
+# PRM reading function reads user data from a hash map.
+# Handles key existence, value is nil and value string is empty
+# @param user_data [Hash] a hash contains a user data
+# @param key [String] key string
+# @param default [Object] values assigned if the data is not available.
+def prm_read_user_data(user_data, key, default = nil)
+  return user_data.key?(key) && !user_data[key].nil && !user_data[key].to_s.empty? ? user_data[key] : default
+end

--- a/lib/openstudio-standards/utilities/assertion.rb
+++ b/lib/openstudio-standards/utilities/assertion.rb
@@ -1,0 +1,17 @@
+# PRM generation custom Error
+class PRMError < StandardError
+end
+
+# Finds capacity in W
+#
+# @param bool [Boolean, Object] an object for truthy evaluation
+# @param log_dir [String] log file directory
+# @param log_msg [String] message add to the log
+# @param err_msg [String] message raise the exception
+def prm_raise(bool, log_dir, log_msg, err_msg)
+  unless bool
+    OpenStudio.logFree(OpenStudio::Debug, 'prm.log', log_msg)
+    log_messages_to_file_prm("#{log_dir}/prm.log", true)
+    raise PRMError, err_msg
+  end
+end

--- a/lib/openstudio-standards/utilities/assertion.rb
+++ b/lib/openstudio-standards/utilities/assertion.rb
@@ -2,8 +2,11 @@
 class PRMError < StandardError
 end
 
-# Finds capacity in W
+# PRM assertion method
+# Raise assertion if the test (bool) is failed
 #
+# Before raise the exception, the method will generate the prm.log for debugging
+# 
 # @param bool [Boolean, Object] an object for truthy evaluation
 # @param log_dir [String] log file directory
 # @param log_msg [String] message add to the log

--- a/lib/openstudio-standards/utilities/assertion.rb
+++ b/lib/openstudio-standards/utilities/assertion.rb
@@ -6,7 +6,6 @@ end
 # Raise assertion if the test (bool) is failed
 #
 # Before raise the exception, the method will generate the prm.log for debugging
-# 
 # @param bool [Boolean, Object] an object for truthy evaluation
 # @param log_dir [String] log file directory
 # @param log_msg [String] message add to the log


### PR DESCRIPTION
We discover one issue with a sample model below (change the txt to osm to test)
[sample_med_os_ad1.txt](https://github.com/NREL/openstudio-standards/files/11426666/sample_med_os_ad1.txt)

The model does not have defaultConstructionSet assigned to space, spaceType, building or even model. However, it does run successfully.
This causes our code failure when searching for the [defaultConstructionSet ](https://github.com/NREL/openstudio-standards/blob/master/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.PlanarSurface.rb#L33-L58)to fill up empty construction.

The failure cause EnergyPlus simulation failure due to missing construction name.

I suggest to handle this as assertion instead of return empty hashmap - give enough information for user to debug their model.