### PR TITLE
removing PERFORM_STANDARDS variable

### DIFF
--- a/test/necb/unit_tests/tests/test_btap_geometry_wizards.rb
+++ b/test/necb/unit_tests/tests/test_btap_geometry_wizards.rb
@@ -5,9 +5,6 @@ include(NecbHelper)
 #Test Geometry Wizards
 class TestBTAPGeometryWizards < Minitest::Test
 
-  # Set to true to run the standards in the test.
-  #PERFORM_STANDARDS = true
-
   #def setup()
   #  define_folders(__dir__)
   #  define_std_ranges

--- a/test/necb/unit_tests/tests/test_daylighting_sensor_control.rb
+++ b/test/necb/unit_tests/tests/test_daylighting_sensor_control.rb
@@ -8,9 +8,6 @@ include(NecbHelper)
 
 class NECB_Daylighting_Sensor_Control_Tests < Minitest::Test
 
-  # Set to true to run the standards in the test.
-  PERFORM_STANDARDS = true
-
   def setup()
     define_folders(__dir__)
     define_std_ranges

--- a/test/necb/unit_tests/tests/test_ecm_hs14_cgshp_fancoils.rb
+++ b/test/necb/unit_tests/tests/test_ecm_hs14_cgshp_fancoils.rb
@@ -5,9 +5,6 @@ include(NecbHelper)
 
 class ECM_HS14_CGSHP_FanCoils_Tests < Minitest::Test
 
-  # Set to true to run the standards in the test.
-  PERFORM_STANDARDS = true
-
   def setup()
     define_folders(__dir__)
     define_std_ranges

--- a/test/necb/unit_tests/tests/test_ecm_modify_unitary_rules.rb
+++ b/test/necb/unit_tests/tests/test_ecm_modify_unitary_rules.rb
@@ -6,9 +6,6 @@ include(NecbHelper)
 
 class NECB_HVAC_Unitary_Tests < Minitest::Test
 
-  # set to true to run the standards in the test.
-  PERFORM_STANDARDS = true
-
   def setup()
     define_folders(__dir__)
     define_std_ranges
@@ -117,7 +114,7 @@ class NECB_HVAC_Unitary_Tests < Minitest::Test
               # Run sizing.
               sql_db_vars_map = {}
               ecm.modify_unitary_cop(model: model, unitary_cop: "#{unitary_ecm}", sizing_done: false, sql_db_vars_map: sql_db_vars_map)
-              run_sizing(model: model, template: template, test_name: name, sql_db_vars_map: sql_db_vars_map, save_model_versions: save_intermediate_models) if PERFORM_STANDARDS
+              run_sizing(model: model, template: template, test_name: name, sql_db_vars_map: sql_db_vars_map, save_model_versions: save_intermediate_models)
               ecm.modify_unitary_cop(model: model, unitary_cop: "#{unitary_ecm}", sizing_done: true, sql_db_vars_map: sql_db_vars_map)
 
               case speed

--- a/test/necb/unit_tests/tests/test_necb_airloop_sizing_parameters.rb
+++ b/test/necb/unit_tests/tests/test_necb_airloop_sizing_parameters.rb
@@ -6,9 +6,6 @@ include(NecbHelper)
 
 class NECB_Airloop_Sizing_Parameters_Tests < Minitest::Test
 
-  # Set to true to run the standards in the test.
-  PERFORM_STANDARDS = true
-
   def setup()
     define_folders(__dir__)
     define_std_ranges
@@ -53,7 +50,7 @@ begin
       hw_loop: hw_loop)
     
     # Run sizing.
-    run_sizing(model: model, template: template, test_name: name, save_model_versions: save_intermediate_models) if PERFORM_STANDARDS
+    run_sizing(model: model, template: template, test_name: name, save_model_versions: save_intermediate_models)
 
     airloops = model.getAirLoopHVACs
     airloops.each do |iloop|
@@ -147,7 +144,7 @@ begin
       new_auto_zoner: false)
 
     # Run sizing.
-    run_sizing(model: model, template: template, test_name: name, save_model_versions: save_intermediate_models) if PERFORM_STANDARDS
+    run_sizing(model: model, template: template, test_name: name, save_model_versions: save_intermediate_models)
 
     airloops = model.getAirLoopHVACs
     airloops.each do |iloop|

--- a/test/necb/unit_tests/tests/test_necb_auto_zone_test.rb
+++ b/test/necb/unit_tests/tests/test_necb_auto_zone_test.rb
@@ -6,9 +6,6 @@ include(NecbHelper)
 
 class NECB_Autozone_Tests < Minitest::Test
 
-  # Set to true to run the standards in the test.
-  PERFORM_STANDARDS = true
-
   def setup()
     define_folders(__dir__)
     define_std_ranges

--- a/test/necb/unit_tests/tests/test_necb_boiler_rules.rb
+++ b/test/necb/unit_tests/tests/test_necb_boiler_rules.rb
@@ -5,9 +5,6 @@ include(NecbHelper)
 
 class NECB_HVAC_Boiler_Tests < Minitest::Test
 
-  # Set to true to run the standards in the test.
-  PERFORM_STANDARDS = true
-
   def setup()
     define_folders(__dir__)
     define_std_ranges
@@ -109,7 +106,7 @@ class NECB_HVAC_Boiler_Tests < Minitest::Test
           model.getBoilerHotWaters.each {|iboiler| iboiler.setNominalCapacity(boiler_cap)}
 
           # Run sizing.
-          run_sizing(model: model, template: template, test_name: name, save_model_versions: save_intermediate_models) if PERFORM_STANDARDS
+          run_sizing(model: model, template: template, test_name: name, save_model_versions: save_intermediate_models)
           
           # Recover the thermal efficiency set in the measure for checking below.
           model.getBoilerHotWaters.each do |iboiler|
@@ -204,7 +201,7 @@ class NECB_HVAC_Boiler_Tests < Minitest::Test
       model.getBoilerHotWaters.each {|iboiler| iboiler.setNominalCapacity(boiler_cap)}
 
       # Run sizing.
-      run_sizing(model: model, template: template, test_name: name, save_model_versions: save_intermediate_models) if PERFORM_STANDARDS
+      run_sizing(model: model, template: template, test_name: name, save_model_versions: save_intermediate_models)
 
       boilers = model.getBoilerHotWaters
       
@@ -290,7 +287,7 @@ class NECB_HVAC_Boiler_Tests < Minitest::Test
                                                    hw_loop: hw_loop)
 
     # Run sizing.
-    run_sizing(model: model, template: template, test_name: name, save_model_versions: save_intermediate_models) if PERFORM_STANDARDS
+    run_sizing(model: model, template: template, test_name: name, save_model_versions: save_intermediate_models)
 
     boilers = model.getBoilerHotWaters
     boiler_curve = boilers[0].normalizedBoilerEfficiencyCurve.get.to_CurveCubic.get
@@ -351,7 +348,7 @@ class NECB_HVAC_Boiler_Tests < Minitest::Test
         model.getBoilerHotWaters.each {|iboiler| iboiler.setNominalCapacity(boiler_cap)}
 
         # Run sizing.
-        run_sizing(model: model, template: template, test_name: name, save_model_versions: save_intermediate_models) if PERFORM_STANDARDS
+        run_sizing(model: model, template: template, test_name: name, save_model_versions: save_intermediate_models)
 
         # Customize the efficiency.
         standard_ecms.modify_boiler_efficiency(model: model, boiler_eff: cust_eff_test)

--- a/test/necb/unit_tests/tests/test_necb_chiller_rules.rb
+++ b/test/necb/unit_tests/tests/test_necb_chiller_rules.rb
@@ -5,9 +5,6 @@ include(NecbHelper)
 
 class NECB_HVAC_Chiller_Test < Minitest::Test
 
-  # Set to true to run the standards in the test.
-  PERFORM_STANDARDS = true
-
   def setup()
     define_folders(__dir__)
     define_std_ranges
@@ -105,7 +102,7 @@ class NECB_HVAC_Chiller_Test < Minitest::Test
           model.getChillerElectricEIRs.each {|ichiller| ichiller.setReferenceCapacity(chiller_cap)}
 
           # Run sizing.
-          run_sizing(model: model,  template: template, test_name: name,save_model_versions: save_intermediate_models) if PERFORM_STANDARDS
+          run_sizing(model: model,  template: template, test_name: name,save_model_versions: save_intermediate_models)
           
           model.getChillerElectricEIRs.each do |ichiller|
             if ichiller.referenceCapacity.to_f > 1
@@ -181,7 +178,7 @@ class NECB_HVAC_Chiller_Test < Minitest::Test
         model.getChillerElectricEIRs.each {|ichiller| ichiller.setReferenceCapacity(chiller_cap)}
 
         # Run the standards.
-        run_sizing(model: model, template: template, test_name: name, save_model_versions: save_intermediate_models) if PERFORM_STANDARDS
+        run_sizing(model: model, template: template, test_name: name, save_model_versions: save_intermediate_models)
         
         # Check that there are two chillers in the model.
         chillers = model.getChillerElectricEIRs
@@ -275,7 +272,7 @@ class NECB_HVAC_Chiller_Test < Minitest::Test
                                        hw_loop: hw_loop)
       
       # Run sizing.
-      run_sizing(model: model, template: template, test_name: name, save_model_versions: save_intermediate_models) if PERFORM_STANDARDS
+      run_sizing(model: model, template: template, test_name: name, save_model_versions: save_intermediate_models)
 
       chillers = model.getChillerElectricEIRs
       chiller_cap_ft_curve = chillers[0].coolingCapacityFunctionOfTemperature.to_CurveBiquadratic.get

--- a/test/necb/unit_tests/tests/test_necb_constructions_fdwr.rb
+++ b/test/necb/unit_tests/tests/test_necb_constructions_fdwr.rb
@@ -9,9 +9,6 @@ include(NecbHelper)
 ## to specifically test aspects of the NECB2011 code that are HDD dependant. 
 class NECB_Constructions_FDWR_Tests < Minitest::Test
 
-  # Set to true to run the standards in the test.
-  PERFORM_STANDARDS = true
-
   def setup()
     define_folders(__dir__)
     define_std_ranges

--- a/test/necb/unit_tests/tests/test_necb_coolingtower_rules.rb
+++ b/test/necb/unit_tests/tests/test_necb_coolingtower_rules.rb
@@ -6,9 +6,6 @@ include(NecbHelper)
 
 class NECB_HVAC_Cooling_Tower_Tests < Minitest::Test
 
-  # Set to true to run the standards in the test.
-  PERFORM_STANDARDS = true
-
   def setup()
     define_folders(__dir__)
     define_std_ranges
@@ -64,7 +61,7 @@ class NECB_HVAC_Cooling_Tower_Tests < Minitest::Test
         model.getChillerElectricEIRs.each { |ichiller| ichiller.setReferenceCapacity(chiller_cap) }
 
         # Run the measure.
-        run_sizing(model: model, template: template, test_name: name, save_model_versions: save_intermediate_models) if PERFORM_STANDARDS
+        run_sizing(model: model, template: template, test_name: name, save_model_versions: save_intermediate_models)
 
         necb2011_refCOP = 5.0
         model.getChillerElectricEIRs.each do |ichiller|
@@ -154,7 +151,7 @@ class NECB_HVAC_Cooling_Tower_Tests < Minitest::Test
       model.getChillerElectricEIRs.each { |ichiller| ichiller.setReferenceCapacity(chiller_cap) }
 
       # Run sizing.
-      run_sizing(model: model, template: template, test_name: name, save_model_versions: save_intermediate_models) if PERFORM_STANDARDS
+      run_sizing(model: model, template: template, test_name: name, save_model_versions: save_intermediate_models)
 
       refCOP = 5.0
       model.getChillerElectricEIRs.each do |ichiller|

--- a/test/necb/unit_tests/tests/test_necb_default_spacetypes.rb
+++ b/test/necb/unit_tests/tests/test_necb_default_spacetypes.rb
@@ -6,9 +6,6 @@ include(NecbHelper)
 # to specifically test aspects of the NECB2011 code that are Spacetype dependant. 
 class NECB_Default_SpaceTypes_Tests < Minitest::Test
 
-  # Set to true to run the standards in the test.
-  PERFORM_STANDARDS = true
-
   def setup()
     define_folders(__dir__)
     define_std_ranges

--- a/test/necb/unit_tests/tests/test_necb_fan_rules.rb
+++ b/test/necb/unit_tests/tests/test_necb_fan_rules.rb
@@ -6,9 +6,6 @@ include(NecbHelper)
 
 class NECB_HVAC_Fan_Rules_Tests < Minitest::Test
 
-  # Set to true to run the standards in the test.
-  PERFORM_STANDARDS = true
-
   def setup()
     define_folders(__dir__)
     define_std_ranges
@@ -73,7 +70,7 @@ class NECB_HVAC_Fan_Rules_Tests < Minitest::Test
       end
 
       # Run sizing.
-      run_sizing(model: model, template: template, test_name: name, save_model_versions: save_intermediate_models) if PERFORM_STANDARDS
+      run_sizing(model: model, template: template, test_name: name, save_model_versions: save_intermediate_models)
 
       vavfans = model.getFanVariableVolumes
       vavfans.each do |ifan|
@@ -162,7 +159,7 @@ class NECB_HVAC_Fan_Rules_Tests < Minitest::Test
                                                             hw_loop: hw_loop)
     
     # Run sizing.
-    run_sizing(model: model, template: template, test_name: name, save_model_versions: save_intermediate_models) if PERFORM_STANDARDS
+    run_sizing(model: model, template: template, test_name: name, save_model_versions: save_intermediate_models)
 
     fans = model.getFanConstantVolumes
     tol = 1.0e-3

--- a/test/necb/unit_tests/tests/test_necb_furnace_rules.rb
+++ b/test/necb/unit_tests/tests/test_necb_furnace_rules.rb
@@ -5,9 +5,6 @@ include(NecbHelper)
 
 class NECB_HVAC_Furnace_Tests < Minitest::Test
 
-  # Set to true to run the standards in the test.
-  PERFORM_STANDARDS = true
-
   def setup()
     define_folders(__dir__)
     define_std_ranges
@@ -131,7 +128,7 @@ class NECB_HVAC_Furnace_Tests < Minitest::Test
             end
 
             # Run sizing.
-            run_sizing(model: model, template: template, test_name: name, save_model_versions: save_intermediate_models) if PERFORM_STANDARDS
+            run_sizing(model: model, template: template, test_name: name, save_model_versions: save_intermediate_models)
           
             if stage_type == 'single'
               if heating_coil_type == 'NaturalGas'
@@ -240,7 +237,7 @@ class NECB_HVAC_Furnace_Tests < Minitest::Test
       end
       
       # Run sizing.
-      run_sizing(model: model, template: template, test_name: name, save_model_versions: save_intermediate_models) if PERFORM_STANDARDS
+      run_sizing(model: model, template: template, test_name: name, save_model_versions: save_intermediate_models)
 
       if stage_type == 'single'
         furnace_curve = model.getCoilHeatingGass[0].partLoadFractionCorrelationCurve.get.to_CurveCubic.get
@@ -306,7 +303,7 @@ class NECB_HVAC_Furnace_Tests < Minitest::Test
       model.getCoilHeatingGasMultiStages.each { |coil| coil.stages.last.setNominalCapacity(cap) }
 
       # Run sizing.
-      run_sizing(model: model, template: template, test_name: name, save_model_versions: save_intermediate_models) if PERFORM_STANDARDS
+      run_sizing(model: model, template: template, test_name: name, save_model_versions: save_intermediate_models)
           
       actual_num_stages = model.getCoilHeatingGasMultiStages[0].stages.size
       assert(actual_num_stages == num_stages_needed[cap], "The actual number of stages for capacity #{cap} W is not #{num_stages_needed[cap]}")

--- a/test/necb/unit_tests/tests/test_necb_heatpump_rules.rb
+++ b/test/necb/unit_tests/tests/test_necb_heatpump_rules.rb
@@ -5,9 +5,6 @@ include(NecbHelper)
 
 class NECB_HVAC_Heat_Pump_Tests < Minitest::Test
 
-  # Set to true to run the standards in the test.
-  PERFORM_STANDARDS = true
-
   def setup()
     define_folders(__dir__)
     define_std_ranges
@@ -84,7 +81,7 @@ class NECB_HVAC_Heat_Pump_Tests < Minitest::Test
         end
 
         # Run sizing.
-        run_sizing(model: model, template: template, test_name: name, save_model_versions: save_intermediate_models) if PERFORM_STANDARDS
+        run_sizing(model: model, template: template, test_name: name, save_model_versions: save_intermediate_models)
         actual_heatpump_cop << model.getCoilHeatingDXSingleSpeeds[0].ratedCOP.to_f
       end
 
@@ -155,7 +152,7 @@ class NECB_HVAC_Heat_Pump_Tests < Minitest::Test
                                                                                                 new_auto_zoner: false)
     
     # Run sizing.
-    run_sizing(model: model, template: template, test_name: name, save_model_versions: save_intermediate_models) if PERFORM_STANDARDS
+    run_sizing(model: model, template: template, test_name: name, save_model_versions: save_intermediate_models)
 
     dx_units = model.getCoilHeatingDXSingleSpeeds
     heatpump_cap_ft_curve = dx_units[0].totalHeatingCapacityFunctionofTemperatureCurve.to_CurveCubic.get

--- a/test/necb/unit_tests/tests/test_necb_hrv_rules.rb
+++ b/test/necb/unit_tests/tests/test_necb_hrv_rules.rb
@@ -6,9 +6,6 @@ include(NecbHelper)
 
 class NECB_HVAC_HRV_Tests < Minitest::Test
 
-  # Set to true to run the standards in the test.
-  PERFORM_STANDARDS = true
-
   def setup()
     define_folders(__dir__)
     define_std_ranges
@@ -61,7 +58,7 @@ class NECB_HVAC_HRV_Tests < Minitest::Test
     end
 
     # Run sizing.
-    run_sizing(model: model, template: template, test_name: name, save_model_versions: save_intermediate_models) if PERFORM_STANDARDS
+    run_sizing(model: model, template: template, test_name: name, save_model_versions: save_intermediate_models)
 
     systems = model.getAirLoopHVACs
     tol = 1.0e-5

--- a/test/necb/unit_tests/tests/test_necb_loop_rules.rb
+++ b/test/necb/unit_tests/tests/test_necb_loop_rules.rb
@@ -6,9 +6,6 @@ include(NecbHelper)
 
 class NECB_HVAC_Loop_Rules_Tests < Minitest::Test
 
-  # Set to true to run the standards in the test.
-  PERFORM_STANDARDS = true
-
   def setup()
     define_folders(__dir__)
     define_std_ranges
@@ -51,7 +48,7 @@ class NECB_HVAC_Loop_Rules_Tests < Minitest::Test
                                                                         hw_loop: hw_loop)
     
     # Run sizing.
-    run_sizing(model: model, template: template, test_name: name, save_model_versions: save_intermediate_models) if PERFORM_STANDARDS
+    run_sizing(model: model, template: template, test_name: name, save_model_versions: save_intermediate_models)
 
     tol = 1.0e-3
     loops = model.getPlantLoops
@@ -122,7 +119,7 @@ class NECB_HVAC_Loop_Rules_Tests < Minitest::Test
                                      hw_loop: hw_loop)
     
     # Run sizing.
-    run_sizing(model: model, template: template, test_name: name, save_model_versions: save_intermediate_models) if PERFORM_STANDARDS
+    run_sizing(model: model, template: template, test_name: name, save_model_versions: save_intermediate_models)
 
     loops = model.getPlantLoops
     tol = 1.0e-3
@@ -196,7 +193,7 @@ class NECB_HVAC_Loop_Rules_Tests < Minitest::Test
                                      hw_loop: hw_loop)
 
     # Run sizing.
-    run_sizing(model: model, template: template, test_name: name, save_model_versions: save_intermediate_models) if PERFORM_STANDARDS
+    run_sizing(model: model, template: template, test_name: name, save_model_versions: save_intermediate_models)
 
     loops = model.getPlantLoops
     tol = 1.0e-3

--- a/test/necb/unit_tests/tests/test_necb_pumppower_rules.rb
+++ b/test/necb/unit_tests/tests/test_necb_pumppower_rules.rb
@@ -6,9 +6,6 @@ include(NecbHelper)
 
 class NECB_2015PumpPower_Test < Minitest::Test
 
-  # Set to true to run the standards in the test.
-  PERFORM_STANDARDS = true
-
   def setup()
     define_folders(__dir__)
     define_std_ranges
@@ -65,7 +62,7 @@ class NECB_2015PumpPower_Test < Minitest::Test
       model.getChillerElectricEIRs.each { |ichiller| ichiller.setReferenceCapacity(chiller_cap) }
 
       # Run sizing.
-      run_sizing(model: model, template: template, test_name: name, save_model_versions: save_intermediate_models) if PERFORM_STANDARDS
+      run_sizing(model: model, template: template, test_name: name, save_model_versions: save_intermediate_models)
 
       # Apply the NECB 2015 pump power rules to the model.
       standard.apply_maximum_loop_pump_power(model)

--- a/test/necb/unit_tests/tests/test_necb_reference_heatpump_rules.rb
+++ b/test/necb/unit_tests/tests/test_necb_reference_heatpump_rules.rb
@@ -5,9 +5,6 @@ include(NecbHelper)
 
 class NECB_HVAC_Ref_Heat_Pump_Tests < Minitest::Test
 
-  # Set to true to run the standards in the test.
-  PERFORM_STANDARDS = true
-
   def setup()
     define_folders(__dir__)
     define_std_ranges
@@ -98,7 +95,7 @@ class NECB_HVAC_Ref_Heat_Pump_Tests < Minitest::Test
           end
 
           # Run sizing.
-          run_sizing(model: model, template: template, test_name: name, necb_ref_hp: true) if PERFORM_STANDARDS
+          run_sizing(model: model, template: template, test_name: name, necb_ref_hp: true)
 
           # Non-sys6 uses AirLoopHVACUnitaryHeatPumpAirToAirs
           unless sys_number == 'sys6'
@@ -274,7 +271,7 @@ class NECB_HVAC_Ref_Heat_Pump_Tests < Minitest::Test
           end
           
           # Run sizing.
-          run_sizing(model: model, template: template, test_name: name, necb_ref_hp: true) if PERFORM_STANDARDS
+          run_sizing(model: model, template: template, test_name: name, necb_ref_hp: true)
 
           # non-sys6 uses AirLoopHVACUnitaryHeatPumpAirToAirs
           unless sys_number == 'sys6'
@@ -375,7 +372,7 @@ class NECB_HVAC_Ref_Heat_Pump_Tests < Minitest::Test
           end
           
           # Run sizing.
-          run_sizing(model: model, template: template, test_name: name, necb_ref_hp: true) if PERFORM_STANDARDS
+          run_sizing(model: model, template: template, test_name: name, necb_ref_hp: true)
 
           #get expected cooling values
           cooling_curve_expected_result_file = File.join(@expected_results_folder, "necb2011_reference_heatpump_cooling_curves_expected_results.csv")
@@ -806,7 +803,7 @@ class NECB_HVAC_Ref_Heat_Pump_Tests < Minitest::Test
         end
         
         # Run sizing.
-        run_sizing(model: model, template: template, test_name: name, necb_ref_hp: true) if PERFORM_STANDARDS
+        run_sizing(model: model, template: template, test_name: name, necb_ref_hp: true)
 
         no_over_sizing = true
         model.getThermalZones.each do |zone|
@@ -892,7 +889,7 @@ def test_ref_heatpump_heating_low_temp
         end
 
         # Run sizing.
-        run_sizing(model: model, template: template, test_name: name, necb_ref_hp: true) if PERFORM_STANDARDS
+        run_sizing(model: model, template: template, test_name: name, necb_ref_hp: true)
 
         # non-sys6 uses AirLoopHVACUnitaryHeatPumpAirToAirs
         unless sys_number == 'sys6'

--- a/test/necb/unit_tests/tests/test_necb_schedules.rb
+++ b/test/necb/unit_tests/tests/test_necb_schedules.rb
@@ -6,9 +6,6 @@ include(NecbHelper)
 # to specifically test aspects of the NECB2011 code that are Spacetype dependant. 
 class NECB_Schedules_Tests < Minitest::Test
 
-  # Set to true to run the standards in the test.
-  PERFORM_STANDARDS = true
-
   def setup()
     define_folders(__dir__)
     define_std_ranges

--- a/test/necb/unit_tests/tests/test_necb_shw.rb
+++ b/test/necb/unit_tests/tests/test_necb_shw.rb
@@ -8,9 +8,6 @@ include(NecbHelper)
 # outpatient.osm file).
 class NECB_SHW_tests < Minitest::Test
 
-  # Set to true to run the standards in the test.
-  PERFORM_STANDARDS = true
-
   def setup()
     define_folders(__dir__)
     define_std_ranges

--- a/test/necb/unit_tests/tests/test_necb_space_types_default_constructions_set.rb
+++ b/test/necb/unit_tests/tests/test_necb_space_types_default_constructions_set.rb
@@ -6,9 +6,6 @@ include(NecbHelper)
 # to specifically test aspects of the NECB2011 code that are Spacetype dependant.
 class NECB_SpaceTypes_DefaultConstructions_Test < Minitest::Test
 
-  # Set to true to run the standards in the test.
-  PERFORM_STANDARDS = true
-
   def setup()
     define_folders(__dir__)
     define_std_ranges

--- a/test/necb/unit_tests/tests/test_necb_total_and_tz_ceiling_centroid.rb
+++ b/test/necb/unit_tests/tests/test_necb_total_and_tz_ceiling_centroid.rb
@@ -8,9 +8,6 @@ include(NecbHelper)
 # a modified version of the initial HighriseApartement.osm geometry file.
 class NECB_Ceiling_Centroid_Test < Minitest::Test
 
-  # Set to true to run the standards in the test.
-  PERFORM_STANDARDS = true
-
   def setup()
     define_folders(__dir__)
     define_std_ranges

--- a/test/necb/unit_tests/tests/test_necb_unitary_rules.rb
+++ b/test/necb/unit_tests/tests/test_necb_unitary_rules.rb
@@ -5,9 +5,6 @@ include(NecbHelper)
 
 class NECB_HVAC_Unitary_Tests < Minitest::Test
 
-  # Set to true to run the standards in the test.
-  PERFORM_STANDARDS = true
-
   def setup()
     define_folders(__dir__)
     define_std_ranges
@@ -118,7 +115,7 @@ class NECB_HVAC_Unitary_Tests < Minitest::Test
             BTAP::FileIO.save_osm(model, "#{output_folder}/#{name}.hvacrb")
 
             # Run the measure.
-            run_sizing(model: model, test_name: name, template: template, save_model_versions: save_intermediate_models) if PERFORM_STANDARDS
+            run_sizing(model: model, template: template, test_name: name, save_model_versions: save_intermediate_models)
 
             case speed
             when 'single'
@@ -203,7 +200,7 @@ class NECB_HVAC_Unitary_Tests < Minitest::Test
                                      hw_loop: hw_loop)
    
     # Run sizing.
-    run_sizing(model: model, test_name: name, template: template, save_model_versions: save_intermediate_models) if PERFORM_STANDARDS
+    run_sizing(model: model, template: template, test_name: name, save_model_versions: save_intermediate_models)
 
     dx_units = model.getCoilCoolingDXSingleSpeeds
     unitary_cap_ft_curve = dx_units[0].totalCoolingCapacityFunctionOfTemperatureCurve.to_CurveBiquadratic.get

--- a/test/necb/unit_tests/tests/test_necb_waterheater_rules.rb
+++ b/test/necb/unit_tests/tests/test_necb_waterheater_rules.rb
@@ -5,9 +5,6 @@ include(NecbHelper)
 
 class NECB_SWH_Additional_Tests < Minitest::Test
 
-  # Set to true to run the standards in the test.
-  PERFORM_STANDARDS = true
-
   def setup()
     define_folders(__dir__)
     define_std_ranges
@@ -74,7 +71,7 @@ class NECB_SWH_Additional_Tests < Minitest::Test
                                                                                                 new_auto_zoner: false)
 
     # Run sizing.
-    run_sizing(model: model, template: template, test_name: name, save_model_versions: save_intermediate_models) if PERFORM_STANDARDS
+    run_sizing(model: model, template: template, test_name: name, save_model_versions: save_intermediate_models)
 
     # Extract standards generated part-load performance curve.
     shw_units = model.getWaterHeaterMixeds
@@ -156,7 +153,7 @@ class NECB_SWH_Additional_Tests < Minitest::Test
         shw_units[0].setTankVolume(ivol/1000.0)
 
         # Run sizing.
-        run_sizing(model: model, template: template, test_name: name, save_model_versions: save_intermediate_models) if PERFORM_STANDARDS
+        run_sizing(model: model, template: template, test_name: name, save_model_versions: save_intermediate_models)
 
         # Get standard water tank efficiency and standby losses.
         actual_shw_tank_eff = shw_units[0].heaterThermalEfficiency.to_f
@@ -260,7 +257,7 @@ class NECB_SWH_Additional_Tests < Minitest::Test
         shw_units[0].setTankVolume(ivol/1000.0)
         
         # Run sizing.
-        run_sizing(model: model, template: template, test_name: name, save_model_versions: save_intermediate_models) if PERFORM_STANDARDS
+        run_sizing(model: model, template: template, test_name: name, save_model_versions: save_intermediate_models)
        
         # Get standard water tank efficiency and standby losses.
         actual_shw_tank_eff = shw_units[0].heaterThermalEfficiency.to_f
@@ -360,7 +357,7 @@ class NECB_SWH_Additional_Tests < Minitest::Test
                                                                                                   new_auto_zoner: false)
 
       # Run sizing.
-      run_sizing(model: model, template: template, test_name: name, save_model_versions: save_intermediate_models) if PERFORM_STANDARDS
+      run_sizing(model: model, template: template, test_name: name, save_model_versions: save_intermediate_models)
 
       # Get standard water tank efficiency and standby losses.
       shw_units = model.getWaterHeaterMixeds

--- a/test/necb/unit_tests/tests/test_necb_weather.rb
+++ b/test/necb/unit_tests/tests/test_necb_weather.rb
@@ -6,9 +6,6 @@ include(NecbHelper)
 # epw/stat files.
 class NECB_Weather_Tests < Minitest::Test
 
-  # Set to true to run the standards in the test.
-  PERFORM_STANDARDS = true
-
   def setup()
     define_folders(__dir__)
     define_std_ranges

--- a/test/necb/unit_tests/tests/test_remove_duplicate_materials_and_constructions.rb
+++ b/test/necb/unit_tests/tests/test_remove_duplicate_materials_and_constructions.rb
@@ -5,9 +5,6 @@ include(NecbHelper)
 
 class NECB_RemoveDuplicateModelObjects_Tests < Minitest::Test
 
-  # Set to true to run the standards in the test.
-  PERFORM_STANDARDS = true
-
   def setup()
     define_folders(__dir__)
     define_std_ranges


### PR DESCRIPTION
Pull request overview
---------------------

Removed unnecessary variable PERFORM_STANDARDS as described in btap_tasks 403.

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [x ] CI status: all green or justified - fails the develop set of tests (but the branch does that anyway).
