### PR TITLE
handle deprecated (in 3.3.0) DesignDay methods 

### DIFF
--- a/lib/openstudio-standards/prototypes/common/objects/Prototype.hvac_systems.rb
+++ b/lib/openstudio-standards/prototypes/common/objects/Prototype.hvac_systems.rb
@@ -612,11 +612,20 @@ class Standard
         next unless dd.dayType == 'SummerDesignDay'
         next unless dd.name.get.to_s.include?('WB=>MDB')
 
-        if dd.humidityIndicatingType == 'Wetbulb'
-          summer_oat_wb_c = dd.humidityIndicatingConditionsAtMaximumDryBulb
-          summer_oat_wbs_f << OpenStudio.convert(summer_oat_wb_c, 'C', 'F').get
+
+        if condenser_water_loop.model.version < OpenStudio::VersionString.new('3.3.0')
+          if dd.humidityIndicatingType == 'Wetbulb'
+            summer_oat_wb_c = dd.humidityIndicatingConditionsAtMaximumDryBulb
+            summer_oat_wbs_f << OpenStudio.convert(summer_oat_wb_c, 'C', 'F').get
+          else
+            OpenStudio.logFree(OpenStudio::Warn, 'openstudio.Prototype.hvac_systems', "For #{dd.name}, humidity is specified as #{dd.humidityIndicatingType}; cannot determine Twb.")
         else
-          OpenStudio.logFree(OpenStudio::Warn, 'openstudio.Prototype.hvac_systems', "For #{dd.name}, humidity is specified as #{dd.humidityIndicatingType}; cannot determine Twb.")
+          if dd.humidityConditionType == 'Wetbulb'
+            summer_oat_wb_c = dd.wetBulbOrDewPointAtMaximumDryBulb
+            summer_oat_wbs_f << OpenStudio.convert(summer_oat_wb_c, 'C', 'F').get
+          else
+            OpenStudio.logFree(OpenStudio::Warn, 'openstudio.Prototype.hvac_systems', "For #{dd.name}, humidity is specified as #{dd.humidityConditionType}; cannot determine Twb.")
+          end
         end
       end
 
@@ -655,7 +664,11 @@ class Standard
             ddy_model.getDesignDays.sort.each do |dd|
               # Save the model wetbulb design conditions Condns WB=>MDB
               if dd.name.get.include? '4% Condns WB=>MDB'
-                summer_oat_wb_c = dd.humidityIndicatingConditionsAtMaximumDryBulb
+                if model.version < OpenStudio::VersionString.new('3.3.0')
+                  summer_oat_wb_c = dd.humidityIndicatingConditionsAtMaximumDryBulb
+                else
+                  summer_oat_wb_c = dd.wetBulbOrDewPointAtMaximumDryBulb
+                end
                 summer_oat_wbs_f << OpenStudio.convert(summer_oat_wb_c, 'C', 'F').get
               end
             end

--- a/lib/openstudio-standards/prototypes/common/objects/Prototype.hvac_systems.rb
+++ b/lib/openstudio-standards/prototypes/common/objects/Prototype.hvac_systems.rb
@@ -666,10 +666,14 @@ class Standard
               if dd.name.get.include? '4% Condns WB=>MDB'
                 if model.version < OpenStudio::VersionString.new('3.3.0')
                   summer_oat_wb_c = dd.humidityIndicatingConditionsAtMaximumDryBulb
+                  summer_oat_wbs_f << OpenStudio.convert(summer_oat_wb_c, 'C', 'F').get
                 else
-                  summer_oat_wb_c = dd.wetBulbOrDewPointAtMaximumDryBulb
+                  if dd.wetBulbOrDewPointAtMaximumDryBulb.is_initialized
+                    summer_oat_wb_c = dd.wetBulbOrDewPointAtMaximumDryBulb
+                    summer_oat_wbs_f << OpenStudio.convert(summer_oat_wb_c, 'C', 'F').get
+                  end
                 end
-                summer_oat_wbs_f << OpenStudio.convert(summer_oat_wb_c, 'C', 'F').get
+
               end
             end
           end

--- a/lib/openstudio-standards/prototypes/common/objects/Prototype.hvac_systems.rb
+++ b/lib/openstudio-standards/prototypes/common/objects/Prototype.hvac_systems.rb
@@ -619,6 +619,7 @@ class Standard
             summer_oat_wbs_f << OpenStudio.convert(summer_oat_wb_c, 'C', 'F').get
           else
             OpenStudio.logFree(OpenStudio::Warn, 'openstudio.Prototype.hvac_systems', "For #{dd.name}, humidity is specified as #{dd.humidityIndicatingType}; cannot determine Twb.")
+          end
         else
           if dd.humidityConditionType == 'Wetbulb'
             summer_oat_wb_c = dd.wetBulbOrDewPointAtMaximumDryBulb

--- a/lib/openstudio-standards/prototypes/common/objects/Prototype.hvac_systems.rb
+++ b/lib/openstudio-standards/prototypes/common/objects/Prototype.hvac_systems.rb
@@ -621,9 +621,8 @@ class Standard
             OpenStudio.logFree(OpenStudio::Warn, 'openstudio.Prototype.hvac_systems', "For #{dd.name}, humidity is specified as #{dd.humidityIndicatingType}; cannot determine Twb.")
           end
         else
-          if dd.humidityConditionType == 'Wetbulb'
-            summer_oat_wb_c = dd.wetBulbOrDewPointAtMaximumDryBulb
-            summer_oat_wbs_f << OpenStudio.convert(summer_oat_wb_c, 'C', 'F').get
+          if dd.humidityConditionType == 'Wetbulb' && dd.wetBulbOrDewPointAtMaximumDryBulb.is_initialized
+            summer_oat_wbs_f << OpenStudio.convert(dd.wetBulbOrDewPointAtMaximumDryBulb.get, 'C', 'F').get
           else
             OpenStudio.logFree(OpenStudio::Warn, 'openstudio.Prototype.hvac_systems', "For #{dd.name}, humidity is specified as #{dd.humidityConditionType}; cannot determine Twb.")
           end

--- a/lib/openstudio-standards/standards/Standards.PlantLoop.rb
+++ b/lib/openstudio-standards/standards/Standards.PlantLoop.rb
@@ -311,9 +311,8 @@ class Standard
           OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.PlantLoop', "For #{dd.name}, humidity is specified as #{dd.humidityIndicatingType}; cannot determine Twb.")
         end
       else
-        if dd.humidityConditionType == 'Wetbulb'
-          summer_oat_wb_c = dd.wetBulbOrDewPointAtMaximumDryBulb
-          summer_oat_wbs_f << OpenStudio.convert(summer_oat_wb_c, 'C', 'F').get
+        if dd.humidityConditionType == 'Wetbulb' && dd.wetBulbOrDewPointAtMaximumDryBulb.is_initialized
+          summer_oat_wbs_f << OpenStudio.convert(dd.wetBulbOrDewPointAtMaximumDryBulb.get, 'C', 'F').get
         else
           OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.PlantLoop', "For #{dd.name}, humidity is specified as #{dd.humidityConditionType}; cannot determine Twb.")
         end

--- a/lib/openstudio-standards/standards/Standards.PlantLoop.rb
+++ b/lib/openstudio-standards/standards/Standards.PlantLoop.rb
@@ -303,11 +303,20 @@ class Standard
       next unless dd.dayType == 'SummerDesignDay'
       next unless dd.name.get.to_s.include?('WB=>MDB')
 
-      if dd.humidityIndicatingType == 'Wetbulb'
-        summer_oat_wb_c = dd.humidityIndicatingConditionsAtMaximumDryBulb
-        summer_oat_wbs_f << OpenStudio.convert(summer_oat_wb_c, 'C', 'F').get
+      if plant_loop.model.version < OpenStudio::VersionString.new('3.3.0')
+        if dd.humidityIndicatingType == 'Wetbulb'
+          summer_oat_wb_c = dd.humidityIndicatingConditionsAtMaximumDryBulb
+          summer_oat_wbs_f << OpenStudio.convert(summer_oat_wb_c, 'C', 'F').get
+        else
+          OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.PlantLoop', "For #{dd.name}, humidity is specified as #{dd.humidityIndicatingType}; cannot determine Twb.")
+        end
       else
-        OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.PlantLoop', "For #{dd.name}, humidity is specified as #{dd.humidityIndicatingType}; cannot determine Twb.")
+        if dd.humidityConditionType == 'Wetbulb'
+          summer_oat_wb_c = dd.wetBulbOrDewPointAtMaximumDryBulb
+          summer_oat_wbs_f << OpenStudio.convert(summer_oat_wb_c, 'C', 'F').get
+        else
+          OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.PlantLoop', "For #{dd.name}, humidity is specified as #{dd.humidityConditionType}; cannot determine Twb.")
+        end
       end
     end
 

--- a/test/90_1_prm/baseline_901_2013_helper.rb
+++ b/test/90_1_prm/baseline_901_2013_helper.rb
@@ -2207,11 +2207,15 @@ module Baseline9012013
           if model.version < OpenStudio::VersionString.new('3.3.0')
             next unless design_day.humidityIndicatingType == "Wetbulb"
             design_wb_c = design_day.humidityIndicatingConditionsAtMaximumDryBulb
+            design_wb_f = OpenStudio.convert(design_wb_c, 'C', 'F').get
           else
             next unless design_day.humidityConditionType == "Wetbulb"
-            design_wb_c = design_day.wetBulbOrDewPointAtMaximumDryBulb
+            if design_day.wetBulbOrDewPointAtMaximumDryBulb.is_initialized
+              design_wb_c = design_day.wetBulbOrDewPointAtMaximumDryBulb
+              design_wb_f = OpenStudio.convert(design_wb_c, 'C', 'F').get
+            end
           end
-          design_wb_f = OpenStudio.convert(design_wb_c, 'C', 'F').get
+
           if design_wb_f_max.nil?
             design_wb_f_max = design_wb_f
           else

--- a/test/90_1_prm/baseline_901_2013_helper.rb
+++ b/test/90_1_prm/baseline_901_2013_helper.rb
@@ -815,9 +815,8 @@ module Baseline9012013
                 puts "#{prm_maj_sec}: #{prm_min_sec}: cannot determine design day information"
               end
             else
-              if dd.humidityConditionType == 'Wetbulb'
-                des_day_wb_si = dd.wetBulbOrDewPointAtMaximumDryBulb
-                des_day_wb_ip << OpenStudio.convert(des_day_wb_si, 'C', 'F').get
+              if dd.humidityConditionType == 'Wetbulb' && dd.wetBulbOrDewPointAtMaximumDryBulb.is_initialized
+                des_day_wb_ip << OpenStudio.convert(dd.wetBulbOrDewPointAtMaximumDryBulb.get, 'C', 'F').get
                 puts "DD WB = #{des_day_wb_ip}"
               else
                 puts "#{prm_maj_sec}: #{prm_min_sec}: cannot determine design day information"

--- a/test/90_1_prm/baseline_901_2013_helper.rb
+++ b/test/90_1_prm/baseline_901_2013_helper.rb
@@ -806,14 +806,23 @@ module Baseline9012013
             next unless dd.dayType == 'SummerDesignDay'
             next unless dd.name.get.to_s.include?('WB=>MDB')
 
-            if dd.humidityIndicatingType == 'Wetbulb'
-              des_day_wb_si = dd.humidityIndicatingConditionsAtMaximumDryBulb
-              des_day_wb_ip << OpenStudio.convert(des_day_wb_si, 'C', 'F').get
-              puts "DD WB = #{des_day_wb_ip}"
+            if base_model.version < OpenStudio::VersionString.new('3.3.0')
+              if dd.humidityIndicatingType == 'Wetbulb'
+                des_day_wb_si = dd.humidityIndicatingConditionsAtMaximumDryBulb
+                des_day_wb_ip << OpenStudio.convert(des_day_wb_si, 'C', 'F').get
+                puts "DD WB = #{des_day_wb_ip}"
+              else
+                puts "#{prm_maj_sec}: #{prm_min_sec}: cannot determine design day information"
+              end
             else
-              puts "#{prm_maj_sec}: #{prm_min_sec}: cannot determine design day information"
+              if dd.humidityConditionType == 'Wetbulb'
+                des_day_wb_si = dd.wetBulbOrDewPointAtMaximumDryBulb
+                des_day_wb_ip << OpenStudio.convert(des_day_wb_si, 'C', 'F').get
+                puts "DD WB = #{des_day_wb_ip}"
+              else
+                puts "#{prm_maj_sec}: #{prm_min_sec}: cannot determine design day information"
+              end
             end
-
           end
 
           if des_day_wb_ip.size == 0
@@ -2195,9 +2204,14 @@ module Baseline9012013
           design_day_name = design_day.name.get.to_s
           next unless design_day.dayType == "SummerDesignDay"
           next unless design_day_name.include? "WB=>MDB"
-          next unless design_day.humidityIndicatingType == "Wetbulb"
 
-          design_wb_c = design_day.humidityIndicatingConditionsAtMaximumDryBulb
+          if model.version < OpenStudio::VersionString.new('3.3.0')
+            next unless design_day.humidityIndicatingType == "Wetbulb"
+            design_wb_c = design_day.humidityIndicatingConditionsAtMaximumDryBulb
+          else
+            next unless design_day.humidityConditionType == "Wetbulb"
+            design_wb_c = design_day.wetBulbOrDewPointAtMaximumDryBulb
+          end
           design_wb_f = OpenStudio.convert(design_wb_c, 'C', 'F').get
           if design_wb_f_max.nil?
             design_wb_f_max = design_wb_f


### PR DESCRIPTION
'[humidityIndicatingType](https://github.com/NREL/OpenStudio/blob/02cf3b838a352eb17c33a78cb8773f478029b318/developer/ruby/deprecated_methods.csv#L63)' and '[humidityIndicatingConditionsAtMaxiumDryBulb](https://github.com/NREL/OpenStudio/blob/02cf3b838a352eb17c33a78cb8773f478029b318/developer/ruby/deprecated_methods.csv#L61)'
See: 

Pull request overview
---------------------

<!--- DESCRIBE PURPOSE OF THIS PULL REQUEST -->

 - Fixes #ISSUENUMBERHERE (IF THIS IS A DEFECT)

### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [x] Method changes or additions
 - [ ] Data changes or additions
 - [ ] Added tests for added methods
 - [ ] If methods have been deprecated, update rest of code to use the new methods
 - [ ] Documented new methods using [yard syntax](https://rubydoc.info/gems/yard/file/docs/GettingStarted.md)
 - [ ] Resolved yard documentation errors for new code (ran `bundle exec rake doc`)
 - [ ] Resolved rubocop syntax errors for new code (ran `bundle exec rake rubocop`)
 - [ ] All new and existing tests passes
 - [ ] If the code adds new `require` statements, ensure these are in core ruby or add to the gemspec

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [x] Perform a code review on GitHub
 - [x] All related changes have been implemented: method additions, changes, tests
 - [x] Check rubocop errors
 - [x] Check yard doc errors
 - [ ] If fixing a defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If a new feature, test the new feature and try creative ways to break it
 - [x] CI status: all green or justified
