### PR TITLE
VRF outdoor unit max_net_vert_distance calculation

### DIFF
--- a/lib/openstudio-standards/standards/necb/ECMS/hvac_systems.rb
+++ b/lib/openstudio-standards/standards/necb/ECMS/hvac_systems.rb
@@ -255,7 +255,9 @@ class ECMS
       end
     end
     max_net_vert_distance = max_vert_distance + min_vert_distance
-    max_net_vert_distance = [max_net_vert_distance, 0.000001].max
+    if max_net_vert_distance.zero?()
+      max_net_vert_distance = 0.000001
+    end
 
     return max_equiv_distance, max_net_vert_distance
   end

--- a/lib/openstudio-standards/standards/necb/ECMS/hvac_systems.rb
+++ b/lib/openstudio-standards/standards/necb/ECMS/hvac_systems.rb
@@ -255,9 +255,6 @@ class ECMS
       end
     end
     max_net_vert_distance = max_vert_distance + min_vert_distance
-    if max_net_vert_distance.zero?()
-      max_net_vert_distance = 0.000001
-    end
 
     return max_equiv_distance, max_net_vert_distance
   end


### PR DESCRIPTION
**background**

- noticed there is a line like this below when calculating `Vertical Height used for Piping Correction Factor` for `AirConditioner:VariableRefrigerantFlow` object

  ```
  max_net_vert_distance = [max_net_vert_distance, 0.000001].max
  ```

- which was not letting `max_net_vert_distance` to be a negative value

- but EP [documentation example](https://bigladdersoftware.com/epx/docs/23-1/input-output-reference/group-variable-refrigerant-flow-equipment.html#field-vertical-height-used-for-piping-correction-factor-000) shows `max_net_vert_distance` can be a negative value. for example, if your VRF outdoor unit is located on the roof, and all of your indoor units are below the roof, `max_net_vert_distance` becomes a negative value.

**change summary**

- so this change is basically removing one line.

- cc-ing: @khaddad 