### PR TITLE
Fix minor log message in PRM lighting

### DIFF
--- a/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.SpaceType.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.SpaceType.rb
@@ -579,7 +579,7 @@ class ASHRAE901PRM < Standard
   def calculate_lpd_by_space(space_type, space)
     # get interior lighting data
     space_type_properties = interior_lighting_get_prm_data(space_type)
-    OpenStudio.logFree(OpenStudio::Info, 'prm.log', "The lighting properties for space: #{space.name.get} is based on lighting_space_type: #{space_type_properties['lighting_space_type']}, primary_space_type: #{space_type_properties['primary_space_type']}, secondary_space_type: #{space_type_properties['secondary_space_type']}.")
+    OpenStudio.logFree(OpenStudio::Info, 'prm.log', "The lighting properties for space: #{space.name.get} is based on lighting_space_type: #{space_type_properties['lpd_space_type']}, primary_space_type: #{space_type_properties['primary_space_type']}, secondary_space_type: #{space_type_properties['secondary_space_type']}.")
     space_lighting_per_area = 0.0
     # Assign data
     lights_have_info = false


### PR DESCRIPTION
Pull request overview
---------------------

Fixes a minor log message
space_type_properties['lighting_space_type'] should be space_type_properties['lpd_space_type']

 - Fixes #1637 

### Pull Request Author
 - [x] Method changes or additions
 - [ ] All new and existing tests passes

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a code review on GitHub
 - [ ] Check rubocop errors
 - [ ] Check yard doc errors
 - [ ] CI status: all green or justified
