### PR TITLE
enforce PRM model to have a non-leap year

### DIFF
--- a/lib/openstudio-standards/standards/Standards.Model.rb
+++ b/lib/openstudio-standards/standards/Standards.Model.rb
@@ -63,6 +63,16 @@ class Standard
   # @param debug [Boolean] If true, will report out more detailed debugging output
   # @return [Boolean] returns true if successful, false if not
   def model_create_prm_any_baseline_building(user_model, building_type, climate_zone, hvac_building_type = 'All others', wwr_building_type = 'All others', swh_building_type = 'All others', model_deep_copy = false, create_proposed_model = false, custom = nil, sizing_run_dir = Dir.pwd, run_all_orients = false, unmet_load_hours_check = true, debug = false)
+    # enforce the user model to be a non-leap year, defaulting to 2009 if the model year is a leap year
+    if user_model.yearDescription.is_initialized
+      year_description = user_model.yearDescription.get
+      if year_description.isLeapYear
+        OpenStudio.logFree(OpenStudio::Warn, 'prm.log',
+          "The user model year #{year_description.assumedYear} is a leap year. Changing to 2009, a non-leap year, as required by PRM guidelines.")
+        year_description.setCalendarYear(2009)
+      end
+    end
+
     if create_proposed_model
       # Perform a user model design day run only to make sure
       # that the user model is valid, i.e. can run without major

--- a/lib/openstudio-standards/standards/Standards.Model.rb
+++ b/lib/openstudio-standards/standards/Standards.Model.rb
@@ -68,7 +68,7 @@ class Standard
       year_description = user_model.yearDescription.get
       if year_description.isLeapYear
         OpenStudio.logFree(OpenStudio::Warn, 'prm.log',
-          "The user model year #{year_description.assumedYear} is a leap year. Changing to 2009, a non-leap year, as required by PRM guidelines.")
+                           "The user model year #{year_description.assumedYear} is a leap year. Changing to 2009, a non-leap year, as required by PRM guidelines.")
         year_description.setCalendarYear(2009)
       end
     end


### PR DESCRIPTION
Pull request overview
---------------------

Per discussion in #1656, have the PRM method enforce that models have a non-leap year, defaulting to 2009 if the user model is a leap year.

### Pull Request Author

 - [x] Method changes or additions
 - [x] Resolved yard documentation errors for new code (ran `bundle exec rake doc`)
 - [x] Resolved rubocop syntax errors for new code (ran `bundle exec rake rubocop`)
 - [x] All new and existing tests passes

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [x] Perform a code review on GitHub
 - [x] All related changes have been implemented: method additions, changes, tests
 - [x] Check rubocop errors
 - [x] Check yard doc errors
 - [x] CI status: all green or justified
