### PR TITLE
fix yard documentation

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -23,6 +23,5 @@ docs/Features.md
 docs/DeveloperInformation.md
 docs/RepositoryStructure.md
 docs/CodeArchitecture.md
-docs/AddingAStandard.md
 License.txt
 LGPL-2.1

--- a/data/standards/manage_OpenStudio_Standards.rb
+++ b/data/standards/manage_OpenStudio_Standards.rb
@@ -202,7 +202,7 @@ def standard_directory_name_from_template(template)
 end
 
 # checks whether your authorization credentials are set up to access the spreadsheets
-# @return [Bool] returns true if api is working, false if not
+# @return [Boolean] returns true if api is working, false if not
 def check_google_drive_configuration
   require 'google_drive'
   client_config_path = File.join(Dir.home, '.credentials', "client_secret.json")

--- a/lib/openstudio-standards/btap/analysis.rb
+++ b/lib/openstudio-standards/btap/analysis.rb
@@ -93,7 +93,7 @@
 #
 #       #This method will do an analysis of the opaque surface conductance sensitivity and returns a string model array.
 #       #@author phylroy.lopez@nrcan.gc.ca
-#       #@param model [OpenStudio::model::Model] A model object   {http://openstudio.nrel.gov/latest-c-sdk-documentation/model}
+#       #@param model [OpenStudio::Model::Model] A model object   {http://openstudio.nrel.gov/latest-c-sdk-documentation/model}
 #       #@param choice [String] description
 #       #@return [modelArray<String>]
 #       def self.opaque_surface_conductance_sensitivity_analysis(model,choice )
@@ -191,7 +191,7 @@
 #
 #       #This method performs a wall sensitivity analysis and returns a string model array.
 #       #@author phylroy.lopez@nrcan.gc.ca
-#       #@param model [OpenStudio::model::Model] A model object   {http://openstudio.nrel.gov/latest-c-sdk-documentation/model}
+#       #@param model [OpenStudio::Model::Model] A model object   {http://openstudio.nrel.gov/latest-c-sdk-documentation/model}
 #       #@param folder_name [String]
 #       #@param values<Fixnum>
 #       #@return [modelArray<String>]
@@ -213,7 +213,7 @@
 #
 #       #This method performs a roof sensitivity analysis and returns a string model array.
 #       #@author phylroy.lopez@nrcan.gc.ca
-#       #@param model_in [OpenStudio::model::Model] A model object {http://openstudio.nrel.gov/latest-c-sdk-documentation/model}
+#       #@param model_in [OpenStudio::Model::Model] A model object {http://openstudio.nrel.gov/latest-c-sdk-documentation/model}
 #       #@param folder_name [String]
 #       #@param values<Fixnum>
 #       #@return [modelArray<String>]
@@ -249,7 +249,7 @@
 #
 #       #This method performs a glazing solar transmittance sensitivity analysis and returns a model array.
 #       #@author phylroy.lopez@nrcan.gc.ca
-#       #@param model_in [OpenStudio::model::Model] A model object {http://openstudio.nrel.gov/latest-c-sdk-documentation/model}
+#       #@param model_in [OpenStudio::Model::Model] A model object {http://openstudio.nrel.gov/latest-c-sdk-documentation/model}
 #       #@param folder_name [String]
 #       #@param values<Fixnum>
 #       #@return [modelArray<String>]
@@ -270,7 +270,7 @@
 #
 #       #This method performs an rvalue sensitivity analysis and returns a model array.
 #       #@author phylroy.lopez@nrcan.gc.ca
-#       #@param model_in [OpenStudio::model::Model] A model object {http://openstudio.nrel.gov/latest-c-sdk-documentation/model}
+#       #@param model_in [OpenStudio::Model::Model] A model object {http://openstudio.nrel.gov/latest-c-sdk-documentation/model}
 #       #@param folder_name [String]
 #       #@param values<Fixnum>
 #       #@return [modelArray<String>]
@@ -291,7 +291,7 @@
 #
 #       #This method performs a full sensitivity analysis on the wall, roof, solar-trans,window,and ground surfaces.
 #       #@author phylroy.lopez@nrcan.gc.ca
-#       #@param model [OpenStudio::model::Model] A model object   {http://openstudio.nrel.gov/latest-c-sdk-documentation/model}
+#       #@param model [OpenStudio::Model::Model] A model object   {http://openstudio.nrel.gov/latest-c-sdk-documentation/model}
 #       #@param parent_folder [String]
 #       def self.full_sensitivity_analysis(model, parent_folder)
 #         self.wall_rvalue_sensitivity_model_analysis(model, (parent_folder + "/wall-r"))
@@ -304,7 +304,7 @@
 #
 #       #This method performs a full analysis (elimination and Sensitivity).
 #       #@author phylroy.lopez@nrcan.gc.ca
-#       #@param model [OpenStudio::model::Model] A model object   {http://openstudio.nrel.gov/latest-c-sdk-documentation/model}
+#       #@param model [OpenStudio::Model::Model] A model object   {http://openstudio.nrel.gov/latest-c-sdk-documentation/model}
 #       #@param folder [String]
 #       def self.full_analysis(model, folder)
 #         FileUtils.rm_rf(folder)
@@ -318,7 +318,7 @@
 #
 #       #This method performs an elimination analysis ( OA, H&C setpoints,infiltration,occupancy,lighting,plug_loads,gas_equipment, hotwater, steam, other) and returns a model array.
 #       #@author phylroy.lopez@nrcan.gc.ca
-#       #@param model_in [OpenStudio::model::Model] A model object {http://openstudio.nrel.gov/latest-c-sdk-documentation/model}
+#       #@param model_in [OpenStudio::Model::Model] A model object {http://openstudio.nrel.gov/latest-c-sdk-documentation/model}
 #       #@param folder_name [String]
 #       #@return [modelArray<String>]
 #       def self.full_elimination_analysis(model_in, folder_name)

--- a/lib/openstudio-standards/btap/bridging.rb
+++ b/lib/openstudio-standards/btap/bridging.rb
@@ -1578,7 +1578,7 @@ module BTAP
     # @param model [OpenStudio::Model::Model] a model
     # @param buffers [Array] identifiers of modified buffer spaces in model
     #
-    # @return [Bool] true if successful
+    # @return [Boolean] true if successful
     def purge_buffer_schedules(model = nil, buffers = [])
       scheds = []
       lgs    = @feedback[:logs]
@@ -1663,7 +1663,7 @@ module BTAP
     # @param model [OpenStudio::Model::Model] a model
     # @param argh [Hash] BTAP/TBD argument hash
     #
-    # @return [Bool] true if valid (check @feedback logs if false)
+    # @return [Boolean] true if valid (check @feedback logs if false)
     def populate(model = nil, argh = {})
       cl     = OpenStudio::Model::Model
       args   = { option: "(non thermal bridging)" }    # for initial TBD dry run
@@ -1855,7 +1855,7 @@ module BTAP
     ##
     # Generate BTAP/TBD tallies
     #
-    # @return [Bool] true if BTAP/TBD tally is successful
+    # @return [Boolean] true if BTAP/TBD tally is successful
     def gen_tallies
       edges  = {}
       return false unless @model.key?(:io)
@@ -1887,7 +1887,7 @@ module BTAP
     ##
     # Generate BTAP/TBD post-processing feedback.
     #
-    # @return [Bool] true if valid BTAP/TBD model
+    # @return [Boolean] true if valid BTAP/TBD model
     def gen_feedback
       lgs = @feedback[:logs]
       return false unless @model.key?(:complies) # all model constructions

--- a/lib/openstudio-standards/btap/btap.model.rb
+++ b/lib/openstudio-standards/btap/btap.model.rb
@@ -472,7 +472,7 @@
 #
 #   #This method will set the infiltration magnitude.
 #   #@author phylroy.lopez@nrcan.gc.ca
-#   #@param self [OpenStudio::model::Model] A model object
+#   #@param self [OpenStudio::Model::Model] A model object
 #   #@param setDesignFlowRate [Float]
 #   #@param setFlowperSpaceFloorArea [Float]
 #   #@param setFlowperExteriorSurfaceArea [Float]
@@ -509,7 +509,7 @@
 #
 #   #This method will scale people loads schedule.
 #   #@author phylroy.lopez@nrcan.gc.ca
-#   #@param model [OpenStudio::model::Model] A model object
+#   #@param model [OpenStudio::Model::Model] A model object
 #   #@param a_coef [Float]
 #   #@param b_coef [Float]
 #   #@param c_coef [Float]
@@ -528,7 +528,7 @@
 #
 #   #This method will scale lighting loads.
 #   #@author phylroy.lopez@nrcan.gc.ca
-#   #@param model [OpenStudio::model::Model] A model object
+#   #@param model [OpenStudio::Model::Model] A model object
 #   #@param factor [Float]
 #   def scale_lighting_loads(factor)
 #     self.getLightss.sort.each do |item|
@@ -538,7 +538,7 @@
 #
 #   #This method will scale lighting loads schedule.
 #   #@author phylroy.lopez@nrcan.gc.ca
-#   #@param model [OpenStudio::model::Model] A model object
+#   #@param model [OpenStudio::Model::Model] A model object
 #   #@param a_coef [Float]
 #   #@param b_coef [Float]
 #   #@param c_coef [Float]
@@ -557,7 +557,7 @@
 #
 #   #This method will scale electrical loads.
 #   #@author phylroy.lopez@nrcan.gc.ca
-#   #@param model [OpenStudio::model::Model] A model object
+#   #@param model [OpenStudio::Model::Model] A model object
 #   #@param factor [Float]
 #   def scale_electrical_loads(model, factor)
 #     self.getElectricEquipments.sort.each do |item|
@@ -567,7 +567,7 @@
 #
 #   #This method will scale electrical loads schedule.
 #   #@author phylroy.lopez@nrcan.gc.ca
-#   #@param model [OpenStudio::model::Model] A model object
+#   #@param model [OpenStudio::Model::Model] A model object
 #   #@param a_coef [Float]
 #   #@param b_coef [Float]
 #   #@param c_coef [Float]
@@ -585,7 +585,7 @@
 #
 #   #This method will scale Outdoor Air loads.
 #   #@author phylroy.lopez@nrcan.gc.ca
-#   #@param model [OpenStudio::model::Model] A model object
+#   #@param model [OpenStudio::Model::Model] A model object
 #   #@param factor [Float]
 #   def scale_oa_loads(factor)
 #     self.getDesignSpecificationOutdoorAirs.sort.each do |oa_def|
@@ -598,7 +598,7 @@
 #
 #   #This method will scale infiltration loads.
 #   #@author phylroy.lopez@nrcan.gc.ca
-#   #@param model [OpenStudio::model::Model] A model object
+#   #@param model [OpenStudio::Model::Model] A model object
 #   #@param factor [Float]
 #   def scale_inflitration_loads(factor)
 #     self.getSpaceInfiltrationDesignFlowRates.sort.each do |infiltration_load|
@@ -612,7 +612,7 @@
 #   # Elimination Methods
 #   #This method removes people loads from the model.
 #   #@author phylroy.lopez@nrcan.gc.ca
-#   #@param model [OpenStudio::model::Model] A model object
+#   #@param model [OpenStudio::Model::Model] A model object
 #   def eliminate_all_people_loads()
 #     self.getPeoples.sort.each {|people| people.remove}
 #     self.getPeopleDefinitions.sort.each {|people| people.remove}
@@ -621,7 +621,7 @@
 #
 #   #This method removes light loads from model.
 #   #@author phylroy.lopez@nrcan.gc.ca
-#   #@param model [OpenStudio::model::Model] A model object
+#   #@param model [OpenStudio::Model::Model] A model object
 #   def eliminate_all_lighting_loads()
 #     self.getLightss.sort.each {|item| item.remove}
 #     self.getLightsDefinitions.sort.each {|item| item.remove}
@@ -630,7 +630,7 @@
 #
 #   #This method removes elec loads from model.
 #   #@author phylroy.lopez@nrcan.gc.ca
-#   #@param model [OpenStudio::model::Model] A model object
+#   #@param model [OpenStudio::Model::Model] A model object
 #   def eliminate_all_electric_loads()
 #     self.getElectricEquipments.sort.each {|item| item.remove}
 #     self.getElectricEquipmentDefinitions.sort.each {|item| item.remove}
@@ -639,7 +639,7 @@
 #
 #   #This method removes all design specification OA from model.
 #   #@author phylroy.lopez@nrcan.gc.ca
-#   #@param model [OpenStudio::model::Model] A model object
+#   #@param model [OpenStudio::Model::Model] A model object
 #   def eliminate_all_design_specification_outdoor_air()
 #     self.getDesignSpecificationOutdoorAirs.sort.each {|item| item.remove}
 #     return self
@@ -647,7 +647,7 @@
 #
 #   #This method removes infiltration from model..
 #   #@author phylroy.lopez@nrcan.gc.ca
-#   #@param model [OpenStudio::model::Model] A model object
+#   #@param model [OpenStudio::Model::Model] A model object
 #   def eliminate_all_space_infiltration_design_flow_rates()
 #     self.getSpaceInfiltrationDesignFlowRates.sort.each {|item| item.remove}
 #     return self
@@ -655,7 +655,7 @@
 #
 #   #This method removes all space loads from model.
 #   #@author phylroy.lopez@nrcan.gc.ca
-#   #@param model [OpenStudio::model::Model] A model object
+#   #@param model [OpenStudio::Model::Model] A model object
 #   def eliminate_all_loads()
 #     conductance = 0.200
 #

--- a/lib/openstudio-standards/btap/btap.rb
+++ b/lib/openstudio-standards/btap/btap.rb
@@ -186,7 +186,7 @@ module BTAP
   module SimulationSettings
     #This sets the simulation period for the model. All arguments are integers.
     #@author Phylroy A. Lopez
-    #@param model [OpenStudio::model::Model] A model object {http://openstudio.nrel.gov/latest-c-sdk-documentation/model}
+    #@param model [OpenStudio::Model::Model] A model object {http://openstudio.nrel.gov/latest-c-sdk-documentation/model}
     #@param start_month [Integer] a list of output variables that you wish to report from the simulation.
     #@param start_day [Integer] a list of output variables that you wish to report from the simulation.
     #@param end_month [Integer] a list of output variables that you wish to report from the simulation.
@@ -208,7 +208,7 @@ module BTAP
     #This method clears all the output variables to make simulations run faster or to
     #start fresh.
     #@author Phylroy A. Lopez
-    #@param model [OpenStudio::model::Model] A model object {http://openstudio.nrel.gov/latest-c-sdk-documentation/model}
+    #@param model [OpenStudio::Model::Model] A model object {http://openstudio.nrel.gov/latest-c-sdk-documentation/model}
     #@return [OpenStudio::Model::Model] the OpenStudio model object (self reference).
     def self.clear_output_variables(model)
       #remove existing outputs
@@ -220,7 +220,7 @@ module BTAP
 
     #This turns all output on. Warning: Long runtimes will result.
     #@author Phylroy A. Lopez
-    #@param model [OpenStudio::model::Model] A model object
+    #@param model [OpenStudio::Model::Model] A model object
     #@param frequency [Fixnum]
     #@return [OpenStudio::Model::Model] a copy of the OpenStudio model object (self reference).
     def self.all_output_variables(model,frequency)
@@ -231,7 +231,7 @@ module BTAP
     #This method returns a vector of the results that are available in the current
     #model.
     #@author Phylroy A. Lopez
-    #@param model [OpenStudio::model::Model] A model object
+    #@param model [OpenStudio::Model::Model] A model object
     #@return [Array<String>] a list of all the possible output variables.
     def self.get_possible_output_variables( model )
       #Run simulation
@@ -256,7 +256,7 @@ module BTAP
 
     #This method sets up some predetermined output variables. May take a while to run with these settings.
     #@author Phylroy A. Lopez
-    #@param model [OpenStudio::model::Model] A model object
+    #@param model [OpenStudio::Model::Model] A model object
     #@param frequency [Fixnum]
     #@param output_variable_array [Array<String>] a list of output variables that you wish to report from the simulation.
     #@return [OpenStudio::Model::Model] the OpenStudio model object (self reference).
@@ -276,7 +276,7 @@ module BTAP
     #This method sets the weather file for the model.
     #It takes a simple string, remember to escape the slashes..(i.e. // not / )
     #@author Phylroy A. Lopez
-    #@param model [OpenStudio::model::Model] A model object
+    #@param model [OpenStudio::Model::Model] A model object
     #@param  epw_path [String] a simple string of the epw file path, remember to escape the slashes..(i.e. // not / )
     def self.set_weather_file(model, epw_path)
       BTAP::Environment::WeatherFile.new(epw_path).set_weather_file(model)
@@ -289,7 +289,7 @@ module BTAP
     #This model checks to see if the obj_array passed is
     #the object we require, or if a string is given to search for a object of that strings name.
     #@author Phylroy A. Lopez
-    #@param model [OpenStudio::model::Model] A model object
+    #@param model [OpenStudio::Model::Model] A model object
     #@param obj_array <Object>
     #@param object_type [Object]
     def self.validate_array(model,obj_array,object_type)

--- a/lib/openstudio-standards/btap/economics.rb
+++ b/lib/openstudio-standards/btap/economics.rb
@@ -27,7 +27,7 @@
 #
 #       #This method removes all costs from model
 #       #@author phylroy.lopez@nrcan.gc.ca
-#       #@param model [OpenStudio::model::Model] A model object
+#       #@param model [OpenStudio::Model::Model] A model object
 #       #@param runner [String]
 #       def self.remove_all_costs(model,runner = nil)
 #         #Remove all cost items.
@@ -39,11 +39,11 @@
 #
 #       #This method will add the costs.
 #       #@author phylroy.lopez@nrcan.gc.ca
-#       #@param model [OpenStudio::model::Model] A model object
+#       #@param model [OpenStudio::Model::Model] A model object
 #       #@param name [String]
 #       #@param cost [Float]
 #       #@param unittype [String]
-#       #return cost_object [OpenStudio::model::Model] A model object
+#       #return cost_object [OpenStudio::Model::Model] A model object
 #       def self.object_cost(model,name,cost,unittype)
 #         unless cost.nil? or cost == 0.0
 #           #add total construction cost if used in place of each construction.
@@ -57,7 +57,7 @@
 #
 #       #This method will add the cost per building.
 #       #@author phylroy.lopez@nrcan.gc.ca
-#       #@param model [OpenStudio::model::Model] A model object
+#       #@param model [OpenStudio::Model::Model] A model object
 #       #@param name [String]
 #       #@param cost [Float]
 #       #@param runner [Float]
@@ -73,7 +73,7 @@
 #
 #       #This method will add the cost per total area.
 #       #@author phylroy.lopez@nrcan.gc.ca
-#       #@param model [OpenStudio::model::Model] A model object
+#       #@param model [OpenStudio::Model::Model] A model object
 #       #@param name [String]
 #       #@param cost [Float]
 #       #@param runner [Float]
@@ -89,7 +89,7 @@
 #
 #       #This method will set the ecm envelope.
 #       #@author phylroy.lopez@nrcan.gc.ca
-#       #@param model [OpenStudio::model::Model] A model object
+#       #@param model [OpenStudio::Model::Model] A model object
 #       #@param library_file_path [String]
 #       #@param default_construction_set_name [String]
 #       #@param ext_wall_rsi [Float]
@@ -259,7 +259,7 @@
 #
 #       #This method will set the ecm infiltration.
 #       #@author phylroy.lopez@nrcan.gc.ca
-#       #@param model [OpenStudio::model::Model] A model object
+#       #@param model [OpenStudio::Model::Model] A model object
 #       #@param infiltration_design_flow_rate [Float]
 #       #@param infiltration_flow_per_space [Float]
 #       #@param infiltration_flow_per_exterior_area [Float]
@@ -321,7 +321,7 @@
 #
 #       #This method will set the ecm fans.
 #       #@author phylroy.lopez@nrcan.gc.ca
-#       #@param model [OpenStudio::model::Model] A model object
+#       #@param model [OpenStudio::Model::Model] A model object
 #       #@return [String] log
 #       def ecm_fans( model )
 #         measure_values =
@@ -413,7 +413,7 @@
 #
 #       #This method will set the ecm pumps.
 #       #@author phylroy.lopez@nrcan.gc.ca
-#       #@param model [OpenStudio::model::Model] A model object
+#       #@param model [OpenStudio::Model::Model] A model object
 #       #@return [String] log
 #       def ecm_pumps( model )
 #         measure_values =
@@ -508,7 +508,7 @@
 #
 #       #This method will set the ecm cooling COP.
 #       #@author phylroy.lopez@nrcan.gc.ca
-#       #@param model [OpenStudio::model::Model] A model object
+#       #@param model [OpenStudio::Model::Model] A model object
 #       def ecm_cooling_cop( model )
 #         log = ""
 #         measure_values =[
@@ -551,7 +551,7 @@
 #
 #       #This method will set the ecm economizers.
 #       #@author phylroy.lopez@nrcan.gc.ca
-#       #@param model [OpenStudio::model::Model] A model object
+#       #@param model [OpenStudio::Model::Model] A model object
 #       #@return [String] log
 #       def ecm_economizers( model )
 #
@@ -582,7 +582,7 @@
 #       end
 #       #This method will set the ecm sizing.
 #       #@author phylroy.lopez@nrcan.gc.ca
-#       #@param model [OpenStudio::model::Model] A model object
+#       #@param model [OpenStudio::Model::Model] A model object
 #       #@return [String] table
 #       def ecm_sizing( model)
 #         measure_values =[
@@ -616,7 +616,7 @@
 #
 #       #This method will set the ecm domestic hot water.
 #       #@author phylroy.lopez@nrcan.gc.ca
-#       #@param model [OpenStudio::model::Model] A model object
+#       #@param model [OpenStudio::Model::Model] A model object
 #       #@return [String] log
 #       def ecm_dhw( model )
 #         log = "shw_setpoint_sched,shw_heater_fuel_type,shw_thermal_eff\n"
@@ -646,7 +646,7 @@
 #
 #       #This method will set the ecm chotwater boilers.
 #       #@author phylroy.lopez@nrcan.gc.ca
-#       #@param model [OpenStudio::model::Model] A model object
+#       #@param model [OpenStudio::Model::Model] A model object
 #       #@return [String] table
 #       def ecm_hotwater_boilers( model )
 #         measure_values = [
@@ -762,7 +762,7 @@
 #
 #       #This method will set the ecm dcv.
 #       #@author phylroy.lopez@nrcan.gc.ca
-#       #@param model [OpenStudio::model::Model] A model object
+#       #@param model [OpenStudio::Model::Model] A model object
 #       #@return [String] log
 #       def ecm_dcv( model )
 #         log = ""
@@ -779,7 +779,7 @@
 #
 #       #This method will set the ecm heating and cooling setpoints.
 #       #@author phylroy.lopez@nrcan.gc.ca
-#       #@param model [OpenStudio::model::Model] A model object
+#       #@param model [OpenStudio::Model::Model] A model object
 #       #@return [String] log
 #       def ecm_heating_cooling_setpoints(model)
 #
@@ -833,7 +833,7 @@
 #
 #       #This method will set the ecm erv.
 #       #@author phylroy.lopez@nrcan.gc.ca
-#       #@param model [OpenStudio::model::Model] A model object
+#       #@param model [OpenStudio::Model::Model] A model object
 #       #@return [String] log
 #       def ecm_erv( model )
 #         log = ""
@@ -907,7 +907,7 @@
 #
 #       #This method will set the ecm cexhaust fans.
 #       #@author phylroy.lopez@nrcan.gc.ca
-#       #@param model [OpenStudio::model::Model] A model object
+#       #@param model [OpenStudio::Model::Model] A model object
 #       #@return [String] log
 #       def ecm_exhaust_fans( model )
 #         log = ""
@@ -928,7 +928,7 @@
 #
 #       #This method will set the ecm lighting.
 #       #@author phylroy.lopez@nrcan.gc.ca
-#       #@param model [OpenStudio::model::Model] A model object
+#       #@param model [OpenStudio::Model::Model] A model object
 #       #@return [String] log
 #       def ecm_lighting( model )
 #         log = ""
@@ -955,7 +955,7 @@
 #
 #       #This method will set the ecm temperature setback.
 #       #@author phylroy.lopez@nrcan.gc.ca
-#       #@param model [OpenStudio::model::Model] A model object
+#       #@param model [OpenStudio::Model::Model] A model object
 #       #@return [String] log
 #       def ecm_plugs( model )
 #         log = ""
@@ -986,7 +986,7 @@
 #
 #       #This method will set the ecm cold deck reset control.
 #       #@author phylroy.lopez@nrcan.gc.ca
-#       #@param model [OpenStudio::model::Model] A model object
+#       #@param model [OpenStudio::Model::Model] A model object
 #       #@return [String] log
 #       def ecm_cold_deck_reset_control( model )
 #         log = ""
@@ -1042,7 +1042,7 @@
 #
 #       #This method will reset the sat ecm.
 #       #@author phylroy.lopez@nrcan.gc.ca
-#       #@param model [OpenStudio::model::Model] A model object
+#       #@param model [OpenStudio::Model::Model] A model object
 #       #@return [String] log
 #       def ecm_sat_reset( model )
 #         log = ""
@@ -1082,7 +1082,7 @@
 #
 #       #This method will set the ecm temperature setback.
 #       #@author phylroy.lopez@nrcan.gc.ca
-#       #@param model [OpenStudio::model::Model] A model object
+#       #@param model [OpenStudio::Model::Model] A model object
 #       #@return [String] log
 #       def ecm_temp_setback( model )
 #         log = ""

--- a/lib/openstudio-standards/btap/envelope.rb
+++ b/lib/openstudio-standards/btap/envelope.rb
@@ -27,7 +27,7 @@ module BTAP
 
       #This method removes all materials from model.
       #@author phylroy.lopez@nrcan.gc.ca
-      #@param model [OpenStudio::model::Model] A model object
+      #@param model [OpenStudio::Model::Model] A model object
       def self.remove_all_materials(model)
         model.getMaterials().each do |item|
           item.remove
@@ -36,28 +36,28 @@ module BTAP
 
       #This method removes all constructions from model.
       #@author phylroy.lopez@nrcan.gc.ca
-      #@param model [OpenStudio::model::Model] A model object
+      #@param model [OpenStudio::Model::Model] A model object
       def self.remove_all_constructions(model)
         model.getConstructions().each { |item| item.remove }
       end
 
       #This method removes all default surface constructions from model.
       #@author phylroy.lopez@nrcan.gc.ca
-      #@param model [OpenStudio::model::Model] A model object
+      #@param model [OpenStudio::Model::Model] A model object
       def self.remove_all_default_surface_constructions(model)
         model.getDefaultSurfaceConstructionss().each { |item| item.remove }
       end
 
       #This method removes all default subsurface constructions from model.
       #@author phylroy.lopez@nrcan.gc.ca
-      #@param model [OpenStudio::model::Model] A model object
+      #@param model [OpenStudio::Model::Model] A model object
       def self.remove_all_default_subsurface_constructions(model)
         model.getDefaultSubSurfaceConstructionss().each { |item| item.remove }
       end
 
       #This method removes all default construction sets from model.
       #@author phylroy.lopez@nrcan.gc.ca
-      #@param model [OpenStudio::model::Model] A model object
+      #@param model [OpenStudio::Model::Model] A model object
       def self.remove_all_default_construction_sets(model)
         model.getDefaultConstructionSets().each { |item| item.remove }
         model.building.get.resetDefaultConstructionSet()
@@ -66,7 +66,7 @@ module BTAP
 
       #This method assignes interior surface construction to adiabatic surfaces from model.
       #@author phylroy.lopez@nrcan.gc.ca
-      #@param model [OpenStudio::model::Model] A model object
+      #@param model [OpenStudio::Model::Model] A model object
       def self.assign_interior_surface_construction_to_adiabatic_surfaces(model, runner = nil)
         BTAP::runner_register("Info", "assign_interior_surface_construction_to_adiabatic_surfaces", runner)
         unless model.building.get.defaultConstructionSet.empty? or model.building.get.defaultConstructionSet.get.defaultInteriorSurfaceConstructions.empty? or model.building.get.defaultConstructionSet.get.defaultInteriorSurfaceConstructions.get.wallConstruction.empty?
@@ -90,7 +90,7 @@ module BTAP
 
       #This method removes all thermal mass definitions from model.
       #@author phylroy.lopez@nrcan.gc.ca
-      #@param model [OpenStudio::model::Model] A model object
+      #@param model [OpenStudio::Model::Model] A model object
       def self.remove_all_thermal_mass_definitions(model)
         model.getInternalMassDefinitions.sort.each { |item| item.remove }
         model.getInternalMasss.sort.each { |item| item.remove }
@@ -98,7 +98,7 @@ module BTAP
 
       #This method removes all envelope information from model.
       #@author phylroy.lopez@nrcan.gc.ca
-      #@param model [OpenStudio::model::Model] A model object
+      #@param model [OpenStudio::Model::Model] A model object
       def self.remove_all_envelope_information(model)
         BTAP::Resources::Envelope::remove_all_materials(model)
         BTAP::Resources::Envelope::remove_all_default_construction_sets(model)

--- a/lib/openstudio-standards/btap/geometry.rb
+++ b/lib/openstudio-standards/btap/geometry.rb
@@ -2121,7 +2121,7 @@ module BTAP
     end
 
     # This method will scale the model
-    # @param model [OpenStudio::Model::Model] the model object.
+    # @param model [OpenStudio::Model::Model] OpenStudio model object
     # @param x [Float] x scalar multiplier.
     # @param y [Float] y scalar multiplier.
     # @param z [Float] z scalar multiplier.
@@ -2165,7 +2165,7 @@ module BTAP
 
 
     # This method will rotate the model
-    # @param model [OpenStudio::Model::Model] the model object.
+    # @param model [OpenStudio::Model::Model] OpenStudio model object
     # @param degrees [Float] rotation value
     # @return [OpenStudio::Model::Model] the model object.
     def self.rotate_model(model, degrees)

--- a/lib/openstudio-standards/btap/mpc.rb
+++ b/lib/openstudio-standards/btap/mpc.rb
@@ -29,7 +29,7 @@
 #
 #       #This method initializes.
 #       #@author phylroy.lopez@nrcan.gc.ca
-#       #@param model_file [OpenStudio::model::Model] A model object
+#       #@param model_file [OpenStudio::Model::Model] A model object
 #       #@param weather_file [String] path to a weather file
 #       #@param analysis_folder [String] path to analysis folder
 #       def initialize (
@@ -55,7 +55,7 @@
 #
 #       #This method creates the schedules.
 #       #@author phylroy.lopez@nrcan.gc.ca
-#       #@param model [OpenStudio::model::Model] A model object
+#       #@param model [OpenStudio::Model::Model] A model object
 #       def create_schedules(model)
 #
 #         #Create cooling temperature schedule
@@ -126,7 +126,7 @@
 #
 #       #This method sets the output variables.
 #       #@author phylroy.lopez@nrcan.gc.ca
-#       #@param model [OpenStudio::model::Model] A model object
+#       #@param model [OpenStudio::Model::Model] A model object
 #       def set_output_variables(model)
 #         output_variable_array =
 #           [
@@ -237,7 +237,7 @@
 #
 #       #This method miso building generation and returns a model array.
 #       #@author phylroy.lopez@nrcan.gc.ca
-#       #@param model [OpenStudio::model::Model] A model object
+#       #@param model [OpenStudio::Model::Model] A model object
 #       #@param standard_weather_file [String] path to a weather file
 #       #@return [model_array<String>]
 #       def miso_building_generation(model,standard_weather_file)
@@ -385,7 +385,7 @@
 #
 #       #This method miso building analysis.
 #       #@author phylroy.lopez@nrcan.gc.ca
-#       #@param model_file [OpenStudio::model::Model] A model object
+#       #@param model_file [OpenStudio::Model::Model] A model object
 #       #@param folder_name [String] path to a folder
 #       #@param standard_weather_file [String] path to a weather file
 #       def miso_building_analysis(folder_name,model_file,standard_weather_file)
@@ -409,7 +409,7 @@
 #
 #       #This method miso zonal analysis.
 #       #@author phylroy.lopez@nrcan.gc.ca
-#       #@param model_file [OpenStudio::model::Model] A model object
+#       #@param model_file [OpenStudio::Model::Model] A model object
 #       #@param folder_name [String] path to a folder
 #       #@param standard_weather_file [String] path to a weather file
 #       def miso_zonal_analysis(folder_name,model_file,standard_weather_file)
@@ -433,7 +433,7 @@
 #
 #       #This method miso zonal generation and returns a model array.
 #       #@author phylroy.lopez@nrcan.gc.ca
-#       #@param model[OpenStudio::model::Model] A model object
+#       #@param model[OpenStudio::Model::Model] A model object
 #       #@param standard_weather_file [String] path to a weather file
 #       #@return [model_array<String>]
 #       def miso_zonal_generation(model,standard_weather_file)

--- a/lib/openstudio-standards/btap/schedules.rb
+++ b/lib/openstudio-standards/btap/schedules.rb
@@ -914,7 +914,7 @@ module BTAP
 
       # Creates ScheduleVariableInterval from TimeSeries
       # @author david.goldwasser@nrel.gov
-      # @param model [OpenStudio::model::Model] A model object
+      # @param model [OpenStudio::Model::Model] A model object
       # @param time_series [OpenStudio::TimeSeries] A TimeSeries object
       # @return [OpenStudio::Model::ScheduleInterval] An interval schedule
       def self.create_schedule_variable_interval_from_time_series(model, time_series)

--- a/lib/openstudio-standards/btap/simmanager.rb
+++ b/lib/openstudio-standards/btap/simmanager.rb
@@ -70,7 +70,7 @@
 #     #This method will run the simulation. You must provide a folder where you wish
 #     #to run the simulation, and if not previously defined, the weather file. This will delete and recreate the folder provided to ensure that it is clean.
 #     #@author Phylroy A. Lopez
-#     #@param model [OpenStudio::model::Model] A model object
+#     #@param model [OpenStudio::Model::Model] A model object
 #     #@param folder_name [String] a simple string of the simulation folder path, remember to escape the slashes..(i.e. // not / )
 #     #@param epw_path [String] a simple string of the epw file path, remember to escape the slashes..(i.e. // not / )
 #     #@return [OpenStudio::Model::Model] the OpenStudio model object (self reference).
@@ -219,7 +219,7 @@
 #
 #       #This method adds the model to the folder.
 #       #@author phylroy.lopez@nrcan.gc.ca
-#       #@param model [OpenStudio::model::Model] A model object
+#       #@param model [OpenStudio::Model::Model] A model object
 #       #@param folder [String]
 #       #@return [String] self
 #       def addModel(model, folder = @analysisFolder  )
@@ -670,7 +670,7 @@
 #       #This method copies report files to a single folder for convenience.
 #       #@author phylroy.lopez@nrcan.gc.ca
 #       #@param run_name [String]
-#       #@return [OpenStudio::model::Model] A model object
+#       #@return [OpenStudio::Model::Model] A model object
 #       def processResults(run_name)
 #         #make sql folder
 #         Dir.mkdir(@outdir.to_s+"\\sqlresults") unless File.exists?(@outdir.to_s+"\\sqlresults")
@@ -723,7 +723,7 @@
 #
 #       #This method will fix underheated hours
 #       #@author Phylroy A. Lopez
-#       #@param model [OpenStudio::model::Model] A model object
+#       #@param model [OpenStudio::Model::Model] A model object
 #       #@param folder_name [String] a simple string of the simulation folder path, remember to escape the slashes..(i.e. // not / )
 #       #@param epw_path [String] a simple string of the epw file path, remember to escape the slashes..(i.e. // not / )
 #       def fix_underheated_hours(model,epw_path,folder_name = "c:/temp/")

--- a/lib/openstudio-standards/btap/spaceloads.rb
+++ b/lib/openstudio-standards/btap/spaceloads.rb
@@ -63,7 +63,7 @@
 #
 #         #This method will scale people loads.
 #         #@author phylroy.lopez@nrcan.gc.ca
-#         #@param model [OpenStudio::model::Model] A model object
+#         #@param model [OpenStudio::Model::Model] A model object
 #         #@param factor [Float]
 #         def self.scale_people_loads( model, factor )
 #           model.getPeoples.sort.each do |item|
@@ -73,7 +73,7 @@
 #
 #         #This method will scale people loads schedule.
 #         #@author phylroy.lopez@nrcan.gc.ca
-#         #@param model [OpenStudio::model::Model] A model object
+#         #@param model [OpenStudio::Model::Model] A model object
 #         #@param a_coef [Float]
 #         #@param b_coef [Float]
 #         #@param c_coef [Float]
@@ -88,7 +88,7 @@
 #
 #         #This method will scale lighting loads.
 #         #@author phylroy.lopez@nrcan.gc.ca
-#         #@param model [OpenStudio::model::Model] A model object
+#         #@param model [OpenStudio::Model::Model] A model object
 #         #@param factor [Float]
 #         def self.scale_lighting_loads( model, factor )
 #           model.getLightss.sort.each do |item|
@@ -98,7 +98,7 @@
 #
 #         #This method will scale lighting loads schedule.
 #         #@author phylroy.lopez@nrcan.gc.ca
-#         #@param model [OpenStudio::model::Model] A model object
+#         #@param model [OpenStudio::Model::Model] A model object
 #         #@param a_coef [Float]
 #         #@param b_coef [Float]
 #         #@param c_coef [Float]
@@ -113,7 +113,7 @@
 #
 #         #This method will scale electrical loads.
 #         #@author phylroy.lopez@nrcan.gc.ca
-#         #@param model [OpenStudio::model::Model] A model object
+#         #@param model [OpenStudio::Model::Model] A model object
 #         #@param factor [Float]
 #         def self.scale_electrical_loads( model, factor )
 #           model.getElectricEquipments.sort.each do |item|
@@ -123,7 +123,7 @@
 #
 #         #This method will scale electrical loads schedule.
 #         #@author phylroy.lopez@nrcan.gc.ca
-#         #@param model [OpenStudio::model::Model] A model object
+#         #@param model [OpenStudio::Model::Model] A model object
 #         #@param a_coef [Float]
 #         #@param b_coef [Float]
 #         #@param c_coef [Float]
@@ -137,7 +137,7 @@
 #
 #         #This method will scale hotwater loads.
 #         #@author phylroy.lopez@nrcan.gc.ca
-#         #@param model [OpenStudio::model::Model] A model object
+#         #@param model [OpenStudio::Model::Model] A model object
 #         #@param factor [Float]
 #         def self.scale_hot_water_loads( model, factor )
 #           model.getHotWaterEquipments.sort.each do |item|
@@ -147,7 +147,7 @@
 #
 #         #This method will scale Outdoor Air loads.
 #         #@author phylroy.lopez@nrcan.gc.ca
-#         #@param model [OpenStudio::model::Model] A model object
+#         #@param model [OpenStudio::Model::Model] A model object
 #         #@param factor [Float]
 #         def self.scale_oa_loads( model, factor )
 #           model.getDesignSpecificationOutdoorAirs.sort.each do |oa_def|
@@ -160,7 +160,7 @@
 #
 #         #This method will scale infiltration loads.
 #         #@author phylroy.lopez@nrcan.gc.ca
-#         #@param model [OpenStudio::model::Model] A model object
+#         #@param model [OpenStudio::Model::Model] A model object
 #         #@param factor [Float]
 #         def self.scale_inflitration_loads( model, factor )
 #           model.getSpaceInfiltrationDesignFlowRates.sort.each do |infiltration_load|
@@ -173,7 +173,7 @@
 #
 #         #This method will set the infiltration magnitude.
 #         #@author phylroy.lopez@nrcan.gc.ca
-#         #@param model [OpenStudio::model::Model] A model object
+#         #@param model [OpenStudio::Model::Model] A model object
 #         #@param setDesignFlowRate [Float]
 #         #@param setFlowperSpaceFloorArea [Float]
 #         #@param setFlowperExteriorSurfaceArea [Float]
@@ -202,7 +202,7 @@
 #
 #       #This method removes people loads from the model.
 #       #@author phylroy.lopez@nrcan.gc.ca
-#       #@param model [OpenStudio::model::Model] A model object
+#       #@param model [OpenStudio::Model::Model] A model object
 #       def self.remove_all_people_loads(model)
 #         model.getPeoples.sort.each {|people| people.remove}
 #         model.getPeopleDefinitions.sort.each {|people| people.remove}
@@ -211,7 +211,7 @@
 #
 #       #This method created people loads from the model.
 #       #@author phylroy.lopez@nrcan.gc.ca
-#       #@param model [OpenStudio::model::Model] A model object
+#       #@param model [OpenStudio::Model::Model] A model object
 #       #@param people_name [String]
 #       #@param floor_area_per_person [Float]
 #       #@param multiplier [Float]
@@ -239,7 +239,7 @@
 #
 #       #This method removes light loads from model.
 #       #@author phylroy.lopez@nrcan.gc.ca
-#       #@param model [OpenStudio::model::Model] A model object
+#       #@param model [OpenStudio::Model::Model] A model object
 #       def self.remove_all_light_loads(model)
 #         model.getLightss.sort.each {|item| item.remove}
 #         model.getLightsDefinitions.sort.each {|item| item.remove}
@@ -247,7 +247,7 @@
 #
 #       #This method created people loads from the model.
 #       #@author phylroy.lopez@nrcan.gc.ca
-#       #@param model [OpenStudio::model::Model] A model object
+#       #@param model [OpenStudio::Model::Model] A model object
 #       #@param light_name [String]
 #       #@param light_watts_per_floor_area [Float]
 #       #@param multiplier [Float]
@@ -268,7 +268,7 @@
 #
 #       #This method removes elec loads from model.
 #       #@author phylroy.lopez@nrcan.gc.ca
-#       #@param model [OpenStudio::model::Model] A model object
+#       #@param model [OpenStudio::Model::Model] A model object
 #       def self.remove_all_electric_loads(model)
 #         model.getElectricEquipments.sort.each {|item| item.remove}
 #         model.getElectricEquipmentDefinitions.sort.each {|item| item.remove}
@@ -277,7 +277,7 @@
 #
 #       #This method created people loads from the model.
 #       #@author phylroy.lopez@nrcan.gc.ca
-#       #@param model [OpenStudio::model::Model] A model object
+#       #@param model [OpenStudio::Model::Model] A model object
 #       #@param elec_name [String]
 #       #@param elec_watts_per_floor_area [Float]
 #       #@param multiplier [Float]
@@ -297,7 +297,7 @@
 #
 #       #This method removes hot water loads from model.
 #       #@author phylroy.lopez@nrcan.gc.ca
-#       #@param model [OpenStudio::model::Model] A model object
+#       #@param model [OpenStudio::Model::Model] A model object
 #       def self.remove_all_hot_water_loads(model)
 #         model.getHotWaterEquipments.sort.each {|item| item.remove}
 #         model.getHotWaterEquipmentDefinitions.sort.each {|item| item.remove}
@@ -305,7 +305,7 @@
 #
 #       #This method creats hot water load.
 #       #@author phylroy.lopez@nrcan.gc.ca
-#       #@param model [OpenStudio::model::Model] A model object
+#       #@param model [OpenStudio::Model::Model] A model object
 #       #@param hot_water_name [String]
 #       #@param hot_water_watts_per_floor_area [Float]
 #       #@param multiplier [Float]
@@ -326,7 +326,7 @@
 #
 #       #This method removes all design specification OA from model.
 #       #@author phylroy.lopez@nrcan.gc.ca
-#       #@param model [OpenStudio::model::Model] A model object
+#       #@param model [OpenStudio::Model::Model] A model object
 #       def self.remove_all_DesignSpecificationOutdoorAir(model)
 #         model.getDesignSpecificationOutdoorAirs.sort.each { |item| item.remove }
 #       end
@@ -334,7 +334,7 @@
 #
 #       #This method removes all space infiltration design flow rate OA from model.
 #       #@author phylroy.lopez@nrcan.gc.ca
-#       #@param model [OpenStudio::model::Model] A model object
+#       #@param model [OpenStudio::Model::Model] A model object
 #       def self.remove_all_SpaceInfiltrationDesignFlowRate(model)
 #         OpenStudio::Model::SpaceInfiltrationDesignFlowRate
 #         model.getSpaceInfiltrationDesignFlowRates.sort.each { |item| item.remove }
@@ -342,7 +342,7 @@
 #
 #       #This method creats hot water load.
 #       #@author phylroy.lopez@nrcan.gc.ca
-#       #@param model [OpenStudio::model::Model] A model object
+#       #@param model [OpenStudio::Model::Model] A model object
 #       #@param oa_name [String]
 #       #@param oa_person [Fixnum]
 #       #@param oa_area [Fixnum]
@@ -350,7 +350,7 @@
 #       #@param oa_flowrate [Fixnum]
 #       #@param method [String]
 #       #@param schedule [Float]
-#       #@return [OpenStudio::model::Model] oa_def
+#       #@return [OpenStudio::Model::Model] oa_def
 #       def self.create_oa_load(model,oa_name,oa_person = 0 ,oa_area = 0, oa_ach = 0, oa_flowrate = 0, method = "Maximum",schedule = nil)
 #         raise("DesignSpecificationOutdoorAir #{name} already exists. Please use a different name") unless model.getDesignSpecificationOutdoorAirByName( oa_name ).empty?
 #         #units are in m3/s for flow and m2 for area.
@@ -373,7 +373,7 @@
 #
 #       #This method removes infiltration from model..
 #       #@author phylroy.lopez@nrcan.gc.ca
-#       #@param model [OpenStudio::model::Model] A model object
+#       #@param model [OpenStudio::Model::Model] A model object
 #       def self.remove_all_SpaceInfiltrationDesignFlowRates(model)
 #         model.getSpaceInfiltrationDesignFlowRates.sort.each { |item| item.remove }
 #       end
@@ -381,7 +381,7 @@
 #       #This method creates infiltration load.
 #       #NECB infiltration rate is 0.25L/s/m2  or 0.00025 m3/s/m2
 #       #@author phylroy.lopez@nrcan.gc.ca
-#       #@param model [OpenStudio::model::Model] A model object
+#       #@param model [OpenStudio::Model::Model] A model object
 #       #@return [String] infiltration_load
 #       def self.create_infiltration_load(model,
 #           infil_name,
@@ -419,7 +419,7 @@
 #
 #       #This method removes all loads from model.
 #       #@author phylroy.lopez@nrcan.gc.ca
-#       #@param model [OpenStudio::model::Model] A model object
+#       #@param model [OpenStudio::Model::Model] A model object
 #       def self.remove_all_casual_loads(model)
 #         self.remove_all_people_loads(model)
 #         self.remove_all_light_loads(model)
@@ -429,7 +429,7 @@
 #
 #       #This method removes all space loads from model.
 #       #@author phylroy.lopez@nrcan.gc.ca
-#       #@param model [OpenStudio::model::Model] A model object
+#       #@param model [OpenStudio::Model::Model] A model object
 #       def self.remove_all_SpaceLoads(model)
 #         model.getSpaceLoads.sort.each { |item| item.remove }
 #         model.getSpaceLoadDefinitions.sort.each { |item| item.remove }

--- a/lib/openstudio-standards/btap/utilities.rb
+++ b/lib/openstudio-standards/btap/utilities.rb
@@ -49,9 +49,9 @@
 #   #argument model(s). This is handy for quickly viewing changes to the file during
 #   #runtime for debugging and QA.
 #   #@author phylroy.lopez@nrcan.gc.ca
-#   #@param model1 [OpenStudio::model::Model] A model object.
-#   #@param model2 [OpenStudio::model::Model] A model object.
-#   #@param model3 [OpenStudio::model::Model] A model object.
+#   #@param model1 [OpenStudio::Model::Model] A model object.
+#   #@param model2 [OpenStudio::Model::Model] A model object.
+#   #@param model3 [OpenStudio::Model::Model] A model object.
 #   def self.kdiff3_model_osm(model1, model2, model3 = "")
 #     Dir::mkdir("C:\\kdiff_test") unless File.exists?("C:\\kdiff_test")
 #     model1.save(OpenStudio::Path.new("c:\\kdiff_test\\diffA.osm"))
@@ -71,9 +71,9 @@
 #   #argument model(s). This is handy for quickly viewing changes to the file during
 #   #runtime for debugging and QA.
 #   #@author phylroy.lopez@nrcan.gc.ca
-#   #@param model1 [OpenStudio::model::Model] A model object.
-#   #@param model2 [OpenStudio::model::Model] A model object.
-#   #@param model3 [OpenStudio::model::Model] A model object.
+#   #@param model1 [OpenStudio::Model::Model] A model object.
+#   #@param model2 [OpenStudio::Model::Model] A model object.
+#   #@param model3 [OpenStudio::Model::Model] A model object.
 #   def self.kdiff3_model_idf(model1, model2, model3 = "")
 #     Dir::mkdir("C:\\kdiff_test") unless File.exists?("C:\\kdiff_test")
 #

--- a/lib/openstudio-standards/btap/vintagizer.rb
+++ b/lib/openstudio-standards/btap/vintagizer.rb
@@ -24,7 +24,7 @@ class Vintagizer
   
   #This method loads Vintage database information.
   #@author phylroy.lopez@nrcan.gc.ca
-  #@param model [OpenStudio::model::Model] A model object
+  #@param model [OpenStudio::Model::Model] A model object
   #@param file [String] 
   #@param selectionHash [???] 
   def initialize(model,file,selectionHash)

--- a/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2004/ashrae_90_1_2004.AirTerminalSingleDuctVAVReheat.rb
+++ b/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2004/ashrae_90_1_2004.AirTerminalSingleDuctVAVReheat.rb
@@ -6,7 +6,7 @@ class ASHRAE9012004 < ASHRAE901
   #
   # @param air_terminal_single_duct_vav_reheat [OpenStudio::Model::AirTerminalSingleDuctVAVReheat] the air terminal object
   # @param zone_oa_per_area [Double] the zone outdoor air per area in m^3/s*m^2
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def air_terminal_single_duct_vav_reheat_apply_initial_prototype_damper_position(air_terminal_single_duct_vav_reheat, zone_oa_per_area)
     min_damper_position = 0.3
 

--- a/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2007/ashrae_90_1_2007.AirTerminalSingleDuctVAVReheat.rb
+++ b/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2007/ashrae_90_1_2007.AirTerminalSingleDuctVAVReheat.rb
@@ -6,7 +6,7 @@ class ASHRAE9012007 < ASHRAE901
   #
   # @param air_terminal_single_duct_vav_reheat [OpenStudio::Model::AirTerminalSingleDuctVAVReheat] the air terminal object
   # @param zone_oa_per_area [Double] the zone outdoor air per area in m^3/s*m^2
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def air_terminal_single_duct_vav_reheat_apply_initial_prototype_damper_position(air_terminal_single_duct_vav_reheat, zone_oa_per_area)
     min_damper_position = 0.3
 

--- a/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2010/ashrae_90_1_2010.AirTerminalSingleDuctVAVReheat.rb
+++ b/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2010/ashrae_90_1_2010.AirTerminalSingleDuctVAVReheat.rb
@@ -6,7 +6,7 @@ class ASHRAE9012010 < ASHRAE901
   #
   # @param air_terminal_single_duct_vav_reheat [OpenStudio::Model::AirTerminalSingleDuctVAVReheat] the air terminal object
   # @param zone_oa_per_area [Double] the zone outdoor air per area in m^3/s*m^2
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def air_terminal_single_duct_vav_reheat_apply_initial_prototype_damper_position(air_terminal_single_duct_vav_reheat, zone_oa_per_area)
     min_damper_position = case air_terminal_single_duct_vav_reheat_reheat_type(air_terminal_single_duct_vav_reheat)
                           when 'HotWater'

--- a/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2010/ashrae_90_1_2010.Model.rb
+++ b/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2010/ashrae_90_1_2010.Model.rb
@@ -3,7 +3,7 @@ class ASHRAE9012010 < ASHRAE901
 
   # Determine the prototypical economizer type for the model.
   #
-  # @param model [OpenStudio::Model::Model] the model
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @return [String] the economizer type.  Possible values are:
   # 'NoEconomizer'

--- a/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2013/ashrae_90_1_2013.AirTerminalSingleDuctVAVReheat.rb
+++ b/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2013/ashrae_90_1_2013.AirTerminalSingleDuctVAVReheat.rb
@@ -6,7 +6,7 @@ class ASHRAE9012013 < ASHRAE901
   #
   # @param air_terminal_single_duct_vav_reheat [OpenStudio::Model::AirTerminalSingleDuctVAVReheat] the air terminal object
   # @param zone_oa_per_area [Double] the zone outdoor air per area in m^3/s*m^2
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def air_terminal_single_duct_vav_reheat_apply_initial_prototype_damper_position(air_terminal_single_duct_vav_reheat, zone_oa_per_area)
     min_damper_position = case air_terminal_single_duct_vav_reheat_reheat_type(air_terminal_single_duct_vav_reheat)
                           when 'HotWater'

--- a/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2013/ashrae_90_1_2013.Model.rb
+++ b/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2013/ashrae_90_1_2013.Model.rb
@@ -38,7 +38,7 @@ class ASHRAE9012013 < ASHRAE901
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_fenestration_orientation(model, climate_zone)
     # Building rotation to meet the same code requirement for
     # 90.1-2010 are kept
@@ -181,7 +181,7 @@ class ASHRAE9012013 < ASHRAE901
   # @note code_sections [90.1-2013_6.5.7.1.2]
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if transfer air is required, false if not
+  # @return [Boolean] returns true if transfer air is required, false if not
   def model_transfer_air_required?(model)
     # @todo It actually is for kitchen but not implemented yet
     return false

--- a/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2013/ashrae_90_1_2013.hvac_systems.rb
+++ b/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2013/ashrae_90_1_2013.hvac_systems.rb
@@ -4,7 +4,7 @@ class ASHRAE9012013 < ASHRAE901
   # Determine which type of fan the cooling tower will have.
   # Variable Speed Fan for ASHRAE 90.1-2013.
   #
-  # @param model [OpenStudio::Model::Model] the model
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @return [String] the fan type: TwoSpeed Fan, Variable Speed Fan
   def model_cw_loop_cooling_tower_fan_type(model)
     fan_type = 'Variable Speed Fan'

--- a/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2016/ashrae_90_1_2016.AirTerminalSingleDuctVAVReheat.rb
+++ b/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2016/ashrae_90_1_2016.AirTerminalSingleDuctVAVReheat.rb
@@ -6,7 +6,7 @@ class ASHRAE9012016 < ASHRAE901
   #
   # @param air_terminal_single_duct_vav_reheat [OpenStudio::Model::AirTerminalSingleDuctVAVReheat] the air terminal object
   # @param zone_oa_per_area [Double] the zone outdoor air per area in m^3/s*m^2
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def air_terminal_single_duct_vav_reheat_apply_initial_prototype_damper_position(air_terminal_single_duct_vav_reheat, zone_oa_per_area)
     min_damper_position = case air_terminal_single_duct_vav_reheat_reheat_type(air_terminal_single_duct_vav_reheat)
                           when 'HotWater'

--- a/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2016/ashrae_90_1_2016.Model.rb
+++ b/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2016/ashrae_90_1_2016.Model.rb
@@ -6,7 +6,7 @@ class ASHRAE9012016 < ASHRAE901
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] Returns true if successful, false otherwise
+  # @return [Boolean] Returns true if successful, false otherwise
   def model_fenestration_orientation(model, climate_zone)
     # Building rotation to meet the same code requirement for
     # 90.1-2010 are kept
@@ -200,7 +200,7 @@ class ASHRAE9012016 < ASHRAE901
   # @note code_sections [90.1-2016_6.5.7.1]
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if transfer air is required, false if not
+  # @return [Boolean] returns true if transfer air is required, false if not
   def model_transfer_air_required?(model)
     return true
   end
@@ -231,7 +231,7 @@ class ASHRAE9012016 < ASHRAE901
   # @author Xuechen (Jerry) Lei, PNNL
   #
   # @param model [OpenStudio::Model::Model] OpenStudio Model
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_add_lights_shutoff(model)
     zones = model.getThermalZones
     num_zones = 0

--- a/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2016/ashrae_90_1_2016.hvac_systems.rb
+++ b/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2016/ashrae_90_1_2016.hvac_systems.rb
@@ -4,7 +4,7 @@ class ASHRAE9012016 < ASHRAE901
   # Determine which type of fan the cooling tower will have.
   # Variable Speed Fan for ASHRAE 90.1-2016.
   #
-  # @param model [OpenStudio::Model::Model] the model
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @return [String] the fan type: TwoSpeed Fan, Variable Speed Fan
   def model_cw_loop_cooling_tower_fan_type(model)
     fan_type = 'Variable Speed Fan'

--- a/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2019/ashrae_90_1_2019.AirTerminalSingleDuctVAVReheat.rb
+++ b/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2019/ashrae_90_1_2019.AirTerminalSingleDuctVAVReheat.rb
@@ -6,7 +6,7 @@ class ASHRAE9012019 < ASHRAE901
   #
   # @param air_terminal_single_duct_vav_reheat [OpenStudio::Model::AirTerminalSingleDuctVAVReheat] the air terminal object
   # @param zone_oa_per_area [Double] the zone outdoor air per area in m^3/s*m^2
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def air_terminal_single_duct_vav_reheat_apply_initial_prototype_damper_position(air_terminal_single_duct_vav_reheat, zone_oa_per_area)
     min_damper_position = case air_terminal_single_duct_vav_reheat_reheat_type(air_terminal_single_duct_vav_reheat)
                           when 'HotWater'

--- a/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2019/ashrae_90_1_2019.Model.rb
+++ b/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2019/ashrae_90_1_2019.Model.rb
@@ -6,7 +6,7 @@ class ASHRAE9012019 < ASHRAE901
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] Returns true if successful, false otherwise
+  # @return [Boolean] Returns true if successful, false otherwise
   def model_fenestration_orientation(model, climate_zone)
     # Building rotation to meet the same code requirement for
     # 90.1-2010 are kept
@@ -200,7 +200,7 @@ class ASHRAE9012019 < ASHRAE901
   # @note code_sections [90.1-2019_6.5.7.1]
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if transfer air is required, false if not
+  # @return [Boolean] returns true if transfer air is required, false if not
   def model_transfer_air_required?(model)
     return true
   end
@@ -231,7 +231,7 @@ class ASHRAE9012019 < ASHRAE901
   # @author Xuechen (Jerry) Lei, PNNL
   #
   # @param model [OpenStudio::Model::Model] OpenStudio Model
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_add_lights_shutoff(model)
     zones = model.getThermalZones
     num_zones = 0

--- a/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2019/ashrae_90_1_2019.Space.rb
+++ b/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2019/ashrae_90_1_2019.Space.rb
@@ -3,7 +3,7 @@ class ASHRAE9012019 < ASHRAE901
 
   # Determine if a space should be modeled with an occupancy standby mode
   #
-  # @param space [OpenStudio::model::Space] OpenStudio Space object
+  # @param space [OpenStudio::Model::Space] OpenStudio Space object
   # @return [Boolean] true if occupancy standby mode is to be modeled, false otherwise
   def space_occupancy_standby_mode_required?(space)
     # Get space type
@@ -35,7 +35,7 @@ class ASHRAE9012019 < ASHRAE901
 
   # Modify thermostat schedule to account for a thermostat setback/up
   #
-  # @param thermostat [OpenStudio::model::ThermostatSetpointDualSetpoint] OpenStudio ThermostatSetpointDualSetpoint object
+  # @param thermostat [OpenStudio::Model::ThermostatSetpointDualSetpoint] OpenStudio ThermostatSetpointDualSetpoint object
   # @return [Boolean] true if success
   def space_occupancy_standby_mode(thermostat)
     htg_sch = thermostat.getHeatingSchedule.get

--- a/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2019/ashrae_90_1_2019.hvac_systems.rb
+++ b/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2019/ashrae_90_1_2019.hvac_systems.rb
@@ -4,7 +4,7 @@ class ASHRAE9012019 < ASHRAE901
   # Determine which type of fan the cooling tower will have.
   # Variable Speed Fan for ASHRAE 90.1-2019.
   #
-  # @param model [OpenStudio::Model::Model] the model
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @return [String] the fan type: TwoSpeed Fan, Variable Speed Fan
   def model_cw_loop_cooling_tower_fan_type(model)
     fan_type = 'Variable Speed Fan'

--- a/lib/openstudio-standards/prototypes/ashrae_90_1/doe_ref_1980_2004/doe_ref_1980_2004.AirTerminalSingleDuctVAVReheat.rb
+++ b/lib/openstudio-standards/prototypes/ashrae_90_1/doe_ref_1980_2004/doe_ref_1980_2004.AirTerminalSingleDuctVAVReheat.rb
@@ -6,7 +6,7 @@ class DOERef1980to2004 < ASHRAE901
   #
   # @param air_terminal_single_duct_vav_reheat [OpenStudio::Model::AirTerminalSingleDuctVAVReheat] the air terminal object
   # @param zone_oa_per_area [Double] the zone outdoor air per area in m^3/s*m^2
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def air_terminal_single_duct_vav_reheat_apply_initial_prototype_damper_position(air_terminal_single_duct_vav_reheat, zone_oa_per_area)
     # Set the minimum flow fraction
     min_damper_position = 0.3

--- a/lib/openstudio-standards/prototypes/ashrae_90_1/doe_ref_1980_2004/doe_ref_1980_2004.Model.elevators.rb
+++ b/lib/openstudio-standards/prototypes/ashrae_90_1/doe_ref_1980_2004/doe_ref_1980_2004.Model.elevators.rb
@@ -78,7 +78,7 @@ class DOERef1980to2004 < ASHRAE901
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @param elevator_type [String] valid choices are Traction, Hydraulic
-  # @param building_type [string] the building type
+  # @param building_type [String] the building type
   # @return [Double] elevator lift power in watts
   def model_elevator_lift_power(model, elevator_type, building_type)
     lift_pwr_w = 0

--- a/lib/openstudio-standards/prototypes/ashrae_90_1/doe_ref_pre_1980/doe_ref_pre_1980.AirTerminalSingleDuctVAVReheat.rb
+++ b/lib/openstudio-standards/prototypes/ashrae_90_1/doe_ref_pre_1980/doe_ref_pre_1980.AirTerminalSingleDuctVAVReheat.rb
@@ -6,7 +6,7 @@ class DOERefPre1980 < ASHRAE901
   #
   # @param air_terminal_single_duct_vav_reheat [OpenStudio::Model::AirTerminalSingleDuctVAVReheat] the air terminal object
   # @param zone_oa_per_area [Double] the zone outdoor air per area in m^3/s*m^2
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def air_terminal_single_duct_vav_reheat_apply_initial_prototype_damper_position(air_terminal_single_duct_vav_reheat, zone_oa_per_area)
     # Set the minimum flow fraction
     min_damper_position = 0.3

--- a/lib/openstudio-standards/prototypes/ashrae_90_1/doe_ref_pre_1980/doe_ref_pre_1980.CoilHeatingGas.rb
+++ b/lib/openstudio-standards/prototypes/ashrae_90_1/doe_ref_pre_1980/doe_ref_pre_1980.CoilHeatingGas.rb
@@ -6,7 +6,7 @@ class DOERefPre1980 < ASHRAE901
   # @todo Refactor: remove inconsistency in logic; all coils should be lower efficiency
   #
   # @param coil_heating_gas [OpenStudio::Model::CoilHeatingGas] a gas heating coil
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def coil_heating_gas_apply_prototype_efficiency(coil_heating_gas)
     # Only modify coils in PSZ-AC units
     name_patterns = ['PSZ-AC Gas Htg Coil',

--- a/lib/openstudio-standards/prototypes/ashrae_90_1/doe_ref_pre_1980/doe_ref_pre_1980.Model.elevators.rb
+++ b/lib/openstudio-standards/prototypes/ashrae_90_1/doe_ref_pre_1980/doe_ref_pre_1980.Model.elevators.rb
@@ -78,7 +78,7 @@ class DOERefPre1980 < ASHRAE901
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @param elevator_type [String] valid choices are Traction, Hydraulic
-  # @param building_type [string] the building type
+  # @param building_type [String] the building type
   # @return [Double] elevator lift power in watts
   def model_elevator_lift_power(model, elevator_type, building_type)
     lift_pwr_w = 0

--- a/lib/openstudio-standards/prototypes/ashrae_90_1/nrel_nze_ready_2017/nrel_zne_ready_2017.AirTerminalSingleDuctVAVReheat.rb
+++ b/lib/openstudio-standards/prototypes/ashrae_90_1/nrel_nze_ready_2017/nrel_zne_ready_2017.AirTerminalSingleDuctVAVReheat.rb
@@ -6,7 +6,7 @@ class NRELZNEReady2017 < ASHRAE901
   #
   # @param air_terminal_single_duct_vav_reheat [OpenStudio::Model::AirTerminalSingleDuctVAVReheat] the air terminal object
   # @param zone_oa_per_area [Double] the zone outdoor air per area in m^3/s*m^2
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def air_terminal_single_duct_vav_reheat_apply_initial_prototype_damper_position(air_terminal_single_duct_vav_reheat, zone_oa_per_area)
     min_damper_position = case air_terminal_single_duct_vav_reheat_reheat_type(air_terminal_single_duct_vav_reheat)
                           when 'HotWater'

--- a/lib/openstudio-standards/prototypes/ashrae_90_1/ze_aedg_multifamily/ze_aedg_multifamily.AirTerminalSingleDuctVAVReheat.rb
+++ b/lib/openstudio-standards/prototypes/ashrae_90_1/ze_aedg_multifamily/ze_aedg_multifamily.AirTerminalSingleDuctVAVReheat.rb
@@ -6,7 +6,7 @@ class ZEAEDGMultifamily < ASHRAE901
   #
   # @param air_terminal_single_duct_vav_reheat [OpenStudio::Model::AirTerminalSingleDuctVAVReheat] the air terminal object
   # @param zone_oa_per_area [Double] the zone outdoor air per area in m^3/s*m^2
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def air_terminal_single_duct_vav_reheat_apply_initial_prototype_damper_position(air_terminal_single_duct_vav_reheat, zone_oa_per_area)
     min_damper_position = case air_terminal_single_duct_vav_reheat_reheat_type(air_terminal_single_duct_vav_reheat)
                           when 'HotWater'

--- a/lib/openstudio-standards/prototypes/common/buildings/Prototype.College.rb
+++ b/lib/openstudio-standards/prototypes/common/buildings/Prototype.College.rb
@@ -4,10 +4,10 @@ module College
   # hvac adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String] the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_hvac_tweaks(model, building_type, climate_zone, prototype_input)
     OpenStudio.logFree(OpenStudio::Info, 'openstudio.model.Model', 'Started building type specific adjustments')
 
@@ -37,7 +37,7 @@ module College
   #
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def add_door_infiltration(climate_zone, model)
     return false if template == 'DOE Ref 1980-2004' || template == 'DOE Ref Pre-1980'
 
@@ -82,10 +82,10 @@ module College
   # swh adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String] the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_swh_tweaks(model, building_type, climate_zone, prototype_input)
     return true
   end
@@ -93,10 +93,10 @@ module College
   # geometry adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String] the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_geometry_tweaks(model, building_type, climate_zone, prototype_input)
     return true
   end

--- a/lib/openstudio-standards/prototypes/common/buildings/Prototype.Courthouse.rb
+++ b/lib/openstudio-standards/prototypes/common/buildings/Prototype.Courthouse.rb
@@ -4,10 +4,10 @@ module Courthouse
   # hvac adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String] the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_hvac_tweaks(model, building_type, climate_zone, prototype_input)
     OpenStudio.logFree(OpenStudio::Info, 'openstudio.model.Model', 'Started building type specific adjustments')
 
@@ -37,7 +37,7 @@ module Courthouse
   #
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def add_door_infiltration(climate_zone, model)
     # add extra infiltration for entry door in m3/s (there is no attic in 'DOE Ref Pre-1980')
     return false if template == 'DOE Ref 1980-2004' || template == 'DOE Ref Pre-1980'
@@ -67,7 +67,7 @@ module Courthouse
   # update water heater loss coefficient
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def update_waterheater_loss_coefficient(model)
     case template
     when '90.1-2004', '90.1-2007', '90.1-2010', '90.1-2013', 'NECB 2011'
@@ -82,10 +82,10 @@ module Courthouse
   # swh adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String] the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_swh_tweaks(model, building_type, climate_zone, prototype_input)
     update_waterheater_loss_coefficient(model)
 
@@ -95,10 +95,10 @@ module Courthouse
   # geometry adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String] the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_geometry_tweaks(model, building_type, climate_zone, prototype_input)
     return true
   end

--- a/lib/openstudio-standards/prototypes/common/buildings/Prototype.FullServiceRestaurant.rb
+++ b/lib/openstudio-standards/prototypes/common/buildings/Prototype.FullServiceRestaurant.rb
@@ -4,10 +4,10 @@ module FullServiceRestaurant
   # hvac adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String] the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_hvac_tweaks(model, building_type, climate_zone, prototype_input)
     OpenStudio.logFree(OpenStudio::Info, 'openstudio.model.Model', 'Started building type specific adjustments')
 
@@ -37,7 +37,7 @@ module FullServiceRestaurant
   #
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def add_door_infiltration(climate_zone, model)
     # add extra infiltration for dining room door and attic (there is no attic in 'DOE Ref Pre-1980')
     return false if template == 'DOE Ref 1980-2004' || template == 'DOE Ref Pre-1980' || template == 'NECB2011'
@@ -114,7 +114,7 @@ module FullServiceRestaurant
   # update exhuast fan efficiency
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_update_exhaust_fan_efficiency(model)
     case template
       when '90.1-2004', '90.1-2007', '90.1-2010', '90.1-2013', '90.1-2016', '90.1-2019'
@@ -137,7 +137,7 @@ module FullServiceRestaurant
   # add zone_mixing between kitchen and dining
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def add_zone_mixing(model)
     # @todo remove zone mixing objects, transfer air is the should be the same for all stds, exhaust flow varies
     space_kitchen = model.getSpaceByName('Kitchen').get
@@ -162,7 +162,7 @@ module FullServiceRestaurant
   # add extra equipment for kitchen
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def add_extra_equip_kitchen(model)
     kitchen_space = model.getSpaceByName('Kitchen')
     kitchen_space = kitchen_space.get
@@ -215,7 +215,7 @@ module FullServiceRestaurant
   # update zone sizing information
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def update_sizing_zone(model)
     case template
       when '90.1-2007', '90.1-2010', '90.1-2013', '90.1-2016', '90.1-2019'
@@ -240,7 +240,7 @@ module FullServiceRestaurant
   #
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def adjust_clg_setpoint(climate_zone, model)
     ['Dining', 'Kitchen'].each do |space_name|
       space_type_name = model.getSpaceByName(space_name).get.spaceType.get.name.get
@@ -274,7 +274,7 @@ module FullServiceRestaurant
   # It takes into account the available OSA in dining as transfer air.
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def reset_kitchen_oa(model)
     space_kitchen = model.getSpaceByName('Kitchen').get
     ventilation = space_kitchen.designSpecificationOutdoorAir.get
@@ -294,7 +294,7 @@ module FullServiceRestaurant
   # update water heater ambient conditions
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def update_waterheater_ambient_parameters(model)
     model.getWaterHeaterMixeds.sort.each do |water_heater|
       if water_heater.name.to_s.include?('Booster')
@@ -309,10 +309,10 @@ module FullServiceRestaurant
   # swh adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String] the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_swh_tweaks(model, building_type, climate_zone, prototype_input)
     update_waterheater_ambient_parameters(model)
 
@@ -322,10 +322,10 @@ module FullServiceRestaurant
   # geometry adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String] the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_geometry_tweaks(model, building_type, climate_zone, prototype_input)
     # Set original building North axis
     model_set_building_north_axis(model, 0.0)

--- a/lib/openstudio-standards/prototypes/common/buildings/Prototype.HighRiseApartment.rb
+++ b/lib/openstudio-standards/prototypes/common/buildings/Prototype.HighRiseApartment.rb
@@ -4,10 +4,10 @@ module HighriseApartment
   # hvac adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String] the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_hvac_tweaks(model, building_type, climate_zone, prototype_input)
     OpenStudio.logFree(OpenStudio::Info, 'openstudio.model.Model', 'Started building type specific HVAC adjustments')
 
@@ -50,7 +50,7 @@ module HighriseApartment
   # add elevator and lights&fans for the top floor corridor
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def add_extra_equip_corridor(model)
     corridor_top_space = model.getSpaceByName('T Corridor').get
     elec_equip_def1 = OpenStudio::Model::ElectricEquipmentDefinition.new(model)
@@ -93,7 +93,7 @@ module HighriseApartment
   #
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def add_door_infiltration(climate_zone, model)
     return false if template == 'DOE Ref 1980-2004' || template == 'DOE Ref Pre-1980'
 
@@ -128,7 +128,7 @@ module HighriseApartment
   # update fan efficiency
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_update_fan_efficiency(model)
     model.getFanOnOffs.sort.each do |fan_onoff|
       next if fan_onoff.name.get.to_s.include?('ERV')
@@ -142,10 +142,10 @@ module HighriseApartment
   # swh adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String] the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_swh_tweaks(model, building_type, climate_zone, prototype_input)
     return true
   end
@@ -153,10 +153,10 @@ module HighriseApartment
   # geometry adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String] the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_geometry_tweaks(model, building_type, climate_zone, prototype_input)
     # Set original building North axis
     model_set_building_north_axis(model, 0.0)

--- a/lib/openstudio-standards/prototypes/common/buildings/Prototype.Hospital.rb
+++ b/lib/openstudio-standards/prototypes/common/buildings/Prototype.Hospital.rb
@@ -4,10 +4,10 @@ module Hospital
   # hvac adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String] the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_hvac_tweaks(model, building_type, climate_zone, prototype_input)
     OpenStudio.logFree(OpenStudio::Info, 'openstudio.model.Model', 'Started building type specific HVAC adjustments')
 
@@ -133,7 +133,7 @@ module Hospital
   # add extra equipment for kitchen
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def add_extra_equip_kitchen(model)
     kitchen_space = model.getSpaceByName('Kitchen_Flr_5')
     kitchen_space = kitchen_space.get
@@ -176,7 +176,7 @@ module Hospital
   # update water heater ambient conditions
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def update_waterheater_ambient_parameters(model)
     model.getWaterHeaterMixeds.sort.each do |water_heater|
       if water_heater.name.to_s.include?('300gal')
@@ -195,10 +195,10 @@ module Hospital
   # swh adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String] the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_swh_tweaks(model, building_type, climate_zone, prototype_input)
     update_waterheater_ambient_parameters(model)
 
@@ -208,7 +208,7 @@ module Hospital
   # reset kitchen outdoor air
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def reset_kitchen_oa(model)
     space_kitchen = model.getSpaceByName('Kitchen_Flr_5').get
     ventilation = space_kitchen.designSpecificationOutdoorAir.get
@@ -226,7 +226,7 @@ module Hospital
   # update exhuast fan efficiency
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_update_exhaust_fan_efficiency(model)
     case template
       when '90.1-2004', '90.1-2007', '90.1-2010', '90.1-2013', '90.1-2016', '90.1-2019'
@@ -248,7 +248,7 @@ module Hospital
   # @param space_name [String] space name
   # @param hot_water_loop [OpenStudio::Model::PlantLoop] hot water loop
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def add_humidifier(space_name, hot_water_loop, model)
     space = model.getSpaceByName(space_name).get
     zone = space.thermalZone.get
@@ -295,7 +295,7 @@ module Hospital
   # add daylighting controls
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_add_daylighting_controls(model)
     space_names = ['Office1_Flr_5', 'Office3_Flr_5', 'Lobby_Records_Flr_1']
     space_names.each do |space_name|
@@ -308,7 +308,7 @@ module Hospital
   # For operating room 1&2 in 2010 and 2013, VAV minimum air flow is set by schedule
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_adjust_vav_minimum_damper(model)
     model.getThermalZones.each do |zone|
       air_terminal = zone.airLoopHVACTerminal
@@ -348,7 +348,7 @@ module Hospital
   #
   # @param prototype_input [Hash] hash of prototype inputs
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_reset_or_room_vav_minimum_damper(prototype_input, model)
     case template
     when '90.1-2010', '90.1-2013', '90.1-2016', '90.1-2019'
@@ -370,7 +370,7 @@ module Hospital
   # certain air handlers do not have an economizer
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_modify_oa_controller(model)
     model.getAirLoopHVACs.sort.each do |air_loop|
       oa_sys = air_loop.airLoopHVACOutdoorAirSystem.get
@@ -386,10 +386,10 @@ module Hospital
   # geometry adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String] the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_geometry_tweaks(model, building_type, climate_zone, prototype_input)
     # Set original building North axis
     model_set_building_north_axis(model, 0.0)
@@ -403,7 +403,7 @@ module Hospital
   #
   # @param air_terminal_single_duct_vav_reheat [OpenStudio::Model::AirTerminalSingleDuctVAVReheat] the air terminal object
   # @param zone_oa_per_area [Double] the zone outdoor air per area in m^3/s*m^2
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def air_terminal_single_duct_vav_reheat_apply_initial_prototype_damper_position(air_terminal_single_duct_vav_reheat, zone_oa_per_area)
     min_damper_position = template == '90.1-2010' || template == '90.1-2013' || template == '90.1-2016' || template == '90.1-2019' ? 0.2 : 0.3
 

--- a/lib/openstudio-standards/prototypes/common/buildings/Prototype.Laboratory.rb
+++ b/lib/openstudio-standards/prototypes/common/buildings/Prototype.Laboratory.rb
@@ -4,10 +4,10 @@ module Laboratory
   # hvac adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String] the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_hvac_tweaks(model, building_type, climate_zone, prototype_input)
     OpenStudio.logFree(OpenStudio::Info, 'openstudio.model.Model', 'Started building type specific adjustments')
 
@@ -59,7 +59,7 @@ module Laboratory
   # lab zones don't have economizer, the air flow rate is determined by the ventilation requirement
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_modify_oa_controller(model)
     model.getAirLoopHVACs.sort.each do |air_loop|
       oa_sys = air_loop.airLoopHVACOutdoorAirSystem.get
@@ -74,10 +74,10 @@ module Laboratory
   # swh adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String] the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_swh_tweaks(model, building_type, climate_zone, prototype_input)
     return true
   end
@@ -85,10 +85,10 @@ module Laboratory
   # geometry adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String] the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_geometry_tweaks(model, building_type, climate_zone, prototype_input)
     return true
   end

--- a/lib/openstudio-standards/prototypes/common/buildings/Prototype.LargeDataCenterHighITE.rb
+++ b/lib/openstudio-standards/prototypes/common/buildings/Prototype.LargeDataCenterHighITE.rb
@@ -4,10 +4,10 @@ module LargeDataCenterHighITE
   # hvac adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String] the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_hvac_tweaks(model, building_type, climate_zone, prototype_input)
     OpenStudio.logFree(OpenStudio::Info, 'openstudio.model.Model', 'Started building type specific adjustments')
 
@@ -27,7 +27,7 @@ module LargeDataCenterHighITE
   # Normal electric equipment has been added in model_add_load prior to this will replace with ITE object here
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def add_data_center_load(model)
     model.getSpaceTypes.each do |space_type|
       # Get the standards data
@@ -121,7 +121,7 @@ module LargeDataCenterHighITE
   # modify CRAH supply air setpoint manager
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def modify_crah_sa_stpt_manager(model)
     supply_temp_sch = get_crah_supply_temp_sch(model)
     model.getSetpointManagerScheduleds.each do |stpt_manager|
@@ -180,10 +180,10 @@ module LargeDataCenterHighITE
   # swh adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String] the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_swh_tweaks(model, building_type, climate_zone, prototype_input)
     return true
   end
@@ -191,10 +191,10 @@ module LargeDataCenterHighITE
   # geometry adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String] the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_geometry_tweaks(model, building_type, climate_zone, prototype_input)
     return true
   end

--- a/lib/openstudio-standards/prototypes/common/buildings/Prototype.LargeDataCenterLowITE.rb
+++ b/lib/openstudio-standards/prototypes/common/buildings/Prototype.LargeDataCenterLowITE.rb
@@ -4,10 +4,10 @@ module LargeDataCenterLowITE
   # hvac adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String] the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_hvac_tweaks(model, building_type, climate_zone, prototype_input)
     OpenStudio.logFree(OpenStudio::Info, 'openstudio.model.Model', 'Started building type specific adjustments')
 
@@ -27,7 +27,7 @@ module LargeDataCenterLowITE
   # Normal electric equipment has been added in model_add_load prior to this will replace with ITE object here
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def add_data_center_load(model)
     model.getSpaceTypes.each do |space_type|
       # Get the standards data
@@ -123,7 +123,7 @@ module LargeDataCenterLowITE
   # modify CRAH supply air setpoint manager
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def modify_crah_sa_stpt_manager(model)
     supply_temp_sch = get_crah_supply_temp_sch(model)
     model.getSetpointManagerScheduleds.each do |stpt_manager|
@@ -181,10 +181,10 @@ module LargeDataCenterLowITE
   # swh adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String] the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_swh_tweaks(model, building_type, climate_zone, prototype_input)
     return true
   end
@@ -192,10 +192,10 @@ module LargeDataCenterLowITE
   # geometry adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String] the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_geometry_tweaks(model, building_type, climate_zone, prototype_input)
     return true
   end

--- a/lib/openstudio-standards/prototypes/common/buildings/Prototype.LargeHotel.rb
+++ b/lib/openstudio-standards/prototypes/common/buildings/Prototype.LargeHotel.rb
@@ -4,10 +4,10 @@ module LargeHotel
   # hvac adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String] the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_hvac_tweaks(model, building_type, climate_zone, prototype_input)
     OpenStudio.logFree(OpenStudio::Info, 'openstudio.model.Model', 'Started building type specific HVAC adjustments')
 
@@ -147,7 +147,7 @@ module LargeHotel
   # add extra equipment for kitchen
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def add_extra_equip_kitchen(model)
     kitchen_space = model.getSpaceByName('Kitchen_Flr_6')
     kitchen_space = kitchen_space.get
@@ -192,7 +192,7 @@ module LargeHotel
   # Add the daylighting controls for lobby, cafe, dinning and banquet
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_add_daylighting_controls(model)
     space_names = ['Banquet_Flr_6', 'Dining_Flr_6', 'Cafe_Flr_1', 'Lobby_Flr_1']
     space_names.each do |space_name|
@@ -205,7 +205,7 @@ module LargeHotel
   # update water heater ambient conditions
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def update_waterheater_ambient_parameters(model)
     model.getWaterHeaterMixeds.sort.each do |water_heater|
       if water_heater.name.to_s.include?('300gal')
@@ -224,10 +224,10 @@ module LargeHotel
   # swh adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String] the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_swh_tweaks(model, building_type, climate_zone, prototype_input)
     update_waterheater_ambient_parameters(model)
     return true
@@ -236,10 +236,10 @@ module LargeHotel
   # geometry adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String] the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_geometry_tweaks(model, building_type, climate_zone, prototype_input)
     # Set original building North axis
     model_set_building_north_axis(model, 0.0)
@@ -253,7 +253,7 @@ module LargeHotel
   #
   # @param air_terminal_single_duct_vav_reheat [OpenStudio::Model::AirTerminalSingleDuctVAVReheat] the air terminal object
   # @param zone_oa_per_area [Double] the zone outdoor air per area in m^3/s*m^2
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def air_terminal_single_duct_vav_reheat_apply_initial_prototype_damper_position(air_terminal_single_duct_vav_reheat, zone_oa_per_area)
     min_damper_position = template == '90.1-2010' || template == '90.1-2013' || template == '90.1-2016' || template == '90.1-2019' ? 0.2 : 0.3
 
@@ -265,7 +265,7 @@ module LargeHotel
 
   # Type of SAT reset for this building type
   #
-  # @param air_loop_hvac [OpenStudio::model::AirLoopHVAC] air loop
+  # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @return [String] Returns type of SAT reset
   def air_loop_hvac_supply_air_temperature_reset_type(air_loop_hvac)
     return 'oa'

--- a/lib/openstudio-standards/prototypes/common/buildings/Prototype.LargeOffice.rb
+++ b/lib/openstudio-standards/prototypes/common/buildings/Prototype.LargeOffice.rb
@@ -4,10 +4,10 @@ module LargeOffice
   # hvac adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String] the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_hvac_tweaks(model, building_type, climate_zone, prototype_input)
     OpenStudio.logFree(OpenStudio::Info, 'openstudio.model.Model', 'Started building type specific HVAC adjustments')
 
@@ -119,10 +119,10 @@ module LargeOffice
   # swh adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String] the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_swh_tweaks(model, building_type, climate_zone, prototype_input)
     return true
   end
@@ -130,10 +130,10 @@ module LargeOffice
   # geometry adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String] the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_geometry_tweaks(model, building_type, climate_zone, prototype_input)
     # Set original building North axis
     model_set_building_north_axis(model, 0.0)
@@ -147,7 +147,7 @@ module LargeOffice
   #
   # @param air_terminal_single_duct_vav_reheat [OpenStudio::Model::AirTerminalSingleDuctVAVReheat] the air terminal object
   # @param zone_oa_per_area [Double] the zone outdoor air per area in m^3/s*m^2
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def air_terminal_single_duct_vav_reheat_apply_initial_prototype_damper_position(air_terminal_single_duct_vav_reheat, zone_oa_per_area)
     min_damper_position = template == '90.1-2010' || template == '90.1-2013' || template == '90.1-2016' || template == '90.1-2019' ? 0.2 : 0.3
 

--- a/lib/openstudio-standards/prototypes/common/buildings/Prototype.LargeOfficeDetailed.rb
+++ b/lib/openstudio-standards/prototypes/common/buildings/Prototype.LargeOfficeDetailed.rb
@@ -4,10 +4,10 @@ module LargeOfficeDetailed
   # hvac adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_hvac_tweaks(model, building_type, climate_zone, prototype_input)
     system_to_space_map = define_hvac_system_map(building_type, climate_zone)
 
@@ -89,7 +89,7 @@ module LargeOfficeDetailed
   # remove basement infiltration
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def remove_basement_infiltration(model)
     space_infltrations = model.getSpaceInfiltrationDesignFlowRates
     space_infltrations.each do |space_inf|
@@ -103,7 +103,7 @@ module LargeOfficeDetailed
   # update water heater loss coefficient
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def update_waterheater_loss_coefficient(model)
     case template
       when '90.1-2004', '90.1-2007', '90.1-2010', '90.1-2013', '90.1-2016', '90.1-2019', 'NECB2011'
@@ -118,10 +118,10 @@ module LargeOfficeDetailed
   # swh adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_swh_tweaks(model, building_type, climate_zone, prototype_input)
     update_waterheater_loss_coefficient(model)
     return true
@@ -130,10 +130,10 @@ module LargeOfficeDetailed
   # geometry adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_geometry_tweaks(model, building_type, climate_zone, prototype_input)
     # Set original building North axis
     model_set_building_north_axis(model, 0.0)
@@ -147,7 +147,7 @@ module LargeOfficeDetailed
   #
   # @param air_terminal_single_duct_vav_reheat [OpenStudio::Model::AirTerminalSingleDuctVAVReheat] the air terminal object
   # @param zone_oa_per_area [Double] the zone outdoor air per area in m^3/s*m^2
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def air_terminal_single_duct_vav_reheat_apply_initial_prototype_damper_position(air_terminal_single_duct_vav_reheat, zone_oa_per_area)
     min_damper_position = template == '90.1-2010' || template == '90.1-2013' || template == '90.1-2016' || template == '90.1-2019' ? 0.2 : 0.3
 

--- a/lib/openstudio-standards/prototypes/common/buildings/Prototype.MediumOffice.rb
+++ b/lib/openstudio-standards/prototypes/common/buildings/Prototype.MediumOffice.rb
@@ -4,10 +4,10 @@ module MediumOffice
   # hvac adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_hvac_tweaks(model, building_type, climate_zone, prototype_input)
     OpenStudio.logFree(OpenStudio::Info, 'openstudio.model.Model', 'Started building type specific HVAC adjustments')
 
@@ -90,7 +90,7 @@ module MediumOffice
   #
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def add_door_infiltration(climate_zone, model)
     # add extra infiltration for entry door in m3/s (there is no attic in 'DOE Ref Pre-1980')
     return false if template == 'DOE Ref 1980-2004' || template == 'DOE Ref Pre-1980'
@@ -135,10 +135,10 @@ module MediumOffice
   # swh adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_swh_tweaks(model, building_type, climate_zone, prototype_input)
     return true
   end
@@ -146,10 +146,10 @@ module MediumOffice
   # geometry adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_geometry_tweaks(model, building_type, climate_zone, prototype_input)
     # Set original building North axis
     model_set_building_north_axis(model, 0.0)
@@ -163,7 +163,7 @@ module MediumOffice
   #
   # @param air_terminal_single_duct_vav_reheat [OpenStudio::Model::AirTerminalSingleDuctVAVReheat] the air terminal object
   # @param zone_oa_per_area [Double] the zone outdoor air per area in m^3/s*m^2
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def air_terminal_single_duct_vav_reheat_apply_initial_prototype_damper_position(air_terminal_single_duct_vav_reheat, zone_oa_per_area)
     min_damper_position = template == '90.1-2010' || template == '90.1-2013' || template == '90.1-2016' || template == '90.1-2019' ? 0.2 : 0.3
 

--- a/lib/openstudio-standards/prototypes/common/buildings/Prototype.MediumOfficeDetailed.rb
+++ b/lib/openstudio-standards/prototypes/common/buildings/Prototype.MediumOfficeDetailed.rb
@@ -4,10 +4,10 @@ module MediumOfficeDetailed
   # hvac adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_hvac_tweaks(model, building_type, climate_zone, prototype_input)
     OpenStudio.logFree(OpenStudio::Info, 'openstudio.model.Model', 'Started building type specific adjustments')
 
@@ -37,7 +37,7 @@ module MediumOfficeDetailed
   #
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def add_door_infiltration(climate_zone, model)
     # add extra infiltration for entry door in m3/s (there is no attic in 'DOE Ref Pre-1980')
     return false if template == 'DOE Ref 1980-2004' || template == 'DOE Ref Pre-1980'
@@ -67,10 +67,10 @@ module MediumOfficeDetailed
   # # daylighting adjustments specific to the prototype model
   # #
   # # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # # @param building_type [string] the building type
+  # # @param building_type [String the building type
   # # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # # @param prototype_input [Hash] hash of prototype inputs
-  # # @return [Bool] returns true if successful, false if not
+  # # @return [Boolean] returns true if successful, false if not
   # def model_custom_daylighting_tweaks(model, building_type, climate_zone, prototype_input)
   #   OpenStudio.logFree(OpenStudio::Info, 'openstudio.model.Model', 'Adjusting daylight sensor positions and fractions')
   #
@@ -128,7 +128,7 @@ module MediumOfficeDetailed
   # update water heater loss coefficient
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def update_waterheater_loss_coefficient(model)
     case template
       when '90.1-2004', '90.1-2007', '90.1-2010', '90.1-2013', '90.1-2016', '90.1-2019', 'NECB2011'
@@ -143,10 +143,10 @@ module MediumOfficeDetailed
   # swh adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_swh_tweaks(model, building_type, climate_zone, prototype_input)
     update_waterheater_loss_coefficient(model)
 
@@ -156,10 +156,10 @@ module MediumOfficeDetailed
   # geometry adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_geometry_tweaks(model, building_type, climate_zone, prototype_input)
     # Set original building North axis
     model_set_building_north_axis(model, 0.0)
@@ -173,7 +173,7 @@ module MediumOfficeDetailed
   #
   # @param air_terminal_single_duct_vav_reheat [OpenStudio::Model::AirTerminalSingleDuctVAVReheat] the air terminal object
   # @param zone_oa_per_area [Double] the zone outdoor air per area in m^3/s*m^2
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def air_terminal_single_duct_vav_reheat_apply_initial_prototype_damper_position(air_terminal_single_duct_vav_reheat, zone_oa_per_area)
     min_damper_position = template == '90.1-2010' || template == '90.1-2013' || template == '90.1-2016' || template == '90.1-2019' ? 0.2 : 0.3
 

--- a/lib/openstudio-standards/prototypes/common/buildings/Prototype.MidriseApartment.rb
+++ b/lib/openstudio-standards/prototypes/common/buildings/Prototype.MidriseApartment.rb
@@ -4,10 +4,10 @@ module MidriseApartment
   # hvac adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_hvac_tweaks(model, building_type, climate_zone, prototype_input)
     OpenStudio.logFree(OpenStudio::Info, 'openstudio.model.Model', 'Started building type specific adjustments')
 
@@ -26,7 +26,7 @@ module MidriseApartment
   # adjust office cooling setpoint in specific climate zones
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def adjust_clg_setpoint(climate_zone, model)
     space_name = 'Office'
     space_type_name = model.getSpaceByName(space_name).get.spaceType.get.name.get
@@ -52,7 +52,7 @@ module MidriseApartment
   # add elevator and lights&fans for the ground floor corridor
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def add_extra_equip_corridor(model)
     corridor_ground_space = model.getSpaceByName('G Corridor').get
     elec_equip_def1 = OpenStudio::Model::ElectricEquipmentDefinition.new(model)
@@ -107,7 +107,7 @@ module MidriseApartment
   #
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def add_door_infiltration(climate_zone, model)
     return false if template == 'DOE Ref 1980-2004' || template == 'DOE Ref Pre-1980'
 
@@ -169,10 +169,10 @@ module MidriseApartment
   # swh adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_swh_tweaks(model, building_type, climate_zone, prototype_input)
     return true
   end
@@ -180,10 +180,10 @@ module MidriseApartment
   # geometry adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_geometry_tweaks(model, building_type, climate_zone, prototype_input)
     # Set original building North axis
     model_set_building_north_axis(model, 0.0)

--- a/lib/openstudio-standards/prototypes/common/buildings/Prototype.Outpatient.rb
+++ b/lib/openstudio-standards/prototypes/common/buildings/Prototype.Outpatient.rb
@@ -4,10 +4,10 @@ module Outpatient
   # hvac adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_hvac_tweaks(model, building_type, climate_zone, prototype_input)
     OpenStudio.logFree(OpenStudio::Info, 'openstudio.model.Model', 'Started Adding HVAC')
 
@@ -82,7 +82,7 @@ module Outpatient
   # add extra equipment for mechanical room
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def add_extra_equip_elevator_pump_room(model)
     elevator_pump_room = model.getSpaceByName('Floor 1 Elevator Pump Room').get
     elec_equip_def = OpenStudio::Model::ElectricEquipmentDefinition.new(model)
@@ -135,7 +135,7 @@ module Outpatient
   #
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def adjust_clg_setpoint(climate_zone, model)
     model.getSpaceTypes.sort.each do |space_type|
       space_type_name = space_type.name.get
@@ -162,7 +162,7 @@ module Outpatient
   # adjust infiltration
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def adjust_infiltration(model)
     case template
       when 'DOE Ref Pre-1980', 'DOE Ref 1980-2004'
@@ -204,7 +204,7 @@ module Outpatient
   #
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def add_door_infiltration(climate_zone, model)
     # add extra infiltration for vestibule door
     case template
@@ -246,7 +246,7 @@ module Outpatient
   #
   # @param hot_water_loop [OpenStudio::Model::PlantLoop] hot water loop
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def add_humidifier(hot_water_loop, model)
     operatingroom1_space = model.getSpaceByName('Floor 1 Operating Room 1').get
     operatingroom1_zone = operatingroom1_space.thermalZone.get
@@ -293,7 +293,7 @@ module Outpatient
   # AHU1 doesn't have economizer
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_modify_oa_controller(model)
     model.getAirLoopHVACs.sort.each do |air_loop|
       oa_system = air_loop.airLoopHVACOutdoorAirSystem.get
@@ -318,7 +318,7 @@ module Outpatient
   # adjust room vav damper minimums
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_adjust_vav_minimum_damper(model)
     # Minimum damper position for Outpatient prototype
     # Based on AIA 2001 ventilation requirements
@@ -385,7 +385,7 @@ module Outpatient
   #
   # @param prototype_input [Hash] hash of prototype inputs
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_reset_or_room_vav_minimum_damper(prototype_input, model)
     case template
     when '90.1-2010', '90.1-2013', '90.1-2016', '90.1-2019'
@@ -407,7 +407,7 @@ module Outpatient
   # reset boiler sizing factor
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def reset_boiler_sizing_factor(model)
     model.getBoilerHotWaters.sort.each do |boiler|
       boiler.setSizingFactor(0.3)
@@ -418,7 +418,7 @@ module Outpatient
   # update exhuast fan efficiency
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_update_exhaust_fan_efficiency(model)
     case template
       when '90.1-2004', '90.1-2007', '90.1-2010', '90.1-2013', '90.1-2016', '90.1-2019'
@@ -443,9 +443,9 @@ module Outpatient
 
   # assign the minimum total air changes to the cooling minimum air flow in Sizing:Zone
   #
-  # @param building_type [string] the building type
+  # @param building_type [String the building type
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def apply_minimum_total_ach(building_type, model)
     model.getSpaces.sort.each do |space|
       space_type_name = space.spaceType.get.standardsSpaceType.get
@@ -487,10 +487,10 @@ module Outpatient
   # swh adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_swh_tweaks(model, building_type, climate_zone, prototype_input)
     return true
   end
@@ -498,10 +498,10 @@ module Outpatient
   # geometry adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_geometry_tweaks(model, building_type, climate_zone, prototype_input)
     # Set original building North axis
     model_set_building_north_axis(model, 0.0)
@@ -515,7 +515,7 @@ module Outpatient
   #
   # @param air_terminal_single_duct_vav_reheat [OpenStudio::Model::AirTerminalSingleDuctVAVReheat] the air terminal object
   # @param zone_oa_per_area [Double] the zone outdoor air per area in m^3/s*m^2
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def air_terminal_single_duct_vav_reheat_apply_initial_prototype_damper_position(air_terminal_single_duct_vav_reheat, zone_oa_per_area)
     # Minimum damper position
     # Based on AIA 2001 ventilation requirements

--- a/lib/openstudio-standards/prototypes/common/buildings/Prototype.PrimarySchool.rb
+++ b/lib/openstudio-standards/prototypes/common/buildings/Prototype.PrimarySchool.rb
@@ -4,10 +4,10 @@ module PrimarySchool
   # hvac adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_hvac_tweaks(model, building_type, climate_zone, prototype_input)
     OpenStudio.logFree(OpenStudio::Info, 'openstudio.model.Model', 'Started building type specific HVAC adjustments')
 
@@ -38,7 +38,7 @@ module PrimarySchool
   # add extra equipment for kitchen
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def add_extra_equip_kitchen(model)
     kitchen_space = model.getSpaceByName('Kitchen_ZN_1_FLR_1')
     kitchen_space = kitchen_space.get
@@ -81,7 +81,7 @@ module PrimarySchool
   # update water heater ambient conditions
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def update_waterheater_ambient_parameters(model)
     model.getWaterHeaterMixeds.sort.each do |water_heater|
       if water_heater.name.to_s.include?('Booster')
@@ -96,10 +96,10 @@ module PrimarySchool
   # swh adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_swh_tweaks(model, building_type, climate_zone, prototype_input)
     update_waterheater_ambient_parameters(model)
     return true
@@ -108,10 +108,10 @@ module PrimarySchool
   # geometry adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_geometry_tweaks(model, building_type, climate_zone, prototype_input)
     # Set original building North axis
     model_set_building_north_axis(model, 0.0)
@@ -125,7 +125,7 @@ module PrimarySchool
   #
   # @param air_terminal_single_duct_vav_reheat [OpenStudio::Model::AirTerminalSingleDuctVAVReheat] the air terminal object
   # @param zone_oa_per_area [Double] the zone outdoor air per area in m^3/s*m^2
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def air_terminal_single_duct_vav_reheat_apply_initial_prototype_damper_position(air_terminal_single_duct_vav_reheat, zone_oa_per_area)
     min_damper_position = template == '90.1-2010' || template == '90.1-2013' || template == '90.1-2016' || template == '90.1-2019' ? 0.2 : 0.3
 
@@ -137,7 +137,7 @@ module PrimarySchool
 
   # Type of SAT reset for this building type
   #
-  # @param air_loop_hvac [OpenStudio::model::AirLoopHVAC] air loop
+  # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @return [String] Returns type of SAT reset
   def air_loop_hvac_supply_air_temperature_reset_type(air_loop_hvac)
     return 'oa'

--- a/lib/openstudio-standards/prototypes/common/buildings/Prototype.QuickServiceRestaurant.rb
+++ b/lib/openstudio-standards/prototypes/common/buildings/Prototype.QuickServiceRestaurant.rb
@@ -4,10 +4,10 @@ module QuickServiceRestaurant
   # hvac adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_hvac_tweaks(model, building_type, climate_zone, prototype_input)
     OpenStudio.logFree(OpenStudio::Info, 'openstudio.model.Model', 'Started building type specific adjustments')
 
@@ -37,7 +37,7 @@ module QuickServiceRestaurant
   #
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def add_door_infiltration(climate_zone, model)
     # add extra infiltration for dining room door and attic (there is no attic in 'DOE Ref Pre-1980')
     return false if template == 'DOE Ref 1980-2004' || template == 'DOE Ref Pre-1980'
@@ -114,7 +114,7 @@ module QuickServiceRestaurant
   # add extra equipment for kitchen
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def add_extra_equip_kitchen(model)
     kitchen_space = model.getSpaceByName('Kitchen')
     kitchen_space = kitchen_space.get
@@ -167,7 +167,7 @@ module QuickServiceRestaurant
   # update zone sizing information
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def update_sizing_zone(model)
     case template
       when '90.1-2007', '90.1-2010', '90.1-2013', '90.1-2016', '90.1-2019'
@@ -192,7 +192,7 @@ module QuickServiceRestaurant
   #
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def adjust_clg_setpoint(climate_zone, model)
     ['Dining', 'Kitchen'].each do |space_name|
       space_type_name = model.getSpaceByName(space_name).get.spaceType.get.name.get
@@ -226,7 +226,7 @@ module QuickServiceRestaurant
   # It takes into account the available OSA in dining as transfer air.
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def reset_kitchen_oa(model)
     space_kitchen = model.getSpaceByName('Kitchen').get
     ventilation = space_kitchen.designSpecificationOutdoorAir.get
@@ -244,7 +244,7 @@ module QuickServiceRestaurant
   # update exhuast fan efficiency
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_update_exhaust_fan_efficiency(model)
     case template
       when '90.1-2004', '90.1-2007', '90.1-2010', '90.1-2013', '90.1-2016', '90.1-2019'
@@ -267,7 +267,7 @@ module QuickServiceRestaurant
   # add zone_mixing between kitchen and dining
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def add_zone_mixing(model)
     # @todo remove zone mixing objects, transfer air is the should be the same for all stds, exhaust flow varies
     space_kitchen = model.getSpaceByName('Kitchen').get
@@ -292,10 +292,10 @@ module QuickServiceRestaurant
   # swh adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_swh_tweaks(model, building_type, climate_zone, prototype_input)
     return true
   end
@@ -303,10 +303,10 @@ module QuickServiceRestaurant
   # geometry adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_geometry_tweaks(model, building_type, climate_zone, prototype_input)
     # Set original building North axis
     model_set_building_north_axis(model, 0.0)

--- a/lib/openstudio-standards/prototypes/common/buildings/Prototype.RetailStandalone.rb
+++ b/lib/openstudio-standards/prototypes/common/buildings/Prototype.RetailStandalone.rb
@@ -10,10 +10,10 @@ module RetailStandalone
   # hvac adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_hvac_tweaks(model, building_type, climate_zone, prototype_input)
     OpenStudio.logFree(OpenStudio::Info, 'openstudio.model.Model', 'Started building type specific adjustments')
 
@@ -119,10 +119,10 @@ module RetailStandalone
   # swh adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_swh_tweaks(model, building_type, climate_zone, prototype_input)
     return true
   end
@@ -130,10 +130,10 @@ module RetailStandalone
   # geometry adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_geometry_tweaks(model, building_type, climate_zone, prototype_input)
     # Set original building North axis
     model_set_building_north_axis(model, 0.0)

--- a/lib/openstudio-standards/prototypes/common/buildings/Prototype.RetailStripmall.rb
+++ b/lib/openstudio-standards/prototypes/common/buildings/Prototype.RetailStripmall.rb
@@ -4,10 +4,10 @@ module RetailStripmall
   # hvac adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_hvac_tweaks(model, building_type, climate_zone, prototype_input)
     OpenStudio.logFree(OpenStudio::Info, 'openstudio.model.Model', 'Started building type specific adjustments')
 
@@ -88,10 +88,10 @@ module RetailStripmall
   # swh adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_swh_tweaks(model, building_type, climate_zone, prototype_input)
     return true
   end
@@ -99,10 +99,10 @@ module RetailStripmall
   # geometry adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_geometry_tweaks(model, building_type, climate_zone, prototype_input)
     # Set original building North axis
     model_set_building_north_axis(model, 0.0)

--- a/lib/openstudio-standards/prototypes/common/buildings/Prototype.SecondarySchool.rb
+++ b/lib/openstudio-standards/prototypes/common/buildings/Prototype.SecondarySchool.rb
@@ -4,10 +4,10 @@ module SecondarySchool
   # hvac adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_hvac_tweaks(model, building_type, climate_zone, prototype_input)
     OpenStudio.logFree(OpenStudio::Info, 'openstudio.model.Model', 'Started building type specific HVAC adjustments')
 
@@ -75,7 +75,7 @@ module SecondarySchool
   # add extra equipment for kitchen
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def add_extra_equip_kitchen(model)
     kitchen_space = model.getSpaceByName('Kitchen_ZN_1_FLR_1')
     kitchen_space = kitchen_space.get
@@ -118,7 +118,7 @@ module SecondarySchool
   # update water heater ambient conditions
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def update_waterheater_ambient_parameters(model)
     model.getWaterHeaterMixeds.sort.each do |water_heater|
       if water_heater.name.to_s.include?('Booster')
@@ -133,10 +133,10 @@ module SecondarySchool
   # swh adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_swh_tweaks(model, building_type, climate_zone, prototype_input)
     update_waterheater_ambient_parameters(model)
 
@@ -150,10 +150,10 @@ module SecondarySchool
   # geometry adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_geometry_tweaks(model, building_type, climate_zone, prototype_input)
     # Set original building North axis
     model_set_building_north_axis(model, 0.0)
@@ -167,7 +167,7 @@ module SecondarySchool
   #
   # @param air_terminal_single_duct_vav_reheat [OpenStudio::Model::AirTerminalSingleDuctVAVReheat] the air terminal object
   # @param zone_oa_per_area [Double] the zone outdoor air per area in m^3/s*m^2
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def air_terminal_single_duct_vav_reheat_apply_initial_prototype_damper_position(air_terminal_single_duct_vav_reheat, zone_oa_per_area)
     min_damper_position = template == '90.1-2010' || template == '90.1-2013' || template == '90.1-2016' || template == '90.1-2019' ? 0.2 : 0.3
 

--- a/lib/openstudio-standards/prototypes/common/buildings/Prototype.SmallDataCenterHighITE.rb
+++ b/lib/openstudio-standards/prototypes/common/buildings/Prototype.SmallDataCenterHighITE.rb
@@ -4,10 +4,10 @@ module SmallDataCenterHighITE
   # hvac adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_hvac_tweaks(model, building_type, climate_zone, prototype_input)
     OpenStudio.logFree(OpenStudio::Info, 'openstudio.model.Model', 'Started building type specific adjustments')
 
@@ -27,7 +27,7 @@ module SmallDataCenterHighITE
   # Normal electric equipment has been added in model_add_load prior to this will replace with ITE object here
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def add_data_center_load(model)
     model.getSpaceTypes.each do |space_type|
       # Get the standards data
@@ -76,7 +76,7 @@ module SmallDataCenterHighITE
   # modify CRAC supply air setpoint manager
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def modify_crac_sa_stpt_manager(model)
     supply_temp_sch = get_crac_supply_temp_sch(model)
     model.getSetpointManagerScheduleds.each do |stpt_manager|
@@ -134,10 +134,10 @@ module SmallDataCenterHighITE
   # swh adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_swh_tweaks(model, building_type, climate_zone, prototype_input)
     return true
   end
@@ -145,10 +145,10 @@ module SmallDataCenterHighITE
   # geometry adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_geometry_tweaks(model, building_type, climate_zone, prototype_input)
     return true
   end

--- a/lib/openstudio-standards/prototypes/common/buildings/Prototype.SmallDataCenterLowITE.rb
+++ b/lib/openstudio-standards/prototypes/common/buildings/Prototype.SmallDataCenterLowITE.rb
@@ -4,10 +4,10 @@ module SmallDataCenterLowITE
   # hvac adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_hvac_tweaks(model, building_type, climate_zone, prototype_input)
     OpenStudio.logFree(OpenStudio::Info, 'openstudio.model.Model', 'Started building type specific adjustments')
 
@@ -27,7 +27,7 @@ module SmallDataCenterLowITE
   # Normal electric equipment has been added in model_add_load prior to this will replace with ITE object here
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def add_data_center_load(model)
     model.getSpaceTypes.each do |space_type|
       # Get the standards data
@@ -75,7 +75,7 @@ module SmallDataCenterLowITE
   # modify CRAC supply air setpoint manager
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def modify_crac_sa_stpt_manager(model)
     supply_temp_sch = get_crac_supply_temp_sch(model)
     model.getSetpointManagerScheduleds.each do |stpt_manager|
@@ -133,10 +133,10 @@ module SmallDataCenterLowITE
   # swh adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_swh_tweaks(model, building_type, climate_zone, prototype_input)
     return true
   end
@@ -144,10 +144,10 @@ module SmallDataCenterLowITE
   # geometry adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_geometry_tweaks(model, building_type, climate_zone, prototype_input)
     return true
   end

--- a/lib/openstudio-standards/prototypes/common/buildings/Prototype.SmallHotel.rb
+++ b/lib/openstudio-standards/prototypes/common/buildings/Prototype.SmallHotel.rb
@@ -4,10 +4,10 @@ module SmallHotel
   # hvac adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_hvac_tweaks(model, building_type, climate_zone, prototype_input)
     OpenStudio.logFree(OpenStudio::Info, 'openstudio.model.Model', 'Started building type specific adjustments')
 
@@ -70,7 +70,7 @@ module SmallHotel
   # add this for elevator lights/fans (elevator lift is implemented through standard lookup)
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def add_extra_equip_elevator_coreflr1(model)
     elevator_coreflr1 = model.getSpaceByName('ElevatorCoreFlr1').get
     elec_equip_def = OpenStudio::Model::ElectricEquipmentDefinition.new(model)
@@ -112,7 +112,7 @@ module SmallHotel
   # update water heater ambient conditions
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def update_waterheater_ambient_parameters(model)
     model.getWaterHeaterMixeds.sort.each do |water_heater|
       if water_heater.name.to_s.include?('200gal')
@@ -127,10 +127,10 @@ module SmallHotel
   # swh adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_swh_tweaks(model, building_type, climate_zone, prototype_input)
     update_waterheater_ambient_parameters(model)
     return true
@@ -139,10 +139,10 @@ module SmallHotel
   # geometry adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_geometry_tweaks(model, building_type, climate_zone, prototype_input)
     # Set original building North axis
     model_set_building_north_axis(model, 90.0)

--- a/lib/openstudio-standards/prototypes/common/buildings/Prototype.SmallOffice.rb
+++ b/lib/openstudio-standards/prototypes/common/buildings/Prototype.SmallOffice.rb
@@ -4,10 +4,10 @@ module SmallOffice
   # hvac adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_hvac_tweaks(model, building_type, climate_zone, prototype_input)
     # add extra infiltration for entry door
     add_door_infiltration(climate_zone, model)
@@ -27,7 +27,7 @@ module SmallOffice
   #
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def add_door_infiltration(climate_zone, model)
     # add extra infiltration for entry door in m3/s (there is no attic in 'DOE Ref Pre-1980')
     return false if template == 'DOE Ref 1980-2004' || template == 'DOE Ref Pre-1980'
@@ -74,7 +74,7 @@ module SmallOffice
   # @param template [String] the model template
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def add_attic_infiltration(template, climate_zone, model)
     # add extra infiltration for attic in m3/s (there is no attic in 'DOE Ref Pre-1980')
     return false if template == 'DOE Ref 1980-2004' || template == 'DOE Ref Pre-1980'
@@ -100,10 +100,10 @@ module SmallOffice
   # swh adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_swh_tweaks(model, building_type, climate_zone, prototype_input)
     return true
   end
@@ -111,10 +111,10 @@ module SmallOffice
   # geometry adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_geometry_tweaks(model, building_type, climate_zone, prototype_input)
     # Set original building North axis
     model_set_building_north_axis(model, 0.0)

--- a/lib/openstudio-standards/prototypes/common/buildings/Prototype.SmallOfficeDetailed.rb
+++ b/lib/openstudio-standards/prototypes/common/buildings/Prototype.SmallOfficeDetailed.rb
@@ -4,10 +4,10 @@ module SmallOfficeDetailed
   # hvac adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_hvac_tweaks(model, building_type, climate_zone, prototype_input)
     # add extra infiltration for entry door
     add_door_infiltration(climate_zone, model)
@@ -27,7 +27,7 @@ module SmallOfficeDetailed
   #
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def add_door_infiltration(climate_zone, model)
     # add extra infiltration for entry door in m3/s (there is no attic in 'DOE Ref Pre-1980')
     return false if template == 'DOE Ref 1980-2004' || template == 'DOE Ref Pre-1980'
@@ -63,7 +63,7 @@ module SmallOfficeDetailed
   # @param template [String] the model template
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def add_attic_infiltration(template, climate_zone, model)
     # add extra infiltration for attic in m3/s (there is no attic in 'DOE Ref Pre-1980')
     return false if template == 'DOE Ref 1980-2004' || template == 'DOE Ref Pre-1980'
@@ -85,10 +85,10 @@ module SmallOfficeDetailed
   # # daylighting adjustments specific to the prototype model
   # #
   # # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # # @param building_type [string] the building type
+  # # @param building_type [String the building type
   # # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # # @param prototype_input [Hash] hash of prototype inputs
-  # # @return [Bool] returns true if successful, false if not
+  # # @return [Boolean] returns true if successful, false if not
   # def model_custom_daylighting_tweaks(model, building_type, climate_zone, prototype_input)
   #   OpenStudio.logFree(OpenStudio::Info, 'openstudio.model.Model', 'Adjusting daylight sensor positions and fractions')
   #
@@ -147,7 +147,7 @@ module SmallOfficeDetailed
   # update water heater loss coefficient
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def update_waterheater_loss_coefficient(model)
     case template
     when '90.1-2004', '90.1-2007', '90.1-2010', '90.1-2013', '90.1-2016', '90.1-2019', 'NECB2011'
@@ -162,10 +162,10 @@ module SmallOfficeDetailed
   # swh adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_swh_tweaks(model, building_type, climate_zone, prototype_input)
     update_waterheater_loss_coefficient(model)
 
@@ -175,10 +175,10 @@ module SmallOfficeDetailed
   # geometry adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_geometry_tweaks(model, building_type, climate_zone, prototype_input)
     # Set original building North axis
     model_set_building_north_axis(model, 0.0)

--- a/lib/openstudio-standards/prototypes/common/buildings/Prototype.SuperMarket.rb
+++ b/lib/openstudio-standards/prototypes/common/buildings/Prototype.SuperMarket.rb
@@ -4,10 +4,10 @@ module SuperMarket
   # hvac adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_hvac_tweaks(model, building_type, climate_zone, prototype_input)
     OpenStudio.logFree(OpenStudio::Info, 'openstudio.model.Model', 'Started building type specific adjustments')
 
@@ -25,7 +25,7 @@ module SuperMarket
   # define additional kitchen loads based on AEDG baseline model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def add_extra_equip_kitchen(model)
     space_names = ['Deli', 'Bakery']
     space_names.each do |space_name|
@@ -49,7 +49,7 @@ module SuperMarket
   # add humidistat to all spaces
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def add_humidistat(model)
     space_names = ['Main Sales', 'Produce', 'West Perimeter Sales', 'East Perimeter Sales', 'Deli', 'Bakery',
                    'Enclosed Office', 'Meeting Room', 'Dining Room', 'Restroom', 'Mechanical Room', 'Corridor', 'Vestibule', 'Active Storage']
@@ -67,7 +67,7 @@ module SuperMarket
   # update exhuast fan efficiency
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_update_exhaust_fan_efficiency(model)
     model.getFanZoneExhausts.sort.each do |exhaust_fan|
       exhaust_fan.setFanEfficiency(0.45)
@@ -79,7 +79,7 @@ module SuperMarket
   # update water heater loss coefficient
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def update_waterheater_loss_coefficient(model)
     case template
       when '90.1-2004', '90.1-2007', '90.1-2010', '90.1-2013', '90.1-2016', '90.1-2019', 'NECB2011'
@@ -94,10 +94,10 @@ module SuperMarket
   # swh adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_swh_tweaks(model, building_type, climate_zone, prototype_input)
     update_waterheater_loss_coefficient(model)
 
@@ -107,10 +107,10 @@ module SuperMarket
   # geometry adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_geometry_tweaks(model, building_type, climate_zone, prototype_input)
     return true
   end

--- a/lib/openstudio-standards/prototypes/common/buildings/Prototype.SuperTallBuilding.rb
+++ b/lib/openstudio-standards/prototypes/common/buildings/Prototype.SuperTallBuilding.rb
@@ -4,10 +4,10 @@ module SuperTallBuilding
   # hvac adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_hvac_tweaks(model, building_type, climate_zone, prototype_input)
     OpenStudio.logFree(OpenStudio::Info, 'openstudio.model.Model', 'Started building type specific adjustments')
 
@@ -50,7 +50,7 @@ module SuperTallBuilding
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @param additional_params [Hash] hash of additional parameters
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def add_elevator_system_loads(model, additional_params)
     # get the elevator machine room space from the model
     if model.getSpaceTypeByName('Elevator Machine Room').empty?
@@ -106,7 +106,7 @@ module SuperTallBuilding
   # @param fan_light_power_per_elev [Double] elevator fan power in watts
   # @param elev_power_sch_name [String] schedule to use for the elevator motor
   # @param elev_fan_light_sch_name [String] schedule to use for the elevator fan
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def add_elevator_equip(model, space, num_of_elev, function_type, motor_power_per_elev, fan_light_power_per_elev,
                          elev_power_sch_name, elev_fan_light_sch_name)
     motor_equip_frac_loss = 0.85
@@ -146,7 +146,7 @@ module SuperTallBuilding
   # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @param prototype_input [Hash] hash of prototype inputs
   # @param additional_params [Hash] hash of additional parameters
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def add_swh_tall_bldg(model, prototype_input, additional_params)
     # get all building stories and rank based on Z-origin
     story_info = {}
@@ -293,7 +293,7 @@ module SuperTallBuilding
   # update the infiltration coefficients of super tall buildings based on Lisa Ng's research (from NIST)
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def update_infil_coeff(model)
     #      System On    |  System Off
     #  A:  -0.019024771 |  0
@@ -361,7 +361,7 @@ module SuperTallBuilding
   # current method is using the E+ default variation trend by specifying the height of outdoor air nodes
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def apply_vertical_weather_variation(model)
     # @todo OA node height is not implemented OpenStudio yet.
     # @todo Temporary fix to be done via adding EnergyPlus measure.
@@ -377,7 +377,7 @@ module SuperTallBuilding
   # HighriseApartment doesn't apply thermostat to corridor spaces
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def add_thermostat_to_corridor(model)
     thermostat = OpenStudio::Model::ThermostatSetpointDualSetpoint.new(model)
     thermostat.setName('HighriseApartment Corridor Thermostat')
@@ -400,10 +400,10 @@ module SuperTallBuilding
   # swh adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_swh_tweaks(model, building_type, climate_zone, prototype_input)
     # customized swh system is not added here, but in model_custom_hvac_tweaks instead
     # because model_custom_swh_tweaks is performed in Prototype.Model after efficiency assignment. If swh added here, efficiency can't be updated.
@@ -414,10 +414,10 @@ module SuperTallBuilding
   # geometry adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_geometry_tweaks(model, building_type, climate_zone, prototype_input)
     # @todo make additional parameters mutable by the user
     # the number of floors for each function type is defined in additional_params
@@ -1048,9 +1048,9 @@ module SuperTallBuilding
   # adjust space boundary conditions to adiabatic
   #
   # @param space [OpenStudio::Model::Space] OpenStudio space object
-  # @param if_top_story_floor_adiabatic [Bool] flag if top floor is adiabatic
-  # @param if_ground_story_plenum_adiabatic [Bool] flag if ground story plenum is adiabatic
-  # @return [Bool] returns true if successful, false if not
+  # @param if_top_story_floor_adiabatic [Boolean] flag if top floor is adiabatic
+  # @param if_ground_story_plenum_adiabatic [Boolean] flag if ground story plenum is adiabatic
+  # @return [Boolean] returns true if successful, false if not
   def update_space_outside_boundary_to_adiabatic(space, if_top_story_floor_adiabatic: false, if_ground_story_plenum_adiabatic: false)
     if (space.name.to_s.include? 'Plenum') && !if_top_story_floor_adiabatic
       space.surfaces.each do |surface|
@@ -1092,9 +1092,9 @@ module SuperTallBuilding
   # @param f_to_c_height [Double] floor to ceiling height in meters
   # @param f_to_f_height [Double] floor to floor height in meters
   # @param current_story [OpenStudio::Model::BuildingStory] OpenStudio building story object
-  # @param if_top_story_floor_adiabatic [Bool] flag if top floor is adiabatic
-  # @param if_ground_story_plenum_adiabatic [Bool] flag if ground story plenum is adiabatic
-  # @return [Bool] returns true if successful, false if not
+  # @param if_top_story_floor_adiabatic [Boolean] flag if top floor is adiabatic
+  # @param if_ground_story_plenum_adiabatic [Boolean] flag if ground story plenum is adiabatic
+  # @return [Boolean] returns true if successful, false if not
   def deep_copy_story(model, original_story, multiplier, new_z_origin, f_to_c_height, f_to_f_height, current_story, if_top_story_floor_adiabatic: false, if_ground_story_plenum_adiabatic: false)
     # clone the story
     new_story = original_story.clone(model).to_BuildingStory.get
@@ -1146,7 +1146,7 @@ module SuperTallBuilding
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
   # building_height [Double] building height in meters
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def add_skylobby_story(model, building_height)
     # locate the skylobby story (find the most middle story bottom, add skylobby below it)
     # rank the stories from low to high (not including the elevator machine room, which hasn't assign the nominal Z coordinate)

--- a/lib/openstudio-standards/prototypes/common/buildings/Prototype.TallBuilding.rb
+++ b/lib/openstudio-standards/prototypes/common/buildings/Prototype.TallBuilding.rb
@@ -4,10 +4,10 @@ module TallBuilding
   # hvac adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_hvac_tweaks(model, building_type, climate_zone, prototype_input)
     OpenStudio.logFree(OpenStudio::Info, 'openstudio.model.Model', 'Started building type specific adjustments')
 
@@ -50,7 +50,7 @@ module TallBuilding
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @param additional_params [Hash] hash of additional parameters
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def add_elevator_system_loads(model, additional_params)
     # get the elevator machine room space from the model
     if model.getSpaceTypeByName('Elevator Machine Room').empty?
@@ -106,7 +106,7 @@ module TallBuilding
   # @param fan_light_power_per_elev [Double] elevator fan power in watts
   # @param elev_power_sch_name [String] schedule to use for the elevator motor
   # @param elev_fan_light_sch_name [String] schedule to use for the elevator fan
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def add_elevator_equip(model, space, num_of_elev, function_type, motor_power_per_elev, fan_light_power_per_elev,
                          elev_power_sch_name, elev_fan_light_sch_name)
     motor_equip_frac_loss = 0.85
@@ -146,7 +146,7 @@ module TallBuilding
   # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @param prototype_input [Hash] hash of prototype inputs
   # @param additional_params [Hash] hash of additional parameters
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def add_swh_tall_bldg(model, prototype_input, additional_params)
     # get all building stories and rank based on Z-origin
     story_info = {}
@@ -294,7 +294,7 @@ module TallBuilding
   # update the infiltration coefficients of tall buildings based on Lisa Ng's research (from NIST)
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def update_infil_coeff(model)
     #       System On  | System Off
     #  A: -0.03973203 | 0
@@ -362,7 +362,7 @@ module TallBuilding
   # current method is using the E+ default variation trend by specifying the height of outdoor air nodes
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def apply_vertical_weather_variation(model)
     # @todo OA node height is not implemented OpenStudio yet.
     # @todo Temporary fix to be done via adding EnergyPlus measure.
@@ -378,7 +378,7 @@ module TallBuilding
   # HighriseApartment doesn't apply thermostat to corridor spaces
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def add_thermostat_to_corridor(model)
     thermostat = OpenStudio::Model::ThermostatSetpointDualSetpoint.new(model)
     thermostat.setName('HighriseApartment Corridor Thermostat')
@@ -401,10 +401,10 @@ module TallBuilding
   # swh adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_swh_tweaks(model, building_type, climate_zone, prototype_input)
     # customized swh system is not added here, but in model_custom_hvac_tweaks instead
     # because model_custom_swh_tweaks is performed in Prototype.Model after efficiency assignment. If swh added here, efficiency can't be updated.
@@ -415,10 +415,10 @@ module TallBuilding
   # geometry adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_geometry_tweaks(model, building_type, climate_zone, prototype_input)
     # @todo make additional parameters mutable by the user
     # the number of floors for each function type is defined in additional_params
@@ -1033,9 +1033,9 @@ module TallBuilding
   # adjust space boundary conditions to adiabatic
   #
   # @param space [OpenStudio::Model::Space] OpenStudio space object
-  # @param if_top_story_floor_adiabatic [Bool] flag if top floor is adiabatic
-  # @param if_ground_story_plenum_adiabatic [Bool] flag if ground story plenum is adiabatic
-  # @return [Bool] returns true if successful, false if not
+  # @param if_top_story_floor_adiabatic [Boolean] flag if top floor is adiabatic
+  # @param if_ground_story_plenum_adiabatic [Boolean] flag if ground story plenum is adiabatic
+  # @return [Boolean] returns true if successful, false if not
   def update_space_outside_boundary_to_adiabatic(space, if_top_story_floor_adiabatic: false, if_ground_story_plenum_adiabatic: false)
     if (space.name.to_s.include? 'Plenum') && !if_top_story_floor_adiabatic
       space.surfaces.each do |surface|
@@ -1077,9 +1077,9 @@ module TallBuilding
   # @param f_to_c_height [Double] floor to ceiling height in meters
   # @param f_to_f_height [Double] floor to floor height in meters
   # @param current_story [OpenStudio::Model::BuildingStory] OpenStudio building story object
-  # @param if_top_story_floor_adiabatic [Bool] flag if top floor is adiabatic
-  # @param if_ground_story_plenum_adiabatic [Bool] flag if ground story plenum is adiabatic
-  # @return [Bool] returns true if successful, false if not
+  # @param if_top_story_floor_adiabatic [Boolean] flag if top floor is adiabatic
+  # @param if_ground_story_plenum_adiabatic [Boolean] flag if ground story plenum is adiabatic
+  # @return [Boolean] returns true if successful, false if not
   def deep_copy_story(model, original_story, multiplier, new_z_origin, f_to_c_height, f_to_f_height, current_story, if_top_story_floor_adiabatic: false, if_ground_story_plenum_adiabatic: false)
     # clone the story
     new_story = original_story.clone(model).to_BuildingStory.get

--- a/lib/openstudio-standards/prototypes/common/buildings/Prototype.Warehouse.rb
+++ b/lib/openstudio-standards/prototypes/common/buildings/Prototype.Warehouse.rb
@@ -4,10 +4,10 @@ module Warehouse
   # hvac adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_hvac_tweaks(model, building_type, climate_zone, prototype_input)
     return true
   end
@@ -15,10 +15,10 @@ module Warehouse
   # swh adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_swh_tweaks(model, building_type, climate_zone, prototype_input)
     return true
   end
@@ -30,10 +30,10 @@ module Warehouse
   # geometry adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_geometry_tweaks(model, building_type, climate_zone, prototype_input)
     # Set original building North axis
     model_set_building_north_axis(model, 90.0)

--- a/lib/openstudio-standards/prototypes/common/objects/Prototype.AirConditionerVariableRefrigerantFlow.rb
+++ b/lib/openstudio-standards/prototypes/common/objects/Prototype.AirConditionerVariableRefrigerantFlow.rb
@@ -10,7 +10,7 @@ class Standard
   # @param type [String] the type of unit to reference for the correct curve set
   # @param cooling_cop [Double] rated cooling coefficient of performance
   # @param heating_cop [Double] rated heating coefficient of performance
-  # @param heat_recovery [Bool] does the unit have heat recovery
+  # @param heat_recovery [Boolean] does the unit have heat recovery
   # @param defrost_strategy [String] type of defrost strategy. options are ReverseCycle or Resistive
   # @param condenser_type [String] type of condenser
   #   options are AirCooled (default), WaterCooled, and EvaporativelyCooled.

--- a/lib/openstudio-standards/prototypes/common/objects/Prototype.AirTerminalSingleDuctVAVReheat.rb
+++ b/lib/openstudio-standards/prototypes/common/objects/Prototype.AirTerminalSingleDuctVAVReheat.rb
@@ -7,7 +7,7 @@ class Standard
   #
   # @param air_terminal_single_duct_vav_reheat [OpenStudio::Model::AirTerminalSingleDuctVAVReheat] the air terminal object
   # @param zone_oa_per_area [Double] the zone outdoor air per area in m^3/s*m^2
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def air_terminal_single_duct_vav_reheat_apply_initial_prototype_damper_position(air_terminal_single_duct_vav_reheat, zone_oa_per_area)
     min_damper_position = 0.3
 

--- a/lib/openstudio-standards/prototypes/common/objects/Prototype.CoilHeatingDXSingleSpeed.rb
+++ b/lib/openstudio-standards/prototypes/common/objects/Prototype.CoilHeatingDXSingleSpeed.rb
@@ -200,7 +200,7 @@ class Standard
   # sets defrost curve limits
   #
   # @param htg_coil [OpenStudio::Model::CoilHeatingDXSingleSpeed] a DX heating coil
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def coil_heating_dx_single_speed_apply_defrost_eir_curve_limits(htg_coil)
     return false unless htg_coil.defrostEnergyInputRatioFunctionofTemperatureCurve.is_initialized
 

--- a/lib/openstudio-standards/prototypes/common/objects/Prototype.CoilHeatingGas.rb
+++ b/lib/openstudio-standards/prototypes/common/objects/Prototype.CoilHeatingGas.rb
@@ -61,7 +61,7 @@ class Standard
   # Defaults to making no changes.
   #
   # @param coil_heating_gas [OpenStudio::Model::CoilHeatingGas] a gas heating coil
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def coil_heating_gas_apply_prototype_efficiency(coil_heating_gas)
     # do nothing
     return true

--- a/lib/openstudio-standards/prototypes/common/objects/Prototype.ControllerWaterCoil.rb
+++ b/lib/openstudio-standards/prototypes/common/objects/Prototype.ControllerWaterCoil.rb
@@ -4,7 +4,7 @@ class Standard
   # Sets the convergence tolerance to 0.0001 deltaC for all hot water coils.
   #
   # @param controller_water_coil [OpenStudio::Model::ControllerWaterCoil] controller water coil object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   # @todo Figure out what the reason for this is, because it seems like a workaround for an E+ bug that was probably addressed long ago.
   def controller_water_coil_set_convergence_limits(controller_water_coil)
     controller_action = controller_water_coil.action

--- a/lib/openstudio-standards/prototypes/common/objects/Prototype.CoolingTower.rb
+++ b/lib/openstudio-standards/prototypes/common/objects/Prototype.CoolingTower.rb
@@ -5,7 +5,7 @@ class Standard
   #
   # @param condenser_loop [<OpenStudio::Model::PlantLoop>] a condenser loop served by a cooling tower
   # @param design_wet_bulb_c [Double] the outdoor design wetbulb conditions in degrees Celsius
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def prototype_apply_condenser_water_temperatures(condenser_loop,
                                                    design_wet_bulb_c: nil)
     sizing_plant = condenser_loop.sizingPlant

--- a/lib/openstudio-standards/prototypes/common/objects/Prototype.Fan.rb
+++ b/lib/openstudio-standards/prototypes/common/objects/Prototype.Fan.rb
@@ -9,7 +9,7 @@ module PrototypeFan
   #
   # @param fan [OpenStudio::Model::StraightComponent] fan object of type:
   #   FanConstantVolume, FanOnOff, FanVariableVolume, and FanZoneExhaust
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def prototype_fan_apply_prototype_fan_efficiency(fan)
     # Do not modify dummy exhaust fans
     return true unless !fan.name.to_s.downcase.include? 'dummy'

--- a/lib/openstudio-standards/prototypes/common/objects/Prototype.FanConstantVolume.rb
+++ b/lib/openstudio-standards/prototypes/common/objects/Prototype.FanConstantVolume.rb
@@ -7,7 +7,7 @@ class Standard
   # and whether the fan lives inside a unit heater, PTAC, etc.
   #
   # @param fan_constant_volume [OpenStudio::Model::FanConstantVolume] constant volume fan object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def fan_constant_volume_apply_prototype_fan_pressure_rise(fan_constant_volume)
     # Don't modify unit heater fans
     return true if fan_constant_volume.name.to_s.include?('UnitHeater Fan')

--- a/lib/openstudio-standards/prototypes/common/objects/Prototype.FanOnOff.rb
+++ b/lib/openstudio-standards/prototypes/common/objects/Prototype.FanOnOff.rb
@@ -8,7 +8,7 @@ class Standard
   # and whether the fan lives inside a unit heater, PTAC, etc.
   #
   # @param fan_on_off [OpenStudio::Model::FanOnOff] on off fan object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def fan_on_off_apply_prototype_fan_pressure_rise(fan_on_off)
     # Get the max flow rate from the fan.
     maximum_flow_rate_m3_per_s = nil

--- a/lib/openstudio-standards/prototypes/common/objects/Prototype.FanVariableVolume.rb
+++ b/lib/openstudio-standards/prototypes/common/objects/Prototype.FanVariableVolume.rb
@@ -8,7 +8,7 @@ class Standard
   # and whether the fan lives inside a unit heater, PTAC, etc.
   #
   # @param fan_variable_volume [OpenStudio::Model::FanVariableVolume] variable volume fan object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def fan_variable_volume_apply_prototype_fan_pressure_rise(fan_variable_volume)
     # Get the max flow rate from the fan.
     maximum_flow_rate_m3_per_s = nil

--- a/lib/openstudio-standards/prototypes/common/objects/Prototype.FanZoneExhaust.rb
+++ b/lib/openstudio-standards/prototypes/common/objects/Prototype.FanZoneExhaust.rb
@@ -6,7 +6,7 @@ class Standard
   # Sets the fan pressure rise based on the Prototype buildings inputs
   #
   # @param fan_zone_exhaust [OpenStudio::Model::FanZoneExhaust] the exhaust fan
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def fan_zone_exhaust_apply_prototype_fan_pressure_rise(fan_zone_exhaust)
     # Do not modify dummy exhaust fans
     return true if fan_zone_exhaust.name.to_s.downcase.include? 'dummy'

--- a/lib/openstudio-standards/prototypes/common/objects/Prototype.HeatExchangerAirToAirSensibleAndLatent.rb
+++ b/lib/openstudio-standards/prototypes/common/objects/Prototype.HeatExchangerAirToAirSensibleAndLatent.rb
@@ -11,7 +11,7 @@ class Standard
 
   # Sets the motor power to account for the extra fan energy from the increase in fan total static pressure
   #
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def heat_exchanger_air_to_air_sensible_and_latent_apply_prototype_nominal_electric_power(heat_exchanger_air_to_air_sensible_and_latent)
     # Get the nominal supply air flow rate
     supply_air_flow_m3_per_s = nil
@@ -77,7 +77,7 @@ class Standard
   # which assume that an enthalpy wheel is used, which exceeds the 50% effectiveness minimum actually defined by 90.1.
   #
   # @param heat_exchanger_air_to_air_sensible_and_latent [OpenStudio::Model::HeatExchangerAirToAirSensibleAndLatent] hx
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def heat_exchanger_air_to_air_sensible_and_latent_apply_prototype_efficiency(heat_exchanger_air_to_air_sensible_and_latent)
     heat_exchanger_air_to_air_sensible_and_latent.setSensibleEffectivenessat100HeatingAirFlow(0.7)
     heat_exchanger_air_to_air_sensible_and_latent.setLatentEffectivenessat100HeatingAirFlow(0.6)

--- a/lib/openstudio-standards/prototypes/common/objects/Prototype.Model.exterior_lights.rb
+++ b/lib/openstudio-standards/prototypes/common/objects/Prototype.Model.exterior_lights.rb
@@ -4,8 +4,8 @@ class Standard
   # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @param exterior_lighting_zone_number [Integer] exterior lighting zone number, 0-4
   # @param onsite_parking_fraction [Double] onsite parking fraction, 0-1
-  # @param add_base_site_allowance [Bool] whether to include the base site allowance
-  # @param use_model_for_entries_and_canopies [Bool] use building geometry for number of entries and canopy size
+  # @param add_base_site_allowance [Boolean] whether to include the base site allowance
+  # @param use_model_for_entries_and_canopies [Boolean] use building geometry for number of entries and canopy size
   # @return [Hash] a hash of OpenStudio::Model::ExteriorLights objects
   # @todo would be nice to add argument for some building types (SmallHotel, MidriseApartment, PrimarySchool, SecondarySchool, RetailStripmall) if it has interior or exterior circulation.
   def model_add_typical_exterior_lights(model, exterior_lighting_zone_number, onsite_parking_fraction = 1.0, add_base_site_allowance = false, use_model_for_entries_and_canopies = false)
@@ -286,8 +286,8 @@ class Standard
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @param space_type_hash [Hash] hash of space types
-  # @param use_model_for_entries_and_canopies [Bool] use building geometry for number of entries and canopy size
-  # @return [hash] hash of exterior lighting value types and building type and model specific values
+  # @param use_model_for_entries_and_canopies [Boolean] use building geometry for number of entries and canopy size
+  # @return [Hhash] hash of exterior lighting value types and building type and model specific values
   # @todo add code in to determine number of entries and canopy area from model geoemtry
   # @todo come up with better logic for entry widths
   def model_create_exterior_lighting_area_length_count_hash(model, space_type_hash, use_model_for_entries_and_canopies)

--- a/lib/openstudio-standards/prototypes/common/objects/Prototype.Model.hvac.rb
+++ b/lib/openstudio-standards/prototypes/common/objects/Prototype.Model.hvac.rb
@@ -5,7 +5,7 @@ class Standard
   # @param building_type [String] the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_add_hvac(model, building_type, climate_zone, prototype_input)
     OpenStudio.logFree(OpenStudio::Info, 'openstudio.model.Model', 'Started Adding HVAC')
 

--- a/lib/openstudio-standards/prototypes/common/objects/Prototype.Model.rb
+++ b/lib/openstudio-standards/prototypes/common/objects/Prototype.Model.rb
@@ -136,7 +136,7 @@ Standard.class_eval do
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @param rel_path_to_osm [String] the path to an .osm file, relative to this file
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_replace_model_from_osm(model, rel_path_to_osm)
     # Take the existing model and remove all the objects
     # (this is cheesy), but need to keep the same memory block
@@ -243,7 +243,7 @@ Standard.class_eval do
   # Some loads are governed by the standard, others are typical values
   # pulled from sources such as the DOE Reference and DOE Prototype Buildings.
   #
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_add_loads(model)
     OpenStudio.logFree(OpenStudio::Info, 'openstudio.model.Model', 'Started applying space types (loads)')
 
@@ -357,7 +357,7 @@ Standard.class_eval do
   # @param model[OpenStudio::Model::Model] OpenStudio Model
   # @param building_type [String] the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_add_constructions(model, building_type, climate_zone)
     OpenStudio.logFree(OpenStudio::Info, 'openstudio.model.Model', 'Started applying constructions')
     is_residential = 'No' # default is nonresidential for building level
@@ -542,8 +542,8 @@ Standard.class_eval do
   # CFactorUndergroundWallConstruction and require some additional parameters when compared to Construction
   #
   # @param model[OpenStudio::Model::Model] OpenStudio Model
-  # @param climate_zone [string] climate zone as described for prototype models. C-Factor is based on this parameter
-  # @param building_type [string] the building type
+  # @param climate_zone [String climate zone as described for prototype models. C-Factor is based on this parameter
+  # @param building_type [String the building type
   # @return [void]
   def model_set_below_grade_wall_constructions(model, building_type, climate_zone)
     # Find ground contact wall building category
@@ -620,8 +620,8 @@ Standard.class_eval do
   # calculated. Used for F-Factor floors that require additional parameters.
   #
   # @param model [OpenStudio Model] OpenStudio model being modified
-  # @param building_type [string] the building type
-  # @param climate_zone [string] climate zone as described for prototype models. F-Factor is based on this parameter
+  # @param building_type [String the building type
+  # @param climate_zone [String climate zone as described for prototype models. F-Factor is based on this parameter
   def model_set_floor_constructions(model, building_type, climate_zone)
     # Find ground contact wall building category
     construction_set_data = model_get_construction_set(building_type)
@@ -788,7 +788,7 @@ Standard.class_eval do
   #
   # @param model[OpenStudio::Model::Model] OpenStudio Model
   # @param building_type [String] the building type
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_add_internal_mass(model, building_type)
     # Assign a material to all internal mass objects
     material = OpenStudio::Model::StandardOpaqueMaterial.new(model)
@@ -847,7 +847,7 @@ Standard.class_eval do
   # e.g. (Prototype.secondary_school.rb) file.
   #
   # @param (see #add_constructions)
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_create_thermal_zones(model, space_multiplier_map = nil)
     OpenStudio.logFree(OpenStudio::Info, 'openstudio.model.Model', 'Started creating thermal zones')
 
@@ -1449,7 +1449,7 @@ Standard.class_eval do
   # the PNNL documentation.
   #
   # @param (see #add_constructions)
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   # @todo genericize and move this method to Standards.Space
   def model_add_occupancy_sensors(model, building_type, climate_zone)
     # Only add occupancy sensors for 90.1-2010
@@ -1553,7 +1553,7 @@ Standard.class_eval do
   # in OpenStudio_Standards_prototype_inputs
   #
   # @param (see #add_constructions)
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   # @todo translate w/linear foot of facade, door, parking, etc
   #   into lookup table and implement that way instead of hard-coding as
   #   inputs in the spreadsheet.
@@ -1628,7 +1628,7 @@ Standard.class_eval do
   # Changes the infiltration coefficients for the prototype vintages.
   #
   # @param (see #add_constructions)
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   # @todo Consistency - make prototype and reference vintages consistent
   def model_modify_infiltration_coefficients(model, building_type, climate_zone)
     # Select the terrain type, which
@@ -1673,7 +1673,7 @@ Standard.class_eval do
   # Sets the inside and outside convection algorithms for different vintages
   #
   # @param (see #add_constructions)
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   # @todo Consistency - make prototype and reference vintages consistent
   def model_modify_surface_convection_algorithm(model)
     inside = model.getInsideSurfaceConvectionAlgorithm
@@ -1721,7 +1721,7 @@ Standard.class_eval do
   # Changes the infiltration coefficients for the prototype vintages.
   #
   # @param (see #add_constructions)
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   # @todo Consistency - make sizing factors consistent
   #   between building types, climate zones, and vintages?
   def model_apply_sizing_parameters(model, building_type)
@@ -1798,7 +1798,7 @@ Standard.class_eval do
   # Applies the Prototype Building assumptions that contradict/supersede
   # the given standard.
   #
-  # @param model [OpenStudio::Model::Model] the model
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
   def model_apply_prototype_hvac_efficiency_adjustments(model)
     building_data = model_get_building_properties(model)
     building_type = building_data['building_type']
@@ -2488,7 +2488,7 @@ Standard.class_eval do
   # by Steven Taylor and Hwakong Cheng.
   # https://tayloreng.egnyte.com/dl/mN0c9t4WSO/ASHRAE_Journal_-_Economizer_High_Limit_Devices_and_Why_Enthalpy_Economizers_Dont_Work.pdf_
   #
-  # @param model [OpenStudio::Model::Model] the model
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @return [String] the economizer type.  Possible values are:
   # 'NoEconomizer'
@@ -2594,7 +2594,7 @@ Standard.class_eval do
   # @author Xuechen (Jerry) Lei, PNNL
   #
   # @param model [OpenStudio::Model::Model] OpenStudio Model
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_add_lights_shutoff(model)
     return false
   end
@@ -2884,8 +2884,8 @@ Standard.class_eval do
   # required to setup/back their thermostat setpoints
   #
   # @param time_offset_hash [Hash] Hash providing time (key) and schedule value offset (values)
-  # @param schedule [OpenStudio::model::ScheduleRuleset] OpenStudio schedule object
-  # @return [OpenStudio::model::ScheduleRuleset] Modified OpenStudio schedule object
+  # @param schedule [OpenStudio::Model::ScheduleRuleset] OpenStudio schedule object
+  # @return [OpenStudio::Model::ScheduleRuleset] Modified OpenStudio schedule object
   def model_offset_schedule_value(schedule, time_offset_hash)
     offset_sch = schedule.clone(schedule.model).to_ScheduleRuleset.get
 
@@ -2924,8 +2924,8 @@ Standard.class_eval do
   # required to setup/back their thermostat setpoints
   #
   # @param time_offset_hash [Hash] Hash providing time (key) and schedule value offset (values)
-  # @param schedule [OpenStudio::model::ScheduleRuleset] OpenStudio schedule object
-  # @return [OpenStudio::model::ScheduleRuleset] Modified OpenStudio schedule object
+  # @param schedule [OpenStudio::Model::ScheduleRuleset] OpenStudio schedule object
+  # @return [OpenStudio::Model::ScheduleRuleset] Modified OpenStudio schedule object
   def model_set_schedule_value(schedule, time_value_hash)
     return nil unless schedule.to_ScheduleRuleset.is_initialized
 
@@ -2962,7 +2962,7 @@ Standard.class_eval do
 
   # Modify thermostat schedule to account for a thermostat setback/up
   #
-  # @param thermostat [OpenStudio::model::ThermostatSetpointDualSetpoint] OpenStudio ThermostatSetpointDualSetpoint object
+  # @param thermostat [OpenStudio::Model::ThermostatSetpointDualSetpoint] OpenStudio ThermostatSetpointDualSetpoint object
   # @return [Boolean] true if success
   def space_occupancy_standby_mode(thermostat)
     return false

--- a/lib/openstudio-standards/prototypes/common/objects/Prototype.Model.swh.rb
+++ b/lib/openstudio-standards/prototypes/common/objects/Prototype.Model.swh.rb
@@ -4,7 +4,7 @@ class Standard
   # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @param building_type [String] building type
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_add_swh(model, building_type, prototype_input)
     OpenStudio.logFree(OpenStudio::Info, 'openstudio.model.Model', 'Started Adding Service Water Heating')
 

--- a/lib/openstudio-standards/prototypes/common/objects/Prototype.ServiceWaterHeating.rb
+++ b/lib/openstudio-standards/prototypes/common/objects/Prototype.ServiceWaterHeating.rb
@@ -14,7 +14,7 @@ class Standard
   # @param water_heater_volume [Double] water heater volume, in m^3
   # @param water_heater_fuel [String] water heater fuel. Valid choices are NaturalGas, Electricity
   # @param parasitic_fuel_consumption_rate [Double] the parasitic fuel consumption rate of the water heater, in W
-  # @param add_pipe_losses [Bool] if true, add piping and associated heat losses to system.  If false, add no pipe heat losses
+  # @param add_pipe_losses [Boolean] if true, add piping and associated heat losses to system.  If false, add no pipe heat losses
   # @param floor_area_served [Double] area served by the SWH loop, in m^2.  Used for pipe loss piping length estimation
   # @param number_of_stories [Integer] number of stories served by the SWH loop.  Used for pipe loss piping length estimation
   # @param pipe_insulation_thickness [Double] thickness of the fiberglass batt pipe insulation, in m.  Use 0 for uninsulated pipes
@@ -151,7 +151,7 @@ class Standard
   # @param service_water_temperature [Double] water heater temperature, in C
   # @param parasitic_fuel_consumption_rate [Double] water heater parasitic fuel consumption rate, in W
   # @param swh_temp_sch [OpenStudio::Model::Schedule] the service water heating schedule. If nil, will be defaulted.
-  # @param set_peak_use_flowrate [Bool] if true, the peak flow rate and flow rate schedule will be set.
+  # @param set_peak_use_flowrate [Boolean] if true, the peak flow rate and flow rate schedule will be set.
   # @param peak_flowrate [Double] in m^3/s
   # @param flowrate_schedule [String] name of the flow rate schedule
   # @param water_heater_thermal_zone [OpenStudio::Model::ThermalZone] zone to place water heater in.
@@ -314,12 +314,12 @@ class Standard
   # @param service_water_temperature [Double] water heater temperature, in C
   # @param parasitic_fuel_consumption_rate [Double] water heater parasitic fuel consumption rate, in W
   # @param swh_temp_sch [OpenStudio::Model::Schedule] the service water heating schedule. If nil, will be defaulted.
-  # @param set_peak_use_flowrate [Bool] if true, the peak flow rate and flow rate schedule will be set.
+  # @param set_peak_use_flowrate [Boolean] if true, the peak flow rate and flow rate schedule will be set.
   # @param peak_flowrate [Double] in m^3/s
   # @param flowrate_schedule [String] name of the flow rate schedule
   # @param water_heater_thermal_zone [OpenStudio::Model::ThermalZone] zone to place water heater in.
   #   If nil, will be assumed in 70F air for heat loss.
-  # @param use_ems_control [Bool] if true, use ems control logic if using a 'WrappedCondenser' style HPWH.
+  # @param use_ems_control [Boolean] if true, use ems control logic if using a 'WrappedCondenser' style HPWH.
   # @return [OpenStudio::Model::WaterHeaterMixed] the resulting water heater
   def model_add_heatpump_water_heater(model,
                                       type: 'PumpedCondenser',
@@ -967,7 +967,7 @@ class Standard
   # @param space [OpenStudio::Model::Space] the Space to add a WaterUseEquipment for
   # @param space_multiplier [Double] the multiplier to use if the supplied Space actually represents
   #   more area than is shown in the model.
-  # @param is_flow_per_area [Bool] if true, use the value in the 'service_water_heating_peak_flow_per_area'
+  # @param is_flow_per_area [Boolean] if true, use the value in the 'service_water_heating_peak_flow_per_area'
   #   field of the space_types JSON.  If false, use the value in the 'service_water_heating_peak_flow_rate' field.
   # @return [OpenStudio::Model::WaterUseEquipment] the WaterUseEquipment for the
   def model_add_swh_end_uses_by_space(model,
@@ -1066,7 +1066,7 @@ class Standard
   # Determine whether or not water fixtures are attached to spaces
   # @todo For hotels and apartments, add the water fixture at the space level
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_attach_water_fixtures_to_spaces?(model)
     # if building_type!=nil && ((building_type.downcase.include?"hotel") || (building_type.downcase.include?"apartment"))
     #   return true
@@ -1133,9 +1133,9 @@ class Standard
   # @param floor_area_served [Double] the area of building served by the service water heating loop, in m^2
   # @param number_of_stories [Integer] the number of stories served by the service water heating loop
   # @param pipe_insulation_thickness [Double] the thickness of the pipe insulation, in m.  Use 0 for no insulation
-  # @param circulating [Bool] use true for circulating systems, false for non-circulating systems
+  # @param circulating [Boolean] use true for circulating systems, false for non-circulating systems
   # @param air_temp_surrounding_piping [Double] the temperature of the air surrounding the piping, in C.
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_add_piping_losses_to_swh_system(model,
                                             swh_loop,
                                             circulating,

--- a/lib/openstudio-standards/prototypes/common/objects/Prototype.SizingSystem.rb
+++ b/lib/openstudio-standards/prototypes/common/objects/Prototype.SizingSystem.rb
@@ -43,7 +43,7 @@ class Standard
   # @todo this needs to be changed in both the sizing system and controller mechanical ventilation objects
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_system_outdoor_air_sizing_vrp_method(air_loop_hvac)
     # Do not apply the adjustment to some of the system in
     # the hospital and outpatient which have their minimum

--- a/lib/openstudio-standards/prototypes/common/objects/Prototype.hvac_systems.rb
+++ b/lib/openstudio-standards/prototypes/common/objects/Prototype.hvac_systems.rb
@@ -1346,7 +1346,7 @@ end
   # @param min_frac_oa_sch [String] name of the minimum fraction of outdoor air schedule, default is always on
   # @param fan_maximum_flow_rate [Double] fan maximum flow rate in cfm, default is autosize
   # @param econo_ctrl_mthd [String] economizer control type, default is Fixed Dry Bulb
-  # @param energy_recovery [Bool] if true, an ERV will be added to the system
+  # @param energy_recovery [Boolean] if true, an ERV will be added to the system
   # @param doas_control_strategy [String] DOAS control strategy
   # @param clg_dsgn_sup_air_temp [Double] design cooling supply air temperature in degrees Fahrenheit, default 65F
   # @param htg_dsgn_sup_air_temp [Double] design heating supply air temperature in degrees Fahrenheit, default 75F
@@ -1578,7 +1578,7 @@ end
   # @param fan_maximum_flow_rate [Double] fan maximum flow rate in cfm, default is autosize
   # @param econo_ctrl_mthd [String] economizer control type, default is Fixed Dry Bulb
   #   If enabled, the DOAS will be sized for twice the ventilation minimum to allow economizing
-  # @param include_exhaust_fan [Bool] if true, include an exhaust fan
+  # @param include_exhaust_fan [Boolean] if true, include an exhaust fan
   # @param clg_dsgn_sup_air_temp [Double] design cooling supply air temperature in degrees Fahrenheit, default 65F
   # @param htg_dsgn_sup_air_temp [Double] design heating supply air temperature in degrees Fahrenheit, default 75F
   # @return [OpenStudio::Model::AirLoopHVAC] the resulting DOAS air loop
@@ -2256,7 +2256,7 @@ end
   # @param chilled_water_loop [OpenStudio::Model::PlantLoop] chilled water loop to connect cooling coils to. If nil, will be DX cooling
   # @param heating_type [String] main heating coil fuel type
   #   valid choices are NaturalGas, Electricity, Water, or nil (defaults to NaturalGas)
-  # @param electric_reheat [Bool] if true electric reheat coils, if false the reheat coils served by hot_water_loop
+  # @param electric_reheat [Boolean] if true electric reheat coils, if false the reheat coils served by hot_water_loop
   # @param hvac_op_sch [String] name of the HVAC operation schedule or nil in which case will be defaulted to always on
   # @param oa_damper_sch [String] name of the oa damper schedule or nil in which case will be defaulted to always open
   # @param econo_ctrl_mthd [String] economizer control type
@@ -3224,7 +3224,7 @@ end
   # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @param space [OpenStudio::Model::Space] which space to assign the data center loads to
   # @param dc_watts_per_area [Double] data center load, in W/m^2
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_add_data_center_load(model, space, dc_watts_per_area)
     # create data center load
     data_center_definition = OpenStudio::Model::ElectricEquipmentDefinition.new(model)
@@ -3248,7 +3248,7 @@ end
   # @param thermal_zones [Array<OpenStudio::Model::ThermalZone>] array of zones to connect to this system
   # @param hvac_op_sch [String] name of the HVAC operation schedule or nil in which case will be defaulted to always on
   # @param oa_damper_sch [String] name of the oa damper schedule or nil in which case will be defaulted to always open
-  # @param main_data_center [Bool] whether or not this is the main data center in the building.
+  # @param main_data_center [Boolean] whether or not this is the main data center in the building.
   # @return [Array<OpenStudio::Model::AirLoopHVAC>] an array of the resulting air loops
   def model_add_data_center_hvac(model,
                                  thermal_zones,
@@ -3618,7 +3618,7 @@ end
   # Creates a CRAH system for larger size data center and adds it to the model.
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param chilled_water_loop [string]
+  # @param chilled_water_loop [String
   # @param system_name [String] the name of the system, or nil in which case it will be defaulted
   # @param thermal_zones [String] zones to connect to this system
   # @param hvac_op_sch [String] name of the HVAC operation schedule
@@ -4055,7 +4055,7 @@ end
   # @param heating_type [String] valid choices are NaturalGas, Electricity, Water, nil (no heat)
   # @param hot_water_loop [OpenStudio::Model::PlantLoop] hot water loop to connect heating coil to. Set to nil for heating types besides water
   # @param fan_type [String] valid choices are ConstantVolume, Cycling
-  # @param ventilation [Bool] If true, ventilation will be supplied through the unit.  If false,
+  # @param ventilation [Boolean] If true, ventilation will be supplied through the unit.  If false,
   #   no ventilation will be supplied through the unit, with the expectation that it will be provided by a DOAS or separate system.
   # @return [Array<OpenStudio::Model::ZoneHVACPackagedTerminalAirConditioner>] an array of the resulting PTACs
   def model_add_ptac(model,
@@ -4174,7 +4174,7 @@ end
   # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @param thermal_zones [Array<OpenStudio::Model::ThermalZone>] array of zones to connect to this system
   # @param fan_type [String] valid choices are ConstantVolume, Cycling
-  # @param ventilation [Bool] If true, ventilation will be supplied through the unit.  If false,
+  # @param ventilation [Boolean] If true, ventilation will be supplied through the unit.  If false,
   #   no ventilation will be supplied through the unit, with the expectation that it will be provided by a DOAS or separate system.
   # @return [Array<OpenStudio::Model::ZoneHVACPackagedTerminalAirConditioner>] an array of the resulting PTACs.
   def model_add_pthp(model,
@@ -4625,7 +4625,7 @@ end
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @param thermal_zones [Array<OpenStudio::Model::ThermalZone>] array of zones to add fan coil units
-  # @param ventilation [Bool] If true, ventilation will be supplied through the unit.  If false,
+  # @param ventilation [Boolean] If true, ventilation will be supplied through the unit.  If false,
   #   no ventilation will be supplied through the unit, with the expectation that it will be provided by a DOAS or separate system.
   # @return [Array<OpenStudio::Model::ZoneHVACTerminalUnitVariableRefrigerantFlow>] array of vrf units.
   def model_add_vrf(model,
@@ -4685,7 +4685,7 @@ end
   # @param chilled_water_loop [OpenStudio::Model::PlantLoop] the chilled water loop that serves the fan coils.
   # @param hot_water_loop [OpenStudio::Model::PlantLoop] the hot water loop that serves the fan coils.
   #   If nil, a zero-capacity, electric heating coil set to Always-Off will be included in the unit.
-  # @param ventilation [Bool] If true, ventilation will be supplied through the unit.  If false,
+  # @param ventilation [Boolean] If true, ventilation will be supplied through the unit.  If false,
   #   no ventilation will be supplied through the unit, with the expectation that it will be provided by a DOAS or separate system.
   # @param capacity_control_method [String] Capacity control method for the fan coil. Options are ConstantFanVariableFlow,
   #   CyclingFan, VariableFanVariableFlow, and VariableFanConstantFlow.  If VariableFan, the fan will be VariableVolume.
@@ -4769,30 +4769,27 @@ end
   # @param thermal_zones [Array<OpenStudio::Model::ThermalZone>] array of zones to add radiant loops
   # @param hot_water_loop [OpenStudio::Model::PlantLoop] the hot water loop that serves the radiant loop.
   # @param chilled_water_loop [OpenStudio::Model::PlantLoop] the chilled water loop that serves the radiant loop.
-  # @param two_pipe_system [Bool] when set to true, it converts the default 4-pipe water plant HVAC system to a 2-pipe system.
+  # @param two_pipe_system [Boolean] when set to true, it converts the default 4-pipe water plant HVAC system to a 2-pipe system.
   # @param two_pipe_control_strategy [String] Method to determine whether the loop is in heating or cooling mode
-  #   'outdoor_air_lockout' - The system will be in heating below the lockout_temperature variable, 
-  #      and cooling above the lockout_temperature. Requires the lockout_temperature variable.
-  #   'zone_demand' - Heating or cooling determined by preponderance of zone demand.
+  #   'outdoor_air_lockout' - The system will be in heating below the two_pipe_lockout_temperature variable, 
+  #      and cooling above the two_pipe_lockout_temperature. Requires the two_pipe_lockout_temperature variable.
+  #   'zone_demand' - Create EMS code to determine heating or cooling mode based on zone heating or cooling load requests.
   #      Requires thermal_zones defined.
   # @param two_pipe_lockout_temperature [Double] hot water plant lockout in degrees Fahrenheit, default 65F.
   #   Hot water plant is unavailable when outdoor drybulb is above the specified threshold.
-  # @param use_zone_demand [Bool] If true, it creates EMS code to define heating and cooling plant availability
-  #   based on zone heating and cooling load requests, default to false. When set to false, heating and cooling plant
-  #   availability schedules are set using the heating outdoor dry-bulb temperature lockout defined above.
   # @param radiant_type [String] type of radiant system, floor or ceiling, to create in zone.
   # @param radiant_temperature_control_type [String] determines the controlled temperature for the radiant system
   #   options are 'MeanAirTemperature', 'MeanRadiantTemperature', 'OperativeTemperature', 'OutdoorDryBulbTemperature',
   #   'OutdoorWetBulbTemperature', 'SurfaceFaceTemperature', 'SurfaceInteriorTemperature'
   # @param radiant_setpoint_control_type [String] determines the response of the radiant system at setpoint temperature
   #   options are 'ZeroFlowPower', 'HalfFlowPower'
-  # @param include_carpet [Bool] boolean to include thin carpet tile over radiant slab, default to true
+  # @param include_carpet [Boolean] boolean to include thin carpet tile over radiant slab, default to true
   # @param carpet_thickness_in [Double] thickness of carpet in inches
   # @param control_strategy [String] name of control strategy.  Options are 'proportional_control' and 'none'.
   #   If control strategy is 'proportional_control', the method will apply the CBE radiant control sequences
   #   detailed in Raftery et al. (2017), 'A new control strategy for high thermal mass radiant systems'.
   #   Otherwise no control strategy will be applied and the radiant system will assume the EnergyPlus default controls.
-  # @param use_zone_occupancy_for_control [Bool] Set to true if radiant system is to use specific zone occupancy objects
+  # @param use_zone_occupancy_for_control [Boolean] Set to true if radiant system is to use specific zone occupancy objects
   #   for CBE control strategy. If false, then it will use values in model_occ_hr_start and model_occ_hr_end
   #   for all radiant zones. default to true.
   # @param occupied_percentage_threshold [Double] the minimum fraction (0 to 1) that counts as occupied
@@ -4811,7 +4808,7 @@ end
   #   If preset is set to 'all_day' radiant system is available 24 hours a day, 'precool' primarily operates
   #   radiant system during night-time hours, 'afternoon_shutoff' avoids operation during peak grid demand,
   #   and 'occupancy' operates radiant system during building occupancy hours.
-  # @param radiant_lockout [Bool] True if system contains a radiant lockout. If true, it will overwrite radiant_availability_type.
+  # @param radiant_lockout [Boolean] True if system contains a radiant lockout. If true, it will overwrite radiant_availability_type.
   # @param radiant_lockout_start_time [double] decimal hour of when radiant lockout starts
   #   Only used if radiant_lockout is true
   # @param radiant_lockout_end_time [double] decimal hour of when radiant lockout ends
@@ -5279,9 +5276,9 @@ end
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @param thermal_zones [Array<OpenStudio::Model::ThermalZone>] array of zones to add fan coil units to.
-  # @param heating [Bool] if true, the unit will include a NaturalGas heating coil
-  # @param cooling [Bool] if true, the unit will include a DX cooling coil
-  # @param ventilation [Bool] if true, the unit will include an OA intake
+  # @param heating [Boolean] if true, the unit will include a NaturalGas heating coil
+  # @param cooling [Boolean] if true, the unit will include a DX cooling coil
+  # @param ventilation [Boolean] if true, the unit will include an OA intake
   # @return [Array<OpenStudio::Model::AirLoopHVAC>] and array of air loops representing the furnaces
   def model_add_furnace_central_ac(model,
                                    thermal_zones,
@@ -5410,9 +5407,9 @@ end
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @param thermal_zones [Array<OpenStudio::Model::ThermalZone>] array of zones to add fan coil units to.
-  # @param heating [Bool] if true, the unit will include a NaturalGas heating coil
-  # @param cooling [Bool] if true, the unit will include a DX cooling coil
-  # @param ventilation [Bool] if true, the unit will include an OA intake
+  # @param heating [Boolean] if true, the unit will include a NaturalGas heating coil
+  # @param cooling [Boolean] if true, the unit will include a DX cooling coil
+  # @param ventilation [Boolean] if true, the unit will include an OA intake
   # @return [Array<OpenStudio::Model::AirLoopHVAC>] and array of air loops representing the heat pumps
   def model_add_central_air_source_heat_pump(model,
                                              thermal_zones,
@@ -5551,7 +5548,7 @@ end
   # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @param thermal_zones [Array<OpenStudio::Model::ThermalZone>] array of zones served by heat pumps
   # @param condenser_loop [OpenStudio::Model::PlantLoop] the condenser loop for the heat pumps  #
-  # @param ventilation [Bool] if true, ventilation will be supplied through the unit.
+  # @param ventilation [Boolean] if true, ventilation will be supplied through the unit.
   #   If false, no ventilation will be supplied through the unit, with the expectation that it will be provided by a DOAS or separate system.
   # @return [Array<OpenStudio::Model::ZoneHVACWaterToAirHeatPump>] an array of heat pumps
   def model_add_water_source_hp(model,
@@ -6055,7 +6052,7 @@ end
   # Adds a waterside economizer to the chilled water and condenser loop
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param integrated [Bool] when set to true, models an integrated waterside economizer
+  # @param integrated [Boolean] when set to true, models an integrated waterside economizer
   #   Integrated: in series with chillers, can run simultaneously with chillers
   #   Non-Integrated: in parallel with chillers, chillers locked out during operation
   def model_add_waterside_economizer(model, chilled_water_loop, condenser_water_loop,
@@ -6315,12 +6312,12 @@ end
   #   EvaporativeFluidCooler, EvaporativeFluidCoolerSingleSpeed, EvaporativeFluidCoolerTwoSpeed
   # @param air_loop_heating_type [String] type of heating coil serving main air loop, options are Gas, DX, or Water
   # @param air_loop_cooling_type [String] type of cooling coil serving main air loop, options are DX or Water
-  # @param zone_equipment_ventilation [Bool] toggle whether to include outdoor air ventilation on zone equipment
+  # @param zone_equipment_ventilation [Boolean] toggle whether to include outdoor air ventilation on zone equipment
   #   including as fan coil units, VRF terminals, or water source heat pumps.
   # @param fan_coil_capacity_control_method [String] Only applicable to Fan Coil system type.
   #   Capacity control method for the fan coil. Options are ConstantFanVariableFlow, CyclingFan, VariableFanVariableFlow,
   #   and VariableFanConstantFlow.  If VariableFan, the fan will be VariableVolume.
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_add_hvac_system(model,
                             system_type,
                             main_heat_fuel,

--- a/lib/openstudio-standards/prototypes/common/objects/Prototype.radiant_system_controls.rb
+++ b/lib/openstudio-standards/prototypes/common/objects/Prototype.radiant_system_controls.rb
@@ -5,7 +5,7 @@ class Standard
   # @param radiant_loop [OpenStudio::Model::ZoneHVACLowTempRadiantVarFlow>] radiant loop in thermal zone
   # @param radiant_temperature_control_type [String] determines the controlled temperature for the radiant system
   #   options are 'SurfaceFaceTemperature', 'SurfaceInteriorTemperature'
-  # @param use_zone_occupancy_for_control [Bool] Set to true if radiant system is to use specific zone occupancy objects
+  # @param use_zone_occupancy_for_control [Boolean] Set to true if radiant system is to use specific zone occupancy objects
   #   for CBE control strategy. If false, then it will use values in model_occ_hr_start and model_occ_hr_end
   #   for all radiant zones. default to true.
   # @param occupied_percentage_threshold [Double] the minimum fraction (0 to 1) that counts as occupied

--- a/lib/openstudio-standards/prototypes/common/objects/Prototype.refrigeration.rb
+++ b/lib/openstudio-standards/prototypes/common/objects/Prototype.refrigeration.rb
@@ -521,7 +521,7 @@ class Standard
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @param building_type [String] building type
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_add_typical_refrigeration(model, building_type)
     # Define system category and scaling factor
     floor_area_ft2 = OpenStudio.convert(model.getBuilding.floorArea, 'm^2', 'ft^2').get
@@ -839,7 +839,7 @@ class Standard
   # @todo Should probably use the model_add_refrigeration_walkin and lookups from the spreadsheet instead of hard-coded values
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_walkin_freezer_latent_case_credit_curve(model)
     latent_case_credit_curve_name = 'Single Shelf Horizontal Latent Energy Multiplier_After2004'
     return latent_case_credit_curve_name
@@ -856,7 +856,7 @@ class Standard
   # @param walkins [Array<Hashs>] an array of walkins with keys:
   #   walkin_type, space_names, and number_of_walkins
   # @param thermal_zone [OpenStudio::Model::ThermalZone] the thermal zone where the refrigeration piping is located
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_add_refrigeration_system(model,
                                      compressor_type,
                                      system_name,

--- a/lib/openstudio-standards/prototypes/common/objects/Prototype.utilities.rb
+++ b/lib/openstudio-standards/prototypes/common/objects/Prototype.utilities.rb
@@ -589,7 +589,7 @@ class Standard
   # @param max_x [Double] the maximum value of independent variable X that will be used
   # @param min_out [Double] the minimum value of dependent variable Z
   # @param max_out [Double] the maximum value of dependent variable Z
-  # @param is_dimensionless [Bool] if true, the X independent variable is considered unitless
+  # @param is_dimensionless [Boolean] if true, the X independent variable is considered unitless
   #   and the resulting output dependent variable is considered unitless
   # @return [OpenStudio::Model::CurveQuadratic] a quadratic curve
   def create_curve_quadratic(model, coeffs, crv_name, min_x, max_x, min_out, max_out, is_dimensionless = false)
@@ -670,8 +670,8 @@ class Standard
   #   'ExteriorRoof', 'Skylight', 'TubularDaylightDome', 'TubularDaylightDiffuser', 'ExteriorFloor',
   #   'ExteriorWall', 'ExteriorWindow', 'ExteriorDoor', 'GlassDoor', 'OverheadDoor', 'GroundContactFloor',
   #   'GroundContactWall', 'GroundContactRoof'
-  # @param int_film [Bool] if true, interior film coefficient will be included in result
-  # @param ext_film [Bool] if true, exterior film coefficient will be included in result
+  # @param int_film [Boolean] if true, interior film coefficient will be included in result
+  # @param ext_film [Boolean] if true, exterior film coefficient will be included in result
   # @return [Double] Returns the R-Value of the film coefficients [m^2*K/W]
   def film_coefficients_r_value(intended_surface_type, int_film, ext_film)
     # Return zero if both interior and exterior are false

--- a/lib/openstudio-standards/prototypes/common/prototype_metaprogramming.rb
+++ b/lib/openstudio-standards/prototypes/common/prototype_metaprogramming.rb
@@ -127,7 +127,7 @@ end
   # update exhuast fan efficiency
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_update_exhaust_fan_efficiency(model)
     return true
   end
@@ -168,10 +168,10 @@ end
   # daylighting adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String] the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_daylighting_tweaks(model, building_type, climate_zone, prototype_input)
     return true
   end
@@ -270,7 +270,7 @@ end
   # update exhuast fan efficiency
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_update_exhaust_fan_efficiency(model)
     return true
   end
@@ -629,7 +629,7 @@ end
   # update exhuast fan efficiency
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_update_exhaust_fan_efficiency(model)
     return true
   end
@@ -650,10 +650,10 @@ end
   # hvac adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String] the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_hvac_tweaks(model, building_type, climate_zone, prototype_input)
     return true
   end
@@ -661,10 +661,10 @@ end
   # swh adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String] the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_swh_tweaks(model, building_type, climate_zone, prototype_input)
     return true
   end
@@ -672,10 +672,10 @@ end
   # geometry adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String] the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_geometry_tweaks(model, building_type, climate_zone, prototype_input)
     return true
   end
@@ -683,10 +683,10 @@ end
   # daylighting adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String] the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_daylighting_tweaks(model, building_type, climate_zone, prototype_input)
     return true
   end
@@ -801,7 +801,7 @@ end
   # update exhuast fan efficiency
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_update_exhaust_fan_efficiency(model)
     return true
   end
@@ -839,10 +839,10 @@ end
   # hvac adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String] the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_hvac_tweaks(model, building_type, climate_zone, prototype_input)
     return true
   end
@@ -850,10 +850,10 @@ end
   # swh adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String] the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_swh_tweaks(model, building_type, climate_zone, prototype_input)
     return true
   end
@@ -861,10 +861,10 @@ end
   # geometry adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String] the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_geometry_tweaks(model, building_type, climate_zone, prototype_input)
     return true
   end
@@ -872,10 +872,10 @@ end
   # daylighting adjustments specific to the prototype model
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param building_type [string] the building type
+  # @param building_type [String] the building type
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param prototype_input [Hash] hash of prototype inputs
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_custom_daylighting_tweaks(model, building_type, climate_zone, prototype_input)
     return true
   end

--- a/lib/openstudio-standards/prototypes/deer/deer.Model.rb
+++ b/lib/openstudio-standards/prototypes/deer/deer.Model.rb
@@ -5,7 +5,7 @@ class DEER
   # Based on the MASControl rules, it appears that
   # only FixedDryBulb economizers are used.
   #
-  # @param model [OpenStudio::Model::Model] the model
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @param climate_zone [String] DEER climate zone
   # @return [String] the economizer type.  Possible values are:
   # 'NoEconomizer'

--- a/lib/openstudio-standards/standards/Standards.AirLoopHVAC.rb
+++ b/lib/openstudio-standards/standards/Standards.AirLoopHVAC.rb
@@ -6,7 +6,7 @@ class Standard
   # Hard-size the resulting min OA into the sizing:system object.
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
-  # return [Bool] returns true if successful, false if not
+  # return [Boolean] returns true if successful, false if not
   # @todo move building-type-specific code to Prototype classes
   def air_loop_hvac_apply_multizone_vav_outdoor_air_sizing(air_loop_hvac)
     # First time adjustment:
@@ -25,7 +25,7 @@ class Standard
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   # @todo optimum start
   # @todo night damper shutoff
   # @todo nightcycle control
@@ -190,7 +190,7 @@ class Standard
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def air_loop_hvac_apply_prm_baseline_controls(air_loop_hvac, climate_zone)
     # Economizers
     if air_loop_hvac_prm_baseline_economizer_required?(air_loop_hvac, climate_zone)
@@ -233,7 +233,7 @@ class Standard
   # Defaults to 90.1-2004 logic, which requires optimum start if > 10,000 cfm
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_optimum_start_required?(air_loop_hvac)
     opt_start_required = false
 
@@ -268,7 +268,7 @@ class Standard
   # Adds optimum start control to the airloop.
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def air_loop_hvac_enable_optimum_start(air_loop_hvac)
     # Get the heating and cooling setpoint schedules
     # for all zones on this airloop.
@@ -374,7 +374,7 @@ class Standard
   end
 
   # Set default fan curve to be VSD with static pressure reset
-  # @return [string] name of appropriate curve for this code version
+  # @return [String name of appropriate curve for this code version
   def air_loop_hvac_set_vsd_curve_type
     return 'Multi Zone VAV with VSD and SP Setpoint Reset'
   end
@@ -387,7 +387,7 @@ class Standard
   #   if the proposed model had multiple fans (supply, return, exhaust, etc.)
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
-  # return [Bool] true if successful, false if not
+  # return [Boolean] true if successful, false if not
   def air_loop_hvac_apply_prm_baseline_fan_power(air_loop_hvac)
     # Main AHU fans
 
@@ -625,7 +625,7 @@ class Standard
   # with or without the fans inside of fan powered terminals.
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
-  # @param include_terminal_fans [Bool] if true, power from fan powered terminals will be included
+  # @param include_terminal_fans [Boolean] if true, power from fan powered terminals will be included
   # @return [Double] total brake horsepower of the fans on the system, in units of horsepower
   def air_loop_hvac_system_fan_brake_horsepower(air_loop_hvac, include_terminal_fans = true)
     # @todo get the template from the parent model itself?
@@ -668,7 +668,7 @@ class Standard
   # the system hitting the baseline allowable fan power
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def air_loop_hvac_apply_baseline_fan_pressure_rise(air_loop_hvac)
     OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.AirLoopHVAC', "#{air_loop_hvac.name}-Setting #{template} baseline fan power.")
 
@@ -949,7 +949,7 @@ class Standard
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if an economizer is required, false if not
+  # @return [Boolean] returns true if an economizer is required, false if not
   def air_loop_hvac_economizer_required?(air_loop_hvac, climate_zone)
     economizer_required = false
 
@@ -1025,7 +1025,7 @@ class Standard
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def air_loop_hvac_apply_economizer_limits(air_loop_hvac, climate_zone)
     # EnergyPlus economizer types
     # 'NoEconomizer'
@@ -1141,7 +1141,7 @@ class Standard
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def air_loop_hvac_apply_economizer_integration(air_loop_hvac, climate_zone)
     # Determine if an integrated economizer is required
     integrated_economizer_required = air_loop_hvac_integrated_economizer_required?(air_loop_hvac, climate_zone)
@@ -1176,7 +1176,7 @@ class Standard
   # Determine if the airloop includes hydronic cooling coils
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
-  # @return [Bool] returns true if hydronic cooling coils are included on the airloop
+  # @return [Boolean] returns true if hydronic cooling coils are included on the airloop
   def air_loop_hvac_include_hydronic_cooling_coil?(air_loop_hvac)
     air_loop_hvac.supplyComponents.each do |comp|
       return true if comp.to_CoilCoolingWater.is_initialized
@@ -1186,7 +1186,7 @@ class Standard
 
   # Determine if the airloop includes cooling coils
   #
-  # @return [Bool] returns true if cooling coils are included on the airloop
+  # @return [Boolean] returns true if cooling coils are included on the airloop
   def air_loop_hvac_include_cooling_coil?(air_loop_hvac)
     air_loop_hvac.supplyComponents.each do |comp|
       return true if comp.to_CoilCoolingWater.is_initialized
@@ -1232,7 +1232,7 @@ class Standard
 
   # Determine if the airloop includes evaporative coolers
   #
-  # @return [Bool] returns true if evaporative coolers are included on the airloop
+  # @return [Boolean] returns true if evaporative coolers are included on the airloop
   def air_loop_hvac_include_evaporative_cooler?(air_loop_hvac)
     air_loop_hvac.supplyComponents.each do |comp|
       return true if comp.to_EvaporativeCoolerDirectResearchSpecial.is_initialized
@@ -1243,7 +1243,7 @@ class Standard
 
   # Determine if the airloop includes an air-economizer
   #
-  # @return [Bool] returns true if the airloop has an air-economizer
+  # @return [Boolean] returns true if the airloop has an air-economizer
   def air_loop_hvac_include_economizer?(air_loop_hvac)
     return false unless air_loop_hvac.airLoopHVACOutdoorAirSystem.is_initialized
 
@@ -1263,7 +1263,7 @@ class Standard
   # Determine if the airloop includes WSHP cooling coils
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
-  # @return [Bool] returns true if WSHP cooling coils are included on the airloop
+  # @return [Boolean] returns true if WSHP cooling coils are included on the airloop
   def air_loop_hvac_include_wshp?(air_loop_hvac)
     air_loop_hvac.supplyComponents.each do |comp|
       return true if comp.to_CoilCoolingWaterToAirHeatPumpEquationFit.is_initialized
@@ -1279,7 +1279,7 @@ class Standard
 
   # Determine if the air loop includes a unitary system
   #
-  # @return [Bool] returns true if a unitary system is included on the air loop
+  # @return [Boolean] returns true if a unitary system is included on the air loop
   def air_loop_hvac_include_unitary_system?(air_loop_hvac)
     air_loop_hvac.supplyComponents.each do |comp|
       return true if comp.to_AirLoopHVACUnitarySystem.is_initialized
@@ -1293,7 +1293,7 @@ class Standard
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_integrated_economizer_required?(air_loop_hvac, climate_zone)
     # Determine if it is a VAV system
     is_vav = air_loop_hvac_vav_system?(air_loop_hvac)
@@ -1371,7 +1371,7 @@ class Standard
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_prm_baseline_economizer_required?(air_loop_hvac, climate_zone)
     economizer_required = false
 
@@ -1433,7 +1433,7 @@ class Standard
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def air_loop_hvac_apply_prm_baseline_economizer(air_loop_hvac, climate_zone)
     # EnergyPlus economizer types
     # 'NoEconomizer'
@@ -1553,7 +1553,7 @@ class Standard
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if allowable, if the system has no economizer or no OA system
+  # @return [Boolean] returns true if allowable, if the system has no economizer or no OA system
   #   Returns false if the economizer type is not allowable.
   def air_loop_hvac_economizer_type_allowable?(air_loop_hvac, climate_zone)
     # EnergyPlus economizer types
@@ -1638,7 +1638,7 @@ class Standard
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   # @todo Add exception logic for systems serving parking garage, warehouse, or multifamily
   def air_loop_hvac_energy_recovery_ventilator_required?(air_loop_hvac, climate_zone)
     # ERV Not Applicable for AHUs that serve
@@ -1798,7 +1798,7 @@ class Standard
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   # @todo Add exception logic for systems serving parking garage, warehouse, or multifamily
   def air_loop_hvac_apply_energy_recovery_ventilator(air_loop_hvac, climate_zone)
     # Get the OA system
@@ -1910,7 +1910,7 @@ class Standard
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   # @todo Add exception logic for systems with AIA healthcare ventilation requirements dual duct systems
   def air_loop_hvac_multizone_vav_optimization_required?(air_loop_hvac, climate_zone)
     multizone_opt_required = false
@@ -1921,7 +1921,7 @@ class Standard
   # in the Controller:MechanicalVentilation object to 'VentilationRateProcedure'
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_enable_multizone_vav_optimization(air_loop_hvac)
     # Enable multizone vav optimization
     # at each timestep.
@@ -1946,7 +1946,7 @@ class Standard
   # in the Controller:MechanicalVentilation object to 'ZoneSum'
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_disable_multizone_vav_optimization(air_loop_hvac)
     # Disable multizone vav optimization
     # at each timestep.
@@ -1975,9 +1975,9 @@ class Standard
   # Set the minimum VAV damper positions.
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
-  # @param has_ddc [Bool] if true, will assume that there is DDC control of vav terminals.
+  # @param has_ddc [Boolean] if true, will assume that there is DDC control of vav terminals.
   #   If false, assumes otherwise.
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def air_loop_hvac_apply_minimum_vav_damper_positions(air_loop_hvac, has_ddc = true)
     air_loop_hvac.thermalZones.each do |zone|
       zone.equipment.each do |equip|
@@ -1996,7 +1996,7 @@ class Standard
   # system outdoor air flow
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   # @todo Add exception logic for systems serving parking garage, warehouse, or multifamily
   def air_loop_hvac_adjust_minimum_vav_damper_positions(air_loop_hvac)
     # Do not apply the adjustment to some of the system in
@@ -2240,7 +2240,7 @@ class Standard
   #
   # @param zone [OpenStudio::Model::ThermalZone] thermal zone
   # @param mdp [Double] minimum damper position
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def air_loop_hvac_set_minimum_damper_position(zone, mdp)
     zone.equipment.each do |equip|
       if equip.to_AirTerminalSingleDuctVAVHeatAndCoolNoReheat.is_initialized
@@ -2269,7 +2269,7 @@ class Standard
   # the results of the current climate zone
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def air_loop_hvac_adjust_minimum_vav_damper_positions_outpatient(air_loop_hvac)
     air_loop_hvac.model.getSpaces.sort.each do |space|
       zone = space.thermalZone.get
@@ -2307,7 +2307,7 @@ class Standard
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   # @todo Add exception logic for systems that serve multifamily, parking garage, warehouse
   def air_loop_hvac_demand_control_ventilation_required?(air_loop_hvac, climate_zone)
     dcv_required = false
@@ -2402,7 +2402,7 @@ class Standard
   # when an energy recovery device is present.  Defaults to true.
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_dcv_required_when_erv(air_loop_hvac)
     dcv_required_when_erv_present = false
     return dcv_required_when_erv_present
@@ -2414,7 +2414,7 @@ class Standard
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_enable_demand_control_ventilation(air_loop_hvac, climate_zone)
     # Get the OA intake
     controller_oa = nil
@@ -2447,7 +2447,7 @@ class Standard
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_supply_air_temperature_reset_required?(air_loop_hvac, climate_zone)
     is_sat_reset_required = false
     return is_sat_reset_required
@@ -2456,7 +2456,7 @@ class Standard
   # Enable supply air temperature (SAT) reset based on the cooling demand of the warmest zone.
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def air_loop_hvac_enable_supply_air_temperature_reset_warmest_zone(air_loop_hvac)
     # Get the current setpoint and calculate
     # the new setpoint.
@@ -2503,7 +2503,7 @@ class Standard
   # and reset linearly when outdoor air is between 50F and 70F.
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def air_loop_hvac_enable_supply_air_temperature_reset_outdoor_temperature(air_loop_hvac)
     # for AHU1 in Outpatient, SAT is 52F constant, no reset
     return true if air_loop_hvac.name.get == 'PVAV Outpatient F1'
@@ -2546,7 +2546,7 @@ class Standard
   # Determine if the system has an economizer
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_economizer?(air_loop_hvac)
     # Get the OA system and OA controller
     oa_sys = air_loop_hvac.airLoopHVACOutdoorAirSystem
@@ -2565,7 +2565,7 @@ class Standard
   # Determine if the system is a VAV system based on the fan which may be inside of a unitary system.
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
-  # @return [Bool] returns true if vav system, false if not
+  # @return [Boolean] returns true if vav system, false if not
   def air_loop_hvac_vav_system?(air_loop_hvac)
     is_vav = false
     air_loop_hvac.supplyComponents.reverse.each do |comp|
@@ -2592,7 +2592,7 @@ class Standard
   # Determine if the system is a multizone VAV system
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
-  # @return [Bool] returns true if multizone vav, false if not
+  # @return [Boolean] returns true if multizone vav, false if not
   def air_loop_hvac_multizone_vav_system?(air_loop_hvac)
     multizone_vav_system = false
 
@@ -2616,7 +2616,7 @@ class Standard
   # Determine if the system has terminal reheat
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
-  # @return [Bool] returns true if has one or more reheat terminals, false if it doesn't
+  # @return [Boolean] returns true if has one or more reheat terminals, false if it doesn't
   def air_loop_hvac_terminal_reheat?(air_loop_hvac)
     has_term_rht = false
     air_loop_hvac.demandComponents.each do |sc|
@@ -2636,7 +2636,7 @@ class Standard
   # Determine if the system has energy recovery already
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
-  # @return [Bool] returns true if an ERV is present, false if not
+  # @return [Boolean] returns true if an ERV is present, false if not
   def air_loop_hvac_energy_recovery?(air_loop_hvac)
     has_erv = false
 
@@ -2658,7 +2658,7 @@ class Standard
   # Determine if the air loop is a unitary system
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
-  # @return [Bool] returns true if a unitary system is present, false if not
+  # @return [Boolean] returns true if a unitary system is present, false if not
   def air_loop_hvac_unitary_system?(air_loop_hvac)
     is_unitary_system = false
     air_loop_hvac.supplyComponents.each do |component|
@@ -2674,7 +2674,7 @@ class Standard
   # Set the VAV damper control to single maximum or dual maximum control depending on the standard.
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   # @todo see if this impacts the sizing run.
   def air_loop_hvac_apply_vav_damper_action(air_loop_hvac)
     damper_action = air_loop_hvac_vav_damper_action(air_loop_hvac)
@@ -2734,7 +2734,7 @@ class Standard
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_motorized_oa_damper_required?(air_loop_hvac, climate_zone)
     motorized_oa_damper_required = false
 
@@ -2829,7 +2829,7 @@ class Standard
   # @param min_occ_pct [Double] the fractional value below which the system will be considered unoccupied.
   # @param occ_sch [OpenStudio::Model::Schedule] the occupancy schedule.
   #   If not supplied, one will be created based on the supplied occupancy threshold.
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def air_loop_hvac_add_motorized_oa_damper(air_loop_hvac, min_occ_pct = 0.05, occ_sch = nil)
     # Get the OA system and OA controller
     oa_sys = air_loop_hvac.airLoopHVACOutdoorAirSystem
@@ -2872,7 +2872,7 @@ class Standard
   # increases building loads unnecessarily during unoccupied hours.
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def air_loop_hvac_remove_motorized_oa_damper(air_loop_hvac)
     # Get the OA system and OA controller
     oa_sys = air_loop_hvac.airLoopHVACOutdoorAirSystem
@@ -2910,7 +2910,7 @@ class Standard
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def air_loop_hvac_apply_single_zone_controls(air_loop_hvac, climate_zone)
     # These controls only apply to systems with DX cooling
     unless air_loop_hvac_dx_cooling?(air_loop_hvac)
@@ -3282,8 +3282,8 @@ class Standard
   #   be added to the OpenStudio data model.
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
-  # @param has_ddc [Bool] whether or not the system has DDC control over VAV terminals.
-  # return [Bool] returns true if static pressure reset is required, false if not
+  # @param has_ddc [Boolean] whether or not the system has DDC control over VAV terminals.
+  # return [Boolean] returns true if static pressure reset is required, false if not
   def air_loop_hvac_static_pressure_reset_required?(air_loop_hvac, has_ddc)
     sp_reset_required = false
 
@@ -3301,7 +3301,7 @@ class Standard
   # Per ASHRAE 90.1 section 6.4.3.3, HVAC systems are required to have off-hour controls
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_unoccupied_fan_shutoff_required?(air_loop_hvac)
     shutoff_required = true
 
@@ -3345,7 +3345,7 @@ class Standard
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param min_occ_pct [Double] the fractional value below which the system will be considered unoccupied.
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def air_loop_hvac_enable_unoccupied_fan_shutoff(air_loop_hvac, min_occ_pct = 0.05)
     # Set the system to night cycle
     # The fan of a parallel PIU terminal are set to only cycle during heating operation
@@ -3550,7 +3550,7 @@ class Standard
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param max_reheat_c [Double] the maximum reheat temperature, in degrees Celsius
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def air_loop_hvac_apply_maximum_reheat_temperature(air_loop_hvac, max_reheat_c)
     air_loop_hvac.demandComponents.each do |sc|
       if sc.to_AirTerminalSingleDuctConstantVolumeReheat.is_initialized
@@ -3578,7 +3578,7 @@ class Standard
   # Set the system sizing properties based on the zone sizing information
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def air_loop_hvac_apply_prm_sizing_temperatures(air_loop_hvac)
     # Get the design heating and cooling SAT information
     # for all zones served by the system.
@@ -3650,7 +3650,7 @@ class Standard
   # Determine if this Air Loop uses DX cooling.
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
-  # @return [Bool] returns true if uses DX cooling, false if not
+  # @return [Boolean] returns true if uses DX cooling, false if not
   def air_loop_hvac_dx_cooling?(air_loop_hvac)
     dx_clg = false
 
@@ -3698,7 +3698,7 @@ class Standard
   # Determine if this Air Loop uses multi-stage DX cooling.
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
-  # @return [Bool] returns true if uses multi-stage DX cooling, false if not
+  # @return [Boolean] returns true if uses multi-stage DX cooling, false if not
   def air_loop_hvac_multi_stage_dx_cooling?(air_loop_hvac)
     dx_clg = false
 
@@ -3741,7 +3741,7 @@ class Standard
 
   # Get return fan power for airloop
   #
-  # @param model [OpenStudio::model::AirLoopHVAC] AirLoopHVAC object
+  # @param air_loop [OpenStudio::Model::AirLoopHVAC] AirLoopHVAC object
   # @return [Float] Fan power
   def air_loop_hvac_get_return_fan_power(air_loop)
     return_fan_power = 0
@@ -3768,7 +3768,7 @@ class Standard
 
   # Get supply fan power for airloop
   #
-  # @param model [OpenStudio::model::AirLoopHVAC] AirLoopHVAC object
+  # @param air_loop [OpenStudio::Model::AirLoopHVAC] AirLoopHVAC object
   # @return [Float] Fan power
   def air_loop_hvac_get_supply_fan_power(air_loop)
     supply_fan_power = 0
@@ -3786,7 +3786,7 @@ class Standard
 
   # Get supply fan for airloop
   #
-  # @param model [OpenStudio::model::AirLoopHVAC] AirLoopHVAC object
+  # @param air_loop [OpenStudio::Model::AirLoopHVAC] AirLoopHVAC object
   # @return fan
   def air_loop_hvac_get_supply_fan(air_loop)
     fan = nil
@@ -3826,7 +3826,7 @@ class Standard
 
   # Get relief fan power for airloop
   #
-  # @param model [OpenStudio::model::AirLoopHVAC] AirLoopHVAC object
+  # @param air_loop [OpenStudio::Model::AirLoopHVAC] AirLoopHVAC object
   # @return [Float] Fan power
   def air_loop_hvac_get_relief_fan_power(air_loop)
     relief_fan_power = 0
@@ -3857,8 +3857,8 @@ class Standard
   # by scheduling air terminal dampers (so load can
   # still be met) and cycling unitary system fans
   #
-  # @param air_loop_hvac [OpenStudio::model::AirLoopHVAC] OpenStudio AirLoopHVAC object
-  # @param standby_mode_space [Array] List of all spaces required to have standby mode controls
+  # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] OpenStudio AirLoopHVAC object
+  # @param standby_mode_spaces [Array<OpenStudio::Model::Space>] List of all spaces required to have standby mode controls
   # @return [Boolean] true if sucessful, false otherwise
   def air_loop_hvac_standby_mode_occupancy_control(air_loop_hvac, standby_mode_spaces)
     return true
@@ -3870,7 +3870,6 @@ class Standard
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] HVAC air loop object
   # @param oa_control [OpenStudio::Model::ControllerOutdoorAir] Outdoor air controller object to have this maximum OA fraction schedule
   # @param snc [String] System name
-  #
   # @return [OpenStudio::Model::ScheduleRuleset] Generated maximum outdoor air fraction schedule for later use
   def set_maximum_fraction_outdoor_air_schedule(air_loop_hvac, oa_control, snc)
     max_oa_sch_name = "#{snc}maxOASch"
@@ -3879,7 +3878,7 @@ class Standard
     max_oa_sch.defaultDaySchedule.setName("#{max_oa_sch_name}Default")
     max_oa_sch.defaultDaySchedule.addValue(OpenStudio::Time.new(0, 24, 0, 0), 0.7)
     oa_control.setMaximumFractionofOutdoorAirSchedule(max_oa_sch)
-    max_oa_sch
+    return max_oa_sch
   end
 
   # Checks if zones served by the air loop use zone exhaust fan

--- a/lib/openstudio-standards/standards/Standards.AirTerminalSingleDuctParallelPIUReheat.rb
+++ b/lib/openstudio-standards/standards/Standards.AirTerminalSingleDuctParallelPIUReheat.rb
@@ -4,7 +4,7 @@ class Standard
   # Sets the fan power of a PIU fan based on the W/cfm specified in the standard.
   #
   # @param air_terminal_single_duct_parallel_piu_reheat [OpenStudio::Model::AirTerminalSingleDuctParallelPIUReheat] air terminal object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def air_terminal_single_duct_parallel_piu_reheat_apply_prm_baseline_fan_power(air_terminal_single_duct_parallel_piu_reheat)
     OpenStudio.logFree(OpenStudio::Debug, 'openstudio.standards.AirTerminalSingleDuctParallelPIUReheat', "Setting PIU fan power for #{air_terminal_single_duct_parallel_piu_reheat.name}.")
 
@@ -90,7 +90,7 @@ class Standard
   #
   # @param air_terminal_single_duct_parallel_piu_reheat [OpenStudio::Model::AirTerminalSingleDuctParallelPIUReheat] the air terminal object
   # @param zone_min_oa [Double] the zone outdoor air flow rate, in m^3/s.
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def air_terminal_single_duct_parallel_piu_reheat_apply_minimum_primary_airflow_fraction(air_terminal_single_duct_parallel_piu_reheat, zone_min_oa = nil)
     # Minimum primary air flow
     min_primary_airflow_frac = air_terminal_single_duct_parallel_reheat_piu_minimum_primary_airflow_fraction(air_terminal_single_duct_parallel_piu_reheat)

--- a/lib/openstudio-standards/standards/Standards.AirTerminalSingleDuctVAVReheat.rb
+++ b/lib/openstudio-standards/standards/Standards.AirTerminalSingleDuctVAVReheat.rb
@@ -9,9 +9,9 @@ class Standard
   # @param zone_min_oa [Double] the zone outdoor air flow rate, in m^3/s.
   #   If supplied, this will be set as a minimum limit in addition to the minimum
   #   damper position.  EnergyPlus will use the larger of the two values during sizing.
-  # @param has_ddc [Bool] whether or not there is DDC control of the VAV terminal,
+  # @param has_ddc [Boolean] whether or not there is DDC control of the VAV terminal,
   #   which impacts the minimum damper position requirement.
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   # @todo remove exception where older vintages don't have minimum positions adjusted.
   def air_terminal_single_duct_vav_reheat_apply_minimum_damper_position(air_terminal_single_duct_vav_reheat, zone_min_oa = nil, has_ddc = true)
     # Minimum damper position
@@ -34,7 +34,7 @@ class Standard
   # Defaults to 30%
   #
   # @param air_terminal_single_duct_vav_reheat [OpenStudio::Model::AirTerminalSingleDuctVAVReheat] the air terminal object
-  # @param has_ddc [Bool] whether or not there is DDC control of the VAV terminal in question
+  # @param has_ddc [Boolean] whether or not there is DDC control of the VAV terminal in question
   # @return [Double] minimum damper position
   def air_terminal_single_duct_vav_reheat_minimum_damper_position(air_terminal_single_duct_vav_reheat, has_ddc = false)
     min_damper_position = 0.3
@@ -44,7 +44,7 @@ class Standard
   # Sets the capacity of the reheat coil based on the minimum flow fraction, and the maximum flow rate.
   #
   # @param air_terminal_single_duct_vav_reheat [OpenStudio::Model::AirTerminalSingleDuctVAVReheat] the air terminal object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def air_terminal_single_duct_vav_reheat_set_heating_cap(air_terminal_single_duct_vav_reheat)
     flow_rate_fraction = 0.0
     if air_terminal_single_duct_vav_reheat.constantMinimumAirFlowFraction.is_initialized

--- a/lib/openstudio-standards/standards/Standards.BoilerHotWater.rb
+++ b/lib/openstudio-standards/standards/Standards.BoilerHotWater.rb
@@ -74,7 +74,7 @@ class Standard
   # Finds lookup object in standards and return minimum thermal efficiency
   #
   # @param boiler_hot_water [OpenStudio::Model::BoilerHotWater] hot water boiler object
-  # @param rename [Bool] if true, rename the boiler to include the new capacity and efficiency
+  # @param rename [Boolean] if true, rename the boiler to include the new capacity and efficiency
   # @return [Double] minimum thermal efficiency
   def boiler_hot_water_standard_minimum_thermal_efficiency(boiler_hot_water, rename = false)
     # Get the boiler properties
@@ -131,7 +131,7 @@ class Standard
   # Applies the standard efficiency ratings and typical performance curves to this object.
   #
   # @param boiler_hot_water [OpenStudio::Model::BoilerHotWater] hot water boiler object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def boiler_hot_water_apply_efficiency_and_curves(boiler_hot_water)
     successfully_set_all_properties = false
 

--- a/lib/openstudio-standards/standards/Standards.ChillerElectricEIR.rb
+++ b/lib/openstudio-standards/standards/Standards.ChillerElectricEIR.rb
@@ -4,7 +4,7 @@ class Standard
   # Finds the search criteria
   #
   # @param chiller_electric_eir [OpenStudio::Model::ChillerElectricEIR] chiller object
-  # @return [hash] has for search criteria to be used for find object
+  # @return [Hash] has for search criteria to be used for find object
   def chiller_electric_eir_find_search_criteria(chiller_electric_eir)
     search_criteria = {}
     search_criteria['template'] = template
@@ -108,7 +108,7 @@ class Standard
   #
   # @param chiller_electric_eir [OpenStudio::Model::ChillerElectricEIR] chiller object
   # @param clg_tower_objs [Array] cooling towers, currently unused
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   # @todo remove clg_tower_objs parameter if unused
   def chiller_electric_eir_apply_efficiency_and_curves(chiller_electric_eir, clg_tower_objs)
     chillers = standards_data['chillers']

--- a/lib/openstudio-standards/standards/Standards.CoilCoolingDXSingleSpeed.rb
+++ b/lib/openstudio-standards/standards/Standards.CoilCoolingDXSingleSpeed.rb
@@ -6,7 +6,7 @@ class Standard
   # Finds capacity in W
   #
   # @param coil_cooling_dx_single_speed [OpenStudio::Model::CoilCoolingDXSingleSpeed] coil cooling dx single speed object
-  # @param necb_ref_hp [Bool] for compatability with NECB ruleset only.
+  # @param necb_ref_hp [Boolean] for compatability with NECB ruleset only.
   # @return [Double] capacity in W to be used for find object
   def coil_cooling_dx_single_speed_find_capacity(coil_cooling_dx_single_speed, necb_ref_hp = false)
     capacity_w = nil
@@ -42,8 +42,8 @@ class Standard
   # Finds lookup object in standards and return efficiency
   #
   # @param coil_cooling_dx_single_speed [OpenStudio::Model::CoilCoolingDXSingleSpeed] coil cooling dx single speed object
-  # @param rename [Bool] if true, object will be renamed to include capacity and efficiency level
-  # @param necb_ref_hp [Bool] for compatability with NECB ruleset only.
+  # @param rename [Boolean] if true, object will be renamed to include capacity and efficiency level
+  # @param necb_ref_hp [Boolean] for compatability with NECB ruleset only.
   # @return [Double] full load efficiency (COP)
   def coil_cooling_dx_single_speed_standard_minimum_cop(coil_cooling_dx_single_speed, rename = false, necb_ref_hp = false)
     search_criteria = coil_dx_find_search_criteria(coil_cooling_dx_single_speed, necb_ref_hp)
@@ -173,7 +173,7 @@ class Standard
   #
   # @param coil_cooling_dx_single_speed [OpenStudio::Model::CoilCoolingDXSingleSpeed] coil cooling dx single speed object
   # @param sql_db_vars_map [Hash] hash map
-  # @param necb_ref_hp [Bool] for compatability with NECB ruleset only.
+  # @param necb_ref_hp [Boolean] for compatability with NECB ruleset only.
   # @return [Hash] hash of coil objects
   def coil_cooling_dx_single_speed_apply_efficiency_and_curves(coil_cooling_dx_single_speed, sql_db_vars_map, necb_ref_hp = false)
     successfully_set_all_properties = true

--- a/lib/openstudio-standards/standards/Standards.CoilCoolingDXTwoSpeed.rb
+++ b/lib/openstudio-standards/standards/Standards.CoilCoolingDXTwoSpeed.rb
@@ -24,7 +24,7 @@ class Standard
   # Finds lookup object in standards and return efficiency
   #
   # @param coil_cooling_dx_two_speed [OpenStudio::Model::CoilCoolingDXTwoSpeed] coil cooling dx two speed object
-  # @param rename [Bool] if true, object will be renamed to include capacity and efficiency level
+  # @param rename [Boolean] if true, object will be renamed to include capacity and efficiency level
   # @return [Double] full load efficiency (COP)
   def coil_cooling_dx_two_speed_standard_minimum_cop(coil_cooling_dx_two_speed, rename = false)
     search_criteria = coil_dx_find_search_criteria(coil_cooling_dx_two_speed)

--- a/lib/openstudio-standards/standards/Standards.CoilCoolingWaterToAirHeatPumpEquationFit.rb
+++ b/lib/openstudio-standards/standards/Standards.CoilCoolingWaterToAirHeatPumpEquationFit.rb
@@ -22,7 +22,7 @@ class Standard
   # Finds lookup object in standards and return efficiency
   #
   # @param coil_cooling_water_to_air_heat_pump [OpenStudio::Model::CoilCoolingWaterToAirHeatPumpEquationFit] coil cooling object
-  # @param rename [Bool] if true, object will be renamed to include capacity and efficiency level
+  # @param rename [Boolean] if true, object will be renamed to include capacity and efficiency level
   # @return [Double] full load efficiency (COP)
   def coil_cooling_water_to_air_heat_pump_standard_minimum_cop(coil_cooling_water_to_air_heat_pump, rename = false, computer_room_air_conditioner = false)
     search_criteria = {}

--- a/lib/openstudio-standards/standards/Standards.CoilDX.rb
+++ b/lib/openstudio-standards/standards/Standards.CoilDX.rb
@@ -48,7 +48,7 @@ module CoilDX
   #
   # @param coil_dx [OpenStudio::Model::StraightComponent] coil cooling object, allowable types:
   #   CoilCoolingDXSingleSpeed, CoilCoolingDXTwoSpeed, CoilCoolingDXMultiSpeed
-  # @return [Bool] returns true if it is a heat pump, false if not
+  # @return [Boolean] returns true if it is a heat pump, false if not
   def coil_dx_heat_pump?(coil_dx)
     heat_pump = false
 
@@ -84,7 +84,7 @@ module CoilDX
   #
   # @param coil_dx [OpenStudio::Model::StraightComponent] coil cooling object, allowable types:
   #   CoilCoolingDXSingleSpeed, CoilCoolingDXTwoSpeed, CoilCoolingDXMultiSpeed
-  # @param necb_ref_hp [Bool] for compatability with NECB ruleset only.
+  # @param necb_ref_hp [Boolean] for compatability with NECB ruleset only.
   # @return [String] the heating type
   def coil_dx_heating_type(coil_dx, necb_ref_hp = false)
     htg_type = nil
@@ -160,8 +160,8 @@ module CoilDX
   #
   # @param coil_dx [OpenStudio::Model::StraightComponent] coil cooling object, allowable types:
   #   CoilCoolingDXSingleSpeed, CoilCoolingDXTwoSpeed, CoilCoolingDXMultiSpeed
-  # @param necb_ref_hp [Bool] for compatability with NECB ruleset only.
-  # @return [hash] has for search criteria to be used for find object
+  # @param necb_ref_hp [Boolean] for compatability with NECB ruleset only.
+  # @return [Hash] has for search criteria to be used for find object
   def coil_dx_find_search_criteria(coil_dx, necb_ref_hp = false)
     search_criteria = {}
     search_criteria['template'] = template

--- a/lib/openstudio-standards/standards/Standards.CoilHeatingDXMultiSpeed.rb
+++ b/lib/openstudio-standards/standards/Standards.CoilHeatingDXMultiSpeed.rb
@@ -4,7 +4,7 @@ class Standard
   # Applies the standard efficiency ratings and typical performance curves to this object.
   #
   # @param coil_heating_dx_multi_speed [OpenStudio::Model::CoilHeatingDXMultiSpeed] coil heating dx multi speed object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def coil_heating_dx_multi_speed_apply_efficiency_and_curves(coil_heating_dx_multi_speed, sql_db_vars_map)
     successfully_set_all_properties = true
 

--- a/lib/openstudio-standards/standards/Standards.CoilHeatingDXSingleSpeed.rb
+++ b/lib/openstudio-standards/standards/Standards.CoilHeatingDXSingleSpeed.rb
@@ -6,7 +6,7 @@ class Standard
   # Finds capacity in W.  This is the cooling capacity of the paired DX cooling coil.
   #
   # @param coil_heating_dx_single_speed [OpenStudio::Model::CoilHeatingDXSingleSpeed] coil heating dx single speed object
-  # @param necb_ref_hp [Bool] for compatability with NECB ruleset only.
+  # @param necb_ref_hp [Boolean] for compatability with NECB ruleset only.
   # @return [Double] capacity in W to be used for find object
   def coil_heating_dx_single_speed_find_capacity(coil_heating_dx_single_speed, necb_ref_hp = false)
     capacity_w = nil
@@ -104,8 +104,8 @@ class Standard
   # Finds lookup object in standards and return efficiency
   #
   # @param coil_heating_dx_single_speed [OpenStudio::Model::CoilHeatingDXSingleSpeed] coil heating dx single speed object
-  # @param rename [Bool] if true, object will be renamed to include capacity and efficiency level
-  # @param necb_ref_hp [Bool] for compatability with NECB ruleset only.
+  # @param rename [Boolean] if true, object will be renamed to include capacity and efficiency level
+  # @param necb_ref_hp [Boolean] for compatability with NECB ruleset only.
   # @return [Double] full load efficiency (COP)
   def coil_heating_dx_single_speed_standard_minimum_cop(coil_heating_dx_single_speed, rename = false, necb_ref_hp = false)
     # find ac properties
@@ -181,7 +181,7 @@ class Standard
   #
   # @param coil_heating_dx_single_speed [OpenStudio::Model::CoilHeatingDXSingleSpeed] coil heating dx single speed object
   # @param sql_db_vars_map [Hash] hash map
-  # @param necb_ref_hp [Bool] for compatability with NECB ruleset only.
+  # @param necb_ref_hp [Boolean] for compatability with NECB ruleset only.
   # @return [Hash] hash of coil objects
   def coil_heating_dx_single_speed_apply_efficiency_and_curves(coil_heating_dx_single_speed, sql_db_vars_map, necb_ref_hp = false)
     successfully_set_all_properties = true

--- a/lib/openstudio-standards/standards/Standards.CoilHeatingGas.rb
+++ b/lib/openstudio-standards/standards/Standards.CoilHeatingGas.rb
@@ -4,7 +4,7 @@ class Standard
   # Applies the standard efficiency ratings to CoilHeatingGas.
   #
   # @param coil_heating_gas [OpenStudio::Model::CoilHeatingGas] coil heating gas object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def coil_heating_gas_apply_efficiency_and_curves(coil_heating_gas)
     successfully_set_all_properties = false
     # Initialize search criteria

--- a/lib/openstudio-standards/standards/Standards.CoilHeatingGasMultiStage.rb
+++ b/lib/openstudio-standards/standards/Standards.CoilHeatingGasMultiStage.rb
@@ -19,7 +19,7 @@ class Standard
   # Applies the standard efficiency ratings and typical performance curves to this object.
   #
   # @param coil_heating_gas_multi_stage [OpenStudio::Model::CoilHeatingGasMultiStage] coil heating gas multi stage object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def coil_heating_gas_multi_stage_apply_efficiency_and_curves(coil_heating_gas_multi_stage)
     successfully_set_all_properties = true
 

--- a/lib/openstudio-standards/standards/Standards.CoilHeatingWaterToAirHeatPumpEquationFit.rb
+++ b/lib/openstudio-standards/standards/Standards.CoilHeatingWaterToAirHeatPumpEquationFit.rb
@@ -88,7 +88,7 @@ class Standard
   # Finds lookup object in standards and return efficiency
   #
   # @param coil_heating_water_to_air_heat_pump [OpenStudio::Model::CoilHeatingWaterToAirHeatPumpEquationFit] coil heating object
-  # @param rename [Bool] if true, object will be renamed to include capacity and efficiency level
+  # @param rename [Boolean] if true, object will be renamed to include capacity and efficiency level
   # @return [Double] full load efficiency (COP)
   def coil_heating_water_to_air_heat_pump_standard_minimum_cop(coil_heating_water_to_air_heat_pump, rename = false)
     search_criteria = {}

--- a/lib/openstudio-standards/standards/Standards.Construction.rb
+++ b/lib/openstudio-standards/standards/Standards.Construction.rb
@@ -12,11 +12,11 @@ class Standard
   #   'ExteriorRoof', 'Skylight', 'TubularDaylightDome', 'TubularDaylightDiffuser', 'ExteriorFloor',
   #   'ExteriorWall', 'ExteriorWindow', 'ExteriorDoor', 'GlassDoor', 'OverheadDoor', 'GroundContactFloor',
   #   'GroundContactWall', 'GroundContactRoof'
-  # @param target_includes_int_film_coefficients [Bool] if true, subtracts off standard film interior coefficients from your
+  # @param target_includes_int_film_coefficients [Boolean] if true, subtracts off standard film interior coefficients from your
   #   target_u_value before modifying insulation thickness.  Film values from 90.1-2010 A9.4.1 Air Films
-  # @param target_includes_ext_film_coefficients [Bool] if true, subtracts off standard exterior film coefficients from your
+  # @param target_includes_ext_film_coefficients [Boolean] if true, subtracts off standard exterior film coefficients from your
   #   target_u_value before modifying insulation thickness.  Film values from 90.1-2010 A9.4.1 Air Films
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   # @todo Put in Phlyroy's logic for inferring the insulation layer of a construction
   def construction_set_u_value(construction, target_u_value_ip, insulation_layer_name = nil, intended_surface_type = 'ExteriorWall', target_includes_int_film_coefficients, target_includes_ext_film_coefficients)
     OpenStudio.logFree(OpenStudio::Debug, 'openstudio.standards.Construction', "Setting U-Value for #{construction.name}.")
@@ -134,11 +134,11 @@ class Standard
   #   'ExteriorRoof', 'Skylight', 'TubularDaylightDome', 'TubularDaylightDiffuser', 'ExteriorFloor',
   #   'ExteriorWall', 'ExteriorWindow', 'ExteriorDoor', 'GlassDoor', 'OverheadDoor', 'GroundContactFloor',
   #   'GroundContactWall', 'GroundContactRoof'
-  # @param target_includes_int_film_coefficients [Bool] if true, subtracts off standard film interior coefficients from your
+  # @param target_includes_int_film_coefficients [Boolean] if true, subtracts off standard film interior coefficients from your
   #   target_u_value before modifying insulation thickness.  Film values from 90.1-2010 A9.4.1 Air Films
-  # @param target_includes_ext_film_coefficients [Bool] if true, subtracts off standard exterior film coefficients from your
+  # @param target_includes_ext_film_coefficients [Boolean] if true, subtracts off standard exterior film coefficients from your
   #   target_u_value before modifying insulation thickness.  Film values from 90.1-2010 A9.4.1 Air Films
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def construction_set_glazing_u_value(construction, target_u_value_ip, intended_surface_type = 'ExteriorWall', target_includes_int_film_coefficients, target_includes_ext_film_coefficients)
     OpenStudio.logFree(OpenStudio::Debug, 'openstudio.standards.Construction', "Setting U-Value for #{construction.name}.")
 
@@ -219,7 +219,7 @@ class Standard
   #
   # @param construction [OpenStudio::Model::Construction] construction object
   # @param target_shgc [Double] Solar Heat Gain Coefficient
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def construction_set_glazing_shgc(construction, target_shgc)
     OpenStudio.logFree(OpenStudio::Debug, 'openstudio.standards.Construction', "Setting SHGC for #{construction.name}.")
 
@@ -244,7 +244,7 @@ class Standard
   # as indicated by having a single layer of type SimpleGlazing.
   #
   # @param construction [OpenStudio::Model::Construction] construction object
-  # @return [Bool] returns true if it is a simple glazing, false if not
+  # @return [Boolean] returns true if it is a simple glazing, false if not
   def construction_simple_glazing?(construction)
     # Not simple if more than 1 layer
     if construction.layers.length > 1
@@ -269,7 +269,7 @@ class Standard
   # @param construction [OpenStudio::Model::Construction] construction object
   # @param target_f_factor_ip [Double] F-Factor
   # @param insulation_layer_name [String] The name of the insulation layer in this construction
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def construction_set_slab_f_factor(construction, target_f_factor_ip, insulation_layer_name = nil)
     # Regression from table A6.3 unheated, fully insulated slab
     r_value_ip = 1.0248 * target_f_factor_ip**-2.186
@@ -289,7 +289,7 @@ class Standard
   # @param construction [OpenStudio::Model::FFactorGroundFloorConstruction] OpenStudio F-factor construction object
   # @param target_f_factor_ip [Float] Targeted F-Factor in IP units
   # @param surface [OpenStudio::Model::Surface] OpenStudio surface object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def construction_set_surface_slab_f_factor(construction, target_f_factor_ip, surface)
     # Get space associated with surface
     space = surface.space.get
@@ -325,7 +325,7 @@ class Standard
   # @param construction [OpenStudio::Model::Construction] construction object
   # @param target_c_factor_ip [Double] C-Factor
   # @param insulation_layer_name [String] The name of the insulation layer in this construction
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def construction_set_underground_wall_c_factor(construction, target_c_factor_ip, insulation_layer_name = nil)
     # Regression from table A4.2 continuous exterior insulation
     r_value_ip = 0.775 * target_c_factor_ip**-1.067
@@ -345,7 +345,7 @@ class Standard
   # @param construction [OpenStudio::Model::CFactorUndergroundWallConstruction] OpenStudio C-factor construction object
   # @param target_c_factor_ip [Float] Targeted C-Factor in IP units
   # @param surface [OpenStudio::Model::Surface] OpenStudio surface object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def construction_set_surface_underground_wall_c_factor(construction, target_c_factor_ip, surface)
     # Get space associated with surface
     space = surface.space.get
@@ -529,8 +529,7 @@ class Standard
   # Calculate the fenestration U-Factor base on the glass, frame,
   # and divider performance and area calculated by EnergyPlus.
   #
-  # @param [OpenStudio:Model:Construction] OpenStudio Construction object
-  #
+  # @param construction [OpenStudio:Model:Construction] OpenStudio Construction object
   # @return [Double] the U-Factor in W/m^2*K
   def construction_calculated_fenestration_u_factor_w_frame(construction)
     construction_name = construction.name.get.to_s
@@ -684,7 +683,7 @@ class Standard
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @param values [Hash] has of values
-  # @param is_percentage [Bool] toggle is percentage
+  # @param is_percentage [Boolean] toggle is percentage
   # @return [Hash] json information
   def change_construction_properties_in_model(model, values, is_percentage = false)
     # puts JSON.pretty_generate(values)
@@ -746,8 +745,8 @@ class Standard
   # @param conductance [Double] conductance value in SI
   # @param shgc [Double] solar heat gain coefficient value, unitless
   # @param tvis [Double] visible transmittance
-  # @param is_percentage [Bool] toggle is percentage
-  # @return [Bool] returns true if successful, false if not
+  # @param is_percentage [Boolean] toggle is percentage
+  # @return [Boolean] returns true if successful, false if not
   def apply_changes_to_surface_construction(model, surface, conductance = nil, shgc = nil, tvis = nil, is_percentage = false)
     # If user has no changes...do nothing and return true.
     return true if conductance.nil? && shgc.nil? && tvis.nil?
@@ -877,7 +876,7 @@ class Standard
   #
   # @param construction [OpenStudio::Model::Construction] construction object
   # @param target_tvis [Double] Visible Transmittance
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def construction_set_glazing_tvis(construction, target_tvis)
     if target_tvis >= 1.0
       OpenStudio.logFree(OpenStudio::Error, 'openstudio.standards.Construction', "Can only set the Tvis can only be set to less than 1.0. #{target_tvis} is greater than 1.0")

--- a/lib/openstudio-standards/standards/Standards.CoolingTower.rb
+++ b/lib/openstudio-standards/standards/Standards.CoolingTower.rb
@@ -18,7 +18,7 @@ module CoolingTower
   #
   # @param cooling_tower [OpenStudio::Model::StraightComponent] cooling tower object, allowable types:
   #   CoolingTowerSingleSpeed, CoolingTowerTwoSpeed, and CoolingTowerVariableSpeed
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def cooling_tower_apply_minimum_power_per_flow(cooling_tower)
     # Get the design water flow rate
     design_water_flow_m3_per_s = nil

--- a/lib/openstudio-standards/standards/Standards.CoolingTowerSingleSpeed.rb
+++ b/lib/openstudio-standards/standards/Standards.CoolingTowerSingleSpeed.rb
@@ -6,7 +6,7 @@ class Standard
   # Applies the standard efficiency ratings and typical performance curves to this object.
   #
   # @param cooling_tower_single_speed [OpenStudio::Model::CoolingTowerSingleSpeed] single speed cooling tower
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def cooling_tower_single_speed_apply_efficiency_and_curves(cooling_tower_single_speed)
     cooling_tower_apply_minimum_power_per_flow(cooling_tower_single_speed)
     return true

--- a/lib/openstudio-standards/standards/Standards.CoolingTowerTwoSpeed.rb
+++ b/lib/openstudio-standards/standards/Standards.CoolingTowerTwoSpeed.rb
@@ -6,7 +6,7 @@ class Standard
   # Applies the standard efficiency ratings and typical performance curves to this object.
   #
   # @param cooling_tower_two_speed [OpenStudio::Model::CoolingTowerTwoSpeed] two speed cooling tower
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def cooling_tower_two_speed_apply_efficiency_and_curves(cooling_tower_two_speed)
     cooling_tower_apply_minimum_power_per_flow(cooling_tower_two_speed)
 

--- a/lib/openstudio-standards/standards/Standards.CoolingTowerVariableSpeed.rb
+++ b/lib/openstudio-standards/standards/Standards.CoolingTowerVariableSpeed.rb
@@ -6,7 +6,7 @@ class Standard
   # Applies the standard efficiency ratings and typical performance curves to this object.
   #
   # @param cooling_tower_variable_speed [OpenStudio::Model::CoolingTowerVariableSpeed] variable speed cooling tower
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def cooling_tower_variable_speed_apply_efficiency_and_curves(cooling_tower_variable_speed)
     cooling_tower_apply_minimum_power_per_flow(cooling_tower_variable_speed)
     return true

--- a/lib/openstudio-standards/standards/Standards.Fan.rb
+++ b/lib/openstudio-standards/standards/Standards.Fan.rb
@@ -8,7 +8,7 @@ module Fan
   # @param fan [OpenStudio::Model::StraightComponent] fan object, allowable types:
   #   FanConstantVolume, FanOnOff, FanVariableVolume, and FanZoneExhaust
   # @param allowed_bhp [Double] allowable brake horsepower
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def fan_apply_standard_minimum_motor_efficiency(fan, allowed_bhp)
     # Find the motor efficiency
     motor_eff, nominal_hp = fan_standard_minimum_motor_efficiency_and_size(fan, allowed_bhp)
@@ -39,7 +39,7 @@ module Fan
   # @param fan [OpenStudio::Model::StraightComponent] fan object, allowable types:
   #   FanConstantVolume, FanOnOff, FanVariableVolume, and FanZoneExhaust
   # @param target_fan_power [Double] the target fan power in watts
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def fan_adjust_pressure_rise_to_meet_fan_power(fan, target_fan_power)
     # Get design supply air flow rate (whether autosized or hard-sized)
     dsn_air_flow_m3_per_s = 0
@@ -161,7 +161,7 @@ module Fan
   # @param fan [OpenStudio::Model::StraightComponent] fan object, allowable types:
   #   FanConstantVolume, FanOnOff, FanVariableVolume, and FanZoneExhaust
   # @param motor_eff [Double] motor efficiency (0.0 to 1.0)
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def fan_change_motor_efficiency(fan, motor_eff)
     # Calculate the existing impeller efficiency
     existing_motor_eff = 0.7
@@ -190,7 +190,7 @@ module Fan
   # @param fan [OpenStudio::Model::StraightComponent] fan object, allowable types:
   #   FanConstantVolume, FanOnOff, FanVariableVolume, and FanZoneExhaust
   # @param impeller_eff [Double] impeller efficiency (0.0 to 1.0)
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def fan_change_impeller_efficiency(fan, impeller_eff)
     # Get the existing motor efficiency
     existing_motor_eff = 0.7
@@ -305,7 +305,7 @@ module Fan
   #
   # @param fan [OpenStudio::Model::StraightComponent] fan object, allowable types:
   #   FanConstantVolume, FanOnOff, FanVariableVolume, and FanZoneExhaust
-  # @return [Bool] returns true if it is a small fan, false if not
+  # @return [Boolean] returns true if it is a small fan, false if not
   def fan_small_fan?(fan)
     is_small = false
 

--- a/lib/openstudio-standards/standards/Standards.FanVariableVolume.rb
+++ b/lib/openstudio-standards/standards/Standards.FanVariableVolume.rb
@@ -17,7 +17,7 @@ class Standard
   #   Multi Zone VAV with VSD and Fixed SP Setpoint,
   #   Multi Zone VAV with VSD and Static Pressure Reset,
   #   Single Zone VAV Fan
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def fan_variable_volume_set_control_type(fan_variable_volume, control_type)
     # Determine the coefficients
     coeff_a = nil
@@ -113,7 +113,7 @@ class Standard
   # Determines whether there is a requirement to have a VSD or some other method to reduce fan power at low part load ratios.
   #
   # @param fan_variable_volume [OpenStudio::Model::FanVariableVolume] variable volume fan object
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def fan_variable_volume_part_load_fan_power_limitation?(fan_variable_volume)
     part_load_control_required = false
 

--- a/lib/openstudio-standards/standards/Standards.FluidCooler.rb
+++ b/lib/openstudio-standards/standards/Standards.FluidCooler.rb
@@ -21,7 +21,7 @@ class Standard
   # @param equipment_type [String] heat rejection equipment type enumeration used for lookup query,
   #   options are 'Closed Cooling Tower', modeled as an EvaporativeFluidCooler,
   #   or 'Dry Cooler', modeled as a FluidCooler
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def fluid_cooler_apply_minimum_power_per_flow(fluid_cooler, equipment_type: 'Closed Cooling Tower')
     # Get the design water flow rate
     if fluid_cooler.designWaterFlowRate.is_initialized

--- a/lib/openstudio-standards/standards/Standards.HeaderedPumpsVariableSpeed.rb
+++ b/lib/openstudio-standards/standards/Standards.HeaderedPumpsVariableSpeed.rb
@@ -7,7 +7,7 @@ class Standard
   #
   # @param headered_pumps_variable_speed [OpenStudio::Model::HeaderedPumpsVariableSpeed] headered variable speed pumps object
   # @param control_type [String] valid choices are Riding Curve, VSD No Reset, VSD DP Reset
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def headered_pumps_variable_speed_set_control_type(headered_pumps_variable_speed, control_type)
     # Determine the coefficients
     coeff_a = nil

--- a/lib/openstudio-standards/standards/Standards.HeatExchangerSensLat.rb
+++ b/lib/openstudio-standards/standards/Standards.HeatExchangerSensLat.rb
@@ -4,7 +4,7 @@ class Standard
   # Sets the minimum effectiveness of the heat exchanger per the standard.
   #
   # @param heat_exchanger_air_to_air_sensible_and_latent [OpenStudio::Model::HeatExchangerAirToAirSensibleAndLatent] the heat exchanger
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def heat_exchanger_air_to_air_sensible_and_latent_apply_effectiveness(heat_exchanger_air_to_air_sensible_and_latent)
     # Assumed to be sensible and latent at all flow
     full_htg_sens_eff, full_htg_lat_eff, part_htg_sens_eff, part_htg_lat_eff, full_cool_sens_eff, full_cool_lat_eff, part_cool_sens_eff, part_cool_lat_eff = heat_exchanger_air_to_air_sensible_and_latent_minimum_effectiveness(heat_exchanger_air_to_air_sensible_and_latent)

--- a/lib/openstudio-standards/standards/Standards.Model.rb
+++ b/lib/openstudio-standards/standards/Standards.Model.rb
@@ -18,30 +18,27 @@ class Standard
   #
   # @note Per 90.1, the Performance Rating Method "does NOT offer an alternative compliance path for minimum standard compliance."
   # This means you can't use this method for code compliance to get a permit.
-  # @param user_model [OpenStudio::model::Model] User specified OpenStudio model
+  # @param model [OpenStudio::Model::Model] User specified OpenStudio model
   # @param climate_zone [String] the climate zone
   # @param hvac_building_type [String] the building type for baseline HVAC system determination (90.1-2016 and onward)
   # @param wwr_building_type [String] the building type for baseline WWR determination (90.1-2016 and onward)
   # @param swh_building_type [String] the building type for baseline SWH determination (90.1-2016 and onward)
   # @param output_dir [String] the directory where the PRM generations will be performed
-  # @param run_all_orients [Boolean] indicate weather a baseline model should be created for all 4 orientations: same as user model, +90 deg, +180 deg, +270 deg
   # @param debug [Boolean] If true, will report out more detailed debugging output
-  # @return [Bool] returns true if successful, false if not
-
-  # Method used for 90.1-2016 and onward
+  # @return [Boolean] returns true if successful, false if not
   def model_create_prm_stable_baseline_building(model, climate_zone, hvac_building_type, wwr_building_type, swh_building_type, output_dir = Dir.pwd, unmet_load_hours_check = true, debug = false)
     model_create_prm_any_baseline_building(model, '', climate_zone, hvac_building_type, wwr_building_type, swh_building_type, true, false, output_dir, true, unmet_load_hours_check, debug)
   end
 
   # Creates a Performance Rating Method (aka Appendix G aka LEED) baseline building model
   # Method used for 90.1-2013 and prior
-  # @param user_model [OpenStudio::model::Model] User specified OpenStudio model
+  # @param model [OpenStudio::Model::Model] User specified OpenStudio model
   # @param building_type [String] the building type
   # @param climate_zone [String] the climate zone
   # @param custom [String] the custom logic that will be applied during baseline creation.  Valid choices are 'Xcel Energy CO EDA' or '90.1-2007 with addenda dn'.
   #   If nothing is specified, no custom logic will be applied; the process will follow the template logic explicitly.
   # @param sizing_run_dir [String] the directory where the sizing runs will be performed
-  # @param debug [Boolean] If true, will report out more detailed debugging output
+  # @param debug [Boolean] if true, will report out more detailed debugging output
   def model_create_prm_baseline_building(model, building_type, climate_zone, custom = nil, sizing_run_dir = Dir.pwd, debug = false)
     model_create_prm_any_baseline_building(model, building_type, climate_zone, 'All others', 'All others', 'All others', false, custom, sizing_run_dir, false, false, debug)
   end
@@ -51,7 +48,7 @@ class Standard
   #
   # @note Per 90.1, the Performance Rating Method "does NOT offer an alternative compliance path for minimum standard compliance."
   # This means you can't use this method for code compliance to get a permit.
-  # @param user_model [OpenStudio::model::Model] User specified OpenStudio model
+  # @param user_model [OpenStudio::Model::Model] User specified OpenStudio model
   # @param building_type [String] the building type
   # @param climate_zone [String] the climate zone
   # @param hvac_building_type [String] the building type for baseline HVAC system determination (90.1-2016 and onward)
@@ -63,7 +60,7 @@ class Standard
   # @param sizing_run_dir [String] the directory where the sizing runs will be performed
   # @param run_all_orients [Boolean] indicate weather a baseline model should be created for all 4 orientations: same as user model, +90 deg, +180 deg, +270 deg
   # @param debug [Boolean] If true, will report out more detailed debugging output
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_create_prm_any_baseline_building(user_model, building_type, climate_zone, hvac_building_type = 'All others', wwr_building_type = 'All others', swh_building_type = 'All others', model_deep_copy = false, custom = nil, sizing_run_dir = Dir.pwd, run_all_orients = false, unmet_load_hours_check = true, debug = false)
     # Check proposed model unmet load hours
     if unmet_load_hours_check
@@ -526,7 +523,7 @@ class Standard
   # These VLT values are needed for the daylighting controls logic for some templates.
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def model_create_prm_baseline_building_requires_vlt_sizing_run(model)
     return false # Not required for most templates
   end
@@ -596,7 +593,7 @@ class Standard
   # Add design day schedule objects for space loads,
   # not used for 2013 and earlier
   # @author Xuechen (Jerry) Lei, PNNL
-  # @param model [OpenStudio::model::Model] OpenStudio model object
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
   #
   def model_apply_prm_baseline_sizing_schedule(model)
     return true
@@ -935,7 +932,7 @@ class Standard
   end
 
   # Before deleting proposed HVAC components, determine for each zone if it has district heating
-  # @return [Hash] of boolean with zone name as key
+  # @return [Hash] Hash of boolean with zone name as key
   def model_get_district_heating_zones(model)
     has_district_hash = {}
     model.getThermalZones.sort.each do |zone|
@@ -959,7 +956,7 @@ class Standard
 
   # Get list of heat types across a list of zones
   # @param zones [array of objects] array of zone objects
-  # @return [string] concatenated string showing different fuel types in a group of zones
+  # @return [String concatenated string showing different fuel types in a group of zones
   def get_group_heat_types(model, zones)
     heat_list = ''
     has_district_heat = false
@@ -998,7 +995,7 @@ class Standard
   # Store fan operation schedule for each zone before deleting HVAC objects
   # @author Doug Maddox, PNNL
   # @param model [object]
-  # @return [hash] of zoneName:fan_schedule_8760
+  # @return [Hash] of zoneName:fan_schedule_8760
   def get_fan_schedule_for_each_zone(model)
     fan_sch_names = {}
 
@@ -1156,7 +1153,7 @@ class Standard
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @param sys_group [hash] Hash defining a group of zones that have the same Appendix G system type
+  # @param sys_group [Hash] Hash defining a group of zones that have the same Appendix G system type
   # @param custom [String] custom fuel type
   # @return [String] The system type.  Possibilities are PTHP, PTAC, PSZ_AC, PSZ_HP, PVAV_Reheat, PVAV_PFP_Boxes,
   #   VAV_Reheat, VAV_PFP_Boxes, Gas_Furnace, Electric_Furnace
@@ -1363,7 +1360,7 @@ class Standard
   # @param zone_heat_fuel [String] zone heating/reheat fuel.  Valid choices are Electricity, NaturalGas, DistrictHeating
   # @param cool_fuel [String] cooling fuel.  Valid choices are Electricity, DistrictCooling
   # @param zones [Array<OpenStudio::Model::ThermalZone>] an array of zones
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   # @todo Add 90.1-2013 systems 11-13
   def model_add_prm_baseline_system(model, system_type, main_heat_fuel, zone_heat_fuel, cool_fuel, zones, zone_fan_scheds)
     case system_type
@@ -2166,8 +2163,8 @@ class Standard
 
   # For a multizone system, create the fan schedule based on zone occupancy/fan schedules
   # @author Doug Maddox, PNNL
-  # @param model
-  # @param zone_fan_scheds [Hash] of hash of zoneName:8760FanSchedPerZone
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
+  # @param zone_op_hrs [Hash] hash of zoneName zone_op_hrs
   # @param pri_zones [Array<String>] names of zones served by the multizone system
   # @param system_name [String] name of air loop
   def model_create_multizone_fan_schedule(model, zone_op_hrs, pri_zones, system_name)
@@ -2226,7 +2223,7 @@ class Standard
   # Does not assign a story to plenum spaces.
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_assign_spaces_to_stories(model)
     # Make hash of spaces and minz values
     sorted_spaces = {}
@@ -2266,7 +2263,7 @@ class Standard
   # @note This must be performed before the sizing run because it impacts component sizes, which in turn impact efficiencies.
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_apply_multizone_vav_outdoor_air_sizing(model)
     OpenStudio.logFree(OpenStudio::Info, 'openstudio.model.Model', 'Started applying multizone vav OA sizing.')
 
@@ -2280,10 +2277,10 @@ class Standard
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @param apply_controls [Bool] toggle whether to apply air loop and plant loop controls
+  # @param apply_controls [Boolean] toggle whether to apply air loop and plant loop controls
   # @param sql_db_vars_map [Hash] hash map
-  # @param necb_ref_hp [Bool] for compatability with NECB ruleset only.
-  # @return [Bool] returns true if successful, false if not
+  # @param necb_ref_hp [Boolean] for compatability with NECB ruleset only.
+  # @return [Boolean] returns true if successful, false if not
   def model_apply_hvac_efficiency_standard(model, climate_zone, apply_controls: true, sql_db_vars_map: nil, necb_ref_hp: false)
     sql_db_vars_map = {} if sql_db_vars_map.nil?
 
@@ -2367,7 +2364,7 @@ class Standard
   # Applies daylighting controls to each space in the model per the standard.
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_add_daylighting_controls(model)
     OpenStudio.logFree(OpenStudio::Info, 'openstudio.model.Model', 'Started adding daylighting controls.')
 
@@ -2381,7 +2378,9 @@ class Standard
   end
 
   # For backward compatibility, infiltration standard not used for 2013 and earlier
-  # @return [Bool] true if successful, false if not
+  #
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
+  # @return [Boolean] true if successful, false if not
   def model_baseline_apply_infiltration_standard(model, climate_zone)
     return true
   end
@@ -2391,7 +2390,7 @@ class Standard
   # and removes the SpaceType-level infiltration objects.
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   # @todo This infiltration method is not used by the Reference buildings, fix this inconsistency.
   def model_apply_infiltration_standard(model)
     # Set the infiltration rate at each space
@@ -3396,7 +3395,7 @@ class Standard
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param building_type [String] the building type
   # @param spc_type [String] the space type
-  # @param is_residential [Bool] true if the building is residential
+  # @param is_residential [Boolean] true if the building is residential
   # @return [OpenStudio::Model::OptionalDefaultConstructionSet] an optional default construction set
   def model_add_construction_set(model, climate_zone, building_type, spc_type, is_residential)
     construction_set = OpenStudio::Model::OptionalDefaultConstructionSet.new
@@ -4000,8 +3999,8 @@ class Standard
   # medium or large based on building area that can be turned off
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param remap_office [bool] re-map small office or leave it alone
-  # @return [hash] key for climate zone, building type, and standards template.  All values are strings.
+  # @param remap_office [Boolean] re-map small office or leave it alone
+  # @return [Hash] key for climate zone, building type, and standards template.  All values are strings.
   def model_get_building_properties(model, remap_office = true)
     # get climate zone from model
     climate_zone = model_standards_climate_zone(model)
@@ -4283,7 +4282,7 @@ class Standard
   #
   # 90.1-2007, 90.1-2010, 90.1-2013
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_apply_prm_construction_types(model)
     types_to_modify = []
 
@@ -4369,7 +4368,7 @@ class Standard
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_apply_standard_constructions(model, climate_zone, wwr_building_type: nil, wwr_info: {})
     types_to_modify = []
 
@@ -4511,7 +4510,7 @@ class Standard
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   # @todo add proper support for 90.1-2013 with all those building type specific values
   # @todo support 90.1-2004 requirement that windows be modeled as horizontal bands.
   #   Currently just using existing window geometry, and shrinking as necessary if WWR is above limit.
@@ -4798,7 +4797,7 @@ class Standard
   # Reduces the SRR to the values specified by the PRM. SRR reduction will be done by shrinking vertices toward the centroid.
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   # @todo support semiheated spaces as a separate SRR category
   # @todo add skylight frame area to calculation of SRR
   def model_apply_prm_baseline_skylight_to_roof_ratio(model)
@@ -4943,7 +4942,7 @@ class Standard
   # Apply baseline values to exterior lights objects
   # Only implemented for stable baseline
   #
-  # @param model [OpenStudio::model::Model] OpenStudio model object
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
   def model_apply_baseline_exterior_lighting(model)
     return false
   end
@@ -4959,7 +4958,7 @@ class Standard
   # This does not include plant loops that serve WaterUse:Equipment or Fan:ZoneExhaust
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_remove_prm_hvac(model)
     # Plant loops
     model.getPlantLoops.sort.each do |loop|
@@ -5015,7 +5014,7 @@ class Standard
   # Remove EMS objects that may be orphaned from removing HVAC
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_remove_prm_ems_objects(model)
     model.getEnergyManagementSystemActuators.each(&:remove)
     model.getEnergyManagementSystemConstructionIndexVariables.each(&:remove)
@@ -5036,7 +5035,7 @@ class Standard
   # Remove external shading devices. Site shading will not be impacted.
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_remove_external_shading_devices(model)
     shading_surfaces_removed = 0
     model.getShadingSurfaceGroups.sort.each do |shade_group|
@@ -5056,7 +5055,7 @@ class Standard
   # Changes the sizing parameters to the PRM specifications.
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_apply_prm_sizing_parameters(model)
     clg = 1.15
     htg = 1.25
@@ -5333,7 +5332,7 @@ class Standard
   # with information that the spacetype needs to be defined.
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_validate_standards_spacetypes_in_model(model)
     error_string = ''
     # populate search hash
@@ -5486,7 +5485,7 @@ class Standard
   # create space_type_hash with info such as effective_num_spaces, num_units, num_meds, num_meals
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param trust_effective_num_spaces [Bool] defaults to false - set to true if modeled every space as a real rpp, vs. space as collection of rooms
+  # @param trust_effective_num_spaces [Boolean] defaults to false - set to true if modeled every space as a real rpp, vs. space as collection of rooms
   # @return [Hash] hash of space types with misc information
   # @todo - add code when determining number of units to makeuse of trust_effective_num_spaces arg
   def model_create_space_type_hash(model, trust_effective_num_spaces = false)
@@ -5597,7 +5596,7 @@ class Standard
   # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @param ratio [Double] ratio
   # @param surface_type [String] surface type
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def apply_limit_to_subsurface_ratio(model, ratio, surface_type = 'Wall')
     fdwr = get_outdoor_subsurface_ratio(model, surface_type)
     if fdwr <= ratio
@@ -5632,7 +5631,7 @@ class Standard
   #   institution: ASHRAE, value: 6A  becomes: ASHRAE 169-2013-6A.
   #   institution: CEC, value: 3  becomes: CEC T24-CEC3.
   #
-  # @param model [OpenStudio::Model::Model] the model
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @return [String] the string representation of the climate zone,
   #   empty string if no climate zone is present in the model.
   def model_standards_climate_zone(model)
@@ -5660,9 +5659,9 @@ class Standard
   # in the format used by the openstudio-standards lookups.
   # Clears out any climate zones previously added to the model.
   #
-  # @param model [OpenStudio::Model::Model] the model
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_set_climate_zone(model, climate_zone)
     # Remove previous climate zones from the model
     model.getClimateZones.clear
@@ -5681,7 +5680,7 @@ class Standard
   # This method return the building ratio of subsurface_area / surface_type_area
   # where surface_type can be "Wall" or "RoofCeiling"
   #
-  # @param model [OpenStudio::Model::Model] the model
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @param surface_type [String] surface type
   # @return [Double] surface ratio
   def get_outdoor_subsurface_ratio(model, surface_type = 'Wall')
@@ -5710,7 +5709,7 @@ class Standard
   # Loads a osm as a starting point.
   #
   # @param osm_file [String] path to the .osm file, relative to the /data folder
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def load_initial_osm(osm_file)
     # Load the geometry .osm
     unless File.exist?(osm_file)
@@ -5727,8 +5726,8 @@ class Standard
 
   # validate that model contains objects
   #
-  # @param model [OpenStudio::Model::Model] the model
-  # @return [Bool] returns true if valid, false if not
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
+  # @return [Boolean] returns true if valid, false if not
   def validate_initial_model(model)
     is_valid = true
     if model.getBuildingStorys.empty?
@@ -5777,7 +5776,7 @@ class Standard
   # When 'Sum', all min OA flow rates are added up.  Commonly used by 90.1.
   # When 'Maximum', only the biggest OA flow rate.  Used by T24.
   #
-  # @param model [OpenStudio::Model::Model] the model
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @return [String] the ventilation method, either Sum or Maximum
   def model_ventilation_method(model)
     building_data = model_get_building_properties(model)
@@ -5794,8 +5793,8 @@ class Standard
   # Removes all of the unused ResourceObjects
   # (Curves, ScheduleDay, Material, etc.) from the model.
   #
-  # @param model [OpenStudio::Model::Model] the model
-  # @return [Bool] returns true if successful, false if not
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
+  # @return [Boolean] returns true if successful, false if not
   def model_remove_unused_resource_objects(model)
     start_size = model.objects.size
     model.getResourceObjects.sort.each do |obj|
@@ -5819,10 +5818,10 @@ class Standard
   # Future new schedules should be designed as paramtric from the start and would not need to run through this inference process
   #
   # @author David Goldwasser
-  # @param model [OpenStudio::Model::Model] the model
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @param fraction_of_daily_occ_range [Double] fraction above/below daily min range required to start and end hours of operation
-  # @param invert_res [Bool] if true will reverse hours of operation for residential space types
-  # @param gen_occ_profile [Bool] if true creates a merged occupancy schedule for diagnostic purposes. This schedule is added to the model but no specifically returned by this method
+  # @param invert_res [Boolean] if true will reverse hours of operation for residential space types
+  # @param gen_occ_profile [Boolean] if true creates a merged occupancy schedule for diagnostic purposes. This schedule is added to the model but no specifically returned by this method
   # @return [ScheduleRuleset] schedule that is assigned to the building as default hours of operation
   def model_infer_hours_of_operation_building(model, fraction_of_daily_occ_range: 0.25, invert_res: true, gen_occ_profile: false)
     # create an array of non-residential and residential spaces
@@ -5973,10 +5972,10 @@ class Standard
   # should be traced back to a space or spaces.
   #
   # @author David Goldwasser
-  # @param model [OpenStudio::Model::Model] the model
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @param step_ramp_logic [String] type of step logic to use
-  # @param infer_hoo_for_non_assigned_objects [Bool] attempt to get hoo for objects like swh with and exterior lighting
-  # @param gather_data_only [Bool] false (stops method before changes made if true)
+  # @param infer_hoo_for_non_assigned_objects [Boolean] attempt to get hoo for objects like swh with and exterior lighting
+  # @param gather_data_only [Boolean] false (stops method before changes made if true)
   # @param hoo_var_method [String] accepts hours and fractional. Any other value value will result in hoo variables not being applied
   # @return [Hash] schedule is key, value is hash of number of objects
   def model_setup_parametric_schedules(model, step_ramp_logic: nil, infer_hoo_for_non_assigned_objects: true, gather_data_only: false, hoo_var_method: 'hours')
@@ -6136,10 +6135,10 @@ class Standard
   # @note This measure will replace any prior chagnes made to ScheduleRule objects with new ScheduleRule values from
   # profile formulas
   # @author David Goldwasser
-  # @param model [OpenStudio::Model::Model] the model
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @param ramp_frequency [Double] ramp frequency in minutes. If nil method will match simulation timestep
-  # @param infer_hoo_for_non_assigned_objects [Bool] # attempt to get hoo for objects like swh with and exterior lighting
-  # @param error_on_out_of_order [Bool] true will error if applying formula creates out of order values
+  # @param infer_hoo_for_non_assigned_objects [Boolean] # attempt to get hoo for objects like swh with and exterior lighting
+  # @param error_on_out_of_order [Boolean] true will error if applying formula creates out of order values
   # @return [Array] of modified ScheduleRuleset objects
   def model_apply_parametric_schedules(model, ramp_frequency: nil, infer_hoo_for_non_assigned_objects: true, error_on_out_of_order: true)
     # get ramp frequency (fractional hour) from timestep
@@ -6181,7 +6180,7 @@ class Standard
   # This function checks whether it is required to adjust the window to wall ratio based on the model WWR and wwr limit.
   # @param wwr_limit [Float] return wwr_limit
   # @param wwr_list [Array] list of wwr of zone conditioning category in a building area type category - residential, nonresidential and semiheated
-  # @return require_adjustment [Boolean] True, require adjustment, false not require adjustment.
+  # @return [Boolean] True, require adjustment, false not require adjustment.
   def model_does_require_wwr_adjustment?(wwr_limit, wwr_list)
     require_adjustment = false
     wwr_list.each do |wwr|
@@ -6194,7 +6193,7 @@ class Standard
   #
   # @param bat [String] building area type category
   # @param wwr_list [Array] list of wwr of zone conditioning category in a building area type category - residential, nonresidential and semiheated
-  # @return wwr_limit [Float] return adjusted wwr_limit
+  # @return [Float] return adjusted wwr_limit
   def model_get_bat_wwr_target(bat, wwr_list)
     return 40.0
   end
@@ -6204,21 +6203,21 @@ class Standard
   # This function shall only be called if the maximum WWR value for surfaces with fenestration is lower than 90% due to
   # accommodating the total door surface areas
   #
-  # @param residual_ratio: [Float] the ratio of residual surfaces among the total wall surface area with no fenestrations
+  # @param residual_ratio [Float] the ratio of residual surfaces among the total wall surface area with no fenestrations
   # @param space [OpenStudio::Model:Space] a space
   # @param model [OpenStudio::Model::Model] openstudio model
-  # @return [Bool] return true if successful, false if not
+  # @return [Boolean] return true if successful, false if not
   def model_readjust_surface_wwr(residual_ratio, space, model)
     return true
   end
 
   # Helper method to fill in hourly values
   #
-  # @param model [OpenStudio::Model::Model] the model
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @param day_sch [OpenStudio::Model::ScheduleDay] schedule day object
   # @param sch_type [String] Constant or Hourly
   # @param values [Array<Double>]
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_add_vals_to_sch(model, day_sch, sch_type, values)
     if sch_type == 'Constant'
       day_sch.addValue(OpenStudio::Time.new(0, 24, 0, 0), values[0])
@@ -6235,9 +6234,9 @@ class Standard
 
   # Modify the existing service water heating loops to match the baseline required heating type.
   #
-  # @param model [OpenStudio::Model::Model] the model
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @param building_type [String] the building type
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   # @author Julien Marrec
   def model_apply_baseline_swh_loops(model, building_type)
     model.getPlantLoops.sort.each do |plant_loop|
@@ -6323,8 +6322,8 @@ class Standard
   # This should be done by the forward translator, and this code should be removed after this bug is fixed:
   # https://github.com/NREL/OpenStudio/issues/2598
   #
-  # @param model [OpenStudio::Model::Model] the model
-  # @return [Bool] returns true if successful, false if not
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
+  # @return [Boolean] returns true if successful, false if not
   # @todo remove this method after OpenStudio issue #2598 is fixed.
   def model_temp_fix_ems_references(model)
     # Internal Variables
@@ -6466,7 +6465,7 @@ class Standard
   # @author David Goldwasser
   # @param space_space_types [Array] array of spaces or space types
   # @param parametric_inputs [Hash]
-  # @param gather_data_only [Bool]
+  # @param gather_data_only [Boolean]
   # @return [Hash]
   def gather_inputs_parametric_space_space_type_schedules(space_space_types, parametric_inputs, gather_data_only)
     space_space_types.each do |space_type|
@@ -6525,7 +6524,7 @@ class Standard
   # @param load_inst [OpenStudio::Model::SpaceLoadInstance]
   # @param parametric_inputs [Hash]
   # @param hours_of_operation [Hash]
-  # @param gather_data_only [Bool]
+  # @param gather_data_only [Boolean]
   # @return [Hash]
   def gather_inputs_parametric_load_inst_schedules(load_inst, parametric_inputs, hours_of_operation, gather_data_only)
     if load_inst.class.to_s == 'OpenStudio::Model::People'
@@ -6551,9 +6550,9 @@ class Standard
   # @param load_inst [OpenStudio::Model::SpaceLoadInstance]
   # @param parametric_inputs [Hash]
   # @param hours_of_operation [Hash]
-  # @param ramp [Bool]
+  # @param ramp [Boolean]
   # @param min_ramp_dur_hr [Double]
-  # @param gather_data_only [Bool]
+  # @param gather_data_only [Boolean]
   # @param hoo_var_method [String] accepts hours and fractional. Any other value value will result in hoo variables not being applied
   # @return [Hash]
   def gather_inputs_parametric_schedules(sch, load_inst, parametric_inputs, hours_of_operation, ramp: true, min_ramp_dur_hr: 2.0, gather_data_only: false, hoo_var_method: 'hours')
@@ -6873,8 +6872,8 @@ class Standard
 
   # Retrieves the lowest story in a model
   #
-  # @param model [OpenStudio::model::Model] OpenStudio model object
-  # @return [OpenStudio::model::BuildingStory] Lowest story included in the model
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
+  # @return [OpenStudio::Model::BuildingStory] Lowest story included in the model
   def find_lowest_story(model)
     min_z_story = 1E+10
     lowest_story = nil
@@ -6918,8 +6917,8 @@ class Standard
 
   # Identifies non mechanically cooled ("nmc") systems, if applicable
   #
-  # @param model [OpenStudio::model::Model] OpenStudio model object
-  # @return zone_nmc_sys_type [Hash] Zone to nmc system type mapping
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
+  # @return [Hash] Zone to nmc system type mapping
   def model_identify_non_mechanically_cooled_systems(model)
     return true
   end
@@ -6938,6 +6937,7 @@ class Standard
   # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @param wwr_parameter [Hash] parameters to choose min and max percent of surfaces,
   #         could be different set in different standard
+  # @return [Hash] Hash of minimum_percent_of_surface and maximum_percent_of_surface
   def model_get_percent_of_surface_range(model, wwr_parameter = {})
     return { 'minimum_percent_of_surface' => nil, 'maximum_percent_of_surface' => nil }
   end
@@ -6984,7 +6984,7 @@ class Standard
   # @param [String] default_wwr_building_type
   # @param [String] default_swh_building_type
   # @param [Hash] bldg_type_hvac_zone_hash A hash maps building type for hvac to a list of thermal zones
-  # @return True
+  # @return [Boolean] returns true if successful, false if not
   def handle_user_input_data(model, climate_zone, default_hvac_building_type, default_wwr_building_type, default_swh_building_type, bldg_type_hvac_zone_hash)
     return true
   end
@@ -6993,9 +6993,9 @@ class Standard
   # ASHRAE 90.1-2019 Appendix G.
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model
-  # @param thermalZones Array([OpenStudio::Model::ThermalZone]) thermal zone array
-  # @param coil Heating Coils
-  # @return [Boolean] true
+  # @param thermal_zones [Array<OpenStudio::Model::ThermalZone>] thermal zone array
+  # @param coil [OpenStudio::Model::StraightComponent] heating coil
+  # @return [Boolean] returns true if successful, false if not
   def model_set_central_preheat_coil_spm(model, thermal_zones, coil)
     return true
   end
@@ -7004,6 +7004,7 @@ class Standard
   #
   # @author Xuechen (Jerry) Lei, PNNL
   # @param model [OpenStudio::Model::Model] OpenStudio model
+  # @return [Boolean] returns true if successful, false if not
   def model_mark_zone_dcv_existence(model)
     return true
   end
@@ -7011,8 +7012,9 @@ class Standard
   # Check whether the baseline model generation needs to run all four orientations
   # The default shall be true
   #
-  # @param [Boolean] run_all_orients: user inputs to indicate whether it is required to run all orientations
-  # @param [OpenStudio::Model::Model] OpenStudio model
+  # @param run_all_orients [Boolean] user inputs to indicate whether it is required to run all orientations
+  # @param user_model [OpenStudio::Model::Model] OpenStudio model
+  # @return [Boolean] return True if all orientation need to be run, False if not
   def run_all_orientations(run_all_orients, user_model)
     return run_all_orients
   end
@@ -7021,6 +7023,7 @@ class Standard
   #
   # @author Xuechen (Jerry) Lei, PNNL
   # @param model [OpenStudio::Model::Model] OpenStudio model
+  # @return [Boolean] returns true if successful, false if not
   def model_add_dcv_user_exception_properties(model)
     return true
   end
@@ -7029,6 +7032,7 @@ class Standard
   #
   # @author Xuechen (Jerry) Lei, PNNL
   # @param model [OpenStudio::Model::Model] OpenStudio model
+  # @return [Boolean] returns true if successful, false if not
   def model_raise_user_model_dcv_errors(model)
     return true
   end
@@ -7037,6 +7041,7 @@ class Standard
   #
   # @author Xuechen (Jerry) Lei, PNNL
   # @param model [OpenStudio::Model::Model] OpenStudio model
+  # @return [Boolean] returns true if successful, false if not
   def model_add_dcv_requirement_properties(model)
     return true
   end
@@ -7046,6 +7051,7 @@ class Standard
   #
   # @author Xuechen (Jerry) Lei, PNNL
   # @param model [OpenStudio::Model::Model] OpenStudio model
+  # @return [Boolean] returns true if successful, false if not
   def model_add_apxg_dcv_properties(model)
     return true
   end
@@ -7054,6 +7060,7 @@ class Standard
   #
   # @author Xuechen (Jerry) Lei, PNNL
   # @param model [OpenStudio::Model::Model] OpenStudio model
+  # @return [Boolean] returns true if successful, false if not
   def model_set_baseline_demand_control_ventilation(model, climate_zone)
     return true
   end
@@ -7061,6 +7068,7 @@ class Standard
   # Identify the return air type associated with each thermal zone
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
+  # @return [String] return air type
   def model_identify_return_air_type(model)
     # air-loop based system
     model.getThermalZones.each do |zone|
@@ -7139,6 +7147,7 @@ class Standard
       zone.additionalProperties.setFeature('plenum', return_plenum) unless return_plenum.nil?
       zone.additionalProperties.setFeature('proposed_model_zone_design_air_flow', zone.autosizedDesignAirFlowRate.to_f)
     end
+    return return_air_type
   end
 
   # Determine the baseline return air type associated with each zone
@@ -7210,6 +7219,7 @@ class Standard
   # @param model [OpenStudio::Model::Model] OpenStudio Model
   # @param heating_tolerance_deg_f [Float] Tolerance for time heating setpoint not met in degree F
   # @param cooling_tolerance_deg_f [Float] Tolerance for time cooling setpoint not met in degree F
+  # @return [Boolean] returns true if successful, false if not
   def model_add_reporting_tolerances(model, heating_tolerance_deg_f: 1.0, cooling_tolerance_deg_f: 1.0)
     reporting_tolerances = model.getOutputControlReportingTolerances
     heating_tolerance_deg_c = OpenStudio.convert(heating_tolerance_deg_f, 'R', 'K').get
@@ -7222,10 +7232,10 @@ class Standard
 
   # Apply the standard construction to each surface in the model, based on the construction type currently assigned.
   #
-  # @return [Bool] true if successful, false if not
+  # @return [Boolean] true if successful, false if not
   # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_apply_constructions(model, climate_zone, wwr_building_type, wwr_info)
     model_apply_standard_constructions(model, climate_zone, wwr_building_type: nil, wwr_info: {})
 
@@ -7234,6 +7244,7 @@ class Standard
 
   # Generate baseline log to a specific file directory
   # @param file_directory [String] file directory
+  # @return [Boolean] returns true if successful, false if not
   def generate_baseline_log(file_directory)
     return true
   end
@@ -7242,7 +7253,7 @@ class Standard
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_update_ground_temperature_profile(model, climate_zone)
     return true
   end

--- a/lib/openstudio-standards/standards/Standards.Model.rb
+++ b/lib/openstudio-standards/standards/Standards.Model.rb
@@ -6206,7 +6206,7 @@ class Standard
   # @param residual_ratio [Float] the ratio of residual surfaces among the total wall surface area with no fenestrations
   # @param space [OpenStudio::Model:Space] a space
   # @param model [OpenStudio::Model::Model] openstudio model
-  # @return [Boolean] return true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_readjust_surface_wwr(residual_ratio, space, model)
     return true
   end

--- a/lib/openstudio-standards/standards/Standards.Model.rb
+++ b/lib/openstudio-standards/standards/Standards.Model.rb
@@ -7068,7 +7068,7 @@ class Standard
   # Identify the return air type associated with each thermal zone
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [String] return air type
+  # @return [Boolean] returns true if successful, false if not
   def model_identify_return_air_type(model)
     # air-loop based system
     model.getThermalZones.each do |zone|
@@ -7147,7 +7147,7 @@ class Standard
       zone.additionalProperties.setFeature('plenum', return_plenum) unless return_plenum.nil?
       zone.additionalProperties.setFeature('proposed_model_zone_design_air_flow', zone.autosizedDesignAirFlowRate.to_f)
     end
-    return return_air_type
+    return true
   end
 
   # Determine the baseline return air type associated with each zone

--- a/lib/openstudio-standards/standards/Standards.PlanarSurface.rb
+++ b/lib/openstudio-standards/standards/Standards.PlanarSurface.rb
@@ -201,8 +201,8 @@ class Standard
 
   # Get appropriate construction object based on type of surface or subsurface
   # @author: Doug Maddox, PNNL
-  # @param: surface_category [string] type of surface: this is not an OpenStudio string
-  # @param: surface_type [string] SubSurfaceType: this is an OpenStudio string
+  # @param: surface_category [String type of surface: this is not an OpenStudio string
+  # @param: surface_type [String SubSurfaceType: this is an OpenStudio string
   # @param: cons_set [object] DefaultSubSurfaceConstructions object
   # @return: [object] Construction object
   def get_default_surface_cons_from_surface_type(surface_category, surface_type, cons_set)

--- a/lib/openstudio-standards/standards/Standards.PlantLoop.rb
+++ b/lib/openstudio-standards/standards/Standards.PlantLoop.rb
@@ -5,7 +5,7 @@ class Standard
   #
   # @param plant_loop [OpenStudio::Model::PlantLoop] plant loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def plant_loop_apply_standard_controls(plant_loop, climate_zone)
     # Supply water temperature reset
     # plant_loop_enable_supply_water_temperature_reset(plant_loop) if plant_loop_supply_water_temperature_reset_required?(plant_loop)
@@ -17,7 +17,7 @@ class Standard
   # @param chilled_water_loop [OpenStudio::Model::PlantLoop] chilled water loop
   # @param dsgn_sup_wtr_temp [Double] design chilled water supply T
   # @param dsgn_sup_wtr_temp_delt [Double] design chilled water supply delta T
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def chw_sizing_control(model, chilled_water_loop, dsgn_sup_wtr_temp, dsgn_sup_wtr_temp_delt)
     # chilled water loop sizing and controls
     if dsgn_sup_wtr_temp.nil?
@@ -62,7 +62,7 @@ class Standard
   # Returns true if primary and/or secondary pumps are variable speed.
   #
   # @param plant_loop [OpenStudio::Model::PlantLoop] plant loop
-  # @return [Bool] returns true if variable flow, false if not
+  # @return [Boolean] returns true if variable flow, false if not
   def plant_loop_variable_flow_system?(plant_loop)
     variable_flow = false
 
@@ -89,7 +89,7 @@ class Standard
   #   you could set at 0.9 and just calculate the pressure rise to have your 19 W/GPM or whatever
   #
   # @param plant_loop [OpenStudio::Model::PlantLoop] plant loop
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def plant_loop_apply_prm_baseline_pump_power(plant_loop)
     # Determine the pumping power per
     # flow based on loop type.
@@ -187,7 +187,7 @@ class Standard
   # Applies the temperatures to the plant loop based on Appendix G.
   #
   # @param plant_loop [OpenStudio::Model::PlantLoop] plant loop
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def plant_loop_apply_prm_baseline_temperatures(plant_loop)
     sizing_plant = plant_loop.sizingPlant
     loop_type = sizing_plant.loopType
@@ -206,7 +206,7 @@ class Standard
   # Applies the hot water temperatures to the plant loop based on Appendix G.
   #
   # @param plant_loop [OpenStudio::Model::PlantLoop] plant loop
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def plant_loop_apply_prm_baseline_hot_water_temperatures(plant_loop)
     sizing_plant = plant_loop.sizingPlant
 
@@ -243,7 +243,7 @@ class Standard
   # Applies the chilled water temperatures to the plant loop based on Appendix G.
   #
   # @param plant_loop [OpenStudio::Model::PlantLoop] plant loop
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def plant_loop_apply_prm_baseline_chilled_water_temperatures(plant_loop)
     sizing_plant = plant_loop.sizingPlant
 
@@ -286,7 +286,7 @@ class Standard
   # Applies the condenser water temperatures to the plant loop based on Appendix G.
   #
   # @param plant_loop [OpenStudio::Model::PlantLoop] plant loop
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def plant_loop_apply_prm_baseline_condenser_water_temperatures(plant_loop)
     sizing_plant = plant_loop.sizingPlant
     loop_type = sizing_plant.loopType
@@ -447,7 +447,7 @@ class Standard
   # Required if heating or cooling capacity is greater than 300,000 Btu/hr.
   #
   # @param plant_loop [OpenStudio::Model::PlantLoop] plant loop
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def plant_loop_supply_water_temperature_reset_required?(plant_loop)
     reset_required = false
 
@@ -488,7 +488,7 @@ class Standard
   # Enable reset of hot or chilled water temperature based on outdoor air temperature.
   #
   # @param plant_loop [OpenStudio::Model::PlantLoop] plant loop
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def plant_loop_enable_supply_water_temperature_reset(plant_loop)
     # Get the current setpoint manager on the outlet node
     # and determine if already has temperature reset
@@ -743,7 +743,7 @@ class Standard
   # Applies the pumping controls to the loop based on Appendix G.
   #
   # @param plant_loop [OpenStudio::Model::PlantLoop] plant loop
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def plant_loop_apply_prm_baseline_pumping_type(plant_loop)
     sizing_plant = plant_loop.sizingPlant
     loop_type = sizing_plant.loopType
@@ -763,7 +763,7 @@ class Standard
   # Applies the chilled water pumping controls to the loop based on Appendix G.
   #
   # @param plant_loop [OpenStudio::Model::PlantLoop] chilled water loop
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def plant_loop_apply_prm_baseline_chilled_water_pumping_type(plant_loop)
     # Determine the pumping type.
     minimum_cap_tons = 300.0
@@ -835,7 +835,7 @@ class Standard
   # Applies the hot water pumping controls to the loop based on Appendix G.
   #
   # @param plant_loop [OpenStudio::Model::PlantLoop] hot water loop
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def plant_loop_apply_prm_baseline_hot_water_pumping_type(plant_loop)
     # Determine the minimum area to determine
     # pumping type.
@@ -870,7 +870,7 @@ class Standard
   # Applies the condenser water pumping controls to the loop based on Appendix G.
   #
   # @param plant_loop [OpenStudio::Model::PlantLoop] condenser water loop
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def plant_loop_apply_prm_baseline_condenser_water_pumping_type(plant_loop)
     # All condenser water loops are constant flow
     control_type = 'Constant Flow'
@@ -898,7 +898,7 @@ class Standard
   # into multiple separate boilers based on Appendix G.
   #
   # @param plant_loop [OpenStudio::Model::PlantLoop] hot water loop
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def plant_loop_apply_prm_number_of_boilers(plant_loop)
     # Skip non-heating plants
     return true unless plant_loop.sizingPlant.loopType == 'Heating'
@@ -961,8 +961,9 @@ class Standard
   # Splits the single chiller used for the initial sizing run
   # into multiple separate chillers based on Appendix G.
   #
-  # @param plant_loop_args [Array] chilled water loop (OpenStudio::Model::PlantLoop), sizing run directory
-  # @return [Bool] returns true if successful, false if not
+  # @param plant_loop [OpenStudio::Model::PlantLoop] chilled water loop
+  # @param sizing_run_dir [String] sizing run directory
+  # @return [Boolean] returns true if successful, false if not
   def plant_loop_apply_prm_number_of_chillers(plant_loop, sizing_run_dir = nil)
     # Skip non-cooling plants
     return true unless plant_loop.sizingPlant.loopType == 'Cooling'
@@ -1110,7 +1111,7 @@ class Standard
   # into multiple separate cooling towers based on Appendix G.
   #
   # @param plant_loop [OpenStudio::Model::PlantLoop] condenser water loop
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def plant_loop_apply_prm_number_of_cooling_towers(plant_loop)
     # Skip non-cooling plants
     return true unless plant_loop.sizingPlant.loopType == 'Condenser'

--- a/lib/openstudio-standards/standards/Standards.Pump.rb
+++ b/lib/openstudio-standards/standards/Standards.Pump.rb
@@ -9,7 +9,7 @@ module Pump
   # @param pump [OpenStudio::Model::StraightComponent] pump object, allowable types:
   #   PumpConstantSpeed, PumpVariableSpeed
   # @param target_w_per_gpm [Double] the target power per flow, in W/gpm
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   # @author jmarrec
   def pump_apply_prm_pressure_rise_and_motor_efficiency(pump, target_w_per_gpm)
     # Eplus assumes an impeller efficiency of 0.78 to determine the total efficiency
@@ -94,7 +94,7 @@ module Pump
   #
   # @param pump [OpenStudio::Model::StraightComponent] pump object, allowable types:
   #   PumpConstantSpeed, PumpVariableSpeed
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def pump_apply_standard_minimum_motor_efficiency(pump)
     # Get the horsepower
     bhp = pump_brake_horsepower(pump)

--- a/lib/openstudio-standards/standards/Standards.ScheduleConstant.rb
+++ b/lib/openstudio-standards/standards/Standards.ScheduleConstant.rb
@@ -33,8 +33,8 @@ end
 # Intended use is for storing fan schedules to hash of ZoneName:SchedArray so schedules
 # can be saved when HVAC objects are deleted
 # @author Doug Maddox, PNNL
-# @param [object] model
-# @param [Object] schedule_ruleset
+# @param model [OpenStudio::Model::Model] OpenStudio model object
+# @param schedule_constant [OpenStudio::Model::ScheduleConstant] schedule
 # @return [Array<Double>] Array of sequential hourly values for year + 24 hours at end for holiday
 def get_8760_values_from_schedule_constant(model, schedule_constant)
   yd = model.getYearDescription

--- a/lib/openstudio-standards/standards/Standards.ScheduleRuleset.rb
+++ b/lib/openstudio-standards/standards/Standards.ScheduleRuleset.rb
@@ -415,8 +415,8 @@ class Standard
   # @author David Goldwasser
   # @param schedule [OpenStudio::Model::ScheduleRuleset] schedule ruleset object
   # @param ramp_frequency [Double] ramp frequency in minutes
-  # @param infer_hoo_for_non_assigned_objects [Bool] attempt to get hoo for objects like swh with and exterior lighting
-  # @param error_on_out_of_order [Bool] true will error if applying formula creates out of order values
+  # @param infer_hoo_for_non_assigned_objects [Boolean] attempt to get hoo for objects like swh with and exterior lighting
+  # @param error_on_out_of_order [Boolean] true will error if applying formula creates out of order values
   # @return [OpenStudio::Model::ScheduleRuleset] schedule ruleset object
   def schedule_apply_parametric_inputs(schedule, ramp_frequency, infer_hoo_for_non_assigned_objects, error_on_out_of_order, parametric_inputs = nil)
     # Check if parametric inputs were supplied and generate them if not
@@ -611,7 +611,7 @@ class Standard
   # @param sat_end_time [OpenStudio::Time] Saturday end time.  If greater than 24:00, hours of operation will wrap over midnight.
   # @param sun_start_time [OpenStudio::Time] Sunday start time.  If nil, no change will be made to this day.
   # @param sun_end_time [OpenStudio::Time] Sunday end time.  If greater than 24:00, hours of operation will wrap over midnight.
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def schedule_ruleset_set_hours_of_operation(schedule_ruleset, wkdy_start_time: nil, wkdy_end_time: nil, sat_start_time: nil, sat_end_time: nil, sun_start_time: nil, sun_end_time: nil)
     # Default day is assumed to represent weekdays
     if wkdy_start_time && wkdy_end_time
@@ -645,9 +645,9 @@ class Standard
   #
   # Return Array of weekday values from Array of all day values
   # @author Xuechen (Jerry) Lei, PNNL
-  # @param model [OpenStudio::model::Model] OpenStudio model object
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @param values [Array] hourly time-series values of all days
-  # @param value_includes_holiday [Bool] whether the input values include a day of holiday at the end of the array
+  # @param value_includes_holiday [Boolean] whether the input values include a day of holiday at the end of the array
   #
   # @return [Array] hourly time-series values in weekdays
   #
@@ -1186,8 +1186,8 @@ class Standard
   # @param val_flr [Double] value floor
   # @param val_clg [Double] value ceiling
   # @param ramp_frequency [Double] ramp frequency in minutes
-  # @param infer_hoo_for_non_assigned_objects [Bool] attempt to get hoo for objects like swh with and exterior lighting
-  # @param error_on_out_of_order [Bool] true will error if applying formula creates out of order values
+  # @param infer_hoo_for_non_assigned_objects [Boolean] attempt to get hoo for objects like swh with and exterior lighting
+  # @param error_on_out_of_order [Boolean] true will error if applying formula creates out of order values
   # @return [OpenStudio::Model::ScheduleDay] schedule day
   # @api private
   def process_hrs_of_operation_hash(sch_day, hoo_start, hoo_end, val_flr, val_clg, ramp_frequency, infer_hoo_for_non_assigned_objects, error_on_out_of_order)

--- a/lib/openstudio-standards/standards/Standards.Space.rb
+++ b/lib/openstudio-standards/standards/Standards.Space.rb
@@ -8,7 +8,7 @@ class Standard
   #   situations.  When it fails, it will log warnings/errors for users to see.
   #
   # @param space [OpenStudio::Model::Space] space object
-  # @param draw_daylight_areas_for_debugging [Bool] If this argument is set to true,
+  # @param draw_daylight_areas_for_debugging [Boolean] If this argument is set to true,
   #   daylight areas will be added to the model as surfaces for visual debugging.
   #   Yellow = toplighted area, Red = primary sidelighted area,
   #   Blue = secondary sidelighted area, Light Blue = floor
@@ -804,9 +804,9 @@ class Standard
 
   # Default for 2013 and earlier is to Add daylighting controls (sidelighting and toplighting) per the template
   # @param space [OpenStudio::Model::Space] the space with daylighting
-  # @param remove_existing_controls [Bool] if true, will remove existing controls then add new ones
-  # @param draw_daylight_areas_for_debugging [Bool] If this argument is set to true,
-  # @return [boolean] true if successful
+  # @param remove_existing [Boolean] if true, will remove existing controls then add new ones
+  # @param draw_areas_for_debug [Boolean] If this argument is set to true,
+  # @return [Boolean] true if successful
   def space_set_baseline_daylighting_controls(space, remove_existing = false, draw_areas_for_debug = false)
     added = space_add_daylighting_controls(space, remove_existing, draw_areas_for_debug)
     return added
@@ -818,12 +818,12 @@ class Standard
   #   situations.  When it fails, it will log warnings/errors for users to see.
   #
   # @param space [OpenStudio::Model::Space] the space with daylighting
-  # @param remove_existing_controls [Bool] if true, will remove existing controls then add new ones
-  # @param draw_daylight_areas_for_debugging [Bool] If this argument is set to true,
+  # @param remove_existing_controls [Boolean] if true, will remove existing controls then add new ones
+  # @param draw_daylight_areas_for_debugging [Boolean] If this argument is set to true,
   #   daylight areas will be added to the model as surfaces for visual debugging.
   #   Yellow = toplighted area, Red = primary sidelighted area,
   #   Blue = secondary sidelighted area, Light Blue = floor
-  # @return [boolean] true if successful
+  # @return [Boolean] true if successful
   # @todo add a list of valid choices for template argument
   # @todo add exception for retail spaces
   # @todo add exception 2 for skylights with VT < 0.4
@@ -1223,9 +1223,9 @@ class Standard
   # @param areas [Hash] a hash of daylighted areas
   # @param sorted_windows [Hash] a hash of windows, sorted by priority
   # @param sorted_skylights [Hash] a hash of skylights, sorted by priority
-  # @param req_top_ctrl [Bool] if toplighting controls are required
-  # @param req_pri_ctrl [Bool] if primary sidelighting controls are required
-  # @param req_sec_ctrl [Bool] if secondary sidelighting controls are required
+  # @param req_top_ctrl [Boolean] if toplighting controls are required
+  # @param req_pri_ctrl [Boolean] if primary sidelighting controls are required
+  # @param req_sec_ctrl [Boolean] if secondary sidelighting controls are required
   # @return [Array] array of 4 items
   #   [sensor 1 fraction, sensor 2 fraction, sensor 1 window, sensor 2 window]
   def space_daylighting_fractions_and_windows(space,
@@ -1481,7 +1481,7 @@ class Standard
   # or if the space type name contains the word plenum.
   #
   # @param space [OpenStudio::Model::Space] space object
-  # return [Bool] returns true if plenum, false if not
+  # return [Boolean] returns true if plenum, false if not
   def space_plenum?(space)
     plenum_status = false
 
@@ -1523,7 +1523,7 @@ class Standard
   # type of the space below the largest floor in the plenum.
   #
   # @param space [OpenStudio::Model::Space] space object
-  # return [Bool] true if residential, false if nonresidential
+  # return [Boolean] true if residential, false if nonresidential
   def space_residential?(space)
     is_res = false
 
@@ -1596,7 +1596,6 @@ class Standard
   # Determines whether the space is conditioned per 90.1, which is based on heating and cooling loads.
   #
   # @param space [OpenStudio::Model::Space] space object
-  # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @return [String] NonResConditioned, ResConditioned, Semiheated, Unconditioned
   # @todo add logic to detect indirectly-conditioned spaces based on air transfer
   def space_conditioning_category(space)
@@ -1717,7 +1716,7 @@ class Standard
   #
   # @author Andrew Parker, Julien Marrec
   # @param space [OpenStudio::Model::Space] space object
-  # @return [Bool] returns true if heated, false if not
+  # @return [Boolean] returns true if heated, false if not
   def space_heated?(space)
     # Get the zone this space is inside
     zone = space.thermalZone
@@ -1738,7 +1737,7 @@ class Standard
   #
   # @author Andrew Parker, Julien Marrec
   # @param space [OpenStudio::Model::Space] space object
-  # @return [Bool] returns true if cooled, false if not
+  # @return [Boolean] returns true if cooled, false if not
   def space_cooled?(space)
     # Get the zone this space is inside
     zone = space.thermalZone
@@ -1854,7 +1853,7 @@ class Standard
   # and fraction lost for equipment
   # @author Doug Maddox, PNNL
   # @param space object
-  # @param return_noncoincident_value [boolean] if true, return value is noncoincident peak; if false, return is array off coincident load
+  # @param return_noncoincident_value [Boolean] if true, return value is noncoincident peak; if false, return is array off coincident load
   # @return [Double] 8760 array of the design internal load, in W, for this space
   def space_internal_load_annual_array(model, space, return_noncoincident_value)
     # For each type of load, first convert schedules to 8760 arrays so coincident load can be determined
@@ -2070,13 +2069,13 @@ class Standard
   # to determine whether specific zones should be isolated to PSZ based on
   # space loads that differ significantly from other zones on the multizone system
   #
-  # @param model [OpenStudio::Model::Model] the model
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @param space [OpenStudio::Model::Space] the space
   # @param equips [object] This is an array of equipment objects in the model
   # @param eqp_type [String] string description of the type of equipment object
   # @param ppl_total [Numeric] total number of people in the space
   # @param load_values [Array] 8760 array of load values for the equipment type
-  # @param return_noncoincident_value [boolean] return a single peak value if true; return 8760 gain profile if false
+  # @param return_noncoincident_value [Boolean] return a single peak value if true; return 8760 gain profile if false
   #
   # @return [Array] load values array; if return_noncoincident_value is true, array has only one value
   #
@@ -2108,13 +2107,13 @@ class Standard
   # to determine whether specific zones should be isolated to PSZ based on
   # space loads that differ significantly from other zones on the multizone system
   #
-  # @param model [OpenStudio::Model::Model] the model
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @param space [OpenStudio::Model::Space] the space
   # @param equip [object] This can be any type of equipment object in the space
   # @param eqp_type [String] string description of the type of equipment object
   # @param ppl_total [Numeric] total number of people in the space
   # @param load_values [Array] 8760 array of load values for the equipment type
-  # @param return_noncoincident_value [boolean] return a single peak value if true; return 8760 gain profile if false
+  # @param return_noncoincident_value [Boolean] return a single peak value if true; return 8760 gain profile if false
   #
   # @return [Array] load values array; if return_noncoincident_value is true, array has only one value
   #
@@ -2216,7 +2215,7 @@ class Standard
   # will return a sorted array of array of spaces and connected area (Descending)
   #
   # @param space [OpenStudio::Model::Space] space object
-  # @param same_floor [Bool] only consider spaces on the same floor
+  # @param same_floor [Boolean] only consider spaces on the same floor
   # @return [Hash] sorted hash with array of spaces and area
   def space_get_adjacent_spaces_with_shared_wall_areas(space, same_floor = true)
     same_floor_spaces = []
@@ -2281,7 +2280,7 @@ class Standard
   # Find the space that has the most wall area touching this space.
   #
   # @param space [OpenStudio::Model::Space] space object
-  # @param same_floor [Bool] only consider spaces on the same floor
+  # @param same_floor [Boolean] only consider spaces on the same floor
   # @return [OpenStudio::Model::Space] space object
   def space_get_adjacent_space_with_most_shared_wall_area(space, same_floor = true)
     return get_adjacent_spaces_with_touching_area(same_floor)[0][0]
@@ -2938,8 +2937,8 @@ class Standard
 
   # A function to check whether a space is a return / supply plenum.
   # This function only works on spaces used as a AirLoopSupplyPlenum or AirLoopReturnPlenum
-  # @param [OpenStudio::Model::Space] space
-  # @return boolean true if it is plenum, else false.
+  # @param space [OpenStudio::Model::Space]
+  # @return [Boolean] true if it is plenum, else false.
   def space_is_plenum(space)
     # Get the zone this space is inside
     zone = space.thermalZone
@@ -2970,8 +2969,8 @@ class Standard
 
   # Provide the type of daylighting control type
   #
-  # @param [OpenStudio::Model::Space] OpenStudio Space object
-  # return [String] daylighting control type
+  # @param space [OpenStudio::Model::Space] OpenStudio Space object
+  # @return [String] daylighting control type
   def space_daylighting_control_type(space)
     return 'Stepped'
   end
@@ -2979,8 +2978,8 @@ class Standard
   # Provide the minimum input power fraction for continuous
   # dimming daylighting control
   #
-  # @param [OpenStudio::Model::Space] OpenStudio Space object
-  # return [Float] daylighting minimum input power fraction
+  # @param space [OpenStudio::Model::Space] OpenStudio Space object
+  # @return [Float] daylighting minimum input power fraction
   def space_daylighting_minimum_input_power_fraction(space)
     return 0.3
   end

--- a/lib/openstudio-standards/standards/Standards.SpaceType.rb
+++ b/lib/openstudio-standards/standards/Standards.SpaceType.rb
@@ -4,7 +4,7 @@ class Standard
   # Returns standards data for selected space type and template
   #
   # @param space_type [OpenStudio::Model::SpaceType] space type object
-  # @return [hash] hash of internal loads for different load types
+  # @return [Hash] hash of internal loads for different load types
   def space_type_get_standards_data(space_type)
     standards_building_type = if space_type.standardsBuildingType.is_initialized
                                 space_type.standardsBuildingType.get
@@ -58,7 +58,7 @@ class Standard
   # Sets the color for the space types as shown in the SketchUp plugin using render by space type.
   #
   # @param space_type [OpenStudio::Model::SpaceType] space type object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def space_type_apply_rendering_color(space_type)
     # Get the standards data
     space_type_properties = space_type_get_standards_data(space_type)
@@ -91,16 +91,16 @@ class Standard
   # loads directly assigned to spaces.  This method skips plenums.
   #
   # @param space_type [OpenStudio::Model::SpaceType] space type object
-  # @param set_people [Bool] if true, set the people density.
+  # @param set_people [Boolean] if true, set the people density.
   #   Also, assign reasonable clothing, air velocity, and work efficiency inputs
   #   to allow reasonable thermal comfort metrics to be calculated.
-  # @param set_lights [Bool] if true, set the lighting density, lighting fraction
+  # @param set_lights [Boolean] if true, set the lighting density, lighting fraction
   #   to return air, fraction radiant, and fraction visible.
-  # @param set_electric_equipment [Bool] if true, set the electric equipment density
-  # @param set_gas_equipment [Bool] if true, set the gas equipment density
-  # @param set_ventilation [Bool] if true, set the ventilation rates (per-person and per-area)
-  # @param set_infiltration [Bool] if true, set the infiltration rates
-  # @return [Bool] returns true if successful, false if not
+  # @param set_electric_equipment [Boolean] if true, set the electric equipment density
+  # @param set_gas_equipment [Boolean] if true, set the gas equipment density
+  # @param set_ventilation [Boolean] if true, set the ventilation rates (per-person and per-area)
+  # @param set_infiltration [Boolean] if true, set the infiltration rates
+  # @return [Boolean] returns true if successful, false if not
   def space_type_apply_internal_loads(space_type, set_people, set_lights, set_electric_equipment, set_gas_equipment, set_ventilation, set_infiltration)
     # Skip plenums
     # Check if the space type name
@@ -478,8 +478,9 @@ class Standard
   # Initially, only lighting power density will be set
   # Possibly infiltration will also be set from here
   #
-  # @param model [OpenStudio::Model::SpaceType] OpenStudio space type object
+  # @param space_type [OpenStudio::Model::SpaceType] OpenStudio space type object
   # @param model [OpenStudio::Model::Model] OpenStudio model object
+  # @return [Boolean] return true if successful, false if not
   def space_type_apply_int_loads_prm(space_type, model)
     # Skip plenums
     # Check if the space type name
@@ -580,11 +581,13 @@ class Standard
         space_type.remove
       end
     end
+    return true
   end
 
   # Modify the lighting schedules for Appendix G PRM for 2016 and later
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
+  # @return [Boolean] return true if successful, false if not 
   def space_type_light_sch_change(model)
     return true
   end
@@ -597,15 +600,15 @@ class Standard
   # does not inherit from the default schedule set.
   #
   # @param space_type [OpenStudio::Model::SpaceType] space type object
-  # @param set_people [Bool] if true, set the occupancy and activity schedules
-  # @param set_lights [Bool] if true, set the lighting schedule
-  # @param set_electric_equipment [Bool] if true, set the electric schedule schedule
-  # @param set_gas_equipment [Bool] if true, set the gas equipment density
-  # @param set_infiltration [Bool] if true, set the infiltration schedule
-  # @param make_thermostat [Bool] if true, makes a thermostat for this space type from the
+  # @param set_people [Boolean] if true, set the occupancy and activity schedules
+  # @param set_lights [Boolean] if true, set the lighting schedule
+  # @param set_electric_equipment [Boolean] if true, set the electric schedule schedule
+  # @param set_gas_equipment [Boolean] if true, set the gas equipment density
+  # @param set_infiltration [Boolean] if true, set the infiltration schedule
+  # @param make_thermostat [Boolean] if true, makes a thermostat for this space type from the
   #   schedules listed for the space type.  This thermostat is not hooked to any zone by this method,
   #   but may be found and used later.
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def space_type_apply_internal_load_schedules(space_type, set_people, set_lights, set_electric_equipment, set_gas_equipment, set_ventilation, set_infiltration, make_thermostat)
     # Get the standards data
     space_type_properties = space_type_get_standards_data(space_type)
@@ -697,7 +700,7 @@ class Standard
   # @param space_type [OpenStudio::Model::SpaceType] space type object
   # @param space_type_properties [Hash] hash of space type properties
   # @param default_sch_set [OpenStudio::Model::DefaultScheduleSet] default schedule set
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def apply_lighting_schedule(space_type, space_type_properties, default_sch_set)
     lighting_sch = space_type_properties['lighting_schedule']
     return false if lighting_sch.nil?
@@ -710,9 +713,9 @@ class Standard
   # Returns standards data for selected construction
   #
   # @param space_type [OpenStudio::Model::SpaceType] space type object
-  # @param intended_surface_type [string] the type of surface
-  # @param standards_construction_type [string] the type of construction
-  # @return [hash] hash of construction properties
+  # @param intended_surface_type [String] the type of surface
+  # @param standards_construction_type [String] the type of construction
+  # @return [Hash] hash of construction properties
   def space_type_get_construction_properties(space_type, intended_surface_type, standards_construction_type)
     # get building_category value
     building_category = if !space_type_get_standards_data(space_type).nil? && space_type_get_standards_data(space_type)['is_residential'] == 'Yes'

--- a/lib/openstudio-standards/standards/Standards.SpaceType.rb
+++ b/lib/openstudio-standards/standards/Standards.SpaceType.rb
@@ -480,7 +480,7 @@ class Standard
   #
   # @param space_type [OpenStudio::Model::SpaceType] OpenStudio space type object
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Boolean] return true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def space_type_apply_int_loads_prm(space_type, model)
     # Skip plenums
     # Check if the space type name
@@ -587,7 +587,7 @@ class Standard
   # Modify the lighting schedules for Appendix G PRM for 2016 and later
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Boolean] return true if successful, false if not 
+  # @return [Boolean] returns true if successful, false if not 
   def space_type_light_sch_change(model)
     return true
   end

--- a/lib/openstudio-standards/standards/Standards.SubSurface.rb
+++ b/lib/openstudio-standards/standards/Standards.SubSurface.rb
@@ -78,7 +78,7 @@ class Standard
   #
   # @param sub_surface [OpenStudio::Model::SubSurface] sub surface object
   # @param percent_reduction [Double] the fractional amount to reduce the area
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def sub_surface_reduce_area_by_percent_by_shrinking_toward_centroid(sub_surface, percent_reduction)
     # if percent_reduction > 1=> percent increase instead of reduction
     mult = percent_reduction <= 1 ? 1 - percent_reduction : percent_reduction
@@ -113,7 +113,7 @@ class Standard
   #
   # @param sub_surface [OpenStudio::Model::SubSurface] sub surface object
   # @param percent_reduction [Double] the fractional amount to reduce the area.
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def sub_surface_reduce_area_by_percent_by_raising_sill(sub_surface, percent_reduction)
     mult = 1 - percent_reduction
 
@@ -162,7 +162,7 @@ class Standard
   # meaning a rectangle where the bottom is parallel to the ground.
   #
   # @param sub_surface [OpenStudio::Model::SubSurface] sub surface object
-  # @return [Bool] returns true if the surface is a vertical rectangle, false if not
+  # @return [Boolean] returns true if the surface is a vertical rectangle, false if not
   def sub_surface_vertical_rectangle?(sub_surface)
     # Get the vertices once
     verts = sub_surface.vertices
@@ -195,7 +195,7 @@ class Standard
   #
   # @param surface [OpenStudio::Model::Surface] surface object
   # @param area_fraction [Double] fraction of area of the larger surface
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def sub_surface_create_centered_subsurface_from_scaled_surface(surface, area_fraction)
     # Get rid of all existing subsurfaces.
     remove_all_subsurfaces(surface: surface)
@@ -245,7 +245,7 @@ class Standard
   # @param surface [OpenStudio::Model::Surface] surface object
   # @param area_fraction [Double] fraction of area of the larger surface
   # @param construction [OpenStudio::Model::Construction] construction to use for the new surface
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def sub_surface_create_scaled_subsurfaces_from_surface(surface:, area_fraction:, construction:)
     # Set geometry tolerences:
     geometry_tolerence = 12
@@ -334,7 +334,7 @@ class Standard
   # @param surface [OpenStudio::Model::Surface] surface object
   # @param area_fraction [Double] fraction of area of the larger surface
   # @param construction [OpenStudio::Model::Construction] construction to use for the new surface
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def set_window_to_wall_ratio_set_name(surface:, area_fraction:, construction:)
     surface.setWindowToWallRatio(area_fraction)
     surface.subSurfaces.sort.each do |sub_surf|
@@ -350,7 +350,7 @@ class Standard
   # Is a preparation for replaceing windows or clearing doors before adding windows.
   #
   # @param surface [OpenStudio::Model::Surface] surface object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def remove_all_subsurfaces(surface:)
     surface.subSurfaces.sort.each(&:remove)
     return true

--- a/lib/openstudio-standards/standards/Standards.Surface.rb
+++ b/lib/openstudio-standards/standards/Standards.Surface.rb
@@ -89,7 +89,7 @@ class Standard
   # @param sill_height_m [Double] sill height in meters
   # @param window_height_m [Double] window height in meters
   # @param fdwr [Double] fdwr
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def surface_replace_existing_subsurfaces_with_centered_subsurface(model, sill_height_m, window_height_m, fdwr)
     vertical_surfaces = find_exposed_conditioned_vertical_surfaces(model)
     vertical_surfaces.each do |vertical_surface|
@@ -381,9 +381,8 @@ class Standard
 
   # Returns the surface and subsurface UA product
   #
-  # @param [OpenStudio::Model::Surface] OpenStudio model surface object
-  #
-  # @retrun [Double] UA product in W/K
+  # @param surface [OpenStudio::Model::Surface] OpenStudio model surface object
+  # @return [Double] UA product in W/K
   def surface_subsurface_ua(surface)
     # Compute the surface UA product
     if surface.outsideBoundaryCondition.to_s == 'GroundFCfactorMethod' && surface.construction.is_initialized
@@ -507,7 +506,7 @@ class Standard
   # @param surface [OpenStudio::Model:Surface] openstudio surface object
   # @param reduction [Float] ratio of adjustments
   # @param model [OpenStudio::Model::Model] openstudio model
-  # @return [Bool] return true if successful, false if not
+  # @return [Boolean] return true if successful, false if not
   def surface_adjust_fenestration_in_a_surface(surface, reduction, model)
     # Subsurfaces in this surface
     # Default case only handles reduction

--- a/lib/openstudio-standards/standards/Standards.Surface.rb
+++ b/lib/openstudio-standards/standards/Standards.Surface.rb
@@ -506,7 +506,7 @@ class Standard
   # @param surface [OpenStudio::Model:Surface] openstudio surface object
   # @param reduction [Float] ratio of adjustments
   # @param model [OpenStudio::Model::Model] openstudio model
-  # @return [Boolean] return true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def surface_adjust_fenestration_in_a_surface(surface, reduction, model)
     # Subsurfaces in this surface
     # Default case only handles reduction

--- a/lib/openstudio-standards/standards/Standards.ThermalZone.rb
+++ b/lib/openstudio-standards/standards/Standards.ThermalZone.rb
@@ -96,7 +96,7 @@ class Standard
   # Convert total minimum OA requirement to a per-area value.
   #
   # @param thermal_zone [OpenStudio::Model::ThermalZone] thermal zone
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def thermal_zone_convert_oa_req_to_per_area(thermal_zone)
     # For each space in the zone, convert
     # all design OA to per-area
@@ -561,7 +561,7 @@ class Standard
   # In the event that they are equal, it will be assumed nonresidential.
   #
   # @param thermal_zone [OpenStudio::Model::ThermalZone] thermal zone
-  # return [Bool] true if residential, false if nonresidential
+  # return [Boolean] true if residential, false if nonresidential
   def thermal_zone_residential?(thermal_zone)
     # Determine the respective areas
     res_area_m2 = 0
@@ -591,7 +591,7 @@ class Standard
   # This is as-defined by 90.1 Appendix G.
   #
   # @param thermal_zone [OpenStudio::Model::ThermalZone] thermal zone
-  # @return [Bool] true if Fossil Fuel, Fossil/Electric Hybrid, and Purchased Heat zone,
+  # @return [Boolean] true if Fossil Fuel, Fossil/Electric Hybrid, and Purchased Heat zone,
   #   false if Electric or Other.
   # @todo It's not doing it properly right now.
   #   If you have a zone with a VRF + a DOAS (via an ATU SingleDUct Uncontrolled)
@@ -635,10 +635,10 @@ class Standard
   end
 
   # for 2013 and prior, baseline fuel = proposed fuel
-  # @param themal_zone
-  # @return [string] with applicable DistrictHeating and/or DistrictCooling
-  def thermal_zone_get_zone_fuels_for_occ_and_fuel_type(zone)
-    zone_fuels = thermal_zone_fossil_or_electric_type(zone, '')
+  # @param thermal_zone
+  # @return [String with applicable DistrictHeating and/or DistrictCooling
+  def thermal_zone_get_zone_fuels_for_occ_and_fuel_type(thermal_zone)
+    zone_fuels = thermal_zone_fossil_or_electric_type(thermal_zone, '')
     return zone_fuels
   end
 
@@ -724,7 +724,7 @@ class Standard
   # Determine if the thermal zone is Fossil/Purchased Heat/Electric Hybrid
   #
   # @param thermal_zone [OpenStudio::Model::ThermalZone] thermal zone
-  # @return [Bool] true if mixed Fossil/Electric Hybrid, and Purchased Heat zone, false if not
+  # @return [Boolean] true if mixed Fossil/Electric Hybrid, and Purchased Heat zone, false if not
   def thermal_zone_mixed_heating_fuel?(thermal_zone)
     is_mixed = false
 
@@ -974,7 +974,7 @@ class Standard
   #
   # @author Andrew Parker, Julien Marrec
   # @param thermal_zone [OpenStudio::Model::ThermalZone] thermal zone
-  # @return [Bool] returns true if heated, false if not
+  # @return [Boolean] returns true if heated, false if not
   def thermal_zone_heated?(thermal_zone)
     temp_f = 41
     temp_c = OpenStudio.convert(temp_f, 'F', 'C').get
@@ -1124,7 +1124,7 @@ class Standard
   #
   # @author Andrew Parker, Julien Marrec
   # @param thermal_zone [OpenStudio::Model::ThermalZone] thermal zone
-  # @return [Bool] returns true if cooled, false if not
+  # @return [Boolean] returns true if cooled, false if not
   def thermal_zone_cooled?(thermal_zone)
     temp_f = 91
     temp_c = OpenStudio.convert(temp_f, 'F', 'C').get
@@ -1265,7 +1265,7 @@ class Standard
   # Determine if the thermal zone is a plenum based on whether a majority of the spaces in the zone are plenums or not.
   #
   # @param thermal_zone [OpenStudio::Model::ThermalZone] thermal zone
-  # @return [Bool] returns true if majority plenum, false if not
+  # @return [Boolean] returns true if majority plenum, false if not
   def thermal_zone_plenum?(thermal_zone)
     plenum_status = false
 
@@ -1291,7 +1291,7 @@ class Standard
   # Zone must be less than 200 ft^2 and also have an infiltration object specified using Flow/Zone.
   #
   # @param thermal_zone [OpenStudio::Model::ThermalZone] thermal zone
-  # @return [Bool] returns true if vestibule, false if not
+  # @return [Boolean] returns true if vestibule, false if not
   def thermal_zone_vestibule?(thermal_zone)
     is_vest = false
 
@@ -1560,7 +1560,7 @@ class Standard
   # This value determines zone air flows, which will be summed during system design airflow calculation.
   #
   # @param thermal_zone [OpenStudio::Model::ThermalZone] thermal zone
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def thermal_zone_apply_prm_baseline_supply_temperatures(thermal_zone)
     # Skip spaces that aren't heated or cooled
     return true unless thermal_zone_heated?(thermal_zone) || thermal_zone_cooled?(thermal_zone)
@@ -1590,7 +1590,7 @@ class Standard
   # or cooled by thermal_zone_cooled?() and thermal_zone_heated?()
   #
   # @param thermal_zone [OpenStudio::Model::ThermalZone] thermal zone
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def thermal_zone_add_unconditioned_thermostat(thermal_zone)
     # Heated to 0F (below thermal_zone_heated?(thermal_zone)  threshold)
     htg_t_f = 0
@@ -1804,7 +1804,7 @@ class Standard
   #
   # @param thermal_zone [OpenStudio::Model::ThermalZone] thermal zone
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] Returns true if required, false if not
+  # @return [Boolean] Returns true if required, false if not
   # @todo Add exception logic for 90.1-2013
   #   for cells, sickrooms, labs, barbers, salons, and bowling alleys
   def thermal_zone_demand_control_ventilation_required?(thermal_zone, climate_zone)
@@ -2002,7 +2002,7 @@ class Standard
   # returns adjacent zones that share a wall with the zone
   #
   # @param thermal_zone [OpenStudio::Model::ThermalZone] thermal zone
-  # @param same_floor [Bool] only valid option for now is true
+  # @param same_floor [Boolean] only valid option for now is true
   # @return [Array<OpenStudio::Model::ThermalZone>] array of adjacent thermal zones
   def thermal_zone_get_adjacent_zones_with_shared_wall_areas(thermal_zone, same_floor = true)
     adjacent_zones = []
@@ -2026,16 +2026,16 @@ class Standard
   # returns true if DCV is required for exhaust fan for specified tempate
   #
   # @param thermal_zone [OpenStudio::Model::ThermalZone] thermal zone
-  # @return [Bool] returns true if DCV is required for exhaust fan for specified template, false if not
+  # @return [Boolean] returns true if DCV is required for exhaust fan for specified template, false if not
   def thermal_zone_exhaust_fan_dcv_required?(thermal_zone); end
 
   # Add DCV to exhaust fan and if requsted to related objects
   #
   # @param thermal_zone [OpenStudio::Model::ThermalZone] thermal zone
-  # @param change_related_objects [Bool] change related objects
+  # @param change_related_objects [Boolean] change related objects
   # @param zone_mixing_objects [Array<OpenStudio::Model::ZoneMixing>] array of zone mixing objects
   # @param transfer_air_source_zones [Array<OpenStudio::Model::ThermalZone>] array thermal zones that transfer air
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   # @todo this method is currently empty
   def thermal_zone_add_exhaust_fan_dcv(thermal_zone, change_related_objects = true, zone_mixing_objects = [], transfer_air_source_zones = [])
     # set flow fraction schedule for all zone exhaust fans and then set zone mixing schedule to the intersection of exhaust availability and exhaust fractional schedule

--- a/lib/openstudio-standards/standards/Standards.WaterHeaterMixed.rb
+++ b/lib/openstudio-standards/standards/Standards.WaterHeaterMixed.rb
@@ -7,7 +7,7 @@ class Standard
   # Appendix A: Service Water Heating
   #
   # @param water_heater_mixed [OpenStudio::Model::WaterHeaterMixed] water heater mixed object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def water_heater_mixed_apply_efficiency(water_heater_mixed)
     # @todo remove this once workaround for HPWHs is removed
     if water_heater_mixed.partLoadFactorCurve.is_initialized
@@ -208,7 +208,7 @@ class Standard
   #
   # @param water_heater_mixed [OpenStudio::Model::WaterHeaterMixed] water heater mixed object
   # @param building_type [String] the building type
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def water_heater_mixed_apply_prm_baseline_fuel_type(water_heater_mixed, building_type)
     # baseline is same as proposed per Table G3.1 item 11.b
     return true # Do nothing

--- a/lib/openstudio-standards/standards/Standards.ZoneHVACComponent.rb
+++ b/lib/openstudio-standards/standards/Standards.ZoneHVACComponent.rb
@@ -14,7 +14,7 @@ class Standard
   # based on the W/cfm specified in the standard.
   #
   # @param zone_hvac_component [OpenStudio::Model::ZoneHVACComponent] zone hvac component
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def zone_hvac_component_apply_prm_baseline_fan_power(zone_hvac_component)
     OpenStudio.logFree(OpenStudio::Debug, 'openstudio.standards.ZoneHVACComponent', "Setting fan power for #{zone_hvac_component.name}.")
 
@@ -138,7 +138,7 @@ class Standard
   # and the zone requires ventilation, override it to follow the zone occupancy schedule
   #
   # @param zone_hvac_component [OpenStudio::Model::ZoneHVACComponent] zone hvac component
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def zone_hvac_component_occupancy_ventilation_control(zone_hvac_component)
     ventilation = false
     # Zone HVAC operating schedule if providing ventilation
@@ -216,7 +216,7 @@ class Standard
   # Apply all standard required controls to the zone equipment
   #
   # @param zone_hvac_component [OpenStudio::Model::ZoneHVACComponent] zone hvac component
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def zone_hvac_component_apply_standard_controls(zone_hvac_component)
     # Vestibule heating control
     if zone_hvac_component_vestibule_heating_control_required?(zone_hvac_component)
@@ -262,7 +262,7 @@ class Standard
   # Defaults to 90.1-2004 through 2010, not required.
   #
   # @param zone_hvac_component [OpenStudio::Model::ZoneHVACComponent] zone hvac component
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def zone_hvac_component_vestibule_heating_control_required?(zone_hvac_component)
     vest_htg_control_required = false
     return vest_htg_control_required
@@ -273,7 +273,7 @@ class Standard
   # fan during the occupant standby mode hours
   #
   # @param zone_hvac_component OpenStudio zonal equipment object
-  # @retrun [Boolean] true if sucessful, false otherwise
+  # @return [Boolean] true if sucessful, false otherwise
   def zone_hvac_model_standby_mode_occupancy_control(zone_hvac_component)
     return true
   end
@@ -281,7 +281,7 @@ class Standard
   # Turns off vestibule heating below 45F
   #
   # @param zone_hvac_component [OpenStudio::Model::ZoneHVACComponent] zone hvac component
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def zone_hvac_component_apply_vestibule_heating_control(zone_hvac_component)
     # Ensure that the equipment is assigned to a thermal zone
     if zone_hvac_component.thermalZone.empty?

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2004/ashrae_90_1_2004.AirLoopHVAC.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2004/ashrae_90_1_2004.AirLoopHVAC.rb
@@ -5,7 +5,7 @@ class ASHRAE9012004 < ASHRAE901
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_prm_baseline_economizer_required?(air_loop_hvac, climate_zone)
     economizer_required = false
 

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2004/ashrae_90_1_2004.PlantLoop.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2004/ashrae_90_1_2004.PlantLoop.rb
@@ -4,7 +4,7 @@ class ASHRAE9012004 < ASHRAE901
   # Set the primary and secondary pumping control types for the chilled water loop, as specified in Appendix G.
   #
   # @param plant_loop [OpenStudio::Model::PlantLoop] chilled water loop
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def plant_loop_apply_prm_baseline_chilled_water_pumping_type(plant_loop)
     # Determine the pumping type.
     minimum_area_ft2 = 120_000

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2010/ashrae_90_1_2010.AirLoopHVAC.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2010/ashrae_90_1_2010.AirLoopHVAC.rb
@@ -44,7 +44,7 @@ class ASHRAE9012010 < ASHRAE901
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_integrated_economizer_required?(air_loop_hvac, climate_zone)
     return true
   end
@@ -54,7 +54,7 @@ class ASHRAE9012010 < ASHRAE901
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] Returns true if allowable, if the system has no economizer or no OA system.
+  # @return [Boolean] Returns true if allowable, if the system has no economizer or no OA system.
   #   Returns false if the economizer type is not allowable.
   def air_loop_hvac_economizer_type_allowable?(air_loop_hvac, climate_zone)
     # EnergyPlus economizer types
@@ -142,7 +142,7 @@ class ASHRAE9012010 < ASHRAE901
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   # @todo Add exception logic for systems with AIA healthcare ventilation requirements dual duct systems
   def air_loop_hvac_multizone_vav_optimization_required?(air_loop_hvac, climate_zone)
     multizone_opt_required = false
@@ -296,7 +296,7 @@ class ASHRAE9012010 < ASHRAE901
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_supply_air_temperature_reset_required?(air_loop_hvac, climate_zone)
     is_sat_reset_required = false
 

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2010/ashrae_90_1_2010.AirTerminalSingleDuctVAVReheat.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2010/ashrae_90_1_2010.AirTerminalSingleDuctVAVReheat.rb
@@ -5,7 +5,7 @@ class ASHRAE9012010 < ASHRAE901
   # For terminals with hot water heat and DDC, the minimum is 20%, otherwise the minimum is 30%.
   #
   # @param air_terminal_single_duct_vav_reheat [OpenStudio::Model::AirTerminalSingleDuctVAVReheat] the air terminal object
-  # @param has_ddc [Bool] whether or not there is DDC control of the VAV terminal in question
+  # @param has_ddc [Boolean] whether or not there is DDC control of the VAV terminal in question
   # @return [Double] minimum damper position
   def air_terminal_single_duct_vav_reheat_minimum_damper_position(air_terminal_single_duct_vav_reheat, has_ddc = false)
     min_damper_position = nil

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2010/ashrae_90_1_2010.Space.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2010/ashrae_90_1_2010.Space.rb
@@ -97,9 +97,9 @@ class ASHRAE9012010 < ASHRAE901
   # @param areas [Hash] a hash of daylighted areas
   # @param sorted_windows [Hash] a hash of windows, sorted by priority
   # @param sorted_skylights [Hash] a hash of skylights, sorted by priority
-  # @param req_top_ctrl [Bool] if toplighting controls are required
-  # @param req_pri_ctrl [Bool] if primary sidelighting controls are required
-  # @param req_sec_ctrl [Bool] if secondary sidelighting controls are required
+  # @param req_top_ctrl [Boolean] if toplighting controls are required
+  # @param req_pri_ctrl [Boolean] if primary sidelighting controls are required
+  # @param req_sec_ctrl [Boolean] if secondary sidelighting controls are required
   # @return [Array] array of 4 items
   #   [sensor 1 fraction, sensor 2 fraction, sensor 1 window, sensor 2 window]
   def space_daylighting_fractions_and_windows(space,

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2013/ashrae_90_1_2013.AirLoopHVAC.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2013/ashrae_90_1_2013.AirLoopHVAC.rb
@@ -50,7 +50,7 @@ class ASHRAE9012013 < ASHRAE901
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_integrated_economizer_required?(air_loop_hvac, climate_zone)
     return true
   end
@@ -123,7 +123,7 @@ class ASHRAE9012013 < ASHRAE901
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] Returns true if allowable, if the system has no economizer or no OA system.
+  # @return [Boolean] Returns true if allowable, if the system has no economizer or no OA system.
   #   Returns false if the economizer type is not allowable.
   def air_loop_hvac_economizer_type_allowable?(air_loop_hvac, climate_zone)
     # EnergyPlus economizer types
@@ -211,7 +211,7 @@ class ASHRAE9012013 < ASHRAE901
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   # @todo Add exception logic for systems with AIA healthcare ventilation requirements dual duct systems
   def air_loop_hvac_multizone_vav_optimization_required?(air_loop_hvac, climate_zone)
     multizone_opt_required = false
@@ -365,7 +365,7 @@ class ASHRAE9012013 < ASHRAE901
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_supply_air_temperature_reset_required?(air_loop_hvac, climate_zone)
     is_sat_reset_required = false
 

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2013/ashrae_90_1_2013.AirTerminalSingleDuctVAVReheat.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2013/ashrae_90_1_2013.AirTerminalSingleDuctVAVReheat.rb
@@ -5,7 +5,7 @@ class ASHRAE9012013 < ASHRAE901
   # For terminals with hot water heat and DDC, the minimum is 20%, otherwise the minimum is 30%.
   #
   # @param air_terminal_single_duct_vav_reheat [OpenStudio::Model::AirTerminalSingleDuctVAVReheat] the air terminal object
-  # @param has_ddc [Bool] whether or not there is DDC control of the VAV terminal in question
+  # @param has_ddc [Boolean] whether or not there is DDC control of the VAV terminal in question
   # @return [Double] minimum damper position
   def air_terminal_single_duct_vav_reheat_minimum_damper_position(air_terminal_single_duct_vav_reheat, has_ddc = false)
     min_damper_position = nil

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2013/ashrae_90_1_2013.CoolingTowerVariableSpeed.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2013/ashrae_90_1_2013.CoolingTowerVariableSpeed.rb
@@ -6,7 +6,7 @@ class ASHRAE9012013 < ASHRAE901
   # Apply the efficiency, plus Multicell heat rejection with VSD per 90.1-2013 6.5.2.2
   #
   # @param cooling_tower_variable_speed [OpenStudio::Model::CoolingTowerVariableSpeed] variable speed cooling tower
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def cooling_tower_variable_speed_apply_efficiency_and_curves(cooling_tower_variable_speed)
     cooling_tower_apply_minimum_power_per_flow(cooling_tower_variable_speed)
     cooling_tower_variable_speed.setCellControl('MaximalCell')

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2013/ashrae_90_1_2013.Space.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2013/ashrae_90_1_2013.Space.rb
@@ -102,9 +102,9 @@ class ASHRAE9012013 < ASHRAE901
   # @param areas [Hash] a hash of daylighted areas
   # @param sorted_windows [Hash] a hash of windows, sorted by priority
   # @param sorted_skylights [Hash] a hash of skylights, sorted by priority
-  # @param req_top_ctrl [Bool] if toplighting controls are required
-  # @param req_pri_ctrl [Bool] if primary sidelighting controls are required
-  # @param req_sec_ctrl [Bool] if secondary sidelighting controls are required
+  # @param req_top_ctrl [Boolean] if toplighting controls are required
+  # @param req_pri_ctrl [Boolean] if primary sidelighting controls are required
+  # @param req_sec_ctrl [Boolean] if secondary sidelighting controls are required
   # @return [Array] array of 4 items
   #   [sensor 1 fraction, sensor 2 fraction, sensor 1 window, sensor 2 window]
   def space_daylighting_fractions_and_windows(space,

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2013/ashrae_90_1_2013.WaterHeaterMixed.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2013/ashrae_90_1_2013.WaterHeaterMixed.rb
@@ -6,7 +6,7 @@ class ASHRAE9012013 < ASHRAE901
   # from the proposed building in some scenarios.
   #
   # @param building_type [String] the building type
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def water_heater_mixed_apply_prm_baseline_fuel_type(water_heater_mixed, building_type)
     # Determine the building-type specific
     # fuel requirements from Table G3.1.1-2

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2013/ashrae_90_1_2013.ZoneHVACComponent.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2013/ashrae_90_1_2013.ZoneHVACComponent.rb
@@ -6,7 +6,7 @@ class ASHRAE9012013 < ASHRAE901
   #
   # @ref [References::ASHRAE9012013] 6.4.3.9
   # @param zone_hvac_component [OpenStudio::Model::ZoneHVACComponent] zone hvac component
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def zone_hvac_component_vestibule_heating_control_required?(zone_hvac_component)
     # Ensure that the equipment is assigned to a thermal zone
     if zone_hvac_component.thermalZone.empty?

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2016/ashrae_90_1_2016.AirLoopHVAC.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2016/ashrae_90_1_2016.AirLoopHVAC.rb
@@ -82,7 +82,7 @@ class ASHRAE9012016 < ASHRAE901
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_integrated_economizer_required?(air_loop_hvac, climate_zone)
     return true
   end
@@ -92,7 +92,7 @@ class ASHRAE9012016 < ASHRAE901
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] Returns true if allowable, if the system has no economizer or no OA system.
+  # @return [Boolean] Returns true if allowable, if the system has no economizer or no OA system.
   #   Returns false if the economizer type is not allowable.
   def air_loop_hvac_economizer_type_allowable?(air_loop_hvac, climate_zone)
     # EnergyPlus economizer types
@@ -180,7 +180,7 @@ class ASHRAE9012016 < ASHRAE901
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   # @todo Add exception logic for systems with AIA healthcare ventilation requirements dual duct systems
   def air_loop_hvac_multizone_vav_optimization_required?(air_loop_hvac, climate_zone)
     multizone_opt_required = false
@@ -327,7 +327,7 @@ class ASHRAE9012016 < ASHRAE901
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_supply_air_temperature_reset_required?(air_loop_hvac, climate_zone)
     is_sat_reset_required = false
 

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2016/ashrae_90_1_2016.AirTerminalSingleDuctVAVReheat.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2016/ashrae_90_1_2016.AirTerminalSingleDuctVAVReheat.rb
@@ -5,7 +5,7 @@ class ASHRAE9012016 < ASHRAE901
   # For terminals with hot water heat and DDC, the minimum is 20%, otherwise the minimum is 30%.
   #
   # @param air_terminal_single_duct_vav_reheat [OpenStudio::Model::AirTerminalSingleDuctVAVReheat] the air terminal object
-  # @param has_ddc [Bool] whether or not there is DDC control of the VAV terminal in question
+  # @param has_ddc [Boolean] whether or not there is DDC control of the VAV terminal in question
   # @return [Double] minimum damper position
   def air_terminal_single_duct_vav_reheat_minimum_damper_position(air_terminal_single_duct_vav_reheat, has_ddc = false)
     min_damper_position = nil

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2016/ashrae_90_1_2016.CoolingTowerVariableSpeed.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2016/ashrae_90_1_2016.CoolingTowerVariableSpeed.rb
@@ -6,7 +6,7 @@ class ASHRAE9012016 < ASHRAE901
   # Apply the efficiency, plus Multicell heat rejection with VSD
   #
   # @param cooling_tower_variable_speed [OpenStudio::Model::CoolingTowerVariableSpeed] variable speed cooling tower
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def cooling_tower_variable_speed_apply_efficiency_and_curves(cooling_tower_variable_speed)
     cooling_tower_apply_minimum_power_per_flow(cooling_tower_variable_speed)
     cooling_tower_variable_speed.setCellControl('MaximalCell')

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2016/ashrae_90_1_2016.Space.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2016/ashrae_90_1_2016.Space.rb
@@ -102,9 +102,9 @@ class ASHRAE9012016 < ASHRAE901
   # @param areas [Hash] a hash of daylighted areas
   # @param sorted_windows [Hash] a hash of windows, sorted by priority
   # @param sorted_skylights [Hash] a hash of skylights, sorted by priority
-  # @param req_top_ctrl [Bool] if toplighting controls are required
-  # @param req_pri_ctrl [Bool] if primary sidelighting controls are required
-  # @param req_sec_ctrl [Bool] if secondary sidelighting controls are required
+  # @param req_top_ctrl [Boolean] if toplighting controls are required
+  # @param req_pri_ctrl [Boolean] if primary sidelighting controls are required
+  # @param req_sec_ctrl [Boolean] if secondary sidelighting controls are required
   # @return [Array] array of 4 items
   #   [sensor 1 fraction, sensor 2 fraction, sensor 1 window, sensor 2 window]
   def space_daylighting_fractions_and_windows(space,

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2016/ashrae_90_1_2016.ZoneHVACComponent.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2016/ashrae_90_1_2016.ZoneHVACComponent.rb
@@ -6,7 +6,7 @@ class ASHRAE9012016 < ASHRAE901
   #
   # @ref [References::ASHRAE9012016] 6.4.3.9
   # @param zone_hvac_component [OpenStudio::Model::ZoneHVACComponent] zone hvac component
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def zone_hvac_component_vestibule_heating_control_required?(zone_hvac_component)
     # Ensure that the equipment is assigned to a thermal zone
     if zone_hvac_component.thermalZone.empty?

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2016/comstock_ashrae_90_1_2016/comstock_ashrae_90_1_2016.AirLoopHVAC.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2016/comstock_ashrae_90_1_2016/comstock_ashrae_90_1_2016.AirLoopHVAC.rb
@@ -8,7 +8,7 @@ class ComStockASHRAE9012016 < ASHRAE9012016
   # by Steven Taylor and Hwakong Cheng.
   # https://tayloreng.egnyte.com/dl/mN0c9t4WSO/ASHRAE_Journal_-_Economizer_High_Limit_Devices_and_Why_Enthalpy_Economizers_Dont_Work.pdf_
   #
-  # @param model [OpenStudio::Model::Model] the model
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @return [String] the economizer type.  Possible values are:
   # 'NoEconomizer'

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2019/ashrae_90_1_2019.AirLoopHVAC.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2019/ashrae_90_1_2019.AirLoopHVAC.rb
@@ -82,7 +82,7 @@ class ASHRAE9012019 < ASHRAE901
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_integrated_economizer_required?(air_loop_hvac, climate_zone)
     return true
   end
@@ -92,7 +92,7 @@ class ASHRAE9012019 < ASHRAE901
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] Returns true if allowable, if the system has no economizer or no OA system.
+  # @return [Boolean] Returns true if allowable, if the system has no economizer or no OA system.
   #   Returns false if the economizer type is not allowable.
   def air_loop_hvac_economizer_type_allowable?(air_loop_hvac, climate_zone)
     # EnergyPlus economizer types
@@ -180,7 +180,7 @@ class ASHRAE9012019 < ASHRAE901
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   # @todo Add exception logic for systems with AIA healthcare ventilation requirements dual duct systems
   def air_loop_hvac_multizone_vav_optimization_required?(air_loop_hvac, climate_zone)
     multizone_opt_required = false
@@ -327,7 +327,7 @@ class ASHRAE9012019 < ASHRAE901
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_supply_air_temperature_reset_required?(air_loop_hvac, climate_zone)
     is_sat_reset_required = false
 
@@ -557,7 +557,7 @@ class ASHRAE9012019 < ASHRAE901
   # system outdoor air flow following ASHRAE Std. 62.1-2019
   #
   # @param (see #economizer_required?)
-  # @return [Bool] Returns true if required, false if not.
+  # @return [Boolean] Returns true if required, false if not.
   # @todo Add exception logic for systems serving parking garage, warehouse, or multifamily
   def air_loop_hvac_adjust_minimum_vav_damper_positions(air_loop_hvac)
     # Do not apply the adjustment to some of the system in
@@ -742,8 +742,8 @@ class ASHRAE9012019 < ASHRAE901
   # by scheduling air terminal dampers (so load can
   # still be met) and cycling unitary system fans
   #
-  # @param air_loop_hvac [OpenStudio::model::AirLoopHVAC] OpenStudio AirLoopHVAC object
-  # @param standby_mode_space [Array] List of all spaces required to have standby mode controls
+  # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] OpenStudio AirLoopHVAC object
+  # @param standby_mode_spaces [Array<OpenStudio::Model::Space>] List of all spaces required to have standby mode controls
   # @return [Boolean] true if sucessful, false otherwise
   def air_loop_hvac_standby_mode_occupancy_control(air_loop_hvac, standby_mode_spaces)
     if air_loop_hvac_include_unitary_system?(air_loop_hvac)

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2019/ashrae_90_1_2019.AirTerminalSingleDuctVAVReheat.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2019/ashrae_90_1_2019.AirTerminalSingleDuctVAVReheat.rb
@@ -5,7 +5,7 @@ class ASHRAE9012019 < ASHRAE901
   # For terminals with hot water heat and DDC, the minimum is 20%, otherwise the minimum is 30%.
   #
   # @param air_terminal_single_duct_vav_reheat [OpenStudio::Model::AirTerminalSingleDuctVAVReheat] the air terminal object
-  # @param has_ddc [Bool] whether or not there is DDC control of the VAV terminal in question
+  # @param has_ddc [Boolean] whether or not there is DDC control of the VAV terminal in question
   # @return [Double] minimum damper position
   def air_terminal_single_duct_vav_reheat_minimum_damper_position(air_terminal_single_duct_vav_reheat, has_ddc = false)
     min_damper_position = nil

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2019/ashrae_90_1_2019.CoolingTowerVariableSpeed.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2019/ashrae_90_1_2019.CoolingTowerVariableSpeed.rb
@@ -6,7 +6,7 @@ class ASHRAE9012019 < ASHRAE901
   # Apply the efficiency, plus Multicell heat rejection with VSD
   #
   # @param cooling_tower_variable_speed [OpenStudio::Model::CoolingTowerVariableSpeed] variable speed cooling tower
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def cooling_tower_variable_speed_apply_efficiency_and_curves(cooling_tower_variable_speed)
     cooling_tower_apply_minimum_power_per_flow(cooling_tower_variable_speed)
     cooling_tower_variable_speed.setCellControl('MaximalCell')

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2019/ashrae_90_1_2019.Space.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2019/ashrae_90_1_2019.Space.rb
@@ -102,9 +102,9 @@ class ASHRAE9012019 < ASHRAE901
   # @param areas [Hash] a hash of daylighted areas
   # @param sorted_windows [Hash] a hash of windows, sorted by priority
   # @param sorted_skylights [Hash] a hash of skylights, sorted by priority
-  # @param req_top_ctrl [Bool] if toplighting controls are required
-  # @param req_pri_ctrl [Bool] if primary sidelighting controls are required
-  # @param req_sec_ctrl [Bool] if secondary sidelighting controls are required
+  # @param req_top_ctrl [Boolean] if toplighting controls are required
+  # @param req_pri_ctrl [Boolean] if primary sidelighting controls are required
+  # @param req_sec_ctrl [Boolean] if secondary sidelighting controls are required
   # @return [Array] array of 4 items
   #   [sensor 1 fraction, sensor 2 fraction, sensor 1 window, sensor 2 window]
   def space_daylighting_fractions_and_windows(space,
@@ -192,7 +192,7 @@ class ASHRAE9012019 < ASHRAE901
 
   # Provide the type of daylighting control type
   #
-  # @param [OpenStudio::Model::Space] OpenStudio Space object
+  # @param space [OpenStudio::Model::Space] OpenStudio Space object
   # return [String] daylighting control type
   def space_daylighting_control_type(space)
     return 'ContinuousOff'
@@ -201,7 +201,7 @@ class ASHRAE9012019 < ASHRAE901
   # Provide the minimum input power fraction for continuous
   # dimming daylighting control
   #
-  # @param [OpenStudio::Model::Space] OpenStudio Space object
+  # @param space [OpenStudio::Model::Space] OpenStudio Space object
   # return [Float] daylighting minimum input power fraction
   def space_daylighting_minimum_input_power_fraction(space)
     return 0.2

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2019/ashrae_90_1_2019.ZoneHVACComponent.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2019/ashrae_90_1_2019.ZoneHVACComponent.rb
@@ -6,7 +6,7 @@ class ASHRAE9012019 < ASHRAE901
   #
   # @ref [References::ASHRAE9012019] 6.4.3.9
   # @param zone_hvac_component [OpenStudio::Model::ZoneHVACComponent] zone hvac component
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def zone_hvac_component_vestibule_heating_control_required?(zone_hvac_component)
     # Ensure that the equipment is assigned to a thermal zone
     if zone_hvac_component.thermalZone.empty?
@@ -26,7 +26,7 @@ class ASHRAE9012019 < ASHRAE901
   # fan during the occupant standby mode hours
   #
   # @param zone_hvac_component OpenStudio zonal equipment object
-  # @retrun [Boolean] true if sucessful, false otherwise
+  # @return [Boolean] true if sucessful, false otherwise
   def zone_hvac_model_standby_mode_occupancy_control(zone_hvac_component)
     # Ensure that the equipment is assigned to a thermal zone
     if zone_hvac_component.thermalZone.empty?

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2019/comstock_ashrae_90_1_2019/comstock_ashrae_90_1_2019.AirLoopHVAC.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2019/comstock_ashrae_90_1_2019/comstock_ashrae_90_1_2019.AirLoopHVAC.rb
@@ -8,7 +8,7 @@ class ComStockASHRAE9012019 < ASHRAE9012019
   # by Steven Taylor and Hwakong Cheng.
   # https://tayloreng.egnyte.com/dl/mN0c9t4WSO/ASHRAE_Journal_-_Economizer_High_Limit_Devices_and_Why_Enthalpy_Economizers_Dont_Work.pdf_
   #
-  # @param model [OpenStudio::Model::Model] the model
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @return [String] the economizer type.  Possible values are:
   # 'NoEconomizer'

--- a/lib/openstudio-standards/standards/ashrae_90_1/doe_ref_1980_2004/doe_ref_1980_2004.AirLoopHVAC.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/doe_ref_1980_2004/doe_ref_1980_2004.AirLoopHVAC.rb
@@ -5,7 +5,7 @@ class DOERef1980to2004 < ASHRAE901
   # Currently doesn't do anything for the DOE prototype buildings.
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
-  # return [Bool] returns true if successful, false if not
+  # return [Boolean] returns true if successful, false if not
   # @todo enable damper position adjustment for legacy IDFS
   def air_loop_hvac_apply_multizone_vav_outdoor_air_sizing(air_loop_hvac)
     OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.AirLoopHVAC', 'Damper positions not modified for DOE Ref Pre-1980 or DOE Ref 1980-2004 vintages.')
@@ -21,8 +21,8 @@ class DOERef1980to2004 < ASHRAE901
   #   be added to the OpenStudio data model.
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
-  # @param has_ddc [Bool] whether or not the system has DDC control over VAV terminals.
-  # return [Bool] returns true if static pressure reset is required, false if not
+  # @param has_ddc [Boolean] whether or not the system has DDC control over VAV terminals.
+  # return [Boolean] returns true if static pressure reset is required, false if not
   def air_loop_hvac_static_pressure_reset_required?(air_loop_hvac, has_ddc)
     sp_reset_required = false
     return sp_reset_required
@@ -32,7 +32,7 @@ class DOERef1980to2004 < ASHRAE901
   # Not required by DOE Ref 1980-2004.
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_optimum_start_required?(air_loop_hvac)
     opt_start_required = false
     return opt_start_required

--- a/lib/openstudio-standards/standards/ashrae_90_1/doe_ref_1980_2004/doe_ref_1980_2004.Model.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/doe_ref_1980_2004/doe_ref_1980_2004.Model.rb
@@ -7,7 +7,7 @@ class DOERef1980to2004 < ASHRAE901
   # no changes are actually made to the model.
   #
   # base infiltration rates off of.
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   # @todo This infiltration method is not used by the Reference
   # buildings, fix this inconsistency.
   def model_apply_infiltration_standard(model)

--- a/lib/openstudio-standards/standards/ashrae_90_1/doe_ref_1980_2004/doe_ref_1980_2004.PlantLoop.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/doe_ref_1980_2004/doe_ref_1980_2004.PlantLoop.rb
@@ -5,7 +5,7 @@ class DOERef1980to2004 < ASHRAE901
   # Not required for the older DOE buildings.
   #
   # @param plant_loop [OpenStudio::Model::PlantLoop] plant loop
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def plant_loop_supply_water_temperature_reset_required?(plant_loop)
     reset_required = false
     return reset_required

--- a/lib/openstudio-standards/standards/ashrae_90_1/doe_ref_pre_1980/doe_ref_pre_1980.AirLoopHVAC.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/doe_ref_pre_1980/doe_ref_pre_1980.AirLoopHVAC.rb
@@ -5,7 +5,7 @@ class DOERefPre1980 < ASHRAE901
   # Currently doesn't do anything for the DOE prototype buildings.
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
-  # return [Bool] returns true if successful, false if not
+  # return [Boolean] returns true if successful, false if not
   # @todo enable damper position adjustment for legacy IDFS
   def air_loop_hvac_apply_multizone_vav_outdoor_air_sizing(air_loop_hvac)
     OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.AirLoopHVAC', 'Damper positions not modified for DOE Ref Pre-1980 or DOE Ref 1980-2004 vintages.')
@@ -21,8 +21,8 @@ class DOERefPre1980 < ASHRAE901
   #   be added to the OpenStudio data model.
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
-  # @param has_ddc [Bool] whether or not the system has DDC control over VAV terminals.
-  # return [Bool] returns true if static pressure reset is required, false if not
+  # @param has_ddc [Boolean] whether or not the system has DDC control over VAV terminals.
+  # return [Boolean] returns true if static pressure reset is required, false if not
   def air_loop_hvac_static_pressure_reset_required?(air_loop_hvac, has_ddc)
     sp_reset_required = false
     return sp_reset_required
@@ -32,7 +32,7 @@ class DOERefPre1980 < ASHRAE901
   # Not required by DOE Pre-1980.
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_optimum_start_required?(air_loop_hvac)
     opt_start_required = false
     return opt_start_required

--- a/lib/openstudio-standards/standards/ashrae_90_1/doe_ref_pre_1980/doe_ref_pre_1980.Model.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/doe_ref_pre_1980/doe_ref_pre_1980.Model.rb
@@ -7,7 +7,7 @@ class DOERefPre1980 < ASHRAE901
   # no changes are actually made to the model.
   #
   # base infiltration rates off of.
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   # @todo This infiltration method is not used by the Reference
   # buildings, fix this inconsistency.
   def model_apply_infiltration_standard(model)

--- a/lib/openstudio-standards/standards/ashrae_90_1/doe_ref_pre_1980/doe_ref_pre_1980.PlantLoop.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/doe_ref_pre_1980/doe_ref_pre_1980.PlantLoop.rb
@@ -5,7 +5,7 @@ class DOERefPre1980 < ASHRAE901
   # Not required for the older DOE buildings.
   #
   # @param plant_loop [OpenStudio::Model::PlantLoop] plant loop
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def plant_loop_supply_water_temperature_reset_required?(plant_loop)
     reset_required = false
     return reset_required

--- a/lib/openstudio-standards/standards/ashrae_90_1/nrel_zne_ready_2017/nrel_zne_ready_2017.AirLoopHVAC.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/nrel_zne_ready_2017/nrel_zne_ready_2017.AirLoopHVAC.rb
@@ -82,7 +82,7 @@ class NRELZNEReady2017 < ASHRAE901
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_integrated_economizer_required?(air_loop_hvac, climate_zone)
     return true
   end
@@ -93,7 +93,7 @@ class NRELZNEReady2017 < ASHRAE901
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] Returns true if allowable, if the system has no economizer or no OA system.
+  # @return [Boolean] Returns true if allowable, if the system has no economizer or no OA system.
   #   Returns false if the economizer type is not allowable.
   def air_loop_hvac_economizer_type_allowable?(air_loop_hvac, climate_zone)
     # EnergyPlus economizer types
@@ -181,7 +181,7 @@ class NRELZNEReady2017 < ASHRAE901
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   # @todo Add exception logic for systems with AIA healthcare ventilation requirements dual duct systems
   def air_loop_hvac_multizone_vav_optimization_required?(air_loop_hvac, climate_zone)
     multizone_opt_required = false
@@ -278,7 +278,7 @@ class NRELZNEReady2017 < ASHRAE901
   # DCV and an ERV may be used in conjunction.
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_dcv_required_when_erv(air_loop_hvac)
     dcv_required_when_erv_present = true
     return dcv_required_when_erv_present
@@ -347,7 +347,7 @@ class NRELZNEReady2017 < ASHRAE901
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_supply_air_temperature_reset_required?(air_loop_hvac, climate_zone)
     is_sat_reset_required = false
 
@@ -418,7 +418,7 @@ class NRELZNEReady2017 < ASHRAE901
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] Returns true if required, false if not
+  # @return [Boolean] Returns true if required, false if not
   def air_loop_hvac_energy_recovery_ventilator_required?(air_loop_hvac, climate_zone)
     if air_loop_hvac.airLoopHVACOutdoorAirSystem.is_initialized
       oa_system = air_loop_hvac.airLoopHVACOutdoorAirSystem.get

--- a/lib/openstudio-standards/standards/ashrae_90_1/nrel_zne_ready_2017/nrel_zne_ready_2017.AirTerminalSingleDuctVAVReheat.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/nrel_zne_ready_2017/nrel_zne_ready_2017.AirTerminalSingleDuctVAVReheat.rb
@@ -5,7 +5,7 @@ class NRELZNEReady2017 < ASHRAE901
   # For terminals with hot water heat and DDC, the minimum is 20%, otherwise the minimum is 30%.
   #
   # @param air_terminal_single_duct_vav_reheat [OpenStudio::Model::AirTerminalSingleDuctVAVReheat] the air terminal object
-  # @param has_ddc [Bool] whether or not there is DDC control of the VAV terminal in question
+  # @param has_ddc [Boolean] whether or not there is DDC control of the VAV terminal in question
   # @return [Double] minimum damper position
   def air_terminal_single_duct_vav_reheat_minimum_damper_position(air_terminal_single_duct_vav_reheat, has_ddc = true)
     min_damper_position = nil

--- a/lib/openstudio-standards/standards/ashrae_90_1/nrel_zne_ready_2017/nrel_zne_ready_2017.CoolingTowerVariableSpeed.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/nrel_zne_ready_2017/nrel_zne_ready_2017.CoolingTowerVariableSpeed.rb
@@ -6,7 +6,7 @@ class NRELZNEReady2017 < ASHRAE901
   # Apply the efficiency, plus Multicell heat rejection with VSD per 90.1-2013 6.5.2.2
   #
   # @param cooling_tower_variable_speed [OpenStudio::Model::CoolingTowerVariableSpeed] variable speed cooling tower
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def cooling_tower_variable_speed_apply_efficiency_and_curves(cooling_tower_variable_speed)
     cooling_tower_apply_minimum_power_per_flow(cooling_tower_variable_speed)
     cooling_tower_variable_speed.setCellControl('MaximalCell')

--- a/lib/openstudio-standards/standards/ashrae_90_1/nrel_zne_ready_2017/nrel_zne_ready_2017.PlantLoop.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/nrel_zne_ready_2017/nrel_zne_ready_2017.PlantLoop.rb
@@ -4,7 +4,7 @@ class NRELZNEReady2017 < ASHRAE901
   # Applies the chilled water pumping controls to the loop based on Appendix G.
   #
   # @param plant_loop [OpenStudio::Model::PlantLoop] chilled water loop
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def plant_loop_apply_prm_baseline_chilled_water_pumping_type(plant_loop)
     pri_control_type = 'VSD DP Reset'
     sec_control_type = 'VSD DP Reset'

--- a/lib/openstudio-standards/standards/ashrae_90_1/nrel_zne_ready_2017/nrel_zne_ready_2017.Space.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/nrel_zne_ready_2017/nrel_zne_ready_2017.Space.rb
@@ -79,9 +79,9 @@ class NRELZNEReady2017 < ASHRAE901
   # @param areas [Hash] a hash of daylighted areas
   # @param sorted_windows [Hash] a hash of windows, sorted by priority
   # @param sorted_skylights [Hash] a hash of skylights, sorted by priority
-  # @param req_top_ctrl [Bool] if toplighting controls are required
-  # @param req_pri_ctrl [Bool] if primary sidelighting controls are required
-  # @param req_sec_ctrl [Bool] if secondary sidelighting controls are required
+  # @param req_top_ctrl [Boolean] if toplighting controls are required
+  # @param req_pri_ctrl [Boolean] if primary sidelighting controls are required
+  # @param req_sec_ctrl [Boolean] if secondary sidelighting controls are required
   # @return [Array] array of 4 items
   #   [sensor 1 fraction, sensor 2 fraction, sensor 1 window, sensor 2 window]
   def space_daylighting_fractions_and_windows(space,

--- a/lib/openstudio-standards/standards/ashrae_90_1/ze_aedg_multifamily/ze_aedg_multifamily.AirLoopHVAC.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ze_aedg_multifamily/ze_aedg_multifamily.AirLoopHVAC.rb
@@ -82,7 +82,7 @@ class ZEAEDGMultifamily < ASHRAE901
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_integrated_economizer_required?(air_loop_hvac, climate_zone)
     return true
   end
@@ -93,7 +93,7 @@ class ZEAEDGMultifamily < ASHRAE901
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] Returns true if allowable, if the system has no economizer or no OA system.
+  # @return [Boolean] Returns true if allowable, if the system has no economizer or no OA system.
   #   Returns false if the economizer type is not allowable.
   def air_loop_hvac_economizer_type_allowable?(air_loop_hvac, climate_zone)
     # EnergyPlus economizer types
@@ -181,7 +181,7 @@ class ZEAEDGMultifamily < ASHRAE901
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   # @todo Add exception logic for systems with AIA healthcare ventilation requirements dual duct systems
   def air_loop_hvac_multizone_vav_optimization_required?(air_loop_hvac, climate_zone)
     multizone_opt_required = false
@@ -278,7 +278,7 @@ class ZEAEDGMultifamily < ASHRAE901
   # DCV and an ERV may be used in conjunction.
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_dcv_required_when_erv(air_loop_hvac)
     dcv_required_when_erv_present = true
     return dcv_required_when_erv_present
@@ -347,7 +347,7 @@ class ZEAEDGMultifamily < ASHRAE901
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_supply_air_temperature_reset_required?(air_loop_hvac, climate_zone)
     is_sat_reset_required = false
 
@@ -418,7 +418,7 @@ class ZEAEDGMultifamily < ASHRAE901
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] Returns true if required, false if not
+  # @return [Boolean] Returns true if required, false if not
   def air_loop_hvac_energy_recovery_ventilator_required?(air_loop_hvac, climate_zone)
     if air_loop_hvac.airLoopHVACOutdoorAirSystem.is_initialized
       oa_system = air_loop_hvac.airLoopHVACOutdoorAirSystem.get

--- a/lib/openstudio-standards/standards/ashrae_90_1/ze_aedg_multifamily/ze_aedg_multifamily.AirTerminalSingleDuctVAVReheat.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ze_aedg_multifamily/ze_aedg_multifamily.AirTerminalSingleDuctVAVReheat.rb
@@ -5,7 +5,7 @@ class ZEAEDGMultifamily < ASHRAE901
   # For terminals with hot water heat and DDC, the minimum is 20%, otherwise the minimum is 30%.
   #
   # @param air_terminal_single_duct_vav_reheat [OpenStudio::Model::AirTerminalSingleDuctVAVReheat] the air terminal object
-  # @param has_ddc [Bool] whether or not there is DDC control of the VAV terminal in question
+  # @param has_ddc [Boolean] whether or not there is DDC control of the VAV terminal in question
   # @return [Double] minimum damper position
   def air_terminal_single_duct_vav_reheat_minimum_damper_position(air_terminal_single_duct_vav_reheat, has_ddc = true)
     min_damper_position = nil

--- a/lib/openstudio-standards/standards/ashrae_90_1/ze_aedg_multifamily/ze_aedg_multifamily.CoolingTowerVariableSpeed.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ze_aedg_multifamily/ze_aedg_multifamily.CoolingTowerVariableSpeed.rb
@@ -6,7 +6,7 @@ class ZEAEDGMultifamily < ASHRAE901
   # Apply the efficiency, plus Multicell heat rejection with VSD per 90.1-2013 6.5.2.2
   #
   # @param cooling_tower_variable_speed [OpenStudio::Model::CoolingTowerVariableSpeed] variable speed cooling tower
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def cooling_tower_variable_speed_apply_efficiency_and_curves(cooling_tower_variable_speed)
     cooling_tower_apply_minimum_power_per_flow(cooling_tower_variable_speed)
     cooling_tower_variable_speed.setCellControl('MaximalCell')

--- a/lib/openstudio-standards/standards/ashrae_90_1/ze_aedg_multifamily/ze_aedg_multifamily.PlantLoop.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ze_aedg_multifamily/ze_aedg_multifamily.PlantLoop.rb
@@ -4,7 +4,7 @@ class ZEAEDGMultifamily < ASHRAE901
   # Applies the chilled water pumping controls to the loop based on Appendix G.
   #
   # @param plant_loop [OpenStudio::Model::PlantLoop] chilled water loop
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def plant_loop_apply_prm_baseline_chilled_water_pumping_type(plant_loop)
     pri_control_type = 'VSD DP Reset'
     sec_control_type = 'VSD DP Reset'

--- a/lib/openstudio-standards/standards/ashrae_90_1/ze_aedg_multifamily/ze_aedg_multifamily.Space.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ze_aedg_multifamily/ze_aedg_multifamily.Space.rb
@@ -79,9 +79,9 @@ class ZEAEDGMultifamily < ASHRAE901
   # @param areas [Hash] a hash of daylighted areas
   # @param sorted_windows [Hash] a hash of windows, sorted by priority
   # @param sorted_skylights [Hash] a hash of skylights, sorted by priority
-  # @param req_top_ctrl [Bool] if toplighting controls are required
-  # @param req_pri_ctrl [Bool] if primary sidelighting controls are required
-  # @param req_sec_ctrl [Bool] if secondary sidelighting controls are required
+  # @param req_top_ctrl [Boolean] if toplighting controls are required
+  # @param req_pri_ctrl [Boolean] if primary sidelighting controls are required
+  # @param req_sec_ctrl [Boolean] if secondary sidelighting controls are required
   # @return [Array] array of 4 items
   #   [sensor 1 fraction, sensor 2 fraction, sensor 1 window, sensor 2 window]
   def space_daylighting_fractions_and_windows(space,

--- a/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.AirLoopHVAC.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.AirLoopHVAC.rb
@@ -10,7 +10,7 @@ class ASHRAE901PRM < Standard
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param min_occ_pct [Double] the fractional value below which the system will be considered unoccupied.
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def air_loop_hvac_enable_unoccupied_fan_shutoff(air_loop_hvac, min_occ_pct = 0.05)
     if air_loop_hvac.additionalProperties.hasFeature('zone_group_type')
       zone_group_type = air_loop_hvac.additionalProperties.getFeatureAsString('zone_group_type').get
@@ -93,7 +93,7 @@ class ASHRAE901PRM < Standard
 
   # Determine if the system is a multizone VAV system
   #
-  # @return [Bool] Returns true if required, false if not.
+  # @return [Boolean] Returns true if required, false if not.
   def air_loop_hvac_multizone_vav_system?(air_loop_hvac)
     return true if air_loop_hvac.name.to_s.include?('Sys5') || air_loop_hvac.name.to_s.include?('Sys6') || air_loop_hvac.name.to_s.include?('Sys7') || air_loop_hvac.name.to_s.include?('Sys8')
 
@@ -121,7 +121,7 @@ class ASHRAE901PRM < Standard
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_integrated_economizer_required?(air_loop_hvac, climate_zone)
     return true
   end
@@ -154,7 +154,7 @@ class ASHRAE901PRM < Standard
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_prm_baseline_economizer_required?(air_loop_hvac, climate_zone)
     economizer_required = false
     baseline_system_type = air_loop_hvac.additionalProperties.getFeatureAsString('baseline_system_type').get
@@ -193,7 +193,7 @@ class ASHRAE901PRM < Standard
   end
 
   # Set fan curve for stable baseline to be VSD with fixed static pressure setpoint
-  # @return [string] name of appropriate curve for this code version
+  # @return [String name of appropriate curve for this code version
   def air_loop_hvac_set_vsd_curve_type
     return 'Multi Zone VAV with VSD and Fixed SP Setpoint'
   end
@@ -202,7 +202,7 @@ class ASHRAE901PRM < Standard
   # PRM does not require optimum start - override it to false.
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_optimum_start_required?(air_loop_hvac)
     return false
   end
@@ -218,7 +218,7 @@ class ASHRAE901PRM < Standard
   # Also adjusts the fan power and flow rates
   # of any parallel PIU terminals on the system.
   #
-  # return [Bool] true if successful, false if not.
+  # return [Boolean] true if successful, false if not.
   def air_loop_hvac_apply_prm_baseline_fan_power(air_loop_hvac)
     # Get system type associated with air loop
     system_type = air_loop_hvac.additionalProperties.getFeatureAsString('baseline_system_type').get
@@ -564,9 +564,9 @@ class ASHRAE901PRM < Standard
   # Set the minimum VAV damper positions.
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
-  # @param has_ddc [Bool] if true, will assume that there is DDC control of vav terminals.
+  # @param has_ddc [Boolean] if true, will assume that there is DDC control of vav terminals.
   #   If false, assumes otherwise.
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def air_loop_hvac_apply_minimum_vav_damper_positions(air_loop_hvac, has_ddc = true)
     air_loop_hvac.thermalZones.each do |zone|
       zone.equipment.each do |equip|

--- a/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.AirTerminalSingleDuctVAVReheat.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.AirTerminalSingleDuctVAVReheat.rb
@@ -9,9 +9,9 @@ class ASHRAE901PRM < Standard
   # @param zone_min_oa [Double] the zone outdoor air flow rate, in m^3/s.
   #   If supplied, this will be set as a minimum limit in addition to the minimum
   #   damper position.  EnergyPlus will use the larger of the two values during sizing.
-  # @param has_ddc [Bool] whether or not there is DDC control of the VAV terminal,
+  # @param has_ddc [Boolean] whether or not there is DDC control of the VAV terminal,
   #   which impacts the minimum damper position requirement.
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   # @todo remove exception where older vintages don't have minimum positions adjusted.
   def air_terminal_single_duct_vav_reheat_apply_minimum_damper_position(air_terminal_single_duct_vav_reheat, zone_min_oa = nil, has_ddc = true)
     # Minimum damper position

--- a/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.BoilerHotWater.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.BoilerHotWater.rb
@@ -4,7 +4,7 @@ class ASHRAE901PRM < Standard
   # Applies the standard efficiency ratings to this object.
   #
   # @param boiler_hot_water [OpenStudio::Model::BoilerHotWater] hot water boiler object
-  # @return [Bool] true if successful, false if not
+  # @return [Boolean] true if successful, false if not
   def boiler_hot_water_apply_efficiency_and_curves(boiler_hot_water)
     # Get the minimum efficiency standards
     thermal_eff = boiler_hot_water_standard_minimum_thermal_efficiency(boiler_hot_water)

--- a/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.ChillerElectricEIR.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.ChillerElectricEIR.rb
@@ -4,7 +4,7 @@ class ASHRAE901PRM < Standard
   # Applies the standard efficiency ratings to this object.
   #
   # @param chiller_electric_eir [OpenStudio::Model::ChillerElectricEIR] chiller object
-  # @return [Bool] true if successful, false if not
+  # @return [Boolean] true if successful, false if not
   def chiller_electric_eir_apply_efficiency_and_curves(chiller_electric_eir)
     # Get the chiller capacity
     capacity_w = chiller_electric_eir_find_capacity(chiller_electric_eir)

--- a/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.CoilCoolingDXSingleSpeed.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.CoilCoolingDXSingleSpeed.rb
@@ -82,7 +82,7 @@ class ASHRAE901PRM < Standard
   #
   # @param coil_cooling_dx_single_speed [OpenStudio::Model::CoilCoolingDXSingleSpeed] coil cooling dx single speed object
   # @param sys_type [String] HVAC system type
-  # @param rename [Bool] if true, object will be renamed to include capacity and efficiency level
+  # @param rename [Boolean] if true, object will be renamed to include capacity and efficiency level
   # @return [Double] full load efficiency (COP)
   def coil_cooling_dx_single_speed_standard_minimum_cop(coil_cooling_dx_single_speed, sys_type, rename = false)
     # find properties

--- a/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.CoilCoolingDXTwoSpeed.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.CoilCoolingDXTwoSpeed.rb
@@ -43,7 +43,7 @@ class ASHRAE901PRM < Standard
   #
   # @param coil_cooling_dx_two_speed [OpenStudio::Model::CoilCoolingDXTwoSpeed] coil cooling dx two speed object
   # @param sys_type [String] HVAC system type
-  # @param rename [Bool] if true, object will be renamed to include capacity and efficiency level
+  # @param rename [Boolean] if true, object will be renamed to include capacity and efficiency level
   # @return [Double] full load efficiency (COP)
   def coil_cooling_dx_two_speed_standard_minimum_cop(coil_cooling_dx_two_speed, sys_type, rename = false)
     # find properties

--- a/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.CoilDX.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.CoilDX.rb
@@ -49,7 +49,7 @@ module ASHRAEPRMCoilDX
   # @param coil_dx [OpenStudio::Model::StraightComponent] coil cooling object
   # @param capacity [Double] capacity in btu/hr
   # @param sys_type [String] HVAC system type
-  # @return [hash] has for search criteria to be used for find object
+  # @return [Hash] has for search criteria to be used for find object
   def coil_dx_find_search_criteria(coil_dx, capacity, sys_type)
     search_criteria = {}
     search_criteria['template'] = template

--- a/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.CoilHeatingDXSingleSpeed.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.CoilHeatingDXSingleSpeed.rb
@@ -137,7 +137,7 @@ class ASHRAE901PRM < Standard
   #
   # @param coil_heating_dx_single_speed [OpenStudio::Model::CoilHeatingDXSingleSpeed] coil heating dx single speed object
   # @param sys_type [String] HVAC system type
-  # @param rename [Bool] if true, object will be renamed to include capacity and efficiency level
+  # @param rename [Boolean] if true, object will be renamed to include capacity and efficiency level
   # @return [Double] full load efficiency (COP)
   def coil_heating_dx_single_speed_standard_minimum_cop(coil_heating_dx_single_speed, sys_type, rename = false)
     # find ac properties

--- a/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.CoilHeatingGas.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.CoilHeatingGas.rb
@@ -27,7 +27,7 @@ class ASHRAE901PRM < Standard
   #
   # @param coil_heating_gas [OpenStudio::Model::CoilHeatingGas] coil heating gas object
   # @param sys_type [String] HVAC system type
-  # @param rename [Bool] if true, object will be renamed to include capacity and efficiency level
+  # @param rename [Boolean] if true, object will be renamed to include capacity and efficiency level
   # @return [Double] minimum thermal efficiency
   def coil_heating_gas_standard_minimum_thermal_efficiency(coil_heating_gas, sys_type, rename = false)
     # Get the coil properties

--- a/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.FanVariableVolume.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.FanVariableVolume.rb
@@ -6,7 +6,7 @@ class ASHRAE901PRM
   # Determines whether there is a requirement to have a VSD or some other method to reduce fan power at low part load ratios.
   # Required for all VAV fans for stable baseline
   # @param fan_variable_volume [OpenStudio::Model::FanVariableVolume] variable volume fan object
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def fan_variable_volume_part_load_fan_power_limitation?(fan_variable_volume)
     part_load_control_required = true
     return part_load_control_required

--- a/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.Model.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.Model.rb
@@ -2237,7 +2237,7 @@ class ASHRAE901PRM < Standard
   # @param residual_ratio [Float] the ratio of residual surfaces among the total wall surface area with no fenestrations
   # @param space [OpenStudio::Model:Space] a space
   # @param model [OpenStudio::Model::Model] openstudio model
-  # @return [Boolean] return true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_readjust_surface_wwr(residual_ratio, space, model)
     # In this loop, we will focus on the surfaces with newly added a fenestration.
     space.surfaces.sort.each do |surface|

--- a/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.Model.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.Model.rb
@@ -1,10 +1,10 @@
 class ASHRAE901PRM < Standard
   # @!group Model
 
-  # Determines which system number is used
-  # for the baseline system.
-  # @return [String] the system number: 1_or_2, 3_or_4,
-  # 5_or_6, 7_or_8, 9_or_10
+  # Determines which system number is used for the baseline system.
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
+  # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
+  # @return [String] the system number: 1_or_2, 3_or_4, 5_or_6, 7_or_8, 9_or_10
   def model_prm_baseline_system_number(model, climate_zone, area_type, fuel_type, area_ft2, num_stories, custom)
     sys_num = nil
 
@@ -97,6 +97,7 @@ class ASHRAE901PRM < Standard
 
   # Determines the fan type used by VAV_Reheat and VAV_PFP_Boxes systems.
   # Variable speed fan for 90.1-2013
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @return [String] the fan type: TwoSpeed Fan, Variable Speed Fan
   def model_baseline_system_vav_fan_type(model)
     fan_type = 'Variable Speed Fan'
@@ -106,7 +107,9 @@ class ASHRAE901PRM < Standard
   # This method creates customized infiltration objects for each
   # space and removes the SpaceType-level infiltration objects.
   #
-  # @return [Bool] true if successful, false if not
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
+  # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
+  # @return [Boolean] true if successful, false if not
   def model_baseline_apply_infiltration_standard(model, climate_zone)
     # Model shouldn't use SpaceInfiltrationEffectiveLeakageArea
     # Excerpt from the EnergyPlus Input/Output reference manual:
@@ -171,6 +174,7 @@ class ASHRAE901PRM < Standard
   # used in the model. If input is inconsitent, returns
   # Flow/Area
   #
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @return [String] infiltration input type
   def model_get_infiltration_method(model)
     infil_method = nil
@@ -206,6 +210,7 @@ class ASHRAE901PRM < Standard
   # used in the model. If input is inconsitent, returns
   # [0, 0, 0.224, 0] as per PRM user manual
   #
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @return [String] infiltration input type
   def model_get_infiltration_coefficients(model)
     cst = nil
@@ -258,9 +263,8 @@ class ASHRAE901PRM < Standard
   # It assumes that the model follows the PRM methods, see G3.1.1.4
   # in 90.1-2019 for reference.
   #
-  # @param [OpenStudio::Model::Model] OpenStudio Model object
-  # @param [Double] Building envelope area as per 90.1 in m^2
-  #
+  # @param model [OpenStudio::Model::Model] OpenStudio Model object
+  # @param building_envelope_area_m2 [Double] Building envelope area as per 90.1 in m^2
   # @return [Float] building model air leakage rate
   def model_current_building_envelope_infiltration_at_75pa(model, building_envelope_area_m2)
     bldg_air_leakage_rate = 0
@@ -309,6 +313,8 @@ class ASHRAE901PRM < Standard
   # This method calculates the building envelope infiltration,
   # this approach uses the 90.1 PRM rules
   #
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
+  # @param building_envelope_area_m2 [Double] Building envelope area as per 90.1 in m^2
   # @return [Float] building envelope infiltration
   def model_adjusted_building_envelope_infiltration(model, building_envelope_area_m2)
     # Determine the total building baseline infiltration rate in cfm per ft2 of the building envelope at 75 Pa
@@ -333,10 +339,9 @@ class ASHRAE901PRM < Standard
 
   # Apply the standard construction to each surface in the model, based on the construction type currently assigned.
   #
-  # @return [Bool] true if successful, false if not
   # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_apply_standard_constructions(model, climate_zone, wwr_building_type: nil, wwr_info: {})
     types_to_modify = []
 
@@ -486,10 +491,10 @@ class ASHRAE901PRM < Standard
   # Go through the default construction sets and hard-assigned constructions.
   # Clone the existing constructions and set their intended surface type and standards construction type per the PRM.
   # For some standards, this will involve making modifications.  For others, it will not.
-  #
-  # 90.1-2007, 90.1-2010, 90.1-2013
+  #   90.1-2007, 90.1-2010, 90.1-2013
+  # 
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_apply_prm_construction_types(model)
     types_to_modify = []
 
@@ -609,7 +614,7 @@ class ASHRAE901PRM < Standard
 
   # Reduces the SRR to the values specified by the PRM. SRR reduction will be done by shrinking vertices toward the centroid.
   #
-  # @param model [OpenStudio::model::Model] OpenStudio model object
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
   def model_apply_prm_baseline_skylight_to_roof_ratio(model)
     # Loop through all spaces in the model, and
     # per the 90.1-2019 PRM User Manual, only
@@ -691,7 +696,7 @@ class ASHRAE901PRM < Standard
   # Apply baseline values to exterior lights objects
   # Characterization of objects must be done via user data
   #
-  # @param model [OpenStudio::model::Model] OpenStudio model object
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
   def model_apply_baseline_exterior_lighting(model)
     user_ext_lights = @standards_data.key?('userdata_exterior_lights') ? @standards_data['userdata_exterior_lights'] : nil
     return false if user_ext_lights.nil?
@@ -857,8 +862,7 @@ class ASHRAE901PRM < Standard
 
   # Add design day schedule objects for space loads, for PRM 2019 baseline models
   # @author Xuechen (Jerry) Lei, PNNL
-  # @param model [OpenStudio::model::Model] OpenStudio model object
-  #
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
   def model_apply_prm_baseline_sizing_schedule(model)
     space_loads = model.getSpaceLoads
     loads = []
@@ -950,7 +954,7 @@ class ASHRAE901PRM < Standard
   # @note This is not applicable to the stable baseline; hence no action in this method
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_apply_multizone_vav_outdoor_air_sizing(model)
     return true
   end
@@ -961,8 +965,8 @@ class ASHRAE901PRM < Standard
   #       by OpenStudio, will need to be added to the method when
   #       supported.
   #
-  # @param model [OpenStudio::model::Model] OpenStudio model object
-  # @return zone_nmc_sys_type [Hash] Zone to nmc system type mapping
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
+  # @return [Hash] Zone to nmc system type mapping
   def model_identify_non_mechanically_cooled_systems(model)
     # Iterate through zones to find out if they are served by nmc systems
     model.getThermalZones.sort.each do |zone|
@@ -992,7 +996,6 @@ class ASHRAE901PRM < Standard
   # Specify supply air temperature setpoint for unit heaters based on 90.1 Appendix G G3.1.2.8.2
   #
   # @param thermal_zone [OpenStudio::Model::ThermalZone] OpenStudio ThermalZone Object
-  #
   # @return [Double] for zone with unit heaters, return design supply temperature; otherwise, return nil
   def thermal_zone_prm_unitheater_design_supply_temperature(thermal_zone)
     thermal_zone.equipment.each do |eqt|
@@ -1006,7 +1009,6 @@ class ASHRAE901PRM < Standard
   # Specify supply to room delta for laboratory spaces based on 90.1 Appendix G Exception to G3.1.2.8.1
   #
   # @param thermal_zone [OpenStudio::Model::ThermalZone] OpenStudio ThermalZone Object
-  #
   # @return [Double] for zone with laboratory space, return 17; otherwise, return nil
   def thermal_zone_prm_lab_delta_t(thermal_zone)
     # For labs, add 17 delta-T; otherwise, add 20 delta-T
@@ -1030,9 +1032,9 @@ class ASHRAE901PRM < Standard
   # Applies the HVAC parts of the template to all objects in the model using the the template specified in the model.
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @param apply_controls [Bool] toggle whether to apply air loop and plant loop controls
+  # @param apply_controls [Boolean] toggle whether to apply air loop and plant loop controls
   # @param sql_db_vars_map [Hash] hash map
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_apply_hvac_efficiency_standard(model, climate_zone, apply_controls: true, sql_db_vars_map: nil)
     sql_db_vars_map = {} if sql_db_vars_map.nil?
 
@@ -1163,8 +1165,8 @@ class ASHRAE901PRM < Standard
   # ASHRAE 90.1-2019 Appendix G.
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model
-  # @param thermalZones Array([OpenStudio::Model::ThermalZone]) thermal zone array
-  # @param coil Heating Coils
+  # @param thermal_zones Array([OpenStudio::Model::ThermalZone]) thermal zone array
+  # @param coil [OpenStudio::Model::StraightComponent] heating coil
   # @return [Boolean] true
   def model_set_central_preheat_coil_spm(model, thermal_zones, coil)
     # search for the highest zone setpoint temperature
@@ -1438,13 +1440,13 @@ class ASHRAE901PRM < Standard
   # include data source from:
   # 1. user data csv files
   # 2. data from measure and OpenStudio interface
-  # @param [OpenStudio:model:Model] model
-  # @param [String] climate_zone
-  # @param [String] default_hvac_building_type
-  # @param [String] default_wwr_building_type
-  # @param [String] default_swh_building_type
-  # @param [Hash] bldg_type_hvac_zone_hash A hash maps building type for hvac to a list of thermal zones
-  # @return True
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
+  # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
+  # @param default_hvac_building_type [String] (Fourth Hierarchy hvac building type)
+  # @param default_wwr_building_type [String] (Fourth Hierarchy wwr building type)
+  # @param default_swh_building_type [String] (Fourth Hierarchy swh building type)
+  # @param bldg_type_hvac_zone_hash [Hash] A hash maps building type for hvac to a list of thermal zones
+  # @return [Boolean] returns true if successful, false if not
   def handle_user_input_data(model, climate_zone, default_hvac_building_type, default_wwr_building_type, default_swh_building_type, bldg_type_hvac_zone_hash)
     # load the multiple building area types from user data
     handle_multi_building_area_types(model, climate_zone, default_hvac_building_type, default_wwr_building_type, default_swh_building_type, bldg_type_hvac_zone_hash)
@@ -1459,7 +1461,7 @@ class ASHRAE901PRM < Standard
   end
 
   # A function to load airloop data from userdata csv files
-  # @param [OpenStudio::Model::Model] OpenStudio model object
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
   def handle_airloop_user_input_data(model)
     # ============================Process airloop info ============================================
     user_airloops = @standards_data.key?('userdata_airloop_hvac') ? @standards_data['userdata_airloop_hvac'] : nil
@@ -1528,7 +1530,7 @@ class ASHRAE901PRM < Standard
   end
 
   # A function to load airloop DOAS data from userdata csv files
-  # @param [OpenStudio::Model::Model] OpenStudio model object
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
   def handle_airloop_doas_user_input_data(model)
     # Get user data
     user_airloop_doass = @standards_data.key?('userdata_airloop_hvac_doas') ? @standards_data['userdata_airloop_hvac_doas'] : nil
@@ -1584,7 +1586,7 @@ class ASHRAE901PRM < Standard
   end
 
   # A function to load thermal zone data from userdata csv files
-  # @param [OpenStudio::Model::Model] OpenStudio model object
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
   def handle_thermal_zone_user_input_data(model)
     model.getThermalZones.each do |thermal_zone|
       nightcycle_exception = false
@@ -1621,13 +1623,13 @@ class ASHRAE901PRM < Standard
   # NOTE! This function will add building types to OpenStudio objects as an additional features for hierarchy 1-3
   # The object additional feature is empty when the function determined it uses fourth hierarchy.
   #
-  # @param [OpenStudio::Model::Model] model
-  # @param [String] climate_zone
-  # @param [String] default_hvac_building_type (Fourth Hierarchy hvac building type)
-  # @param [String] default_wwr_building_type (Fourth Hierarchy wwr building type)
-  # @param [String] default_swh_building_type (Fourth Hierarchy swh building type)
-  # @param [Hash] bldg_type_zone_hash An empty hash that maps building type for hvac to a list of thermal zones
-  # @return True
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
+  # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
+  # @param default_hvac_building_type [String] (Fourth Hierarchy hvac building type)
+  # @param default_wwr_building_type [String] (Fourth Hierarchy wwr building type)
+  # @param default_swh_building_type [String] (Fourth Hierarchy swh building type)
+  # @param bldg_type_hvac_zone_hash [Hash] An empty hash that maps building type for hvac to a list of thermal zones
+  # @return [Boolean] returns true if successful, false if not
   def handle_multi_building_area_types(model, climate_zone, default_hvac_building_type, default_wwr_building_type, default_swh_building_type, bldg_type_hvac_zone_hash)
     # Construct the user_building hashmap
     user_buildings = @standards_data.key?('userdata_building') ? @standards_data['userdata_building'] : nil
@@ -1821,9 +1823,9 @@ class ASHRAE901PRM < Standard
 
   # Modify the existing service water heating loops to match the baseline required heating type.
   #
-  # @param model [OpenStudio::Model::Model] the model
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @param building_type [String] the building type
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_apply_baseline_swh_loops(model, building_type)
     model.getPlantLoops.sort.each do |plant_loop|
       # Skip non service water heating loops
@@ -1933,8 +1935,8 @@ class ASHRAE901PRM < Standard
   # Check whether the baseline model generation needs to run all four orientations
   # The default shall be true
   #
-  # @param [Boolean] run_all_orients: user inputs to indicate whether it is required to run all orientations
-  # @param [OpenStudio::Model::Model] OpenStudio model
+  # @param run_all_orients [Boolean] user inputs to indicate whether it is required to run all orientations
+  # @param user_model [OpenStudio::Model::Model] OpenStudio model
   def run_all_orientations(run_all_orients, user_model)
     # Step 0, assign the default value
     run_orients_flag = run_all_orients
@@ -1964,6 +1966,7 @@ class ASHRAE901PRM < Standard
     return run_orients_flag
   end
 
+  # @param user_model [OpenStudio::Model::Model] OpenStudio model
   def get_model_fenestration_area_by_orientation(user_model)
     # First index is wall, second index is window
     fenestration_area_hash = {
@@ -1997,10 +2000,9 @@ class ASHRAE901PRM < Standard
 
   # Apply the standard construction to each surface in the model, based on the construction type currently assigned.
   #
-  # @return [Bool] true if successful, false if not
   # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_apply_constructions(model, climate_zone, wwr_building_type, wwr_info)
     model_apply_standard_constructions(model, climate_zone, wwr_building_type: wwr_building_type, wwr_info: wwr_info)
 
@@ -2011,7 +2013,7 @@ class ASHRAE901PRM < Standard
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_update_ground_temperature_profile(model, climate_zone)
     # Check if the ground temperature profile is needed
     surfaces_with_fc_factor_boundary = false
@@ -2058,7 +2060,7 @@ class ASHRAE901PRM < Standard
 
   # Retrieve zone HVAC user specified compliance inputs from CSV file
   #
-  # @param [OpenStudio::Model::Model] OpenStudio model object
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
   def handle_zone_hvac_user_input_data(model)
     user_zone_hvac = @standards_data.key?('userdata_zone_hvac') ? @standards_data['userdata_zone_hvac'] : nil
     return unless user_zone_hvac && !user_zone_hvac.empty?
@@ -2134,7 +2136,7 @@ class ASHRAE901PRM < Standard
   # This function checks whether it is required to adjust the window to wall ratio based on the model WWR and wwr limit.
   # @param wwr_limit [Float] return wwr_limit
   # @param wwr_list [Array] list of wwr of zone conditioning category in a building area type category - residential, nonresidential and semiheated
-  # @return require_adjustment [Boolean] True, require adjustment, false not require adjustment.
+  # @return [Boolean] True, require adjustment, false not require adjustment
   def model_does_require_wwr_adjustment?(wwr_limit, wwr_list)
     # 90.1 PRM routine requires
     return true
@@ -2144,7 +2146,7 @@ class ASHRAE901PRM < Standard
   #
   # @param bat [String] building category
   # @param wwr_list [Array] list of zone conditioning category-based WWR - residential, nonresidential and semiheated
-  # @return wwr_limit [Float] return adjusted wwr_limit
+  # @return [Float] return adjusted wwr_limit
   def model_get_bat_wwr_target(bat, wwr_list)
     wwr_limit = 40.0
     # Lookup WWR target from stable baseline table
@@ -2232,10 +2234,10 @@ class ASHRAE901PRM < Standard
   # This function shall only be called if the maximum WWR value for surfaces with fenestration is lower than 90% due to
   # accommodating the total door surface areas
   #
-  # @param residual_ratio: [Float] the ratio of residual surfaces among the total wall surface area with no fenestrations
+  # @param residual_ratio [Float] the ratio of residual surfaces among the total wall surface area with no fenestrations
   # @param space [OpenStudio::Model:Space] a space
   # @param model [OpenStudio::Model::Model] openstudio model
-  # @return [Bool] return true if successful, false if not
+  # @return [Boolean] return true if successful, false if not
   def model_readjust_surface_wwr(residual_ratio, space, model)
     # In this loop, we will focus on the surfaces with newly added a fenestration.
     space.surfaces.sort.each do |surface|
@@ -2251,10 +2253,12 @@ class ASHRAE901PRM < Standard
 
   # Assign spaces to system groups based on building area type
   # Get zone groups separately for each hvac building type
+  #
+  # @param model [OpenStudio::Model::Model] openstudio model
   # @param custom [String] identifier for custom programs, not used here, but included for backwards compatibility
   # @param bldg_type_hvac_zone_hash [Hash of bldg_type:list of zone objects] association of zones to each hvac building type
   # @return [Array<Hash>] an array of hashes of area information,
-  # with keys area_ft2, type, fuel, and zones (an array of zones)
+  #   with keys area_ft2, type, fuel, and zones (an array of zones)
   def model_prm_baseline_system_groups(model, custom, bldg_type_hvac_zone_hash)
     bldg_groups = []
 
@@ -2277,9 +2281,10 @@ class ASHRAE901PRM < Standard
   # Groups may include zones from multiple floors; separating by floor is handled later
   # For stable baseline, heating type is based on climate, not proposed heating type
   # Isolate zones that have heating-only or district (purchased) heat or chilled water
-  # @param bldg_type_hvac_zone_hash [Hash of bldg_type:list of zone objects] association of zones to each hvac building type
+  # @param hvac_building_type [String] Chosen by user via measure interface or user data files
+  # @param zones_in_building_type [Array<OpenStudio::Model::ThermalZone>] array of thermal zones
   # @return [Array<Hash>] an array of hashes of area information,
-  # with keys area_ft2, type, fuel, and zones (an array of zones)
+  #   with keys area_ft2, type, fuel, and zones (an array of zones)
   def get_baseline_system_groups_for_one_building_type(model, hvac_building_type, zones_in_building_type)
     # Build zones hash of [zone, zone area, occupancy type, building type, fuel]
     zones = model_zones_with_occ_and_fuel_type(model, 'custom')
@@ -2639,11 +2644,11 @@ class ASHRAE901PRM < Standard
   # Heating fuel is based on climate zone, unless district heat is in proposed
   #
   # @note Select system type from data table base on key parameters
-  # @param climate_zone [string] id code for the climate
-  # @param sys_group [hash] Hash defining a group of zones that have the same Appendix G system type
-  # @param custom [string] included here for backwards compatibility (not used here)
+  # @param climate_zone [String] id code for the climate
+  # @param sys_group [Hash] Hash defining a group of zones that have the same Appendix G system type
+  # @param custom [String] included here for backwards compatibility (not used here)
   # @param hvac_building_type [String] Chosen by user via measure interface or user data files
-  # @param district_heat_zones [hash] of zone name => true for has district heat, false for has not
+  # @param district_heat_zones [Hash] of zone name => true for has district heat, false for has not
   # @return [String] The system type.  Possibilities are PTHP, PTAC, PSZ_AC, PSZ_HP, PVAV_Reheat, PVAV_PFP_Boxes,
   #   VAV_Reheat, VAV_PFP_Boxes, Gas_Furnace, Electric_Furnace
   def model_prm_baseline_system_type(model, climate_zone, sys_group, custom, hvac_building_type, district_heat_zones)
@@ -2777,8 +2782,8 @@ class ASHRAE901PRM < Standard
 
   # For a multizone system, create the fan schedule based on zone occupancy/fan schedules
   # @author Doug Maddox, PNNL
-  # @param model
-  # @param zone_fan_scheds [Hash] of hash of zoneName:8760FanSchedPerZone
+  # @param model [OpenStudio::Model::Model] openstudio model
+  # @param zone_op_hrs [Hash] of hash of zoneName zone_op_hrs
   # @param pri_zones [Array<String>] names of zones served by the multizone system
   # @param system_name [String] name of air loop
   def model_create_multizone_fan_schedule(model, zone_op_hrs, pri_zones, system_name)
@@ -2823,9 +2828,9 @@ class ASHRAE901PRM < Standard
   # @author Doug Maddox, PNNL
   # @param model
   # @param zones [Array<Object>]
-  # @param zone_fan_scheds [Hash] hash of zoneName:8760FanSchedPerZone
+  # @param zone_fan_scheds [Hash] hash of zoneName 8760FanSchedPerZone
   # @return [Hash] A hash of two arrays of ThermalZones,
-  # where the keys are 'primary' and 'secondary'
+  #   where the keys are 'primary' and 'secondary'
   def model_differentiate_primary_secondary_thermal_zones(model, zones, zone_fan_scheds)
     pri_zones = []
     sec_zones = []
@@ -3002,7 +3007,7 @@ class ASHRAE901PRM < Standard
   # to account for recent model changes
   # @author Doug Maddox, PNNL
   # @param model
-  # @return [Bool] true if successful, false if not
+  # @return [Boolean] true if successful, false if not
   def model_refine_size_dependent_values(model, sizing_run_dir)
     # Final sizing run before refining size-dependent values
     if model_run_sizing_run(model, "#{sizing_run_dir}/SR3") == false

--- a/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.PlantLoop.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.PlantLoop.rb
@@ -2,7 +2,7 @@ class ASHRAE901PRM < Standard
   # Keep only one cooling tower, but use one condenser pump per chiller
 
   # @param plant_loop [OpenStudio::Model::PlantLoop] plant loop
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def plant_loop_apply_prm_number_of_cooling_towers(plant_loop)
     # Skip non-cooling plants
     return true unless plant_loop.sizingPlant.loopType == 'Condenser'
@@ -93,8 +93,9 @@ class ASHRAE901PRM < Standard
   # Splits the single chiller used for the initial sizing run
   # into multiple separate chillers based on Appendix G.
   #
-  # @param plant_loop_args [Array] chilled water loop (OpenStudio::Model::PlantLoop), sizing run directory
-  # @return [Bool] returns true if successful, false if not
+  # @param plant_loop [OpenStudio::Model::PlantLoop] chilled water loop
+  # @param sizing_run_dir [String] sizing run directory
+  # @return [Boolean] returns true if successful, false if not
   def plant_loop_apply_prm_number_of_chillers(plant_loop, sizing_run_dir = nil)
     # Skip non-cooling plants & secondary cooling loop
     return true unless plant_loop.sizingPlant.loopType == 'Cooling'
@@ -250,7 +251,7 @@ class ASHRAE901PRM < Standard
   #   you could set at 0.9 and just calculate the pressure rise to have your 19 W/GPM or whatever
   #
   # @param plant_loop [OpenStudio::Model::PlantLoop] plant loop
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def plant_loop_apply_prm_baseline_pump_power(plant_loop)
     hot_water_pump_power = 19 # W/gpm
     hot_water_district_pump_power = 14 # W/gpm
@@ -335,7 +336,7 @@ class ASHRAE901PRM < Standard
   # @param chilled_water_loop [OpenStudio::Model::PlantLoop] chilled water loop
   # @param dsgn_sup_wtr_temp [Double] design chilled water supply T
   # @param dsgn_sup_wtr_temp_delt [Double] design chilled water supply delta T
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def chw_sizing_control(model, chilled_water_loop, dsgn_sup_wtr_temp, dsgn_sup_wtr_temp_delt)
 
     design_chilled_water_temperature = 44 # Loop design chilled water temperature (F)

--- a/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.Space.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.Space.rb
@@ -96,9 +96,9 @@ class ASHRAE901PRM < Standard
 
   # For stable baseline, remove all daylighting controls (sidelighting and toplighting)
   # @param space [OpenStudio::Model::Space] the space with daylighting
-  # @param remove_existing_controls [Bool] if true, will remove existing controls then add new ones
-  # @param draw_daylight_areas_for_debugging [Bool] If this argument is set to true,
-  # @return [boolean] true if successful
+  # @param remove_existing [Boolean] if true, will remove existing controls then add new ones
+  # @param draw_areas_for_debug [Boolean] If this argument is set to true,
+  # @return [Boolean] true if successful
   def space_set_baseline_daylighting_controls(space, remove_existing = false, draw_areas_for_debug = false)
     removed = space_remove_daylighting_controls(space)
     return removed

--- a/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.SpaceType.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.SpaceType.rb
@@ -9,16 +9,16 @@ class ASHRAE901PRM2019 < ASHRAE901PRM
   # loads directly assigned to spaces.  This method skips plenums.
   #
   # @param space_type [OpenStudio::Model::SpaceType] space type object
-  # @param set_people [Bool] if true, set the people density.
+  # @param set_people [Boolean] if true, set the people density.
   #   Also, assign reasonable clothing, air velocity, and work efficiency inputs
   #   to allow reasonable thermal comfort metrics to be calculated.
-  # @param set_lights [Bool] if true, set the lighting density, lighting fraction
+  # @param set_lights [Boolean] if true, set the lighting density, lighting fraction
   #   to return air, fraction radiant, and fraction visible.
-  # @param set_electric_equipment [Bool] if true, set the electric equipment density
-  # @param set_gas_equipment [Bool] if true, set the gas equipment density
-  # @param set_ventilation [Bool] if true, set the ventilation rates (per-person and per-area)
-  # @param set_infiltration [Bool] if true, set the infiltration rates
-  # @return [Bool] returns true if successful, false if not
+  # @param set_electric_equipment [Boolean] if true, set the electric equipment density
+  # @param set_gas_equipment [Boolean] if true, set the gas equipment density
+  # @param set_ventilation [Boolean] if true, set the ventilation rates (per-person and per-area)
+  # @param set_infiltration [Boolean] if true, set the infiltration rates
+  # @return [Boolean] returns true if successful, false if not
   def space_type_apply_internal_loads(space_type, set_people, set_lights, set_electric_equipment, set_gas_equipment, set_ventilation, set_infiltration)
     # Skip plenums
     # Check if the space type name
@@ -271,7 +271,7 @@ class ASHRAE901PRM2019 < ASHRAE901PRM
   # This function works with both electric equipment and gas equipment and applies the ruleset on power equipment
   # The function process user data including the fraction of controlled receptacles and receptacle power savings.
   #
-  # @parma power_equipment [OpenStudio::Model::ElectricEquipment] or [OpenStudio::Model:GasEquipment]
+  # @param power_equipment [OpenStudio::Model::ElectricEquipment] or [OpenStudio::Model:GasEquipment]
   # @param user_power_equipment [Hash] user data for the power equipment
   # @param schedule_hash [Hash] power equipment operation schedules in a hash
   # @param space_type [OpenStudio::Model:SpaceType] space type

--- a/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.Surface.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.Surface.rb
@@ -4,7 +4,7 @@ class ASHRAE901PRM < Standard
   # @param surface [OpenStudio::Model:Surface] openstudio surface object
   # @param reduction [Float] ratio of adjustments
   # @param model [OpenStudio::Model::Model] openstudio model
-  # @return [Boolean] return true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def surface_adjust_fenestration_in_a_surface(surface, reduction, model)
     # do nothing for cases when reduction == 1.0
     if reduction < 1.0

--- a/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.Surface.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.Surface.rb
@@ -4,7 +4,7 @@ class ASHRAE901PRM < Standard
   # @param surface [OpenStudio::Model:Surface] openstudio surface object
   # @param reduction [Float] ratio of adjustments
   # @param model [OpenStudio::Model::Model] openstudio model
-  # @return [Bool] return true if successful, false if not
+  # @return [Boolean] return true if successful, false if not
   def surface_adjust_fenestration_in_a_surface(surface, reduction, model)
     # do nothing for cases when reduction == 1.0
     if reduction < 1.0

--- a/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.ThermalZone.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.ThermalZone.rb
@@ -157,21 +157,21 @@ class ASHRAE901PRM < Standard
   end
 
   # Identify if zone has district energy for occ_and_fuel_type method
-  # @param themal_zone
-  # @return [string] with applicable DistrictHeating and/or DistrictCooling
-  def thermal_zone_get_zone_fuels_for_occ_and_fuel_type(zone)
+  # @param thermal_zone
+  # @return [String with applicable DistrictHeating and/or DistrictCooling
+  def thermal_zone_get_zone_fuels_for_occ_and_fuel_type(thermal_zone)
     zone_fuels = ''
 
     # error if HVACComponent heating fuels method is not available
-    if zone.model.version < OpenStudio::VersionString.new('3.6.0')
+    if thermal_zone.model.version < OpenStudio::VersionString.new('3.6.0')
       OpenStudio.logFree(OpenStudio::Error, 'openstudio.ashrae_90_1_prm.ThermalZone', "Required HVACComponent methods .heatingFuelTypes and .coolingFuelTypes are not available in pre-OpenStudio 3.6.0 versions. Use a more recent version of OpenStudio.")
     end
 
-    htg_fuels = zone.heatingFuelTypes.map { |f| f.valueName }
+    htg_fuels = thermal_zone.heatingFuelTypes.map { |f| f.valueName }
     if htg_fuels.include?('DistrictHeating')
       zone_fuels = 'DistrictHeating'
     end
-    clg_fuels = zone.coolingFuelTypes.map { |f| f.valueName }
+    clg_fuels = thermal_zone.coolingFuelTypes.map { |f| f.valueName }
     if clg_fuels.include?('DistrictCooling')
       zone_fuels += 'DistrictCooling'
     end

--- a/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.ZoneHVACComponent.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.ZoneHVACComponent.rb
@@ -5,7 +5,7 @@ class ASHRAE901PRM < Standard
   # (Fan coils, Unit Heaters, PTACs, PTHPs, VRF Terminals, WSHPs, ERVs)
   # based on the W/cfm specified in the standard.
   #
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def zone_hvac_component_apply_prm_baseline_fan_power(zone_hvac_component)
     OpenStudio.logFree(OpenStudio::Debug, 'openstudio.ashrae_90_1_prm.ZoneHVACComponent', "Setting fan power for #{zone_hvac_component.name}.")
 

--- a/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.rb
@@ -16,9 +16,9 @@ class ASHRAE901PRM < Standard
   # Convert user data csv files to json format and save to project folder
   # Method will create the json_folder in the project_path
   # @author Doug Maddox, PNNL
-  # @param user_data_folder [string] path to folder containing csv files
-  # @param project_folder [string] path to project folder
-  # @return [string] path to json files
+  # @param user_data_path [String path to folder containing csv files
+  # @param project_path [String path to project folder
+  # @return [String] path to json files
   def convert_userdata_csv_to_json(user_data_path, project_path)
     # Get list of possible files from lib\openstudio-standards\standards\ashrae_90_1_prm\userdata_csv
     stds_dir = __dir__
@@ -81,7 +81,7 @@ class ASHRAE901PRM < Standard
   # Load user data from project folder into standards database data structure
   # Each user data object type is a new item in the @standards_data hash
   # @author Doug Maddox, PNNL
-  # @param json_path [string] path to folder containing json files
+  # @param json_path [String path to folder containing json files
   def load_userdata_to_standards_database(json_path)
     files = Dir.glob("#{json_path}/*.json").select { |e| File.file? e }
     files.each do |file|

--- a/lib/openstudio-standards/standards/cbes/cbes.AirLoopHVAC.rb
+++ b/lib/openstudio-standards/standards/cbes/cbes.AirLoopHVAC.rb
@@ -5,7 +5,7 @@ class CBES < Standard
   # Does nothing for CBES.
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
-  # return [Bool] returns true if successful, false if not
+  # return [Boolean] returns true if successful, false if not
   # @todo enable damper position adjustment for legacy IDFS
   def air_loop_hvac_apply_multizone_vav_outdoor_air_sizing(air_loop_hvac)
     # Do nothing
@@ -16,8 +16,8 @@ class CBES < Standard
   # Not required by CBES.
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
-  # @param has_ddc [Bool] whether or not the system has DDC control over VAV terminals.
-  # return [Bool] returns true if static pressure reset is required, false if not
+  # @param has_ddc [Boolean] whether or not the system has DDC control over VAV terminals.
+  # return [Boolean] returns true if static pressure reset is required, false if not
   def air_loop_hvac_static_pressure_reset_required?(air_loop_hvac, has_ddc)
     sp_reset_required = false
     return sp_reset_required
@@ -38,7 +38,7 @@ class CBES < Standard
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_demand_control_ventilation_required?(air_loop_hvac, climate_zone)
     dcv_required = false
     return dcv_required
@@ -49,7 +49,7 @@ class CBES < Standard
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def air_loop_hvac_apply_single_zone_controls(air_loop_hvac, climate_zone)
     # Do nothing
     return true

--- a/lib/openstudio-standards/standards/cbes/cbes.Model.rb
+++ b/lib/openstudio-standards/standards/cbes/cbes.Model.rb
@@ -12,7 +12,7 @@ class CBES
   # When 'Sum', all min OA flow rates are added up.  Commonly used by 90.1.
   # When 'Maximum', only the biggest OA flow rate.  Used by T24.
   #
-  # @param model [OpenStudio::Model::Model] the model
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @return [String] the ventilation method, either Sum or Maximum
   def model_ventilation_method(model)
     ventilation_method = 'Maximum'

--- a/lib/openstudio-standards/standards/cbes/cbes.PlantLoop.rb
+++ b/lib/openstudio-standards/standards/cbes/cbes.PlantLoop.rb
@@ -5,7 +5,7 @@ class CBES < Standard
   # Not required for CBES.
   #
   # @param plant_loop [OpenStudio::Model::PlantLoop] plant loop
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def plant_loop_supply_water_temperature_reset_required?(plant_loop)
     reset_required = false
     return reset_required

--- a/lib/openstudio-standards/standards/deer/deer.AirLoopHVAC.rb
+++ b/lib/openstudio-standards/standards/deer/deer.AirLoopHVAC.rb
@@ -5,7 +5,7 @@ class DEER
   # Overwritten to be required for DEER2020 and beyond
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_unoccupied_fan_shutoff_required?(air_loop_hvac)
     shutoff_required = false
     return shutoff_required
@@ -38,7 +38,7 @@ class DEER
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if an economizer is required, false if not
+  # @return [Boolean] returns true if an economizer is required, false if not
   def air_loop_hvac_economizer_required?(air_loop_hvac, climate_zone)
     economizer_required = false
 
@@ -116,7 +116,7 @@ class DEER
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] Returns true if allowable, if the system has no economizer or no OA system.
+  # @return [Boolean] Returns true if allowable, if the system has no economizer or no OA system.
   #   Returns false if the economizer type is not allowable.
   def air_loop_hvac_economizer_type_allowable?(air_loop_hvac, climate_zone)
     # EnergyPlus economizer types

--- a/lib/openstudio-standards/standards/deer/deer_2014/deer_2014.Space.rb
+++ b/lib/openstudio-standards/standards/deer/deer_2014/deer_2014.Space.rb
@@ -79,9 +79,9 @@ class DEER2014 < DEER
   # @param areas [Hash] a hash of daylighted areas
   # @param sorted_windows [Hash] a hash of windows, sorted by priority
   # @param sorted_skylights [Hash] a hash of skylights, sorted by priority
-  # @param req_top_ctrl [Bool] if toplighting controls are required
-  # @param req_pri_ctrl [Bool] if primary sidelighting controls are required
-  # @param req_sec_ctrl [Bool] if secondary sidelighting controls are required
+  # @param req_top_ctrl [Boolean] if toplighting controls are required
+  # @param req_pri_ctrl [Boolean] if primary sidelighting controls are required
+  # @param req_sec_ctrl [Boolean] if secondary sidelighting controls are required
   # @return [Array] array of 4 items
   #   [sensor 1 fraction, sensor 2 fraction, sensor 1 window, sensor 2 window]
   def space_daylighting_fractions_and_windows(space,

--- a/lib/openstudio-standards/standards/deer/deer_2015/deer_2015.Space.rb
+++ b/lib/openstudio-standards/standards/deer/deer_2015/deer_2015.Space.rb
@@ -79,9 +79,9 @@ class DEER2015 < DEER
   # @param areas [Hash] a hash of daylighted areas
   # @param sorted_windows [Hash] a hash of windows, sorted by priority
   # @param sorted_skylights [Hash] a hash of skylights, sorted by priority
-  # @param req_top_ctrl [Bool] if toplighting controls are required
-  # @param req_pri_ctrl [Bool] if primary sidelighting controls are required
-  # @param req_sec_ctrl [Bool] if secondary sidelighting controls are required
+  # @param req_top_ctrl [Boolean] if toplighting controls are required
+  # @param req_pri_ctrl [Boolean] if primary sidelighting controls are required
+  # @param req_sec_ctrl [Boolean] if secondary sidelighting controls are required
   # @return [Array] array of 4 items
   #   [sensor 1 fraction, sensor 2 fraction, sensor 1 window, sensor 2 window]
   def space_daylighting_fractions_and_windows(space,

--- a/lib/openstudio-standards/standards/deer/deer_2017/deer_2017.Space.rb
+++ b/lib/openstudio-standards/standards/deer/deer_2017/deer_2017.Space.rb
@@ -79,9 +79,9 @@ class DEER2017 < DEER
   # @param areas [Hash] a hash of daylighted areas
   # @param sorted_windows [Hash] a hash of windows, sorted by priority
   # @param sorted_skylights [Hash] a hash of skylights, sorted by priority
-  # @param req_top_ctrl [Bool] if toplighting controls are required
-  # @param req_pri_ctrl [Bool] if primary sidelighting controls are required
-  # @param req_sec_ctrl [Bool] if secondary sidelighting controls are required
+  # @param req_top_ctrl [Boolean] if toplighting controls are required
+  # @param req_pri_ctrl [Boolean] if primary sidelighting controls are required
+  # @param req_sec_ctrl [Boolean] if secondary sidelighting controls are required
   # @return [Array] array of 4 items
   #   [sensor 1 fraction, sensor 2 fraction, sensor 1 window, sensor 2 window]
   def space_daylighting_fractions_and_windows(space,

--- a/lib/openstudio-standards/standards/deer/deer_2020/deer_2020.AirLoopHVAC.rb
+++ b/lib/openstudio-standards/standards/deer/deer_2020/deer_2020.AirLoopHVAC.rb
@@ -6,7 +6,7 @@ class DEER2020 < DEER
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_supply_air_temperature_reset_required?(air_loop_hvac, climate_zone)
     is_sat_reset_required = true
     return is_sat_reset_required
@@ -16,7 +16,7 @@ class DEER2020 < DEER
   # Per ASHRAE 90.1 section 6.4.3.3, HVAC systems are required to have off-hour controls
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_unoccupied_fan_shutoff_required?(air_loop_hvac)
     shutoff_required = true
     return shutoff_required
@@ -27,7 +27,7 @@ class DEER2020 < DEER
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_motorized_oa_damper_required?(air_loop_hvac, climate_zone)
     motorized_oa_damper_required = true
     return motorized_oa_damper_required

--- a/lib/openstudio-standards/standards/deer/deer_2020/deer_2020.FanVariableVolume.rb
+++ b/lib/openstudio-standards/standards/deer/deer_2020/deer_2020.FanVariableVolume.rb
@@ -4,7 +4,7 @@ class DEER2020 < DEER
   # Determines whether there is a requirement to have a VSD or some other method to reduce fan power at low part load ratios.
   #
   # @param fan_variable_volume [OpenStudio::Model::FanVariableVolume] variable volume fan object
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def fan_variable_volume_part_load_fan_power_limitation?(fan_variable_volume)
     part_load_control_required = false
 

--- a/lib/openstudio-standards/standards/deer/deer_2020/deer_2020.Space.rb
+++ b/lib/openstudio-standards/standards/deer/deer_2020/deer_2020.Space.rb
@@ -79,9 +79,9 @@ class DEER2020 < DEER
   # @param areas [Hash] a hash of daylighted areas
   # @param sorted_windows [Hash] a hash of windows, sorted by priority
   # @param sorted_skylights [Hash] a hash of skylights, sorted by priority
-  # @param req_top_ctrl [Bool] if toplighting controls are required
-  # @param req_pri_ctrl [Bool] if primary sidelighting controls are required
-  # @param req_sec_ctrl [Bool] if secondary sidelighting controls are required
+  # @param req_top_ctrl [Boolean] if toplighting controls are required
+  # @param req_pri_ctrl [Boolean] if primary sidelighting controls are required
+  # @param req_sec_ctrl [Boolean] if secondary sidelighting controls are required
   # @return [Array] array of 4 items
   #   [sensor 1 fraction, sensor 2 fraction, sensor 1 window, sensor 2 window]
   def space_daylighting_fractions_and_windows(space,

--- a/lib/openstudio-standards/standards/deer/deer_2025/deer_2025.AirLoopHVAC.rb
+++ b/lib/openstudio-standards/standards/deer/deer_2025/deer_2025.AirLoopHVAC.rb
@@ -6,7 +6,7 @@ class DEER2025 < DEER
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_supply_air_temperature_reset_required?(air_loop_hvac, climate_zone)
     is_sat_reset_required = true
     return is_sat_reset_required
@@ -16,7 +16,7 @@ class DEER2025 < DEER
   # Per ASHRAE 90.1 section 6.4.3.3, HVAC systems are required to have off-hour controls
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_unoccupied_fan_shutoff_required?(air_loop_hvac)
     shutoff_required = true
     return shutoff_required
@@ -27,7 +27,7 @@ class DEER2025 < DEER
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_motorized_oa_damper_required?(air_loop_hvac, climate_zone)
     motorized_oa_damper_required = true
     return motorized_oa_damper_required

--- a/lib/openstudio-standards/standards/deer/deer_2025/deer_2025.FanVariableVolume.rb
+++ b/lib/openstudio-standards/standards/deer/deer_2025/deer_2025.FanVariableVolume.rb
@@ -4,7 +4,7 @@ class DEER2025 < DEER
   # Determines whether there is a requirement to have a VSD or some other method to reduce fan power at low part load ratios.
   #
   # @param fan_variable_volume [OpenStudio::Model::FanVariableVolume] variable volume fan object
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def fan_variable_volume_part_load_fan_power_limitation?(fan_variable_volume)
     part_load_control_required = false
 

--- a/lib/openstudio-standards/standards/deer/deer_2025/deer_2025.Space.rb
+++ b/lib/openstudio-standards/standards/deer/deer_2025/deer_2025.Space.rb
@@ -79,9 +79,9 @@ class DEER2025 < DEER
   # @param areas [Hash] a hash of daylighted areas
   # @param sorted_windows [Hash] a hash of windows, sorted by priority
   # @param sorted_skylights [Hash] a hash of skylights, sorted by priority
-  # @param req_top_ctrl [Bool] if toplighting controls are required
-  # @param req_pri_ctrl [Bool] if primary sidelighting controls are required
-  # @param req_sec_ctrl [Bool] if secondary sidelighting controls are required
+  # @param req_top_ctrl [Boolean] if toplighting controls are required
+  # @param req_pri_ctrl [Boolean] if primary sidelighting controls are required
+  # @param req_sec_ctrl [Boolean] if secondary sidelighting controls are required
   # @return [Array] array of 4 items
   #   [sensor 1 fraction, sensor 2 fraction, sensor 1 window, sensor 2 window]
   def space_daylighting_fractions_and_windows(space,

--- a/lib/openstudio-standards/standards/deer/deer_2030/deer_2030.AirLoopHVAC.rb
+++ b/lib/openstudio-standards/standards/deer/deer_2030/deer_2030.AirLoopHVAC.rb
@@ -6,7 +6,7 @@ class DEER2030 < DEER
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_supply_air_temperature_reset_required?(air_loop_hvac, climate_zone)
     is_sat_reset_required = true
     return is_sat_reset_required
@@ -16,7 +16,7 @@ class DEER2030 < DEER
   # Per ASHRAE 90.1 section 6.4.3.3, HVAC systems are required to have off-hour controls
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_unoccupied_fan_shutoff_required?(air_loop_hvac)
     shutoff_required = true
     return shutoff_required
@@ -27,7 +27,7 @@ class DEER2030 < DEER
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_motorized_oa_damper_required?(air_loop_hvac, climate_zone)
     motorized_oa_damper_required = true
     return motorized_oa_damper_required

--- a/lib/openstudio-standards/standards/deer/deer_2030/deer_2030.FanVariableVolume.rb
+++ b/lib/openstudio-standards/standards/deer/deer_2030/deer_2030.FanVariableVolume.rb
@@ -4,7 +4,7 @@ class DEER2030 < DEER
   # Determines whether there is a requirement to have a VSD or some other method to reduce fan power at low part load ratios.
   #
   # @param fan_variable_volume [OpenStudio::Model::FanVariableVolume] variable volume fan object
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def fan_variable_volume_part_load_fan_power_limitation?(fan_variable_volume)
     part_load_control_required = false
 

--- a/lib/openstudio-standards/standards/deer/deer_2030/deer_2030.Space.rb
+++ b/lib/openstudio-standards/standards/deer/deer_2030/deer_2030.Space.rb
@@ -79,9 +79,9 @@ class DEER2030 < DEER
   # @param areas [Hash] a hash of daylighted areas
   # @param sorted_windows [Hash] a hash of windows, sorted by priority
   # @param sorted_skylights [Hash] a hash of skylights, sorted by priority
-  # @param req_top_ctrl [Bool] if toplighting controls are required
-  # @param req_pri_ctrl [Bool] if primary sidelighting controls are required
-  # @param req_sec_ctrl [Bool] if secondary sidelighting controls are required
+  # @param req_top_ctrl [Boolean] if toplighting controls are required
+  # @param req_pri_ctrl [Boolean] if primary sidelighting controls are required
+  # @param req_sec_ctrl [Boolean] if secondary sidelighting controls are required
   # @return [Array] array of 4 items
   #   [sensor 1 fraction, sensor 2 fraction, sensor 1 window, sensor 2 window]
   def space_daylighting_fractions_and_windows(space,

--- a/lib/openstudio-standards/standards/deer/deer_2035/deer_2035.AirLoopHVAC.rb
+++ b/lib/openstudio-standards/standards/deer/deer_2035/deer_2035.AirLoopHVAC.rb
@@ -6,7 +6,7 @@ class DEER2035 < DEER
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_supply_air_temperature_reset_required?(air_loop_hvac, climate_zone)
     is_sat_reset_required = true
     return is_sat_reset_required
@@ -16,7 +16,7 @@ class DEER2035 < DEER
   # Per ASHRAE 90.1 section 6.4.3.3, HVAC systems are required to have off-hour controls
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_unoccupied_fan_shutoff_required?(air_loop_hvac)
     shutoff_required = true
     return shutoff_required
@@ -27,7 +27,7 @@ class DEER2035 < DEER
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_motorized_oa_damper_required?(air_loop_hvac, climate_zone)
     motorized_oa_damper_required = true
     return motorized_oa_damper_required

--- a/lib/openstudio-standards/standards/deer/deer_2035/deer_2035.FanVariableVolume.rb
+++ b/lib/openstudio-standards/standards/deer/deer_2035/deer_2035.FanVariableVolume.rb
@@ -4,7 +4,7 @@ class DEER2035 < DEER
   # Determines whether there is a requirement to have a VSD or some other method to reduce fan power at low part load ratios.
   #
   # @param fan_variable_volume [OpenStudio::Model::FanVariableVolume] variable volume fan object
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def fan_variable_volume_part_load_fan_power_limitation?(fan_variable_volume)
     part_load_control_required = false
 

--- a/lib/openstudio-standards/standards/deer/deer_2035/deer_2035.Space.rb
+++ b/lib/openstudio-standards/standards/deer/deer_2035/deer_2035.Space.rb
@@ -79,9 +79,9 @@ class DEER2035 < DEER
   # @param areas [Hash] a hash of daylighted areas
   # @param sorted_windows [Hash] a hash of windows, sorted by priority
   # @param sorted_skylights [Hash] a hash of skylights, sorted by priority
-  # @param req_top_ctrl [Bool] if toplighting controls are required
-  # @param req_pri_ctrl [Bool] if primary sidelighting controls are required
-  # @param req_sec_ctrl [Bool] if secondary sidelighting controls are required
+  # @param req_top_ctrl [Boolean] if toplighting controls are required
+  # @param req_pri_ctrl [Boolean] if primary sidelighting controls are required
+  # @param req_sec_ctrl [Boolean] if secondary sidelighting controls are required
   # @return [Array] array of 4 items
   #   [sensor 1 fraction, sensor 2 fraction, sensor 1 window, sensor 2 window]
   def space_daylighting_fractions_and_windows(space,

--- a/lib/openstudio-standards/standards/deer/deer_2040/deer_2040.AirLoopHVAC.rb
+++ b/lib/openstudio-standards/standards/deer/deer_2040/deer_2040.AirLoopHVAC.rb
@@ -6,7 +6,7 @@ class DEER2040 < DEER
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_supply_air_temperature_reset_required?(air_loop_hvac, climate_zone)
     is_sat_reset_required = true
     return is_sat_reset_required
@@ -16,7 +16,7 @@ class DEER2040 < DEER
   # Per ASHRAE 90.1 section 6.4.3.3, HVAC systems are required to have off-hour controls
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_unoccupied_fan_shutoff_required?(air_loop_hvac)
     shutoff_required = true
     return shutoff_required
@@ -27,7 +27,7 @@ class DEER2040 < DEER
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_motorized_oa_damper_required?(air_loop_hvac, climate_zone)
     motorized_oa_damper_required = true
     return motorized_oa_damper_required

--- a/lib/openstudio-standards/standards/deer/deer_2040/deer_2040.FanVariableVolume.rb
+++ b/lib/openstudio-standards/standards/deer/deer_2040/deer_2040.FanVariableVolume.rb
@@ -4,7 +4,7 @@ class DEER2040 < DEER
   # Determines whether there is a requirement to have a VSD or some other method to reduce fan power at low part load ratios.
   #
   # @param fan_variable_volume [OpenStudio::Model::FanVariableVolume] variable volume fan object
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def fan_variable_volume_part_load_fan_power_limitation?(fan_variable_volume)
     part_load_control_required = false
 

--- a/lib/openstudio-standards/standards/deer/deer_2040/deer_2040.Space.rb
+++ b/lib/openstudio-standards/standards/deer/deer_2040/deer_2040.Space.rb
@@ -79,9 +79,9 @@ class DEER2040 < DEER
   # @param areas [Hash] a hash of daylighted areas
   # @param sorted_windows [Hash] a hash of windows, sorted by priority
   # @param sorted_skylights [Hash] a hash of skylights, sorted by priority
-  # @param req_top_ctrl [Bool] if toplighting controls are required
-  # @param req_pri_ctrl [Bool] if primary sidelighting controls are required
-  # @param req_sec_ctrl [Bool] if secondary sidelighting controls are required
+  # @param req_top_ctrl [Boolean] if toplighting controls are required
+  # @param req_pri_ctrl [Boolean] if primary sidelighting controls are required
+  # @param req_sec_ctrl [Boolean] if secondary sidelighting controls are required
   # @return [Array] array of 4 items
   #   [sensor 1 fraction, sensor 2 fraction, sensor 1 window, sensor 2 window]
   def space_daylighting_fractions_and_windows(space,

--- a/lib/openstudio-standards/standards/deer/deer_2045/deer_2045.AirLoopHVAC.rb
+++ b/lib/openstudio-standards/standards/deer/deer_2045/deer_2045.AirLoopHVAC.rb
@@ -6,7 +6,7 @@ class DEER2045 < DEER
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_supply_air_temperature_reset_required?(air_loop_hvac, climate_zone)
     is_sat_reset_required = true
     return is_sat_reset_required
@@ -16,7 +16,7 @@ class DEER2045 < DEER
   # Per ASHRAE 90.1 section 6.4.3.3, HVAC systems are required to have off-hour controls
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_unoccupied_fan_shutoff_required?(air_loop_hvac)
     shutoff_required = true
     return shutoff_required
@@ -27,7 +27,7 @@ class DEER2045 < DEER
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_motorized_oa_damper_required?(air_loop_hvac, climate_zone)
     motorized_oa_damper_required = true
     return motorized_oa_damper_required

--- a/lib/openstudio-standards/standards/deer/deer_2045/deer_2045.FanVariableVolume.rb
+++ b/lib/openstudio-standards/standards/deer/deer_2045/deer_2045.FanVariableVolume.rb
@@ -4,7 +4,7 @@ class DEER2045 < DEER
   # Determines whether there is a requirement to have a VSD or some other method to reduce fan power at low part load ratios.
   #
   # @param fan_variable_volume [OpenStudio::Model::FanVariableVolume] variable volume fan object
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def fan_variable_volume_part_load_fan_power_limitation?(fan_variable_volume)
     part_load_control_required = false
 

--- a/lib/openstudio-standards/standards/deer/deer_2045/deer_2045.Space.rb
+++ b/lib/openstudio-standards/standards/deer/deer_2045/deer_2045.Space.rb
@@ -79,9 +79,9 @@ class DEER2045 < DEER
   # @param areas [Hash] a hash of daylighted areas
   # @param sorted_windows [Hash] a hash of windows, sorted by priority
   # @param sorted_skylights [Hash] a hash of skylights, sorted by priority
-  # @param req_top_ctrl [Bool] if toplighting controls are required
-  # @param req_pri_ctrl [Bool] if primary sidelighting controls are required
-  # @param req_sec_ctrl [Bool] if secondary sidelighting controls are required
+  # @param req_top_ctrl [Boolean] if toplighting controls are required
+  # @param req_pri_ctrl [Boolean] if primary sidelighting controls are required
+  # @param req_sec_ctrl [Boolean] if secondary sidelighting controls are required
   # @return [Array] array of 4 items
   #   [sensor 1 fraction, sensor 2 fraction, sensor 1 window, sensor 2 window]
   def space_daylighting_fractions_and_windows(space,

--- a/lib/openstudio-standards/standards/deer/deer_2050/deer_2050.AirLoopHVAC.rb
+++ b/lib/openstudio-standards/standards/deer/deer_2050/deer_2050.AirLoopHVAC.rb
@@ -6,7 +6,7 @@ class DEER2050 < DEER
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_supply_air_temperature_reset_required?(air_loop_hvac, climate_zone)
     is_sat_reset_required = true
     return is_sat_reset_required
@@ -16,7 +16,7 @@ class DEER2050 < DEER
   # Per ASHRAE 90.1 section 6.4.3.3, HVAC systems are required to have off-hour controls
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_unoccupied_fan_shutoff_required?(air_loop_hvac)
     shutoff_required = true
     return shutoff_required
@@ -27,7 +27,7 @@ class DEER2050 < DEER
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_motorized_oa_damper_required?(air_loop_hvac, climate_zone)
     motorized_oa_damper_required = true
     return motorized_oa_damper_required

--- a/lib/openstudio-standards/standards/deer/deer_2050/deer_2050.FanVariableVolume.rb
+++ b/lib/openstudio-standards/standards/deer/deer_2050/deer_2050.FanVariableVolume.rb
@@ -4,7 +4,7 @@ class DEER2050 < DEER
   # Determines whether there is a requirement to have a VSD or some other method to reduce fan power at low part load ratios.
   #
   # @param fan_variable_volume [OpenStudio::Model::FanVariableVolume] variable volume fan object
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def fan_variable_volume_part_load_fan_power_limitation?(fan_variable_volume)
     part_load_control_required = false
 

--- a/lib/openstudio-standards/standards/deer/deer_2050/deer_2050.Space.rb
+++ b/lib/openstudio-standards/standards/deer/deer_2050/deer_2050.Space.rb
@@ -79,9 +79,9 @@ class DEER2050 < DEER
   # @param areas [Hash] a hash of daylighted areas
   # @param sorted_windows [Hash] a hash of windows, sorted by priority
   # @param sorted_skylights [Hash] a hash of skylights, sorted by priority
-  # @param req_top_ctrl [Bool] if toplighting controls are required
-  # @param req_pri_ctrl [Bool] if primary sidelighting controls are required
-  # @param req_sec_ctrl [Bool] if secondary sidelighting controls are required
+  # @param req_top_ctrl [Boolean] if toplighting controls are required
+  # @param req_pri_ctrl [Boolean] if primary sidelighting controls are required
+  # @param req_sec_ctrl [Boolean] if secondary sidelighting controls are required
   # @return [Array] array of 4 items
   #   [sensor 1 fraction, sensor 2 fraction, sensor 1 window, sensor 2 window]
   def space_daylighting_fractions_and_windows(space,

--- a/lib/openstudio-standards/standards/deer/deer_2055/deer_2055.AirLoopHVAC.rb
+++ b/lib/openstudio-standards/standards/deer/deer_2055/deer_2055.AirLoopHVAC.rb
@@ -6,7 +6,7 @@ class DEER2055 < DEER
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_supply_air_temperature_reset_required?(air_loop_hvac, climate_zone)
     is_sat_reset_required = true
     return is_sat_reset_required
@@ -16,7 +16,7 @@ class DEER2055 < DEER
   # Per ASHRAE 90.1 section 6.4.3.3, HVAC systems are required to have off-hour controls
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_unoccupied_fan_shutoff_required?(air_loop_hvac)
     shutoff_required = true
     return shutoff_required
@@ -27,7 +27,7 @@ class DEER2055 < DEER
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_motorized_oa_damper_required?(air_loop_hvac, climate_zone)
     motorized_oa_damper_required = true
     return motorized_oa_damper_required

--- a/lib/openstudio-standards/standards/deer/deer_2055/deer_2055.FanVariableVolume.rb
+++ b/lib/openstudio-standards/standards/deer/deer_2055/deer_2055.FanVariableVolume.rb
@@ -4,7 +4,7 @@ class DEER2055 < DEER
   # Determines whether there is a requirement to have a VSD or some other method to reduce fan power at low part load ratios.
   #
   # @param fan_variable_volume [OpenStudio::Model::FanVariableVolume] variable volume fan object
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def fan_variable_volume_part_load_fan_power_limitation?(fan_variable_volume)
     part_load_control_required = false
 

--- a/lib/openstudio-standards/standards/deer/deer_2055/deer_2055.Space.rb
+++ b/lib/openstudio-standards/standards/deer/deer_2055/deer_2055.Space.rb
@@ -79,9 +79,9 @@ class DEER2055 < DEER
   # @param areas [Hash] a hash of daylighted areas
   # @param sorted_windows [Hash] a hash of windows, sorted by priority
   # @param sorted_skylights [Hash] a hash of skylights, sorted by priority
-  # @param req_top_ctrl [Bool] if toplighting controls are required
-  # @param req_pri_ctrl [Bool] if primary sidelighting controls are required
-  # @param req_sec_ctrl [Bool] if secondary sidelighting controls are required
+  # @param req_top_ctrl [Boolean] if toplighting controls are required
+  # @param req_pri_ctrl [Boolean] if primary sidelighting controls are required
+  # @param req_sec_ctrl [Boolean] if secondary sidelighting controls are required
   # @return [Array] array of 4 items
   #   [sensor 1 fraction, sensor 2 fraction, sensor 1 window, sensor 2 window]
   def space_daylighting_fractions_and_windows(space,

--- a/lib/openstudio-standards/standards/deer/deer_2060/deer_2060.AirLoopHVAC.rb
+++ b/lib/openstudio-standards/standards/deer/deer_2060/deer_2060.AirLoopHVAC.rb
@@ -6,7 +6,7 @@ class DEER2060 < DEER
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_supply_air_temperature_reset_required?(air_loop_hvac, climate_zone)
     is_sat_reset_required = true
     return is_sat_reset_required
@@ -16,7 +16,7 @@ class DEER2060 < DEER
   # Per ASHRAE 90.1 section 6.4.3.3, HVAC systems are required to have off-hour controls
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_unoccupied_fan_shutoff_required?(air_loop_hvac)
     shutoff_required = true
     return shutoff_required
@@ -27,7 +27,7 @@ class DEER2060 < DEER
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_motorized_oa_damper_required?(air_loop_hvac, climate_zone)
     motorized_oa_damper_required = true
     return motorized_oa_damper_required

--- a/lib/openstudio-standards/standards/deer/deer_2060/deer_2060.FanVariableVolume.rb
+++ b/lib/openstudio-standards/standards/deer/deer_2060/deer_2060.FanVariableVolume.rb
@@ -4,7 +4,7 @@ class DEER2060 < DEER
   # Determines whether there is a requirement to have a VSD or some other method to reduce fan power at low part load ratios.
   #
   # @param fan_variable_volume [OpenStudio::Model::FanVariableVolume] variable volume fan object
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def fan_variable_volume_part_load_fan_power_limitation?(fan_variable_volume)
     part_load_control_required = false
 

--- a/lib/openstudio-standards/standards/deer/deer_2060/deer_2060.Space.rb
+++ b/lib/openstudio-standards/standards/deer/deer_2060/deer_2060.Space.rb
@@ -79,9 +79,9 @@ class DEER2060 < DEER
   # @param areas [Hash] a hash of daylighted areas
   # @param sorted_windows [Hash] a hash of windows, sorted by priority
   # @param sorted_skylights [Hash] a hash of skylights, sorted by priority
-  # @param req_top_ctrl [Bool] if toplighting controls are required
-  # @param req_pri_ctrl [Bool] if primary sidelighting controls are required
-  # @param req_sec_ctrl [Bool] if secondary sidelighting controls are required
+  # @param req_top_ctrl [Boolean] if toplighting controls are required
+  # @param req_pri_ctrl [Boolean] if primary sidelighting controls are required
+  # @param req_sec_ctrl [Boolean] if secondary sidelighting controls are required
   # @return [Array] array of 4 items
   #   [sensor 1 fraction, sensor 2 fraction, sensor 1 window, sensor 2 window]
   def space_daylighting_fractions_and_windows(space,

--- a/lib/openstudio-standards/standards/deer/deer_2065/deer_2065.AirLoopHVAC.rb
+++ b/lib/openstudio-standards/standards/deer/deer_2065/deer_2065.AirLoopHVAC.rb
@@ -6,7 +6,7 @@ class DEER2065 < DEER
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_supply_air_temperature_reset_required?(air_loop_hvac, climate_zone)
     is_sat_reset_required = true
     return is_sat_reset_required
@@ -16,7 +16,7 @@ class DEER2065 < DEER
   # Per ASHRAE 90.1 section 6.4.3.3, HVAC systems are required to have off-hour controls
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_unoccupied_fan_shutoff_required?(air_loop_hvac)
     shutoff_required = true
     return shutoff_required
@@ -27,7 +27,7 @@ class DEER2065 < DEER
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_motorized_oa_damper_required?(air_loop_hvac, climate_zone)
     motorized_oa_damper_required = true
     return motorized_oa_damper_required

--- a/lib/openstudio-standards/standards/deer/deer_2065/deer_2065.FanVariableVolume.rb
+++ b/lib/openstudio-standards/standards/deer/deer_2065/deer_2065.FanVariableVolume.rb
@@ -4,7 +4,7 @@ class DEER2065 < DEER
   # Determines whether there is a requirement to have a VSD or some other method to reduce fan power at low part load ratios.
   #
   # @param fan_variable_volume [OpenStudio::Model::FanVariableVolume] variable volume fan object
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def fan_variable_volume_part_load_fan_power_limitation?(fan_variable_volume)
     part_load_control_required = false
 

--- a/lib/openstudio-standards/standards/deer/deer_2065/deer_2065.Space.rb
+++ b/lib/openstudio-standards/standards/deer/deer_2065/deer_2065.Space.rb
@@ -79,9 +79,9 @@ class DEER2065 < DEER
   # @param areas [Hash] a hash of daylighted areas
   # @param sorted_windows [Hash] a hash of windows, sorted by priority
   # @param sorted_skylights [Hash] a hash of skylights, sorted by priority
-  # @param req_top_ctrl [Bool] if toplighting controls are required
-  # @param req_pri_ctrl [Bool] if primary sidelighting controls are required
-  # @param req_sec_ctrl [Bool] if secondary sidelighting controls are required
+  # @param req_top_ctrl [Boolean] if toplighting controls are required
+  # @param req_pri_ctrl [Boolean] if primary sidelighting controls are required
+  # @param req_sec_ctrl [Boolean] if secondary sidelighting controls are required
   # @return [Array] array of 4 items
   #   [sensor 1 fraction, sensor 2 fraction, sensor 1 window, sensor 2 window]
   def space_daylighting_fractions_and_windows(space,

--- a/lib/openstudio-standards/standards/deer/deer_2070/deer_2070.AirLoopHVAC.rb
+++ b/lib/openstudio-standards/standards/deer/deer_2070/deer_2070.AirLoopHVAC.rb
@@ -6,7 +6,7 @@ class DEER2070 < DEER
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_supply_air_temperature_reset_required?(air_loop_hvac, climate_zone)
     is_sat_reset_required = true
     return is_sat_reset_required
@@ -16,7 +16,7 @@ class DEER2070 < DEER
   # Per ASHRAE 90.1 section 6.4.3.3, HVAC systems are required to have off-hour controls
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_unoccupied_fan_shutoff_required?(air_loop_hvac)
     shutoff_required = true
     return shutoff_required
@@ -27,7 +27,7 @@ class DEER2070 < DEER
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_motorized_oa_damper_required?(air_loop_hvac, climate_zone)
     motorized_oa_damper_required = true
     return motorized_oa_damper_required

--- a/lib/openstudio-standards/standards/deer/deer_2070/deer_2070.FanVariableVolume.rb
+++ b/lib/openstudio-standards/standards/deer/deer_2070/deer_2070.FanVariableVolume.rb
@@ -4,7 +4,7 @@ class DEER2070 < DEER
   # Determines whether there is a requirement to have a VSD or some other method to reduce fan power at low part load ratios.
   #
   # @param fan_variable_volume [OpenStudio::Model::FanVariableVolume] variable volume fan object
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def fan_variable_volume_part_load_fan_power_limitation?(fan_variable_volume)
     part_load_control_required = false
 

--- a/lib/openstudio-standards/standards/deer/deer_2070/deer_2070.Space.rb
+++ b/lib/openstudio-standards/standards/deer/deer_2070/deer_2070.Space.rb
@@ -79,9 +79,9 @@ class DEER2070 < DEER
   # @param areas [Hash] a hash of daylighted areas
   # @param sorted_windows [Hash] a hash of windows, sorted by priority
   # @param sorted_skylights [Hash] a hash of skylights, sorted by priority
-  # @param req_top_ctrl [Bool] if toplighting controls are required
-  # @param req_pri_ctrl [Bool] if primary sidelighting controls are required
-  # @param req_sec_ctrl [Bool] if secondary sidelighting controls are required
+  # @param req_top_ctrl [Boolean] if toplighting controls are required
+  # @param req_pri_ctrl [Boolean] if primary sidelighting controls are required
+  # @param req_sec_ctrl [Boolean] if secondary sidelighting controls are required
   # @return [Array] array of 4 items
   #   [sensor 1 fraction, sensor 2 fraction, sensor 1 window, sensor 2 window]
   def space_daylighting_fractions_and_windows(space,

--- a/lib/openstudio-standards/standards/deer/deer_2075/deer_2075.AirLoopHVAC.rb
+++ b/lib/openstudio-standards/standards/deer/deer_2075/deer_2075.AirLoopHVAC.rb
@@ -6,7 +6,7 @@ class DEER2075 < DEER
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_supply_air_temperature_reset_required?(air_loop_hvac, climate_zone)
     is_sat_reset_required = true
     return is_sat_reset_required
@@ -16,7 +16,7 @@ class DEER2075 < DEER
   # Per ASHRAE 90.1 section 6.4.3.3, HVAC systems are required to have off-hour controls
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_unoccupied_fan_shutoff_required?(air_loop_hvac)
     shutoff_required = true
     return shutoff_required
@@ -27,7 +27,7 @@ class DEER2075 < DEER
   #
   # @param air_loop_hvac [OpenStudio::Model::AirLoopHVAC] air loop
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def air_loop_hvac_motorized_oa_damper_required?(air_loop_hvac, climate_zone)
     motorized_oa_damper_required = true
     return motorized_oa_damper_required

--- a/lib/openstudio-standards/standards/deer/deer_2075/deer_2075.FanVariableVolume.rb
+++ b/lib/openstudio-standards/standards/deer/deer_2075/deer_2075.FanVariableVolume.rb
@@ -4,7 +4,7 @@ class DEER2075 < DEER
   # Determines whether there is a requirement to have a VSD or some other method to reduce fan power at low part load ratios.
   #
   # @param fan_variable_volume [OpenStudio::Model::FanVariableVolume] variable volume fan object
-  # @return [Bool] returns true if required, false if not
+  # @return [Boolean] returns true if required, false if not
   def fan_variable_volume_part_load_fan_power_limitation?(fan_variable_volume)
     part_load_control_required = false
 

--- a/lib/openstudio-standards/standards/deer/deer_2075/deer_2075.Space.rb
+++ b/lib/openstudio-standards/standards/deer/deer_2075/deer_2075.Space.rb
@@ -79,9 +79,9 @@ class DEER2075 < DEER
   # @param areas [Hash] a hash of daylighted areas
   # @param sorted_windows [Hash] a hash of windows, sorted by priority
   # @param sorted_skylights [Hash] a hash of skylights, sorted by priority
-  # @param req_top_ctrl [Bool] if toplighting controls are required
-  # @param req_pri_ctrl [Bool] if primary sidelighting controls are required
-  # @param req_sec_ctrl [Bool] if secondary sidelighting controls are required
+  # @param req_top_ctrl [Boolean] if toplighting controls are required
+  # @param req_pri_ctrl [Boolean] if primary sidelighting controls are required
+  # @param req_sec_ctrl [Boolean] if secondary sidelighting controls are required
   # @return [Array] array of 4 items
   #   [sensor 1 fraction, sensor 2 fraction, sensor 1 window, sensor 2 window]
   def space_daylighting_fractions_and_windows(space,

--- a/lib/openstudio-standards/standards/necb/BTAPPRE1980/building_envelope.rb
+++ b/lib/openstudio-standards/standards/necb/BTAPPRE1980/building_envelope.rb
@@ -156,7 +156,7 @@ class BTAPPRE1980
   # modifications.  For others, it will not.
   #
   # 90.1-2007, 90.1-2010, 90.1-2013
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
 
   def apply_standard_construction_properties(
     model:,

--- a/lib/openstudio-standards/standards/necb/BTAPPRE1980/hvac_systems.rb
+++ b/lib/openstudio-standards/standards/necb/BTAPPRE1980/hvac_systems.rb
@@ -2,7 +2,7 @@ class BTAPPRE1980
   # Check if ERV is required on this airloop.
   #
   # @param (see #economizer_required?)
-  # @return [Bool] Returns true if required, false if not.
+  # @return [Boolean] Returns true if required, false if not.
   def air_loop_hvac_energy_recovery_ventilator_required?(air_loop_hvac, climate_zone)
     # Do not apply ERV to BTAPPRE1980 buildings.
     erv_required = false
@@ -11,7 +11,7 @@ class BTAPPRE1980
 
   # Applies the standard efficiency ratings and typical performance curves to this object from MNECB Supplement 5.4.8.3.
   #
-  # @return [Bool] true if successful, false if not
+  # @return [Boolean] true if successful, false if not
   def chiller_electric_eir_apply_efficiency_and_curves(chiller_electric_eir, clg_tower_objs)
     chillers = standards_data['chillers']
 

--- a/lib/openstudio-standards/standards/necb/ECMS/hvac_systems.rb
+++ b/lib/openstudio-standards/standards/necb/ECMS/hvac_systems.rb
@@ -3336,7 +3336,7 @@ class ECMS
   # If an efficiency is set but is not between 0.01 and 1.0 it returns an error.  Otherwise, it looks for mixed water
   # heaters.  If it finds any it then calls the reset_shw_efficiency method which resets the the shw efficiency and the
   # part load curve. It also renames the shw tank with the following pattern:
-  # {valume}Gal {eff_name} Water Heater - {Capacity}kBtu/hr {efficiency} Therm Eff
+  #   {volume}Gal {eff_name} Water Heater - {Capacity}kBtu/hr {efficiency} Therm Eff
   def modify_shw_efficiency(model:, shw_eff: nil)
     return if shw_eff.nil?
 
@@ -3381,7 +3381,7 @@ class ECMS
   # This method sets the efficiency of the shw heater to whatever is entered in eff["efficiency"].  It then looks for the
   # "part_load_curve" value in the curves.json file.  If it does not find one it returns an error.  If it finds one it
   # resets the part load curve to whatever was found.  It then renames the shw tank according to the following pattern:
-  # {valume}Gal {eff_name} Water Heater - {Capacity}kBtu/hr {efficiency} Therm Eff
+  #   {volume}Gal {eff_name} Water Heater - {Capacity}kBtu/hr {efficiency} Therm Eff
   def reset_shw_efficiency(model:, component:, eff:)
     return if component.heaterFuelType.to_s.upcase == 'ELECTRICITY'
 

--- a/lib/openstudio-standards/standards/necb/NECB2011/autozone.rb
+++ b/lib/openstudio-standards/standards/necb/NECB2011/autozone.rb
@@ -4,7 +4,7 @@ class NECB2011
   # e.g. (Prototype.secondary_school.rb) file.
   #
   # @param (see #add_constructions)
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_create_thermal_zones(model, space_multiplier_map = nil)
     OpenStudio.logFree(OpenStudio::Info, 'openstudio.model.Model', 'Started creating thermal zones')
     space_multiplier_map = {} if space_multiplier_map.nil?
@@ -801,7 +801,7 @@ class NECB2011
   end
 
   # This model determines the dominant NECB schedule type
-  # @param model [OpenStudio::model::Model] A model object
+  # @param model [OpenStudio::Model::Model] A model object
   # return s.each [String]
   def determine_dominant_necb_schedule_type(model)
     return determine_dominant_schedule(model.getSpaces)

--- a/lib/openstudio-standards/standards/necb/NECB2011/beps_compliance_path.rb
+++ b/lib/openstudio-standards/standards/necb/NECB2011/beps_compliance_path.rb
@@ -34,16 +34,16 @@ class NECB2011
   # to have the specified values. This method does not alter any
   # loads directly assigned to spaces.  This method skips plenums.
   #
-  # @param set_people [Bool] if true, set the people density.
+  # @param set_people [Boolean] if true, set the people density.
   # Also, assign reasonable clothing, air velocity, and work efficiency inputs
   # to allow reasonable thermal comfort metrics to be calculated.
-  # @param set_lights [Bool] if true, set the lighting density, lighting fraction
+  # @param set_lights [Boolean] if true, set the lighting density, lighting fraction
   # to return air, fraction radiant, and fraction visible.
-  # @param set_electric_equipment [Bool] if true, set the electric equipment density
-  # @param set_gas_equipment [Bool] if true, set the gas equipment density
-  # @param set_ventilation [Bool] if true, set the ventilation rates (per-person and per-area)
-  # @param set_infiltration [Bool] if true, set the infiltration rates
-  # @return [Bool] returns true if successful, false if not
+  # @param set_electric_equipment [Boolean] if true, set the electric equipment density
+  # @param set_gas_equipment [Boolean] if true, set the gas equipment density
+  # @param set_ventilation [Boolean] if true, set the ventilation rates (per-person and per-area)
+  # @param set_infiltration [Boolean] if true, set the infiltration rates
+  # @return [Boolean] returns true if successful, false if not
   def space_type_apply_internal_loads(space_type:,
                                       set_people: true,
                                       set_lights: true,

--- a/lib/openstudio-standards/standards/necb/NECB2011/building_envelope.rb
+++ b/lib/openstudio-standards/standards/necb/NECB2011/building_envelope.rb
@@ -295,7 +295,7 @@ class NECB2011
   # modifications.  For others, it will not.
   #
   # 90.1-2007, 90.1-2010, 90.1-2013
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
 
   def apply_standard_construction_properties(model:,
                                              runner: nil,
@@ -465,9 +465,8 @@ class NECB2011
   # individual space type, this construction set will be created and applied
   # to this space type, overriding the whole-building construction set.
   #
-  # @param building_type [String] the type of building
-  # @param climate_zone [String] the name of the climate zone the building is in
-  # @return [Bool] returns true if successful, false if not
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
+  # @return [Boolean] returns true if successful, false if not
   def model_add_constructions(model)
     OpenStudio.logFree(OpenStudio::Info, 'openstudio.model.Model', 'Started applying constructions')
 

--- a/lib/openstudio-standards/standards/necb/NECB2011/data/standards_data.rb
+++ b/lib/openstudio-standards/standards/necb/NECB2011/data/standards_data.rb
@@ -115,7 +115,7 @@ class StandardsData
   # desired search criteria, as passed via a hash.
   # Returns an Array (empty if nothing found) of matching objects.
   #
-  # @param hash_of_objects [Hash] hash of objects to search through
+  # @param table_name [String] table name
   # @param search_criteria [Hash] hash of search criteria
   # @param capacity [Double] capacity of the object in question.  If capacity is supplied,
   #   the objects will only be returned if the specified capacity is between
@@ -247,7 +247,7 @@ class StandardsData
   # the minimum_capacity and maximum_capacity values.
   #
   #
-  # @param hash_of_objects [Hash] hash of objects to search through
+  # @param table_name [String] table name
   # @param search_criteria [Hash] hash of search criteria
   # @param capacity [Double] capacity of the object in question.  If capacity is supplied,
   #   the objects will only be returned if the specified capacity is between

--- a/lib/openstudio-standards/standards/necb/NECB2011/hvac_systems.rb
+++ b/lib/openstudio-standards/standards/necb/NECB2011/hvac_systems.rb
@@ -9,7 +9,7 @@ class NECB2011
 
   # NECB does not change damper positions
   #
-  # return [Bool] returns true if successful, false if not
+  # return [Boolean] returns true if successful, false if not
   def air_loop_hvac_apply_multizone_vav_outdoor_air_sizing(air_loop_hvac)
     # Do not change anything.
     return true
@@ -18,7 +18,7 @@ class NECB2011
   # Determine whether or not this system
   # is required to have an economizer.
   #
-  # @return [Bool] returns true if an economizer is required, false if not
+  # @return [Boolean] returns true if an economizer is required, false if not
   def air_loop_hvac_economizer_required?(air_loop_hvac)
     economizer_required = false
 
@@ -86,7 +86,7 @@ class NECB2011
   # @note this method assumes you previously checked that an economizer is required at all
   #   via #economizer_required?
   # @param (see #economizer_required?)
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def air_loop_hvac_apply_economizer_integration(air_loop_hvac, climate_zone)
     # Get the OA system and OA controller
     oa_sys = air_loop_hvac.airLoopHVACOutdoorAirSystem
@@ -105,7 +105,7 @@ class NECB2011
   # Check if ERV is required on this airloop.
   #
   # @param (see #economizer_required?)
-  # @return [Bool] Returns true if required, false if not.
+  # @return [Boolean] Returns true if required, false if not.
   # @todo Add exception logic for systems serving parking garage, warehouse, or multifamily
   def air_loop_hvac_energy_recovery_ventilator_required?(air_loop_hvac, climate_zone)
     # ERV Not Applicable for AHUs that serve
@@ -283,7 +283,7 @@ class NECB2011
   # Will be a rotary-type HX
   #
   # @param (see #economizer_required?)
-  # @return [Bool] Returns true if required, false if not.
+  # @return [Boolean] Returns true if required, false if not.
   # @todo Add exception logic for systems serving parking garage, warehouse, or multifamily
   def air_loop_hvac_apply_energy_recovery_ventilator(air_loop_hvac, climate = nil)
     # Get the oa system
@@ -401,7 +401,7 @@ class NECB2011
   # required for this air loop.
   #
   # @param (see #economizer_required?)
-  # @return [Bool] Returns true if required, false if not.
+  # @return [Boolean] Returns true if required, false if not.
   # @todo Add exception logic for
   #   systems that serve multifamily, parking garage, warehouse
   def air_loop_hvac_demand_control_ventilation_required?(air_loop_hvac, climate_zone)
@@ -413,7 +413,7 @@ class NECB2011
   # Set the VAV damper control to single maximum or
   # dual maximum control depending on the standard.
   #
-  # @return [Bool] Returns true if successful, false if not
+  # @return [Boolean] Returns true if successful, false if not
   # @todo see if this impacts the sizing run.
   def air_loop_hvac_apply_vav_damper_action(air_loop_hvac)
     damper_action = 'Single Maximum'
@@ -462,7 +462,7 @@ class NECB2011
 
   # NECB has no single zone air loop control requirements
   #
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def air_loop_hvac_apply_single_zone_controls(air_loop_hvac, climate_zone)
     OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.AirLoopHVAC', "For #{air_loop_hvac.name}: No special economizer controls were modeled.")
     return true
@@ -470,7 +470,7 @@ class NECB2011
 
   # NECB doesn't require static pressure reset.
   #
-  # return [Bool] returns true if static pressure reset is required, false if not
+  # return [Boolean] returns true if static pressure reset is required, false if not
   def air_loop_hvac_static_pressure_reset_required?(air_loop_hvac, has_ddc)
     # static pressure reset not required
     sp_reset_required = false
@@ -490,7 +490,7 @@ class NECB2011
   # Applies the standard efficiency ratings and typical performance curves to this object.
   #
   # @param boiler_hot_water [OpenStudio::Model::BoilerHotWater] the object to modify
-  # @return [Bool] true if successful, false if not
+  # @return [Boolean] true if successful, false if not
   def boiler_hot_water_apply_efficiency_and_curves(boiler_hot_water)
     successfully_set_all_properties = false
 
@@ -592,7 +592,7 @@ class NECB2011
 
   # Applies the standard efficiency ratings and typical performance curves to this object.
   #
-  # @return [Bool] true if successful, false if not
+  # @return [Boolean] true if successful, false if not
   def chiller_electric_eir_apply_efficiency_and_curves(chiller_electric_eir, clg_tower_objs)
     # Define the criteria to find the chiller properties
     # in the hvac standards data set.
@@ -808,7 +808,7 @@ class NECB2011
 
   # Applies the standard efficiency ratings and typical performance curves to this object.
   #
-  # @return [Bool] true if successful, false if not
+  # @return [Boolean] true if successful, false if not
   def coil_heating_gas_apply_efficiency_and_curves(coil_heating_gas)
     successfully_set_all_properties = true
 
@@ -849,7 +849,7 @@ class NECB2011
 
   # Applies the standard efficiency ratings and typical performance curves to this object.
   #
-  # @return [Bool] true if successful, false if not
+  # @return [Boolean] true if successful, false if not
   def coil_cooling_dx_multi_speed_apply_efficiency_and_curves(coil_cooling_dx_multi_speed, sql_db_vars_map)
     successfully_set_all_properties = true
     model = coil_cooling_dx_multi_speed.model
@@ -1097,7 +1097,7 @@ class NECB2011
 
   # Applies the standard efficiency ratings and typical performance curves to this object.
   #
-  # @return [Bool] true if successful, false if not
+  # @return [Boolean] true if successful, false if not
   def coil_heating_gas_multi_stage_apply_efficiency_and_curves(coil_heating_gas_multi_stage)
     successfully_set_all_properties = true
     model = coil_heating_gas_multi_stage.model
@@ -1467,7 +1467,7 @@ class NECB2011
   # Does not account for System requirements like ERV, economizer, etc.
   # Those are accounted for in the AirLoopHVAC method of the same name.
   #
-  # @return [Bool] Returns true if required, false if not.
+  # @return [Boolean] Returns true if required, false if not.
   # @todo Add exception logic for 90.1-2013
   #   for cells, sickrooms, labs, barbers, salons, and bowling alleys
   def thermal_zone_demand_control_ventilation_required?(thermal_zone, climate_zone)
@@ -2383,7 +2383,7 @@ class NECB2011
   # heating type rules need to be flexible to account for 
   # 1.  DX htg/cooling + gas supplement htg
   # 2.  Potential lack of AirLoopHVACUnitaryHeatPumpAirToAir or AirLoopHVACUnitarySystem  
-  # @param necb_ref_hp [Bool] if true, NECB reference model rules for heat pumps will be used.
+  # @param necb_reference_hp [Boolean] if true, NECB reference model rules for heat pumps will be used.
   def coil_dx_heating_type(coil_dx, necb_reference_hp = false)
     supp_htg_type = nil
 

--- a/lib/openstudio-standards/standards/necb/NECB2011/necb_2011.rb
+++ b/lib/openstudio-standards/standards/necb/NECB2011/necb_2011.rb
@@ -929,7 +929,7 @@ class NECB2011 < Standard
   # @param model [OpenStudio::Model::Model] an OpenStudio model
   # @param tbd_option [String] BTAP/TBD option
   #
-  # @return [Bool] true if successful, e.g. no errors, compliant if uprated
+  # @return [Boolean] true if successful, e.g. no errors, compliant if uprated
 
   ##
   # (Optionally) uprates, then derates, envelope surface constructions due to
@@ -939,12 +939,12 @@ class NECB2011 < Standard
   #
   # @param model [OpenStudio::Model::Model] an OpenStudio model
   # @param tbd_option [String] BTAP/TBD option
-  # @param tbd_interpolate [Bool] true if TBD interpolates between costed Uo
+  # @param tbd_interpolate [Boolean] true if TBD interpolates between costed Uo
   # @param wall_U [Double] wall conductance in W/m2.K (nil by default)
   # @param floor_U [Double] floor conductance in W/m2.K (nil by default)
   # @param roof_U [Double] roof conductance in W/m2.K (nil by default)
   #
-  # @return [Bool] true if successful, e.g. no errors, compliant if uprated
+  # @return [Boolean] true if successful, e.g. no errors, compliant if uprated
   def apply_thermal_bridging(model: nil,
                              tbd_option: 'none',
                              tbd_interpolate: false,
@@ -986,8 +986,7 @@ class NECB2011 < Standard
     true
   end
 
-
-  # @param necb_ref_hp [Bool] if true, NECB reference model rules for heat pumps will be used.
+  # @param necb_reference_hp [Boolean] if true, NECB reference model rules for heat pumps will be used.
   def apply_standard_efficiencies(model:, sizing_run_dir:, dcv_type: 'NECB_Default', necb_reference_hp: false)
     raise('validation of model failed.') unless validate_initial_model(model)
 
@@ -1022,7 +1021,7 @@ class NECB2011 < Standard
   #
   # @param min_occ_pct [Double] the fractional value below which
   # the system will be considered unoccupied.
-  # @return [Bool] true if successful, false if not
+  # @return [Boolean] true if successful, false if not
   def air_loop_hvac_enable_unoccupied_fan_shutoff(air_loop_hvac, min_occ_pct = 0.05)
     # Set the system to night cycle
     air_loop_hvac.setNightCycleControlType('CycleOnAny')
@@ -1204,7 +1203,7 @@ class NECB2011 < Standard
     return true
   end
 
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def set_occ_sensor_spacetypes(model, space_type_map)
     building_type = 'Space Function'
     space_type_map.each do |space_type_name, space_names|
@@ -1862,7 +1861,7 @@ class NECB2011 < Standard
   # Some loads are governed by the standard, others are typical values
   # pulled from sources such as the DOE Reference and DOE Prototype Buildings.
   #
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_add_loads(model, lights_type, lights_scale)
     OpenStudio.logFree(OpenStudio::Info, 'openstudio.model.Model', 'Started applying space types (loads)')
 

--- a/lib/openstudio-standards/standards/necb/NECB2011/service_water_heating.rb
+++ b/lib/openstudio-standards/standards/necb/NECB2011/service_water_heating.rb
@@ -99,7 +99,7 @@ class NECB2011
   # Per PNNL http://www.energycodes.gov/sites/default/files/documents/PrototypeModelEnhancements_2014_0.pdf
   # Appendix A: Service Water Heating
   #
-  # @return [Bool] true if successful, false if not
+  # @return [Boolean] true if successful, false if not
   def water_heater_mixed_apply_efficiency(water_heater_mixed)
     # Get the capacity of the water heater
     # TODO add capability to pull autosized water heater capacity

--- a/lib/openstudio-standards/standards/necb/NECB2015/hvac_systems.rb
+++ b/lib/openstudio-standards/standards/necb/NECB2015/hvac_systems.rb
@@ -1,7 +1,7 @@
 class NECB2015
   # Applies the standard efficiency ratings and typical performance curves to this object.
   #
-  # @return [Bool] true if successful, false if not
+  # @return [Boolean] true if successful, false if not
   def chiller_electric_eir_apply_efficiency_and_curves(chiller_electric_eir, clg_tower_objs)
     chillers = standards_data['chillers']
 

--- a/lib/openstudio-standards/standards/necb/NECB2017/hvac_systems.rb
+++ b/lib/openstudio-standards/standards/necb/NECB2017/hvac_systems.rb
@@ -1,7 +1,7 @@
 class NECB2017
   # Check if ERV is required on this airloop.
   #
-  # @return [Bool] Returns true if required, false if not.
+  # @return [Boolean] Returns true if required, false if not.
   def air_loop_hvac_energy_recovery_ventilator_required?(air_loop_hvac, climate_zone)
     erv_required = nil
 

--- a/lib/openstudio-standards/standards/necb/NECB2020/building_envelope.rb
+++ b/lib/openstudio-standards/standards/necb/NECB2020/building_envelope.rb
@@ -8,7 +8,7 @@ class NECB2020
   # modifications.  For others, it will not.
   #
   # 90.1-2007, 90.1-2010, 90.1-2013
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
 
   def apply_standard_construction_properties(model:,
                                              runner: nil,

--- a/lib/openstudio-standards/standards/necb/NECB2020/service_water_heating.rb
+++ b/lib/openstudio-standards/standards/necb/NECB2020/service_water_heating.rb
@@ -5,7 +5,7 @@ class NECB2020
   # Per PNNL http://www.energycodes.gov/sites/default/files/documents/PrototypeModelEnhancements_2014_0.pdf
   # Appendix A: Service Water Heating
   #
-  # @return [Bool] true if successful, false if not
+  # @return [Boolean] true if successful, false if not
   #
   # NECB2020 uses a different procedure calculate gas water heater efficiencies (compared to previous NECB)
   #

--- a/lib/openstudio-standards/utilities/logging.rb
+++ b/lib/openstudio-standards/utilities/logging.rb
@@ -39,7 +39,6 @@ end
 # A function that writes error message to log file and stop the execution.
 #
 # @param msg [String] error message
-# @param log_level [OpenStudio::LogLevel] log level, eg. OpenStudio::Info
 # @param log_path [String] the log file directory
 # @param debug [Boolean] debug mode
 def terminate_prm_write_log(msg, log_path, debug = false)
@@ -52,7 +51,7 @@ end
 #
 # @param file_path [String] the file path to the log file
 # @param debug [Boolean] debug mode
-# @return message [Array] array of message strings
+# @return [Array] array of message strings
 def log_messages_to_file_prm(file_path, debug = false)
   messages = []
 

--- a/lib/openstudio-standards/utilities/schedule_translator.rb
+++ b/lib/openstudio-standards/utilities/schedule_translator.rb
@@ -54,8 +54,8 @@ class ScheduleTranslator
   end
 
   # Convert from scheduleCompact to scheduleRuleset
-  # @Author Nicholas Long and Andrew Parker, NREL
-  # @Return ScheduleRuleset object
+  # @author Nicholas Long and Andrew Parker, NREL
+  # @return ScheduleRuleset object
   def convert_schedule_compact_to_schedule_ruleset
     @sched_name = @os_schedule.getString(1).get
     @sched_name = "#{@name_prefix} #{@sched_name}" unless @name_prefix.nil?

--- a/lib/openstudio-standards/utilities/simulation.rb
+++ b/lib/openstudio-standards/utilities/simulation.rb
@@ -5,7 +5,7 @@ Standard.class_eval do
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @param run_dir [String] file path location for the annual run, defaults to 'Run' in the current directory
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_run_simulation_and_log_errors(model, run_dir = "#{Dir.pwd}/Run")
     # Make the directory if it doesn't exist
     unless Dir.exist?(run_dir)
@@ -183,7 +183,7 @@ Standard.class_eval do
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @param sizing_run_dir [String] file path location for the sizing run, defaults to 'SR' in the current directory
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_run_sizing_run(model, sizing_run_dir = "#{Dir.pwd}/SR")
     # Change the simulation to only run the sizing days
     sim_control = model.getSimulationControl
@@ -213,7 +213,7 @@ Standard.class_eval do
   # Method to check if all zones have surfaces. This is required to run a simulation.
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_do_all_zones_have_surfaces?(model)
     # Check to see if all zones have surfaces.
     model.getThermalZones.each do |zone|

--- a/lib/openstudio-standards/weather/Weather.Model.rb
+++ b/lib/openstudio-standards/weather/Weather.Model.rb
@@ -127,7 +127,7 @@ class Standard
   # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @param climate_zone [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
   # @param epw_file [String] the name of the epw file; if blank will default to epw file for the ASHRAE climate zone
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_add_design_days_and_weather_file(model, climate_zone, epw_file = '', weather_dir = nil)
     success = true
     require_relative 'Weather.stat_file'
@@ -217,7 +217,7 @@ class Standard
   # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @param [String] openstudio-standards building type
   # @param [String] ASHRAE climate zone, e.g. 'ASHRAE 169-2013-4A'
-  # @return [Bool] returns true if successful, false if not
+  # @return [Boolean] returns true if successful, false if not
   def model_add_ground_temperatures(model, building_type, climate_zone)
     # Define the weather file for each climate zone
     climate_zone_weather_file_map = model_get_climate_zone_weather_file_map
@@ -636,7 +636,7 @@ module BTAP
 
       # This method will set the weather file and returns a log string.
       # @author phylroy.lopez@nrcan.gc.ca
-      # @param model [OpenStudio::model::Model] A model object
+      # @param model [OpenStudio::Model::Model] A model object
       # @return [String] log
       def set_weather_file(model, runner = nil)
         BTAP.runner_register('Info', 'BTAP::Environment::WeatherFile::set_weather', runner)

--- a/test/90_1_prm/test_appendix_g_prm.rb
+++ b/test/90_1_prm/test_appendix_g_prm.rb
@@ -856,7 +856,7 @@ class AppendixGPRMTests < Minitest::Test
   #
   # this check uses very similar code to the one that implements this requirement
   #
-  # @param model [OpenStudio::model::Model] openstudio model object
+  # @param model [OpenStudio::Model::Model] openstudio model object
   # @param building_type [String]  building type
   # @param template [String] template name
   # @param climate_zone [<Type>] climate zone name
@@ -1947,7 +1947,7 @@ class AppendixGPRMTests < Minitest::Test
 
   # Check if baseline system type is a single-zone system with variable-air-volume fan
   #
-  # @param model [OpenStudio::model::Model] OpenStudio model object
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
   def check_cmp_dtctr_system_type(model)
     zone_load_s = 0
     # Individual zone load check
@@ -2572,7 +2572,7 @@ class AppendixGPRMTests < Minitest::Test
   # Placeholder method to indicate that we want to check unmet
   # load hours
   #
-  # @param model [OpenStudio::model::Model] OpenStudio model object
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @param arguments [Array] Not used
   def unmet_load_hours(model, arguments)
     return model
@@ -2580,7 +2580,7 @@ class AppendixGPRMTests < Minitest::Test
 
   # Multiply the zone outdoor air flow rate per area
   #
-  # @param model [OpenStudio::model::Model] OpenStudio model object
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @param arguments [Array] Multiplier
   def mult_oa_per_area(model, arguments)
     # Get multiplier
@@ -2596,7 +2596,7 @@ class AppendixGPRMTests < Minitest::Test
 
   # Add a AirLoopHVACDedicatedOutdoorAirSystem in the model
   #
-  # @param model [OpenStudio::model::Model] OpenStudio model object
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @param arguments [Array] Not used
   def add_ahu_doas(model, arguments)
     # Create new objects
@@ -2618,7 +2618,7 @@ class AppendixGPRMTests < Minitest::Test
   # Change cooling thermostat to 24C
   # This is used to converted a heated only zone to heated and cooled
   #
-  # @param model [OpenStudio::model::Model] OpenStudio model object
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @param arguments [Array] Not used
   def change_clg_therm(model, arguments)
     std = Standard.build("90.1-2019")
@@ -2712,7 +2712,7 @@ class AppendixGPRMTests < Minitest::Test
 
   # Change (medium) office space types to computer room
   #
-  # @param model [OpenStudio::model::Model] OpenStudio model object
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @param arguments [Array] Not used
   def convert_spaces_to_cmp_rms(model, arguments)
     convert_spaces_from_to(model, ['OfficeWholeBuilding - Md Office', 'computer room'])
@@ -2753,7 +2753,7 @@ class AppendixGPRMTests < Minitest::Test
   # Change fenestration area in a model
   # This function will remove the fenestration in all orientations and add new windows by defined WWR
   #
-  # @param [OpenStudio::Model::Model] model
+  # @param model [OpenStudio::Model::Model] model
   # @param [Float] window to wall ratio
   def change_wwr_model(model, arguments)
     target_wwr_north = arguments[0]
@@ -2831,7 +2831,7 @@ class AppendixGPRMTests < Minitest::Test
   end
 
   # Remove transformer from model
-  # @param model [OpenStudio::model::Model] OpenStudio model object
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @param arguments [Array] List of arguments
   def remove_transformer(model, arguments)
     model.getElectricLoadCenterTransformers.each(&:remove)
@@ -2839,7 +2839,7 @@ class AppendixGPRMTests < Minitest::Test
   end
 
   # Increase the size of the skylights in a model
-  # @param model [OpenStudio::model::Model] OpenStudio model object
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @param arguments [Array] List of arguments
   def increase_skylight_size(model, arguments)
     mult = arguments[0]
@@ -2869,9 +2869,9 @@ class AppendixGPRMTests < Minitest::Test
 
   # Applies a multipler to increase the design cooling load of datacenters
   #
-  # @param model [OpenStudio::model::Model] OpenStudio model object
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @param epd_multiplier [Array] EPD multiplier
-  # @returns [OpenStudio::model::Model]
+  # @returns [OpenStudio::Model::Model]
   def increase_computer_rooms_epd(model, epd_multiplier)
     model.getThermalZones.each do |zone|
       zone.spaces.each do |space|
@@ -2887,9 +2887,9 @@ class AppendixGPRMTests < Minitest::Test
 
   # Change equipment power density of a specific zone in a model to a specific value
   # @author Doug Maddox, PNNL
-  # @param model [OpenStudio::model::Model] OpenStudio model object
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @param params [Array] zone_name, new equipment power density
-  # @return [OpenStudio::model::Model]
+  # @return [OpenStudio::Model::Model]
   def change_zone_epd(model, params)
     zone_name = params[0]
     new_epd = params[1]
@@ -2921,9 +2921,9 @@ class AppendixGPRMTests < Minitest::Test
   end
 
   # Remove cooling coil from air loops in model
-  # @param model [OpenStudio::model::Model] OpenStudio model object
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @param params [Array] zone_name, new equipment power density
-  # @return [OpenStudio::model::Model]
+  # @return [OpenStudio::Model::Model]
   def remove_cooling_coils(model, params)
     model.getAirLoopHVACs.each do |air_loop|
       air_loop.supplyComponents.each do |supply_comp|
@@ -2946,9 +2946,9 @@ class AppendixGPRMTests < Minitest::Test
   end
 
   # Add return and relief fans to air loops
-  # @param model [OpenStudio::model::Model] OpenStudio model object
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @param params [Array] zone_name, new equipment power density
-  # @return [OpenStudio::model::Model]
+  # @return [OpenStudio::Model::Model]
   def return_relief_fan(model, params)
     std = Standard.build('90.1-PRM-2019')
     model.getAirLoopHVACs.each do |air_loop|
@@ -2989,9 +2989,9 @@ class AppendixGPRMTests < Minitest::Test
   # Add people object to a specific zone with a long occupancy schedule
   # for testing 40 EFLH check of zones that differ for multizone systems
   # @author Doug Maddox, PNNL
-  # @param model [OpenStudio::model::Model] OpenStudio model object
+  # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @param params [Array] zone_name, new equipment power density
-  # @return [OpenStudio::model::Model]
+  # @return [OpenStudio::Model::Model]
   def change_to_long_occ_sch(model, params)
     zone_name = params[0]
     # Create new long schedule for occupancy for each space in the zone

--- a/test/helpers/compare_models_helper.rb
+++ b/test/helpers/compare_models_helper.rb
@@ -6,7 +6,7 @@
 # @param model_true [OpenStudio::Model::Model] the "true" model
 # @param model_compare [OpenStudio::Model::Model] the model to be
 # compared to the "true" model
-# @param look_for_renamed_objects [Bool] if true, objects that have no match based
+# @param look_for_renamed_objects [Boolean] if true, objects that have no match based
 # on name alone will be compared with all objects of the same type on a field-by-field basis.
 # This finds objects that have been renamed but are otherwise
 # identical between models, but significantly slows down the comparison.
@@ -331,7 +331,7 @@ end
 # This method is recursive because after it finds that some objects have been renamed, it needs to re-compare
 # all remaining unmatched objects because they might have been unmatched due to having fields
 # referencing renamed object names be different.
-# @param look_for_renamed_objects [Bool] if true, objects that have no match based
+# @param look_for_renamed_objects [Boolean] if true, objects that have no match based
 # on name alone will be compared with all objects of the same type in the model_compare
 # on a field-by-field basis.  This finds objects that have been renamed but are otherwise
 # identical between models, but has a significant speed penalty.

--- a/test/necb/unit_tests/tests/test_necb_constructions_fdwr.rb
+++ b/test/necb/unit_tests/tests/test_necb_constructions_fdwr.rb
@@ -108,7 +108,7 @@ class NECB_Constructions_FDWR_Tests < Minitest::Test
   # test will set up  
   # for all HDDs 
   # NECB2011 8.4.4.1
-  # @return [Bool] true if successful. 
+  # @return [Boolean] true if successful. 
   def test_necb_hdd_envelope_rules()
 
 

--- a/test/necb/unit_tests/tests/test_necb_default_spacetypes.rb
+++ b/test/necb/unit_tests/tests/test_necb_default_spacetypes.rb
@@ -20,7 +20,7 @@ class NECB_Default_SpaceTypes_Tests < Minitest::Test
   end
   # Tests to ensure that the NECB default schedules are being defined correctly.
   # This is not for compliance, but for archetype development. 
-  # @return [Bool] true if successful. 
+  # @return [Boolean] true if successful. 
   def test_schedule_type_defaults()
     #Create new model for testing. 
     @model = OpenStudio::Model::Model.new

--- a/test/necb/unit_tests/tests/test_necb_schedules.rb
+++ b/test/necb/unit_tests/tests/test_necb_schedules.rb
@@ -20,7 +20,7 @@ class NECB_Schedules_Tests < Minitest::Test
     
   # Tests to ensure that the NECB default schedules are being defined correctly.
   # This is not for compliance, but for archetype development. 
-  # @return [Bool] true if successful. 
+  # @return [Boolean] true if successful. 
   def test_schedule_type_defaults()
     #Create new model for testing. 
     @model = OpenStudio::Model::Model.new

--- a/test/necb/unit_tests/tests/test_necb_shw.rb
+++ b/test/necb/unit_tests/tests/test_necb_shw.rb
@@ -23,7 +23,7 @@ class NECB_SHW_tests < Minitest::Test
     @top_output_folder = "#{@test_folder}/output/"
   end
 
-  # @return [Bool] true if successful. 
+  # @return [Boolean] true if successful. 
   def test_shw_test()
     output_array = []
     climate_zone = 'none'

--- a/test/necb/unit_tests/tests/test_necb_total_and_tz_ceiling_centroid.rb
+++ b/test/necb/unit_tests/tests/test_necb_total_and_tz_ceiling_centroid.rb
@@ -20,7 +20,7 @@ class NECB_Ceiling_Centroid_Test < Minitest::Test
     @top_output_folder = "#{@test_folder}/output/"
   end
 
-  # @return [Bool] true if successful.
+  # @return [Boolean] true if successful.
   def test_ceiling_centroid()
     output_array = []
     climate_zone = 'none'

--- a/test/necb/unit_tests/tests/test_necb_weather.rb
+++ b/test/necb/unit_tests/tests/test_necb_weather.rb
@@ -19,7 +19,7 @@ class NECB_Weather_Tests < Minitest::Test
   # This is not for compliance, but for archetype development. This will compare
   # to values in an excel/csv file stored in the weather folder.
   # NECB2011 8.4.2.3
-  # @return [Bool] true if successful.
+  # @return [Boolean] true if successful.
   def test_weather_reading()
     #todo Must deal with ground temperatures..They are currently not correct for NECB.
     test_results = File.join(@test_results_folder,'weather_test_results.json')


### PR DESCRIPTION
- resolve documentation errors
- capitalize and standardize types:
  - change [Bool] to [Boolean]
  - change [string] to [String]

does not add missing param, return fields where missing