### PR TITLE
Add schedule limit type to ruleset schedule simple value adjustment t…

### DIFF
--- a/lib/openstudio-standards/schedules/modify.rb
+++ b/lib/openstudio-standards/schedules/modify.rb
@@ -94,8 +94,7 @@ module OpenstudioStandards
     end
 
     # Increase/decrease by percentage or static value.
-    # If the schedule has scheduleTypeLimits object, the adjusted values will subject to the lower and upper
-    # bounds of the schedule type limits object.
+    # If the schedule has a scheduleTypeLimits object, the adjusted values will subject to the lower and upper bounds of the schedule type limits object.
     #
     # @param schedule_ruleset [OpenStudio::Model::ScheduleRuleset] OpenStudio ScheduleRuleset object
     # @param value [Double] Hash of name and time value pairs
@@ -107,10 +106,10 @@ module OpenstudioStandards
     def self.schedule_ruleset_simple_value_adjust(schedule_ruleset, value, modification_type = 'Multiplier')
       # gather profiles
       profiles = []
-      # negative infinity
-      lower_bound = -1.0 / 0.0
       # positive infinity
       upper_bound = Float::INFINITY
+      # negative infinity
+      lower_bound = -upper_bound
       if schedule_ruleset.scheduleTypeLimits.is_initialized
         scheduleTypeLimits = schedule_ruleset.scheduleTypeLimits.get
         if scheduleTypeLimits.lowerLimitValue.is_initialized

--- a/lib/openstudio-standards/schedules/modify.rb
+++ b/lib/openstudio-standards/schedules/modify.rb
@@ -93,7 +93,9 @@ module OpenstudioStandards
       return sch_rule
     end
 
-    # Increase/decrease by percentage or static value
+    # Increase/decrease by percentage or static value.
+    # If the schedule has scheduleTypeLimits object, the adjusted values will subject to the lower and upper
+    # bounds of the schedule type limits object.
     #
     # @param schedule_ruleset [OpenStudio::Model::ScheduleRuleset] OpenStudio ScheduleRuleset object
     # @param value [Double] Hash of name and time value pairs

--- a/test/modules/schedules/test_schedules_modify.rb
+++ b/test/modules/schedules/test_schedules_modify.rb
@@ -65,6 +65,21 @@ class TestSchedulesModify < Minitest::Test
     assert(schedule.to_ScheduleRuleset.is_initialized)
     schedule_max = @sch.schedule_ruleset_get_min_max(schedule)['max']
     assert(schedule_max == 2.0)
+
+    # Test case when schedule type limits put constraint on the adjustment values
+    schedule_type_limits = @sch.create_schedule_type_limits(model,
+                                                            name: 'Fraction Schedule Type',
+                                                            lower_limit_value: 0.0,
+                                                            upper_limit_value: 2.0,
+                                                            numeric_type: 'Continuous',
+                                                            unit_type: 'Dimensionless'
+    )
+    schedule.setScheduleTypeLimits(schedule_type_limits)
+    @sch.schedule_ruleset_simple_value_adjust(schedule, 50)
+    assert(schedule.to_ScheduleRuleset.is_initialized)
+    schedule_max = @sch.schedule_ruleset_get_min_max(schedule)['max']
+    assert(schedule_max == 2.0)
+
   end
 
   def test_schedule_ruleset_conditional_adjust_value

--- a/test/modules/schedules/test_schedules_modify.rb
+++ b/test/modules/schedules/test_schedules_modify.rb
@@ -72,14 +72,12 @@ class TestSchedulesModify < Minitest::Test
                                                             lower_limit_value: 0.0,
                                                             upper_limit_value: 2.0,
                                                             numeric_type: 'Continuous',
-                                                            unit_type: 'Dimensionless'
-    )
+                                                            unit_type: 'Dimensionless')
     schedule.setScheduleTypeLimits(schedule_type_limits)
     @sch.schedule_ruleset_simple_value_adjust(schedule, 50)
     assert(schedule.to_ScheduleRuleset.is_initialized)
     schedule_max = @sch.schedule_ruleset_get_min_max(schedule)['max']
     assert(schedule_max == 2.0)
-
   end
 
   def test_schedule_ruleset_conditional_adjust_value


### PR DESCRIPTION
…o prevent simulation errors that the schedule value over the lower or upper boundary.

Pull request overview
---------------------

We are refactoring some PRM functions using the new schedule modules while reducing the size the test cases as discussed in the last call.
The issue this PR is addressing is when using the `schedule_ruleset_simple_value_adjust`, it does not set a limit following the `scheduleTypeLimits`, which could cause severe simulation errors when the adjusted schedule value goes beyond the limit. The suggested change is to add this limitations to the function.

### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [x] Method changes or additions
 - [ ] Data changes or additions
 - [x] Added tests for added methods
 - [ ] If methods have been deprecated, update rest of code to use the new methods
 - [ ] Documented new methods using [yard syntax](https://rubydoc.info/gems/yard/file/docs/GettingStarted.md)
 - [ ] Resolved yard documentation errors for new code (ran `bundle exec rake doc`)
 - [ ] Resolved rubocop syntax errors for new code (ran `bundle exec rake rubocop`)
 - [x] All new and existing tests passes
 - [ ] If the code adds new `require` statements, ensure these are in core ruby or add to the gemspec

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a code review on GitHub
 - [ ] All related changes have been implemented: method additions, changes, tests
 - [ ] Check rubocop errors
 - [ ] Check yard doc errors
 - [ ] If fixing a defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If a new feature, test the new feature and try creative ways to break it
 - [ ] CI status: all green or justified
