### PR TITLE
Fix OS3.7 DistrictHeating lookup

### DIFF
--- a/lib/openstudio-standards/standards/Standards.PlantLoop.rb
+++ b/lib/openstudio-standards/standards/Standards.PlantLoop.rb
@@ -666,9 +666,9 @@ class Standard
         case sc.iddObjectType.valueName.to_s
         when 'OS_DistrictHeating'
           dist_htg = sc.to_DistrictHeating.get
-        when 'OS_DistrictHeatingWater'
+        when 'OS_DistrictHeating_Water'
           dist_htg = sc.to_DistrictHeatingWater.get
-        when 'OS_DistrictHeatingSteam'
+        when 'OS_DistrictHeating_Steam'
           dist_htg = sc.to_DistrictHeatingSteam.get
         end
         if dist_htg.nominalCapacity.is_initialized
@@ -1389,7 +1389,7 @@ class Standard
       obj_type = component.iddObjectType.valueName.to_s
 
       case obj_type
-        when 'OS_DistrictHeating', 'OS_DistrictHeatingWater', 'OS_DistrictHeatingSteam'
+        when 'OS_DistrictHeating', 'OS_DistrictHeating_Water', 'OS_DistrictHeating_Steam'
           primary_fuels << 'DistrictHeating'
           combination_system = false
         when 'OS_HeatPump_WaterToWater_EquationFit_Heating'

--- a/test/90_1_prm/models/bldg_4.osm
+++ b/test/90_1_prm/models/bldg_4.osm
@@ -1,7 +1,7 @@
 
 OS:Version,
-  {d4322c5a-8ce4-4df8-99db-72c71c02ac47}, !- Handle
-  1.10.0;                                 !- Version Identifier
+  {e43a8c4f-b499-4ea4-9f0e-40311ae433c0}, !- Handle
+  3.7.0;                                  !- Version Identifier
 
 OS:ThermostatSetpoint:DualSetpoint,
   {57716514-0d5c-4f76-8108-73a8ef55c74a}, !- Handle
@@ -69,6 +69,7 @@ OS:Building,
   ,                                       !- Default Schedule Set Name
   ,                                       !- Standards Number of Stories
   ,                                       !- Standards Number of Above Ground Stories
+  ,                                       !- Standards Template
   ,                                       !- Standards Building Type
   ,                                       !- Standards Number of Living Units
   ,                                       !- Relocatable
@@ -107,8 +108,8 @@ OS:ThermostatSetpoint:DualSetpoint,
 OS:ScheduleTypeLimits,
   {55c44e2f-3c81-40b0-84f7-9b6efa1c1036}, !- Handle
   Fractional,                             !- Name
-  0,                                      !- Lower Limit Value {BasedOnField A4}
-  1,                                      !- Upper Limit Value {BasedOnField A4}
+  0,                                      !- Lower Limit Value
+  1,                                      !- Upper Limit Value
   Continuous;                             !- Numeric Type
 
 OS:ThermostatSetpoint:DualSetpoint,
@@ -257,7 +258,8 @@ OS:DefaultConstructionSet,
   {57202d2c-be20-4cff-bb5e-09406a47d137}, !- Interior Partition Construction Name
   ,                                       !- Space Shading Construction Name
   ,                                       !- Building Shading Construction Name
-  ;                                       !- Site Shading Construction Name
+  ,                                       !- Site Shading Construction Name
+  ;                                       !- Adiabatic Surface Construction Name
 
 OS:DefaultSurfaceConstructions,
   {6e044d24-cbba-456f-af36-8b86f1508f50}, !- Handle
@@ -320,7 +322,11 @@ OS:Space,
   {556dacb5-6766-4b7e-9859-166587ff15cb}, !- Building Story Name
   {6f6da13e-8cc0-4b66-ba77-f3f7916b1f52}, !- Thermal Zone Name
   ,                                       !- Part of Total Floor Area
-  ;                                       !- Design Specification Outdoor Air Object Name
+  ,                                       !- Design Specification Outdoor Air Object Name
+  ,                                       !- Building Unit Name
+  ,                                       !- Volume {m3}
+  ,                                       !- Ceiling Height {m}
+  ;                                       !- Floor Area {m2}
 
 OS:Surface,
   {6b03d5c2-1824-43e6-be7b-86e7638b6bcc}, !- Handle
@@ -334,10 +340,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -6.52754599999976, 13.3603865470634, 18.1416543132516, !- X,Y,Z Vertex 1 {m}
-  -6.52754599999976, 13.3603863721678, -4.94918948840723e-016, !- X,Y,Z Vertex 2 {m}
-  -8.36530875862021e-017, 13.3603862832082, 3.74531140665548e-016, !- X,Y,Z Vertex 3 {m}
-  8.36530875862021e-017, 13.3603864581039, 18.1416546049432; !- X,Y,Z Vertex 4 {m}
+  8.36527334021054e-17, 13.3603864581039, 18.1416546049432, !- X,Y,Z Vertex 1 {m}
+  -6.52754599999976, 13.3603865470634, 18.1416543132516, !- X,Y,Z Vertex 2 {m}
+  -6.52754599999976, 13.3603863721678, -4.94918698294115e-16, !- X,Y,Z Vertex 3 {m}
+  -8.36527727558939e-17, 13.3603862832082, 3.74530917957452e-16; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {b786f0e3-b760-4671-b4fa-c4012ca776dc}, !- Handle
@@ -352,9 +358,9 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   0, 13.3603864519657, 18.1416546049432,  !- X,Y,Z Vertex 1 {m}
-  0, 13.3603862893464, 3.15355706184613e-016, !- X,Y,Z Vertex 2 {m}
-  0, 2.80077544640878e-008, -5.37616546933484e-017, !- X,Y,Z Vertex 3 {m}
-  0, 7.29302768435314e-008, 12.5348998262138; !- X,Y,Z Vertex 4 {m}
+  0, 13.3603862893464, 3.15355706184613e-16, !- X,Y,Z Vertex 2 {m}
+  0, 2.80077544640878e-08, -5.37616546933484e-17, !- X,Y,Z Vertex 3 {m}
+  0, 7.29302768435314e-08, 12.5348998262138; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {ed7e34b8-6a5f-4232-a70b-690c9309b747}, !- Handle
@@ -368,10 +374,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  2.30907451831202e-014, 61.7219864359929, 18.1416498034648, !- X,Y,Z Vertex 1 {m}
-  1.04202824735075e-017, 61.7219863186162, -1.25992888784112e-017, !- X,Y,Z Vertex 2 {m}
-  -6.52754599999976, 61.7219863300774, -1.09812286383427e-016, !- X,Y,Z Vertex 3 {m}
-  -6.52754599999974, 61.721986447454, 18.1416498697155; !- X,Y,Z Vertex 4 {m}
+  -6.52754599999974, 61.721986447454, 18.1416498697155, !- X,Y,Z Vertex 1 {m}
+  2.30907451628395e-14, 61.7219864359929, 18.1416498034648, !- X,Y,Z Vertex 2 {m}
+  1.04203433154772e-17, 61.7219863186162, -1.25995130755606e-17, !- X,Y,Z Vertex 3 {m}
+  -6.52754599999976, 61.7219863300774, -1.09812211651044e-16; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {1b25914b-5f8c-4bff-b058-2bda4b410e0a}, !- Handle
@@ -387,8 +393,8 @@ OS:Surface,
   ,                                       !- Number of Vertices
   -6.52754599999974, 37.5411853284818, 28.2892498310001, !- X,Y,Z Vertex 1 {m}
   -6.52754599999974, 61.7219864415193, 18.1416498697155, !- X,Y,Z Vertex 2 {m}
-  -6.52754599999975, 61.7219863360121, -1.48209934297817e-016, !- X,Y,Z Vertex 3 {m}
-  -6.52754599999976, 13.3603863660296, -4.35743514359785e-016, !- X,Y,Z Vertex 4 {m}
+  -6.52754599999975, 61.7219863360121, -1.48209934297817e-16, !- X,Y,Z Vertex 3 {m}
+  -6.52754599999976, 13.3603863660296, -4.35743514359785e-16, !- X,Y,Z Vertex 4 {m}
   -6.52754599999975, 13.3603865532016, 18.1416543132516; !- X,Y,Z Vertex 5 {m}
 
 OS:Surface,
@@ -403,9 +409,9 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  101.1174, 2.81445215485497, 13.7160000817012, !- X,Y,Z Vertex 1 {m}
-  101.1174, 0.228599999999995, 13.7159999989045, !- X,Y,Z Vertex 2 {m}
-  101.1174, 0.228599999999995, 12.6308338213237; !- X,Y,Z Vertex 3 {m}
+  101.1174, 0.228599999999995, 13.7159999989045, !- X,Y,Z Vertex 1 {m}
+  101.1174, 0.228599999999995, 12.6308338213237, !- X,Y,Z Vertex 2 {m}
+  101.1174, 2.81445215485497, 13.7160000817012; !- X,Y,Z Vertex 3 {m}
 
 OS:Surface,
   {1f057cf4-89c4-4bca-9e97-e2921922710f}, !- Handle
@@ -436,10 +442,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  27.9654, 5.65089672965649e-008, 12.5348999687899, !- X,Y,Z Vertex 1 {m}
-  1.0720564761193e-017, 8.38826000551363e-008, 12.5348998262138, !- X,Y,Z Vertex 2 {m}
-  -1.0720564761193e-017, 1.70554312524829e-008, 4.62834141276426e-018, !- X,Y,Z Vertex 3 {m}
-  27.9654, -1.03182022662028e-008, 2.77991657855478e-017; !- X,Y,Z Vertex 4 {m}
+  1.0720564761193e-17, 8.38826000551363e-08, 12.5348998262138, !- X,Y,Z Vertex 1 {m}
+  -1.0720564761193e-17, 1.70554312524829e-08, 4.62834141276425e-18, !- X,Y,Z Vertex 2 {m}
+  27.9654, -1.03182022662028e-08, 2.77991657855479e-17, !- X,Y,Z Vertex 3 {m}
+  27.9654, 5.65089672965649e-08, 12.5348999687899; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {8951fd44-21d5-440c-b3ed-dd7f023ccf2a}, !- Handle
@@ -487,9 +493,9 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   27.9654, 0.228599999999997, 12.6308331578812, !- X,Y,Z Vertex 1 {m}
-  27.9654, 6.74612903835944e-008, 12.5348999687899, !- X,Y,Z Vertex 2 {m}
-  27.9654, -2.12705253532323e-008, 8.61891612275134e-017, !- X,Y,Z Vertex 3 {m}
-  27.9654, 0.228599999999997, -3.15937125270844e-018; !- X,Y,Z Vertex 4 {m}
+  27.9654, 6.74612903835944e-08, 12.5348999687899, !- X,Y,Z Vertex 2 {m}
+  27.9654, -2.12705253532323e-08, 8.61891612275134e-17, !- X,Y,Z Vertex 3 {m}
+  27.9654, 0.228599999999997, -3.15937125270844e-18; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {36361530-6035-4f03-83eb-056f356d636c}, !- Handle
@@ -504,9 +510,9 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   101.1174, 0.228599999999995, 12.6308338213237, !- X,Y,Z Vertex 1 {m}
-  101.117399999996, 0.228599999999995, 1.29229774612291e-016, !- X,Y,Z Vertex 2 {m}
-  101.117399999999, -8.61397499360191e-007, 2.61559989477893e-013, !- X,Y,Z Vertex 3 {m}
-  101.117400000004, 2.93870247097331e-006, 12.5349019894117; !- X,Y,Z Vertex 4 {m}
+  101.117399999996, 0.228599999999995, 1.29229774703226e-16, !- X,Y,Z Vertex 2 {m}
+  101.117399999999, -8.61397499360191e-07, 2.61559989477802e-13, !- X,Y,Z Vertex 3 {m}
+  101.117400000004, 2.93870247097331e-06, 12.5349019894117; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {41247ca2-c8c8-478e-b8b8-c3d047e446b2}, !- Handle
@@ -537,10 +543,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  110.660140948892, 75.0823539430279, 12.534899344047, !- X,Y,Z Vertex 1 {m}
-  110.660140945405, 75.0823541732396, 6.45019898667464e-017, !- X,Y,Z Vertex 2 {m}
-  101.1174, 75.0823542115102, 6.74221957318395e-016, !- X,Y,Z Vertex 3 {m}
-  101.1174, 75.0823539812986, 12.5348995256462; !- X,Y,Z Vertex 4 {m}
+  101.1174, 75.0823539812986, 12.5348995256462, !- X,Y,Z Vertex 1 {m}
+  110.660140948892, 75.0823539430279, 12.534899344047, !- X,Y,Z Vertex 2 {m}
+  110.660140945405, 75.0823541732396, 6.45013534646809e-17, !- X,Y,Z Vertex 3 {m}
+  101.1174, 75.0823542115102, 6.74222381586439e-16; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {c545b6e1-6c79-4ba2-a9d5-66bc127adf26}, !- Handle
@@ -556,8 +562,8 @@ OS:Surface,
   ,                                       !- Number of Vertices
   101.1174, 74.8537541776711, 12.6308331282527, !- X,Y,Z Vertex 1 {m}
   101.1174, 75.0823539813864, 12.5348995256462, !- X,Y,Z Vertex 2 {m}
-  101.1174, 75.0823542114224, 6.72608890216432e-016, !- X,Y,Z Vertex 3 {m}
-  101.1174, 74.8537541776736, 1.26297410893987e-016; !- X,Y,Z Vertex 4 {m}
+  101.1174, 75.0823542114224, 6.72608890216432e-16, !- X,Y,Z Vertex 3 {m}
+  101.1174, 74.8537541776736, 1.26297410893987e-16; !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {da44e4eb-074e-4475-8de0-f8c3c2d51f00}, !- Handle
@@ -567,7 +573,6 @@ OS:SubSurface,
   {41247ca2-c8c8-478e-b8b8-c3d047e446b2}, !- Surface Name
   ,                                       !- Outside Boundary Condition Object
   ,                                       !- View Factor to Ground
-  ,                                       !- Shading Control Name
   ,                                       !- Frame and Divider Name
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
@@ -584,7 +589,6 @@ OS:SubSurface,
   {41247ca2-c8c8-478e-b8b8-c3d047e446b2}, !- Surface Name
   ,                                       !- Outside Boundary Condition Object
   ,                                       !- View Factor to Ground
-  ,                                       !- Shading Control Name
   ,                                       !- Frame and Divider Name
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
@@ -601,7 +605,6 @@ OS:SubSurface,
   {41247ca2-c8c8-478e-b8b8-c3d047e446b2}, !- Surface Name
   ,                                       !- Outside Boundary Condition Object
   ,                                       !- View Factor to Ground
-  ,                                       !- Shading Control Name
   ,                                       !- Frame and Divider Name
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
@@ -618,7 +621,6 @@ OS:SubSurface,
   {41247ca2-c8c8-478e-b8b8-c3d047e446b2}, !- Surface Name
   ,                                       !- Outside Boundary Condition Object
   ,                                       !- View Factor to Ground
-  ,                                       !- Shading Control Name
   ,                                       !- Frame and Divider Name
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
@@ -635,7 +637,6 @@ OS:SubSurface,
   {41247ca2-c8c8-478e-b8b8-c3d047e446b2}, !- Surface Name
   ,                                       !- Outside Boundary Condition Object
   ,                                       !- View Factor to Ground
-  ,                                       !- Shading Control Name
   ,                                       !- Frame and Divider Name
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
@@ -652,7 +653,6 @@ OS:SubSurface,
   {41247ca2-c8c8-478e-b8b8-c3d047e446b2}, !- Surface Name
   ,                                       !- Outside Boundary Condition Object
   ,                                       !- View Factor to Ground
-  ,                                       !- Shading Control Name
   ,                                       !- Frame and Divider Name
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
@@ -669,7 +669,6 @@ OS:SubSurface,
   {41247ca2-c8c8-478e-b8b8-c3d047e446b2}, !- Surface Name
   ,                                       !- Outside Boundary Condition Object
   ,                                       !- View Factor to Ground
-  ,                                       !- Shading Control Name
   ,                                       !- Frame and Divider Name
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
@@ -686,7 +685,6 @@ OS:SubSurface,
   {41247ca2-c8c8-478e-b8b8-c3d047e446b2}, !- Surface Name
   ,                                       !- Outside Boundary Condition Object
   ,                                       !- View Factor to Ground
-  ,                                       !- Shading Control Name
   ,                                       !- Frame and Divider Name
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
@@ -703,7 +701,6 @@ OS:SubSurface,
   {41247ca2-c8c8-478e-b8b8-c3d047e446b2}, !- Surface Name
   ,                                       !- Outside Boundary Condition Object
   ,                                       !- View Factor to Ground
-  ,                                       !- Shading Control Name
   ,                                       !- Frame and Divider Name
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
@@ -720,7 +717,6 @@ OS:SubSurface,
   {41247ca2-c8c8-478e-b8b8-c3d047e446b2}, !- Surface Name
   ,                                       !- Outside Boundary Condition Object
   ,                                       !- View Factor to Ground
-  ,                                       !- Shading Control Name
   ,                                       !- Frame and Divider Name
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
@@ -737,7 +733,6 @@ OS:SubSurface,
   {41247ca2-c8c8-478e-b8b8-c3d047e446b2}, !- Surface Name
   ,                                       !- Outside Boundary Condition Object
   ,                                       !- View Factor to Ground
-  ,                                       !- Shading Control Name
   ,                                       !- Frame and Divider Name
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
@@ -754,7 +749,6 @@ OS:SubSurface,
   {41247ca2-c8c8-478e-b8b8-c3d047e446b2}, !- Surface Name
   ,                                       !- Outside Boundary Condition Object
   ,                                       !- View Factor to Ground
-  ,                                       !- Shading Control Name
   ,                                       !- Frame and Divider Name
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
@@ -771,7 +765,6 @@ OS:SubSurface,
   {41247ca2-c8c8-478e-b8b8-c3d047e446b2}, !- Surface Name
   ,                                       !- Outside Boundary Condition Object
   ,                                       !- View Factor to Ground
-  ,                                       !- Shading Control Name
   ,                                       !- Frame and Divider Name
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
@@ -788,7 +781,6 @@ OS:SubSurface,
   {41247ca2-c8c8-478e-b8b8-c3d047e446b2}, !- Surface Name
   ,                                       !- Outside Boundary Condition Object
   ,                                       !- View Factor to Ground
-  ,                                       !- Shading Control Name
   ,                                       !- Frame and Divider Name
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
@@ -805,7 +797,6 @@ OS:SubSurface,
   {41247ca2-c8c8-478e-b8b8-c3d047e446b2}, !- Surface Name
   ,                                       !- Outside Boundary Condition Object
   ,                                       !- View Factor to Ground
-  ,                                       !- Shading Control Name
   ,                                       !- Frame and Divider Name
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
@@ -822,7 +813,6 @@ OS:SubSurface,
   {41247ca2-c8c8-478e-b8b8-c3d047e446b2}, !- Surface Name
   ,                                       !- Outside Boundary Condition Object
   ,                                       !- View Factor to Ground
-  ,                                       !- Shading Control Name
   ,                                       !- Frame and Divider Name
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
@@ -844,8 +834,8 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   129.08661, 11.177539610068, 7.62,       !- X,Y,Z Vertex 1 {m}
-  129.08661, 11.177539610068, -7.23757035746307e-016, !- X,Y,Z Vertex 2 {m}
-  129.08661, 75.0823542046541, 1.73582290177271e-016, !- X,Y,Z Vertex 3 {m}
+  129.08661, 11.177539610068, -7.23757035746307e-16, !- X,Y,Z Vertex 2 {m}
+  129.08661, 75.0823542046541, 1.73582290177271e-16, !- X,Y,Z Vertex 3 {m}
   129.08661, 75.0823542126357, 7.62;      !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
@@ -877,9 +867,9 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  110.77454947196, -1.36723017394117e-005, 7.62, !- X,Y,Z Vertex 1 {m}
-  110.774549471961, -1.28109040018724e-005, -2.61284106899331e-013, !- X,Y,Z Vertex 2 {m}
-  110.77454947196, 5.11632945681379, 1.44910251845555e-016, !- X,Y,Z Vertex 3 {m}
+  110.77454947196, -1.36723017394117e-05, 7.62, !- X,Y,Z Vertex 1 {m}
+  110.774549471961, -1.28109040018724e-05, -2.61284106899382e-13, !- X,Y,Z Vertex 2 {m}
+  110.77454947196, 5.11632945681379, 1.44910251896399e-16, !- X,Y,Z Vertex 3 {m}
   110.77454947196, 5.11632946079759, 7.62; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
@@ -895,8 +885,8 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   115.523009999993, 8.62229966620142, 7.62, !- X,Y,Z Vertex 1 {m}
-  115.523009999993, 8.62229966620142, 1.54970912562896e-016, !- X,Y,Z Vertex 2 {m}
-  117.9583084912, 8.62229955393414, 1.59378352050832e-016, !- X,Y,Z Vertex 3 {m}
+  115.523009999993, 8.62229966620142, 1.54970912562902e-16, !- X,Y,Z Vertex 2 {m}
+  117.9583084912, 8.62229955393414, 1.59378352050826e-16, !- X,Y,Z Vertex 3 {m}
   117.9583084912, 8.62229955393415, 7.62; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
@@ -912,8 +902,8 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   115.523009999993, 5.11632945465838, 7.62, !- X,Y,Z Vertex 1 {m}
-  115.523009999993, 5.11632945067457, 1.56713499372831e-016, !- X,Y,Z Vertex 2 {m}
-  115.523009999993, 8.62229964986439, 1.54970924944928e-016, !- X,Y,Z Vertex 3 {m}
+  115.523009999993, 5.11632945067457, 1.56713499372831e-16, !- X,Y,Z Vertex 2 {m}
+  115.523009999993, 8.62229964986439, 1.54970924944928e-16, !- X,Y,Z Vertex 3 {m}
   115.523009999993, 8.62229968253845, 7.62; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
@@ -929,8 +919,8 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   117.9583084912, 8.62229953759712, 7.62, !- X,Y,Z Vertex 1 {m}
-  117.9583084912, 8.62229957027117, 1.59378339668797e-016, !- X,Y,Z Vertex 2 {m}
-  117.9583084912, 11.177539610068, 1.59277904516636e-016, !- X,Y,Z Vertex 3 {m}
+  117.9583084912, 8.62229957027117, 1.59378339668797e-16, !- X,Y,Z Vertex 2 {m}
+  117.9583084912, 11.177539610068, 1.59277904516636e-16, !- X,Y,Z Vertex 3 {m}
   117.9583084912, 11.177539610068, 7.62;  !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
@@ -946,8 +936,8 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   123.1399084912, 11.177539610068, 7.62,  !- X,Y,Z Vertex 1 {m}
-  123.1399084912, 11.177539610068, 1.68655468820899e-016, !- X,Y,Z Vertex 2 {m}
-  129.08661, 11.177539610068, -7.23757035746307e-016, !- X,Y,Z Vertex 3 {m}
+  123.1399084912, 11.177539610068, 1.68655468820899e-16, !- X,Y,Z Vertex 2 {m}
+  129.08661, 11.177539610068, -7.23757035746307e-16, !- X,Y,Z Vertex 3 {m}
   129.08661, 11.177539610068, 7.62;       !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
@@ -979,8 +969,8 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   120.552209999994, 5.11632945374419, 7.62, !- X,Y,Z Vertex 1 {m}
-  120.552209999994, -1.4088547167576e-007, 7.62, !- X,Y,Z Vertex 2 {m}
-  119.428082428438, -1.5718904642574e-006, 7.62, !- X,Y,Z Vertex 3 {m}
+  120.552209999994, -1.4088547167576e-07, 7.62, !- X,Y,Z Vertex 2 {m}
+  119.428082428438, -1.5718904642574e-06, 7.62, !- X,Y,Z Vertex 3 {m}
   119.428082428438, 5.11632945374419, 7.62; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
@@ -996,8 +986,8 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   110.774549471957, 5.11632928367435, 14.681994635845, !- X,Y,Z Vertex 1 {m}
-  110.774549471957, -9.01080549129342e-006, 12.5348971742631, !- X,Y,Z Vertex 2 {m}
-  110.774549471959, -1.36723017394117e-005, 7.62, !- X,Y,Z Vertex 3 {m}
+  110.774549471957, -9.01080549129342e-06, 12.5348971742631, !- X,Y,Z Vertex 2 {m}
+  110.774549471959, -1.36723017394117e-05, 7.62, !- X,Y,Z Vertex 3 {m}
   110.77454947196, 5.11632946079759, 7.62; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
@@ -1012,10 +1002,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  115.523009999993, 5.11632927638601, 14.681994678291, !- X,Y,Z Vertex 1 {m}
-  110.774549471957, 5.11632928329131, 14.681994635845, !- X,Y,Z Vertex 2 {m}
-  110.77454947196, 5.11632946118063, 7.62, !- X,Y,Z Vertex 3 {m}
-  115.523009999993, 5.11632945427534, 7.62; !- X,Y,Z Vertex 4 {m}
+  110.774549471957, 5.11632928329131, 14.681994635845, !- X,Y,Z Vertex 1 {m}
+  110.77454947196, 5.11632946118063, 7.62, !- X,Y,Z Vertex 2 {m}
+  115.523009999993, 5.11632945427534, 7.62, !- X,Y,Z Vertex 3 {m}
+  115.523009999993, 5.11632927638601, 14.681994678291; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {48c70f15-5169-414c-a0b3-5cadeed8d3d2}, !- Handle
@@ -1078,10 +1068,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  1.47698927526596e-030, -2.11436575218038e-028, -7.25520973722946e-014, !- X,Y,Z Vertex 1 {m}
-  -1.47698935456609e-030, -7.18375901923986, 7.25520979343103e-014, !- X,Y,Z Vertex 2 {m}
-  -5.1163329435005, -7.18375901923985, 7.1830185972142e-014, !- X,Y,Z Vertex 3 {m}
-  -5.11633321819841, -5.77529135625788e-015, -7.32740093732223e-014; !- X,Y,Z Vertex 4 {m}
+  1.47698927526596e-30, -2.11436575218038e-28, -7.25520973722946e-14, !- X,Y,Z Vertex 1 {m}
+  -1.47698935456609e-30, -7.18375901923986, 7.25520979343103e-14, !- X,Y,Z Vertex 2 {m}
+  -5.1163329435005, -7.18375901923985, 7.1830185972142e-14, !- X,Y,Z Vertex 3 {m}
+  -5.11633321819841, -5.77529135625788e-15, -7.32740093732223e-14; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {3cda9b5d-c68e-4ba7-a180-f52dfbf57a3e}, !- Handle
@@ -1095,10 +1085,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  4.29946719259289e-008, -7.18375901923986, 7.06199410953084, !- X,Y,Z Vertex 1 {m}
-  1.99226546217406e-009, -7.18375901923986, 6.20728148542859e-014, !- X,Y,Z Vertex 2 {m}
-  -2.05012035982098e-008, -4.74846052803378, -1.43225561378266e-015, !- X,Y,Z Vertex 3 {m}
-  2.05012035982098e-008, -4.74846052803377, 7.06199423572032; !- X,Y,Z Vertex 4 {m}
+  2.05012035982098e-08, -4.74846052803377, 7.06199423572032, !- X,Y,Z Vertex 1 {m}
+  4.29946719259289e-08, -7.18375901923986, 7.06199410953084, !- X,Y,Z Vertex 2 {m}
+  1.99226546217407e-09, -7.18375901923986, 6.20728148542859e-14, !- X,Y,Z Vertex 3 {m}
+  -2.05012035982098e-08, -4.74846052803378, -1.43225561378266e-15; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {59fb6386-8f17-4ad8-b182-2ba127ef2129}, !- Handle
@@ -1112,10 +1102,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -5.29559991548467e-008, 2.70781973785501e-015, 7.0619943619098, !- X,Y,Z Vertex 1 {m}
-  -4.35718445349936e-031, -2.70782194126771e-015, -6.20843820797745e-014, !- X,Y,Z Vertex 2 {m}
-  -5.11633321819841, -1.88454744092079e-015, -8.37417246657424e-014, !- X,Y,Z Vertex 3 {m}
-  -5.11633615254608, 1.88454964433349e-015, 4.91490032946463; !- X,Y,Z Vertex 4 {m}
+  -5.29559991548467e-08, 2.70781973785501e-15, 7.0619943619098, !- X,Y,Z Vertex 1 {m}
+  -4.35718445349936e-31, -2.70782194126771e-15, -6.20843820797745e-14, !- X,Y,Z Vertex 2 {m}
+  -5.11633321819841, -1.88454744092079e-15, -8.37417246657424e-14, !- X,Y,Z Vertex 3 {m}
+  -5.11633615254608, 1.88454964433349e-15, 4.91490032946463; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {b128e399-92c5-496e-add8-7b3b314cf9e8}, !- Handle
@@ -1129,10 +1119,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  4.49869373881029e-008, -7.18375901923988, 7.06199410953084, !- X,Y,Z Vertex 1 {m}
+  4.49869373881029e-08, -7.18375901923988, 7.06199410953084, !- X,Y,Z Vertex 1 {m}
   -5.11633587784802, -7.18375901923989, 4.91490008740174, !- X,Y,Z Vertex 2 {m}
-  -5.1163329435005, -7.18375901923987, 8.22979018266777e-014, !- X,Y,Z Vertex 3 {m}
-  -6.23155097265192e-029, -7.18375901923985, 6.20843820797746e-014; !- X,Y,Z Vertex 4 {m}
+  -5.1163329435005, -7.18375901923987, 8.22979018266777e-14, !- X,Y,Z Vertex 3 {m}
+  -6.23155097265192e-29, -7.18375901923985, 6.20843820797746e-14; !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {9df9c546-3a28-422a-84c0-6d023cf108a3}, !- Handle
@@ -1161,10 +1151,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -7.43240921077273e-032, 1.44382283906452e-014, -1.80477854883065e-015, !- X,Y,Z Vertex 1 {m}
-  7.43240921077272e-032, -2.43529849120606, -1.08286712929839e-015, !- X,Y,Z Vertex 2 {m}
-  -3.50597015632364, -2.43529849120606, -3.6095570976613e-016, !- X,Y,Z Vertex 3 {m}
-  -3.50597015632364, 1.44382283906452e-014, -1.08286712929839e-015; !- X,Y,Z Vertex 4 {m}
+  -7.43240921077273e-32, 1.44382283906452e-14, -1.80477854883065e-15, !- X,Y,Z Vertex 1 {m}
+  7.43240921077269e-32, -2.43529849120606, -1.08286712929839e-15, !- X,Y,Z Vertex 2 {m}
+  -3.50597015632364, -2.43529849120606, -3.6095570976613e-16, !- X,Y,Z Vertex 3 {m}
+  -3.50597015632364, 1.44382283906452e-14, -1.08286712929839e-15; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {6633122d-8858-4adc-87c5-5c5cd8a1cdf8}, !- Handle
@@ -1178,10 +1168,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  1.44382283906452e-015, -2.43529849120606, 8.53329282610745, !- X,Y,Z Vertex 1 {m}
-  7.89131844091797e-032, -2.43529849120606, -1.08286712929839e-015, !- X,Y,Z Vertex 2 {m}
-  -1.53099136938525e-032, 1.44382283906452e-014, -1.80477854883065e-015, !- X,Y,Z Vertex 3 {m}
-  1.44382283906452e-015, 1.73258740687743e-014, 8.53329282610745; !- X,Y,Z Vertex 4 {m}
+  1.44382283906452e-15, -2.43529849120606, 8.53329282610745, !- X,Y,Z Vertex 1 {m}
+  9.89502514017934e-32, -2.43529849120606, -1.08286712929839e-15, !- X,Y,Z Vertex 2 {m}
+  4.7271532987612e-33, 1.44382283906452e-14, -1.80477854883065e-15, !- X,Y,Z Vertex 3 {m}
+  1.44382283906452e-15, 1.73258740687743e-14, 8.53329282610745; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {2707717f-e345-4a6f-9ba1-4c25edfe5fbe}, !- Handle
@@ -1195,9 +1185,9 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -3.50597015632364, 3.75393938156776e-014, 7.06199423572032, !- X,Y,Z Vertex 1 {m}
-  -3.50597015632364, 1.44382283906452e-014, -1.08286712929839e-015, !- X,Y,Z Vertex 2 {m}
-  -3.50597015632364, -2.43529849120606, -3.6095570976613e-016, !- X,Y,Z Vertex 3 {m}
+  -3.50597015632364, 3.75393938156776e-14, 7.06199423572032, !- X,Y,Z Vertex 1 {m}
+  -3.50597015632364, 1.44382283906452e-14, -1.08286712929839e-15, !- X,Y,Z Vertex 2 {m}
+  -3.50597015632364, -2.43529849120606, -3.6095570976613e-16, !- X,Y,Z Vertex 3 {m}
   -3.50597015632364, -2.43529849120606, 7.06199423572032; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
@@ -1212,10 +1202,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  1.44382283906452e-015, -2.43529849120606, 8.53329282610745, !- X,Y,Z Vertex 1 {m}
+  1.44382283906452e-15, -2.43529849120606, 8.53329282610745, !- X,Y,Z Vertex 1 {m}
   -3.50597015632364, -2.43529849120606, 7.06199423572032, !- X,Y,Z Vertex 2 {m}
-  -3.50597015632364, -2.43529849120606, -3.6095570976613e-016, !- X,Y,Z Vertex 3 {m}
-  7.43240921077273e-032, -2.43529849120606, -1.08286712929839e-015; !- X,Y,Z Vertex 4 {m}
+  -3.50597015632364, -2.43529849120606, -3.6095570976613e-16, !- X,Y,Z Vertex 3 {m}
+  7.43240921077273e-32, -2.43529849120606, -1.08286712929839e-15; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {48123472-3301-4378-8af1-f47f86c1bf9e}, !- Handle
@@ -1229,10 +1219,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  1.44382283906454e-015, 2.24123670821883e-014, 8.53329282610745, !- X,Y,Z Vertex 1 {m}
-  -1.63708377191523e-029, 9.35173537723122e-015, -1.80477854883064e-015, !- X,Y,Z Vertex 2 {m}
-  -3.50597015632364, 2.05844433113352e-014, -1.0828671292984e-015, !- X,Y,Z Vertex 3 {m}
-  -3.50597015632364, 3.13931788949876e-014, 7.06199423572032; !- X,Y,Z Vertex 4 {m}
+  1.44382283906454e-15, 2.24123670821883e-14, 8.53329282610745, !- X,Y,Z Vertex 1 {m}
+  -1.63708377191523e-29, 9.35173537723119e-15, -1.80477854883064e-15, !- X,Y,Z Vertex 2 {m}
+  -3.50597015632364, 2.05844433113352e-14, -1.0828671292984e-15, !- X,Y,Z Vertex 3 {m}
+  -3.50597015632364, 3.13931788949876e-14, 7.06199423572032; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {ebfd2fac-de7d-433a-a488-e3b6e20ae3c4}, !- Handle
@@ -1246,10 +1236,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  2.00252770125456e-015, 1.73258740687743e-014, 8.53329282610745, !- X,Y,Z Vertex 1 {m}
-  -3.50597015632364, 3.75393938156776e-014, 7.06199423572032, !- X,Y,Z Vertex 2 {m}
+  2.00252770125456e-15, 1.73258740687743e-14, 8.53329282610745, !- X,Y,Z Vertex 1 {m}
+  -3.50597015632364, 3.75393938156776e-14, 7.06199423572032, !- X,Y,Z Vertex 2 {m}
   -3.50597015632364, -2.43529849120606, 7.06199423572032, !- X,Y,Z Vertex 3 {m}
-  2.00252770125456e-015, -2.43529849120606, 8.53329282610745; !- X,Y,Z Vertex 4 {m}
+  2.00252770125456e-15, -2.43529849120606, 8.53329282610745; !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {2068beb1-f72a-42a1-b012-d4c525765164}, !- Handle
@@ -1264,7 +1254,11 @@ OS:Space,
   {556dacb5-6766-4b7e-9859-166587ff15cb}, !- Building Story Name
   {6f6da13e-8cc0-4b66-ba77-f3f7916b1f52}, !- Thermal Zone Name
   ,                                       !- Part of Total Floor Area
-  ;                                       !- Design Specification Outdoor Air Object Name
+  ,                                       !- Design Specification Outdoor Air Object Name
+  ,                                       !- Building Unit Name
+  ,                                       !- Volume {m3}
+  ,                                       !- Ceiling Height {m}
+  ;                                       !- Floor Area {m2}
 
 OS:Surface,
   {4b28e131-d3c1-4b32-8ea0-8e45f150333a}, !- Handle
@@ -1278,10 +1272,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -5.11634312604591, 8.10053357029897e-015, -2.70042833664146e-007, !- X,Y,Z Vertex 1 {m}
-  -1.47384381081743e-013, 6.58378270325972e-014, 8.05753685162482e-007, !- X,Y,Z Vertex 2 {m}
-  -2.37803228241479e-013, -8.65353295647825, 1.34583935259665e-006, !- X,Y,Z Vertex 3 {m}
-  -5.11634312604593, -8.65353295647828, 2.70042833770038e-007; !- X,Y,Z Vertex 4 {m}
+  -5.11634312604591, 8.10053357029902e-15, -2.70042833664145e-07, !- X,Y,Z Vertex 1 {m}
+  -1.47384381081743e-13, 6.58378270325972e-14, 8.05753685162481e-07, !- X,Y,Z Vertex 2 {m}
+  -2.37803228241479e-13, -8.65353295647825, 1.34583935259665e-06, !- X,Y,Z Vertex 3 {m}
+  -5.11634312604593, -8.65353295647828, 2.70042833770037e-07; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {90f27137-eca7-48a3-8e29-9c3848148f04}, !- Handle
@@ -1295,10 +1289,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -9.96237793834317e-014, -8.65353295647829, 7.62, !- X,Y,Z Vertex 1 {m}
-  -1.55210951711459e-013, -8.65353295647827, 1.05947435637777e-006, !- X,Y,Z Vertex 2 {m}
-  -3.60955713530086e-014, -4.74846052803298, 6.64972109455142e-017, !- X,Y,Z Vertex 3 {m}
-  1.94916087037693e-014, -4.74846052803349, 7.62; !- X,Y,Z Vertex 4 {m}
+  -9.96237793834316e-14, -8.65353295647829, 7.62, !- X,Y,Z Vertex 1 {m}
+  -1.55210951711459e-13, -8.65353295647827, 1.05947435637777e-06, !- X,Y,Z Vertex 2 {m}
+  -3.60955713530085e-14, -4.74846052803298, 6.64972109455142e-17, !- X,Y,Z Vertex 3 {m}
+  1.94916087037693e-14, -4.74846052803349, 7.62; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {6e0bf4c6-4753-4f57-90c9-5cd4719c99fe}, !- Handle
@@ -1312,8 +1306,8 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -7.7244521889952e-014, -8.65353295647829, 7.62, !- X,Y,Z Vertex 1 {m}
-  -9.3848484539194e-015, -7.18375901923956, 7.62, !- X,Y,Z Vertex 2 {m}
+  -7.7244521889952e-14, -8.65353295647829, 7.62, !- X,Y,Z Vertex 1 {m}
+  -9.3848484539194e-15, -7.18375901923956, 7.62, !- X,Y,Z Vertex 2 {m}
   -5.11633230913287, -7.1837590192394, 7.62, !- X,Y,Z Vertex 3 {m}
   -5.11634312604592, -8.65353295647829, 7.62; !- X,Y,Z Vertex 4 {m}
 
@@ -1330,9 +1324,9 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   -5.11634312604592, -8.65353295647829, 7.62, !- X,Y,Z Vertex 1 {m}
-  -5.11634312604593, -8.65353295647828, 2.61031713488995e-007, !- X,Y,Z Vertex 2 {m}
-  -1.77590209204936e-013, -8.65353295647827, 1.05947435637777e-006, !- X,Y,Z Vertex 3 {m}
-  -7.7244521889952e-014, -8.65353295647829, 7.62; !- X,Y,Z Vertex 4 {m}
+  -5.11634312604593, -8.65353295647828, 2.61031713488995e-07, !- X,Y,Z Vertex 2 {m}
+  -1.77590209204936e-13, -8.65353295647827, 1.05947435637777e-06, !- X,Y,Z Vertex 3 {m}
+  -7.7244521889952e-14, -8.65353295647829, 7.62; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {9ad5bf34-0241-414e-ae77-3161bc94a224}, !- Handle
@@ -1346,10 +1340,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -8.66293703438718e-015, 2.88764575377273e-014, 7.62, !- X,Y,Z Vertex 1 {m}
-  -9.0960838861065e-014, 4.04270387373697e-014, 5.37410929505693e-007, !- X,Y,Z Vertex 2 {m}
-  -5.11634312604591, 1.7325873917487e-014, -2.61031713383089e-007, !- X,Y,Z Vertex 3 {m}
-  -5.11634312604592, 5.77529150754544e-015, 7.62; !- X,Y,Z Vertex 4 {m}
+  -8.66293703438718e-15, 2.88764575377273e-14, 7.62, !- X,Y,Z Vertex 1 {m}
+  -9.0960838861065e-14, 4.04270387373697e-14, 5.37410929505693e-07, !- X,Y,Z Vertex 2 {m}
+  -5.11634312604591, 1.7325873917487e-14, -2.61031713383089e-07, !- X,Y,Z Vertex 3 {m}
+  -5.11634312604592, 5.77529150754538e-15, 7.62; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {e0db5b97-c34d-4e82-8235-396a6d173832}, !- Handle
@@ -1363,9 +1357,9 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -5.11634312604592, 1.44382283906452e-014, 7.62, !- X,Y,Z Vertex 1 {m}
-  -5.11634312604592, 8.66293703438715e-015, -2.61031713383089e-007, !- X,Y,Z Vertex 2 {m}
-  -5.11634312604592, -8.65353295647828, 2.61031713488995e-007, !- X,Y,Z Vertex 3 {m}
+  -5.11634312604592, 1.44382283906452e-14, 7.62, !- X,Y,Z Vertex 1 {m}
+  -5.11634312604592, 8.66293703438715e-15, -2.61031713383089e-07, !- X,Y,Z Vertex 2 {m}
+  -5.11634312604592, -8.65353295647828, 2.61031713488995e-07, !- X,Y,Z Vertex 3 {m}
   -5.11634312604593, -8.65353295647829, 7.62; !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
@@ -1396,8 +1390,8 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   -3.50597015632364, -3.90507242844529, 7.62, !- X,Y,Z Vertex 1 {m}
-  -3.50597015632364, -3.90507242844529, 7.26849023161001e-017, !- X,Y,Z Vertex 2 {m}
-  0, -3.90507242844529, 5.77675466816808e-017, !- X,Y,Z Vertex 3 {m}
+  -3.50597015632364, -3.90507242844529, 7.26849023161001e-17, !- X,Y,Z Vertex 2 {m}
+  0, -3.90507242844529, 5.77675466816808e-17, !- X,Y,Z Vertex 3 {m}
   0, -3.90507242844529, 7.62;             !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
@@ -1412,9 +1406,9 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -3.50597015632364, -4.8512447392568e-013, 7.62, !- X,Y,Z Vertex 1 {m}
-  -3.50597015632364, -4.8512447392568e-013, 8.18876040168917e-017, !- X,Y,Z Vertex 2 {m}
-  -3.50597015632364, -3.90507242844529, 7.26849023161001e-017, !- X,Y,Z Vertex 3 {m}
+  -3.50597015632364, -4.8512447392568e-13, 7.62, !- X,Y,Z Vertex 1 {m}
+  -3.50597015632364, -4.8512447392568e-13, 8.18876040168917e-17, !- X,Y,Z Vertex 2 {m}
+  -3.50597015632364, -3.90507242844529, 7.26849023161001e-17, !- X,Y,Z Vertex 3 {m}
   -3.50597015632364, -3.90507242844529, 7.62; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
@@ -1429,10 +1423,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -1.80477854883578e-016, -3.90507242844529, 7.62, !- X,Y,Z Vertex 1 {m}
-  1.80477854883522e-016, -3.90507242844529, 5.77675466816808e-017, !- X,Y,Z Vertex 2 {m}
-  -1.06481934381022e-014, -2.43529849120659, 6.53352777633091e-017, !- X,Y,Z Vertex 3 {m}
-  -1.10091491478654e-014, -2.43529849120712, 7.62; !- X,Y,Z Vertex 4 {m}
+  -1.80477854883578e-16, -3.90507242844529, 7.62, !- X,Y,Z Vertex 1 {m}
+  1.80477854883522e-16, -3.90507242844529, 5.77675466816808e-17, !- X,Y,Z Vertex 2 {m}
+  -1.06481934381022e-14, -2.43529849120659, 6.53352777633091e-17, !- X,Y,Z Vertex 3 {m}
+  -1.10091491478654e-14, -2.43529849120712, 7.62; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {dce800d6-1c25-467b-83e2-dd4beeaa6ac8}, !- Handle
@@ -1447,7 +1441,7 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   0, -3.90507242844529, 7.62,             !- X,Y,Z Vertex 1 {m}
-  -1.1189627002749e-014, -2.43529849120712, 7.62, !- X,Y,Z Vertex 2 {m}
+  -1.1189627002749e-14, -2.43529849120712, 7.62, !- X,Y,Z Vertex 2 {m}
   -3.50597015632364, -2.43529849120656, 7.62, !- X,Y,Z Vertex 3 {m}
   -3.50597015632364, -3.90507242844529, 7.62; !- X,Y,Z Vertex 4 {m}
 
@@ -1463,10 +1457,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -2.88764567812905e-015, -4.8512447392568e-013, 7.62, !- X,Y,Z Vertex 1 {m}
-  0, -4.8512447392568e-013, 6.69702483824724e-017, !- X,Y,Z Vertex 2 {m}
-  -3.50597015632364, -4.8512447392568e-013, 8.18876040168917e-017, !- X,Y,Z Vertex 3 {m}
-  -3.50597015632364, -4.8512447392568e-013, 7.62; !- X,Y,Z Vertex 4 {m}
+  -2.88764567812905e-15, -4.8512447392568e-13, 7.62, !- X,Y,Z Vertex 1 {m}
+  0, -4.8512447392568e-13, 6.69702483824724e-17, !- X,Y,Z Vertex 2 {m}
+  -3.50597015632364, -4.8512447392568e-13, 8.18876040168917e-17, !- X,Y,Z Vertex 3 {m}
+  -3.50597015632364, -4.8512447392568e-13, 7.62; !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {4175322b-3017-44b7-86ae-61332a8665fc}, !- Handle
@@ -1481,7 +1475,11 @@ OS:Space,
   {556dacb5-6766-4b7e-9859-166587ff15cb}, !- Building Story Name
   {6f6da13e-8cc0-4b66-ba77-f3f7916b1f52}, !- Thermal Zone Name
   ,                                       !- Part of Total Floor Area
-  ;                                       !- Design Specification Outdoor Air Object Name
+  ,                                       !- Design Specification Outdoor Air Object Name
+  ,                                       !- Building Unit Name
+  ,                                       !- Volume {m3}
+  ,                                       !- Ceiling Height {m}
+  ;                                       !- Floor Area {m2}
 
 OS:Surface,
   {2130411a-0f3d-4de7-af8e-b419a73d4a95}, !- Handle
@@ -1495,12 +1493,12 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  2.88764567812905e-014, 1.29944055515807e-014, 4.80756586899059e-017, !- X,Y,Z Vertex 1 {m}
-  2.88764567812905e-014, -5.18159999999999, -1.06098305571319e-017, !- X,Y,Z Vertex 2 {m}
-  -4.13004000000012, -5.18159999999999, 6.08613186521379e-017, !- X,Y,Z Vertex 3 {m}
-  -4.13004000000012, -2.59390150879426, 9.01689363725774e-017, !- X,Y,Z Vertex 4 {m}
-  -2.55524000000012, -2.59390150879426, 6.29167146568667e-017, !- X,Y,Z Vertex 5 {m}
-  -2.55524000000012, 1.29944055515807e-014, 9.22945861834649e-017; !- X,Y,Z Vertex 6 {m}
+  2.88764567812905e-14, 1.29944055515807e-14, 4.80756586899059e-17, !- X,Y,Z Vertex 1 {m}
+  2.88764567812905e-14, -5.18159999999999, -1.06098305571319e-17, !- X,Y,Z Vertex 2 {m}
+  -4.13004000000012, -5.18159999999999, 6.08613186521379e-17, !- X,Y,Z Vertex 3 {m}
+  -4.13004000000012, -2.59390150879426, 9.01689363725774e-17, !- X,Y,Z Vertex 4 {m}
+  -2.55524000000012, -2.59390150879426, 6.29167146568667e-17, !- X,Y,Z Vertex 5 {m}
+  -2.55524000000012, 1.29944055515807e-14, 9.22945861834649e-17; !- X,Y,Z Vertex 6 {m}
 
 OS:Surface,
   {4dedb03f-1fa9-4258-bb12-4217ee5ff160}, !- Handle
@@ -1514,9 +1512,9 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  2.88764567812905e-014, -2.59390150879442, 7.62, !- X,Y,Z Vertex 1 {m}
-  2.88764567812905e-014, 1.29944055515807e-014, 7.62, !- X,Y,Z Vertex 2 {m}
-  -2.55524000000012, 1.29944055515807e-014, 7.62, !- X,Y,Z Vertex 3 {m}
+  2.88764567812905e-14, -2.59390150879442, 7.62, !- X,Y,Z Vertex 1 {m}
+  2.88764567812905e-14, 1.29944055515807e-14, 7.62, !- X,Y,Z Vertex 2 {m}
+  -2.55524000000012, 1.29944055515807e-14, 7.62, !- X,Y,Z Vertex 3 {m}
   -2.55524000000012, -2.59390150879426, 7.62; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
@@ -1531,10 +1529,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  2.88764567812905e-014, 1.29944055515807e-014, 7.62, !- X,Y,Z Vertex 1 {m}
-  2.88764567812905e-014, 1.29944055515807e-014, 4.80756586899059e-017, !- X,Y,Z Vertex 2 {m}
-  -2.55524000000012, 1.29944055515807e-014, 9.22945861834649e-017, !- X,Y,Z Vertex 3 {m}
-  -2.55524000000012, 1.29944055515807e-014, 7.62; !- X,Y,Z Vertex 4 {m}
+  2.88764567812905e-14, 1.29944055515807e-14, 7.62, !- X,Y,Z Vertex 1 {m}
+  2.88764567812905e-14, 1.29944055515807e-14, 4.80756586899059e-17, !- X,Y,Z Vertex 2 {m}
+  -2.55524000000012, 1.29944055515807e-14, 9.22945861834649e-17, !- X,Y,Z Vertex 3 {m}
+  -2.55524000000012, 1.29944055515807e-14, 7.62; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {c931a23b-edd0-48f3-8afd-f68a2f8b06a2}, !- Handle
@@ -1548,9 +1546,9 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -2.55524000000012, 1.29944055515807e-014, 7.62, !- X,Y,Z Vertex 1 {m}
-  -2.55524000000012, 1.29944055515807e-014, 9.22945861834649e-017, !- X,Y,Z Vertex 2 {m}
-  -2.55524000000012, -1.46977393723869, 1.80477854883065e-016, !- X,Y,Z Vertex 3 {m}
+  -2.55524000000012, 1.29944055515807e-14, 7.62, !- X,Y,Z Vertex 1 {m}
+  -2.55524000000012, 1.29944055515807e-14, 9.22945861834649e-17, !- X,Y,Z Vertex 2 {m}
+  -2.55524000000012, -1.46977393723869, 1.80477854883065e-16, !- X,Y,Z Vertex 3 {m}
   -2.55524000000012, -1.46977393723869, 7.62; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
@@ -1566,8 +1564,8 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   -2.55524000000012, -2.59390150879426, 7.62, !- X,Y,Z Vertex 1 {m}
-  -2.55524000000012, -2.59390150879426, 6.29167146568667e-017, !- X,Y,Z Vertex 2 {m}
-  -4.13004000000012, -2.59390150879426, 9.01689363725774e-017, !- X,Y,Z Vertex 3 {m}
+  -2.55524000000012, -2.59390150879426, 6.29167146568667e-17, !- X,Y,Z Vertex 2 {m}
+  -4.13004000000012, -2.59390150879426, 9.01689363725774e-17, !- X,Y,Z Vertex 3 {m}
   -4.13004000000012, -2.59390150879426, 7.62; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
@@ -1583,8 +1581,8 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   -4.13004000000012, -2.59390150879426, 7.62, !- X,Y,Z Vertex 1 {m}
-  -4.13004000000012, -2.59390150879426, 9.01689363725774e-017, !- X,Y,Z Vertex 2 {m}
-  -4.13004000000012, -5.18159999999999, 6.08613186521379e-017, !- X,Y,Z Vertex 3 {m}
+  -4.13004000000012, -2.59390150879426, 9.01689363725774e-17, !- X,Y,Z Vertex 2 {m}
+  -4.13004000000012, -5.18159999999999, 6.08613186521379e-17, !- X,Y,Z Vertex 3 {m}
   -4.13004000000012, -5.18159999999999, 7.62; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
@@ -1600,9 +1598,9 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   -4.13004000000012, -5.18159999999999, 7.62, !- X,Y,Z Vertex 1 {m}
-  -4.13004000000012, -5.18159999999999, 6.08613186521379e-017, !- X,Y,Z Vertex 2 {m}
-  2.88764567812905e-014, -5.18159999999999, -1.06098305571319e-017, !- X,Y,Z Vertex 3 {m}
-  2.88764567812905e-014, -5.18159999999999, 7.62; !- X,Y,Z Vertex 4 {m}
+  -4.13004000000012, -5.18159999999999, 6.08613186521379e-17, !- X,Y,Z Vertex 2 {m}
+  2.88764567812905e-14, -5.18159999999999, -1.06098305571319e-17, !- X,Y,Z Vertex 3 {m}
+  2.88764567812905e-14, -5.18159999999999, 7.62; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {b69c5724-a645-4b14-a6ef-71f1c5fc115c}, !- Handle
@@ -1616,10 +1614,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  2.88764567812905e-014, -5.18159999999999, 7.62, !- X,Y,Z Vertex 1 {m}
-  2.88764567812905e-014, -5.18159999999999, -1.06098305571319e-017, !- X,Y,Z Vertex 2 {m}
-  2.88764567812905e-014, 1.29944055515807e-014, 4.80756586899059e-017, !- X,Y,Z Vertex 3 {m}
-  2.88764567812905e-014, 1.29944055515807e-014, 7.62; !- X,Y,Z Vertex 4 {m}
+  2.88764567812905e-14, -5.18159999999999, 7.62, !- X,Y,Z Vertex 1 {m}
+  2.88764567812905e-14, -5.18159999999999, -1.06098305571319e-17, !- X,Y,Z Vertex 2 {m}
+  2.88764567812905e-14, 1.29944055515807e-14, 4.80756586899059e-17, !- X,Y,Z Vertex 3 {m}
+  2.88764567812905e-14, 1.29944055515807e-14, 7.62; !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {0ea5422a-d3d4-4527-a933-6f4216516b56}, !- Handle
@@ -1648,12 +1646,12 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  3.50597015632364, 2.88764567812905e-015, -3.96307593883482e-017, !- X,Y,Z Vertex 1 {m}
-  3.50597015632364, -1.12412757155557, -8.17210265459168e-017, !- X,Y,Z Vertex 2 {m}
-  1.93117015632364, -1.12412757155557, -5.86711626651611e-017, !- X,Y,Z Vertex 3 {m}
-  1.93117015632364, -3.7118260627613, -1.55561340945698e-016, !- X,Y,Z Vertex 4 {m}
-  1.44382283906452e-015, -3.7118260627613, -1.27295396550322e-016, !- X,Y,Z Vertex 5 {m}
-  1.44382283906452e-015, 2.88764567812905e-015, 1.16850488877833e-017; !- X,Y,Z Vertex 6 {m}
+  3.50597015632364, 2.88764567812905e-15, -3.96307593883482e-17, !- X,Y,Z Vertex 1 {m}
+  3.50597015632364, -1.12412757155557, -8.17210265459168e-17, !- X,Y,Z Vertex 2 {m}
+  1.93117015632364, -1.12412757155557, -5.86711626651611e-17, !- X,Y,Z Vertex 3 {m}
+  1.93117015632364, -3.7118260627613, -1.55561340945698e-16, !- X,Y,Z Vertex 4 {m}
+  1.44382283906452e-15, -3.7118260627613, -1.27295396550322e-16, !- X,Y,Z Vertex 5 {m}
+  1.44382283906452e-15, 2.88764567812905e-15, 1.16850488877833e-17; !- X,Y,Z Vertex 6 {m}
 
 OS:Surface,
   {8354d5ba-e44a-49bf-8022-a12130da7fcf}, !- Handle
@@ -1668,8 +1666,8 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   1.93117015632364, -1.12412757155557, 7.62, !- X,Y,Z Vertex 1 {m}
-  1.93117015632364, -1.12412757155557, -5.86711626651611e-017, !- X,Y,Z Vertex 2 {m}
-  3.50597015632364, -1.12412757155557, -8.17210265459168e-017, !- X,Y,Z Vertex 3 {m}
+  1.93117015632364, -1.12412757155557, -5.86711626651611e-17, !- X,Y,Z Vertex 2 {m}
+  3.50597015632364, -1.12412757155557, -8.17210265459168e-17, !- X,Y,Z Vertex 3 {m}
   3.50597015632364, -1.12412757155557, 7.62; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
@@ -1684,10 +1682,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  3.50597015632364, 2.88764567812905e-015, 7.62, !- X,Y,Z Vertex 1 {m}
-  3.50597015632364, 2.88764567812905e-015, -3.96307593883482e-017, !- X,Y,Z Vertex 2 {m}
-  1.44382283906452e-015, 2.88764567812905e-015, 1.16850488877833e-017, !- X,Y,Z Vertex 3 {m}
-  1.44382283906452e-015, 2.88764567812905e-015, 7.62; !- X,Y,Z Vertex 4 {m}
+  3.50597015632364, 2.88764567812905e-15, 7.62, !- X,Y,Z Vertex 1 {m}
+  3.50597015632364, 2.88764567812905e-15, -3.96307593883482e-17, !- X,Y,Z Vertex 2 {m}
+  1.44382283906452e-15, 2.88764567812905e-15, 1.16850488877833e-17, !- X,Y,Z Vertex 3 {m}
+  1.44382283906452e-15, 2.88764567812905e-15, 7.62; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {d0adfa5b-07f3-4dae-9577-f54c19df32ce}, !- Handle
@@ -1702,8 +1700,8 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   1.93117015632364, -3.7118260627613, 7.62, !- X,Y,Z Vertex 1 {m}
-  1.93117015632364, -3.7118260627613, -1.55561340945698e-016, !- X,Y,Z Vertex 2 {m}
-  1.93117015632364, -1.12412757155557, -5.86711626651611e-017, !- X,Y,Z Vertex 3 {m}
+  1.93117015632364, -3.7118260627613, -1.55561340945698e-16, !- X,Y,Z Vertex 2 {m}
+  1.93117015632364, -1.12412757155557, -5.86711626651611e-17, !- X,Y,Z Vertex 3 {m}
   1.93117015632364, -1.12412757155557, 7.62; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
@@ -1718,10 +1716,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  1.44382283906452e-015, -1.12412757155568, 7.62, !- X,Y,Z Vertex 1 {m}
-  3.50597015632364, -1.12412757155557, 7.62, !- X,Y,Z Vertex 2 {m}
-  3.50597015632364, 2.88764567812905e-015, 7.62, !- X,Y,Z Vertex 3 {m}
-  1.44382283906452e-015, 2.88764567812905e-015, 7.62; !- X,Y,Z Vertex 4 {m}
+  3.50597015632364, -1.12412757155557, 7.62, !- X,Y,Z Vertex 1 {m}
+  3.50597015632364, 2.88764567812905e-15, 7.62, !- X,Y,Z Vertex 2 {m}
+  1.44382283906452e-15, 2.88764567812905e-15, 7.62, !- X,Y,Z Vertex 3 {m}
+  1.44382283906452e-15, -1.12412757155568, 7.62; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {5c264968-7dda-4091-8f71-836f40ba4179}, !- Handle
@@ -1735,10 +1733,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  1.44382283906452e-015, 2.88764567812905e-015, 7.62, !- X,Y,Z Vertex 1 {m}
-  1.44382283906452e-015, 2.88764567812905e-015, 1.16850488877833e-017, !- X,Y,Z Vertex 2 {m}
-  1.44382283906452e-015, -3.7118260627613, -1.27295396550322e-016, !- X,Y,Z Vertex 3 {m}
-  1.44382283906452e-015, -3.7118260627613, 7.62; !- X,Y,Z Vertex 4 {m}
+  1.44382283906452e-15, 2.88764567812905e-15, 7.62, !- X,Y,Z Vertex 1 {m}
+  1.44382283906452e-15, 2.88764567812905e-15, 1.16850488877833e-17, !- X,Y,Z Vertex 2 {m}
+  1.44382283906452e-15, -3.7118260627613, -1.27295396550322e-16, !- X,Y,Z Vertex 3 {m}
+  1.44382283906452e-15, -3.7118260627613, 7.62; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {013e9731-cf10-4c07-b8a4-53885a700bb1}, !- Handle
@@ -1753,9 +1751,9 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   3.50597015632364, -1.12412757155557, 7.62, !- X,Y,Z Vertex 1 {m}
-  3.50597015632364, -1.12412757155557, -8.17210265459168e-017, !- X,Y,Z Vertex 2 {m}
-  3.50597015632364, 2.88764567812905e-015, -3.96307593883482e-017, !- X,Y,Z Vertex 3 {m}
-  3.50597015632364, 2.88764567812905e-015, 7.62; !- X,Y,Z Vertex 4 {m}
+  3.50597015632364, -1.12412757155557, -8.17210265459168e-17, !- X,Y,Z Vertex 2 {m}
+  3.50597015632364, 2.88764567812905e-15, -3.96307593883482e-17, !- X,Y,Z Vertex 3 {m}
+  3.50597015632364, 2.88764567812905e-15, 7.62; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {5cad73a8-fdd2-4915-a762-451256db9550}, !- Handle
@@ -1769,9 +1767,9 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  1.44382283906452e-015, -3.7118260627613, 7.62, !- X,Y,Z Vertex 1 {m}
-  1.44382283906452e-015, -3.7118260627613, -1.27295396550322e-016, !- X,Y,Z Vertex 2 {m}
-  1.93117015632364, -3.7118260627613, -1.55561340945698e-016, !- X,Y,Z Vertex 3 {m}
+  1.44382283906452e-15, -3.7118260627613, 7.62, !- X,Y,Z Vertex 1 {m}
+  1.44382283906452e-15, -3.7118260627613, -1.27295396550322e-16, !- X,Y,Z Vertex 2 {m}
+  1.93117015632364, -3.7118260627613, -1.55561340945698e-16, !- X,Y,Z Vertex 3 {m}
   1.93117015632364, -3.7118260627613, 7.62; !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
@@ -1801,10 +1799,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -11.1775397579712, 2.58769849120541, 7.62, !- X,Y,Z Vertex 1 {m}
-  -6.06121015632376, 2.58769849120562, 7.62, !- X,Y,Z Vertex 2 {m}
-  -6.06121015632376, 3.7118260627613, 7.62, !- X,Y,Z Vertex 3 {m}
-  -11.1775532823697, 3.7118260627613, 7.62; !- X,Y,Z Vertex 4 {m}
+  -6.06121015632376, 2.58769849120562, 7.62, !- X,Y,Z Vertex 1 {m}
+  -6.06121015632376, 3.7118260627613, 7.62, !- X,Y,Z Vertex 2 {m}
+  -11.1775532823697, 3.7118260627613, 7.62, !- X,Y,Z Vertex 3 {m}
+  -11.1775397579712, 2.58769849120541, 7.62; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {f0157ed9-9f37-4dab-89e5-53552f037ae2}, !- Handle
@@ -1818,9 +1816,9 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -6.06121015632376, 2.88764567812905e-015, 7.62, !- X,Y,Z Vertex 1 {m}
-  -6.06121015632376, 2.88764567812905e-015, 9.02389274415323e-017, !- X,Y,Z Vertex 2 {m}
-  -6.06121015632376, 3.7118260627613, 1.18559630718392e-016, !- X,Y,Z Vertex 3 {m}
+  -6.06121015632376, 2.88764567812905e-15, 7.62, !- X,Y,Z Vertex 1 {m}
+  -6.06121015632376, 2.88764567812905e-15, 9.02389274415323e-17, !- X,Y,Z Vertex 2 {m}
+  -6.06121015632376, 3.7118260627613, 1.18559630718392e-16, !- X,Y,Z Vertex 3 {m}
   -6.06121015632376, 3.7118260627613, 7.62; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
@@ -1835,10 +1833,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  2.88764567812905e-014, -5.94670150880041, 7.62, !- X,Y,Z Vertex 1 {m}
-  2.88764567812905e-014, -5.94670150880041, -2.63092609398371e-017, !- X,Y,Z Vertex 2 {m}
-  2.88764567812905e-014, 2.88764567812905e-015, 3.30809055525356e-019, !- X,Y,Z Vertex 3 {m}
-  2.88764567812905e-014, 2.88764567812905e-015, 7.62; !- X,Y,Z Vertex 4 {m}
+  2.88764567812905e-14, -5.94670150880041, 7.62, !- X,Y,Z Vertex 1 {m}
+  2.88764567812905e-14, -5.94670150880041, -2.63092609398371e-17, !- X,Y,Z Vertex 2 {m}
+  2.88764567812905e-14, 2.88764567812905e-15, 3.30809055525356e-19, !- X,Y,Z Vertex 3 {m}
+  2.88764567812905e-14, 2.88764567812905e-15, 7.62; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {583ff918-79ee-4dad-b760-731641168041}, !- Handle
@@ -1853,8 +1851,8 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   -11.1775532823697, 3.7118260627613, 7.62, !- X,Y,Z Vertex 1 {m}
-  -11.1775532823697, 3.7118260627613, 2.0432193157678e-016, !- X,Y,Z Vertex 2 {m}
-  -11.177539610068, -5.94670150880041, 1.61053371174331e-016, !- X,Y,Z Vertex 3 {m}
+  -11.1775532823697, 3.7118260627613, 2.0432193157678e-16, !- X,Y,Z Vertex 2 {m}
+  -11.177539610068, -5.94670150880041, 1.61053371174331e-16, !- X,Y,Z Vertex 3 {m}
   -11.177539610068, -5.94670150880041, 7.62; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
@@ -1869,10 +1867,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  2.88764567812905e-014, 2.88764567812905e-015, 7.62, !- X,Y,Z Vertex 1 {m}
-  2.88764567812905e-014, 2.88764567812905e-015, 3.30809055525356e-019, !- X,Y,Z Vertex 2 {m}
-  -4.13004000000012, 2.88764567812905e-015, 6.14877838383153e-017, !- X,Y,Z Vertex 3 {m}
-  -4.13004000000012, 2.88764567812905e-015, 7.62; !- X,Y,Z Vertex 4 {m}
+  2.88764567812905e-14, 2.88764567812905e-15, 7.62, !- X,Y,Z Vertex 1 {m}
+  2.88764567812905e-14, 2.88764567812905e-15, 3.30809055525356e-19, !- X,Y,Z Vertex 2 {m}
+  -4.13004000000012, 2.88764567812905e-15, 6.14877838383153e-17, !- X,Y,Z Vertex 3 {m}
+  -4.13004000000012, 2.88764567812905e-15, 7.62; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {ee7540d4-e54b-4058-953c-c49826893bb8}, !- Handle
@@ -1887,9 +1885,9 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   -11.177539610068, -5.94670150880041, 7.62, !- X,Y,Z Vertex 1 {m}
-  -11.177539610068, -5.94670150880041, 1.61053371174331e-016, !- X,Y,Z Vertex 2 {m}
-  2.88764567812905e-014, -5.94670150880041, -2.63092609398371e-017, !- X,Y,Z Vertex 3 {m}
-  2.88764567812905e-014, -5.94670150880041, 7.62; !- X,Y,Z Vertex 4 {m}
+  -11.177539610068, -5.94670150880041, 1.61053371174331e-16, !- X,Y,Z Vertex 2 {m}
+  2.88764567812905e-14, -5.94670150880041, -2.63092609398371e-17, !- X,Y,Z Vertex 3 {m}
+  2.88764567812905e-14, -5.94670150880041, 7.62; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {68b288fa-5c40-43df-bf10-4e0987b53e97}, !- Handle
@@ -1904,8 +1902,8 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   120.552209999994, 75.0823541518511, 7.62, !- X,Y,Z Vertex 1 {m}
-  120.552209999994, 75.0823541438696, 1.60143946953225e-016, !- X,Y,Z Vertex 2 {m}
-  120.552209999994, 69.2970070000574, -6.40232186815051e-009, !- X,Y,Z Vertex 3 {m}
+  120.552209999994, 75.0823541438696, 1.60143946953225e-16, !- X,Y,Z Vertex 2 {m}
+  120.552209999994, 69.2970070000574, -6.40232186815051e-09, !- X,Y,Z Vertex 3 {m}
   120.552209999994, 69.2970070000573, 7.62; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
@@ -1937,10 +1935,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  110.660140930164, 69.2970067219677, 14.9627505869168, !- X,Y,Z Vertex 1 {m}
-  120.552209999994, 69.2970066524515, 14.9627501227822, !- X,Y,Z Vertex 2 {m}
-  120.552209999994, 69.2970069652994, 7.62, !- X,Y,Z Vertex 3 {m}
-  110.66014092893, 69.2970070348156, 7.62; !- X,Y,Z Vertex 4 {m}
+  120.552209999994, 69.2970066524515, 14.9627501227822, !- X,Y,Z Vertex 1 {m}
+  120.552209999994, 69.2970069652994, 7.62, !- X,Y,Z Vertex 2 {m}
+  110.66014092893, 69.2970070348156, 7.62, !- X,Y,Z Vertex 3 {m}
+  110.660140930164, 69.2970067219677, 14.9627505869168; !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {57afc005-a9f0-4332-b376-06f605f98162}, !- Handle
@@ -1969,10 +1967,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  5.78534713884114, -2.02135197469033e-014, 1.75050062042711e-018, !- X,Y,Z Vertex 1 {m}
-  5.78534713884114, -9.89206907057826, -1.75050062042711e-018, !- X,Y,Z Vertex 2 {m}
-  3.46517481375486e-014, -9.89206907057826, -5.25150186128132e-018, !- X,Y,Z Vertex 3 {m}
-  3.46517481375486e-014, -2.02135197469033e-014, -1.75050062042711e-018; !- X,Y,Z Vertex 4 {m}
+  5.78534713884114, -2.02135197469033e-14, 1.75050062042711e-18, !- X,Y,Z Vertex 1 {m}
+  5.78534713884114, -9.89206907057826, -1.75050062042711e-18, !- X,Y,Z Vertex 2 {m}
+  3.46517481375486e-14, -9.89206907057826, -5.25150186128132e-18, !- X,Y,Z Vertex 3 {m}
+  3.46517481375486e-14, -2.02135197469033e-14, -1.75050062042711e-18; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {127573e8-028c-4c8e-8a61-2d1c7f7b6dfd}, !- Handle
@@ -1987,9 +1985,9 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   5.78534713884114, -9.89206907057826, 7.62, !- X,Y,Z Vertex 1 {m}
-  5.78534713884114, -9.89206907057826, -1.75050062042711e-018, !- X,Y,Z Vertex 2 {m}
-  5.78534713884114, -2.02135197469033e-014, 1.75050062042711e-018, !- X,Y,Z Vertex 3 {m}
-  5.78534713884114, -2.02135197469033e-014, 7.62; !- X,Y,Z Vertex 4 {m}
+  5.78534713884114, -9.89206907057826, -1.75050062042711e-18, !- X,Y,Z Vertex 2 {m}
+  5.78534713884114, -2.02135197469033e-14, 1.75050062042711e-18, !- X,Y,Z Vertex 3 {m}
+  5.78534713884114, -2.02135197469033e-14, 7.62; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {c0771b30-51e3-458f-b2f4-5a234bf0fc5b}, !- Handle
@@ -2003,10 +2001,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  3.46517481375486e-014, -2.02135197469033e-014, 7.62, !- X,Y,Z Vertex 1 {m}
-  3.46517481375486e-014, -2.02135197469033e-014, -1.75050062042711e-018, !- X,Y,Z Vertex 2 {m}
-  3.46517481375486e-014, -9.89206907057826, -5.25150186128132e-018, !- X,Y,Z Vertex 3 {m}
-  3.46517481375486e-014, -9.89206907057826, 7.62; !- X,Y,Z Vertex 4 {m}
+  3.46517481375486e-14, -2.02135197469033e-14, 7.62, !- X,Y,Z Vertex 1 {m}
+  3.46517481375486e-14, -2.02135197469033e-14, -1.75050062042711e-18, !- X,Y,Z Vertex 2 {m}
+  3.46517481375486e-14, -9.89206907057826, -5.25150186128132e-18, !- X,Y,Z Vertex 3 {m}
+  3.46517481375486e-14, -9.89206907057826, 7.62; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {eca7133a-6d1f-4541-9485-9de483b1b2e9}, !- Handle
@@ -2020,9 +2018,9 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  3.46517481375486e-014, -9.89206907057826, 7.62, !- X,Y,Z Vertex 1 {m}
-  3.46517481375486e-014, -9.89206907057826, -5.25150186128132e-018, !- X,Y,Z Vertex 2 {m}
-  5.78534713884114, -9.89206907057826, -1.75050062042711e-018, !- X,Y,Z Vertex 3 {m}
+  3.46517481375486e-14, -9.89206907057826, 7.62, !- X,Y,Z Vertex 1 {m}
+  3.46517481375486e-14, -9.89206907057826, -5.25150186128132e-18, !- X,Y,Z Vertex 2 {m}
+  5.78534713884114, -9.89206907057826, -1.75050062042711e-18, !- X,Y,Z Vertex 3 {m}
   5.78534713884114, -9.89206907057826, 7.62; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
@@ -2037,10 +2035,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  5.78534713884114, -2.02135197469033e-014, 7.62, !- X,Y,Z Vertex 1 {m}
-  5.78534713884114, -2.02135197469033e-014, 1.75050062042711e-018, !- X,Y,Z Vertex 2 {m}
-  3.46517481375486e-014, -2.02135197469033e-014, -1.75050062042711e-018, !- X,Y,Z Vertex 3 {m}
-  3.46517481375486e-014, -2.02135197469033e-014, 7.62; !- X,Y,Z Vertex 4 {m}
+  5.78534713884114, -2.02135197469033e-14, 7.62, !- X,Y,Z Vertex 1 {m}
+  5.78534713884114, -2.02135197469033e-14, 1.75050062042711e-18, !- X,Y,Z Vertex 2 {m}
+  3.46517481375486e-14, -2.02135197469033e-14, -1.75050062042711e-18, !- X,Y,Z Vertex 3 {m}
+  3.46517481375486e-14, -2.02135197469033e-14, 7.62; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {23dc377e-3c7a-486b-8ee1-e5ef628413f1}, !- Handle
@@ -2055,9 +2053,9 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   5.78534713884114, -9.89206907057826, 7.62, !- X,Y,Z Vertex 1 {m}
-  5.78534713884114, -2.02135197469033e-014, 7.62, !- X,Y,Z Vertex 2 {m}
-  3.46517481375486e-014, -2.02135197469033e-014, 7.62, !- X,Y,Z Vertex 3 {m}
-  3.46517481375486e-014, -9.89206907057826, 7.62; !- X,Y,Z Vertex 4 {m}
+  5.78534713884114, -2.02135197469033e-14, 7.62, !- X,Y,Z Vertex 2 {m}
+  3.46517481375486e-14, -2.02135197469033e-14, 7.62, !- X,Y,Z Vertex 3 {m}
+  3.46517481375486e-14, -9.89206907057826, 7.62; !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {7d77740b-1876-4aca-bd46-1dc4402fe86b}, !- Handle
@@ -2086,10 +2084,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  5.78534715300304, -1.32119665522623e-008, 0, !- X,Y,Z Vertex 1 {m}
-  5.78534715300304, -9.89206907057851, 0, !- X,Y,Z Vertex 2 {m}
-  3.46517481375486e-014, -9.89206907057851, 0, !- X,Y,Z Vertex 3 {m}
-  3.46517481375486e-014, 9.08901492948644e-009, 0; !- X,Y,Z Vertex 4 {m}
+  3.46517481375486e-14, 9.08901492948644e-09, 0, !- X,Y,Z Vertex 1 {m}
+  5.78534715300304, -1.32119665522623e-08, 0, !- X,Y,Z Vertex 2 {m}
+  5.78534715300304, -9.89206907057851, 0, !- X,Y,Z Vertex 3 {m}
+  3.46517481375486e-14, -9.89206907057851, 0; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {57f445d1-22a3-4a13-886d-0c37651242f2}, !- Handle
@@ -2105,8 +2103,8 @@ OS:Surface,
   ,                                       !- Number of Vertices
   5.78534694473738, -9.89206907057851, 4.9148993484292, !- X,Y,Z Vertex 1 {m}
   5.78534715300304, -9.89206907057851, 0, !- X,Y,Z Vertex 2 {m}
-  5.78534715300304, -1.32119665522623e-008, 0, !- X,Y,Z Vertex 3 {m}
-  5.78534694473738, -1.94765203787028e-008, 4.9148993484292; !- X,Y,Z Vertex 4 {m}
+  5.78534715300304, -1.32119665522623e-08, 0, !- X,Y,Z Vertex 3 {m}
+  5.78534694473738, -1.94765203787028e-08, 4.9148993484292; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {1966a5d6-36c6-40a5-8fc8-fb0a6bb16ac1}, !- Handle
@@ -2120,10 +2118,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  3.46517481375486e-014, -2.02135197469033e-014, 7.3427511208222, !- X,Y,Z Vertex 1 {m}
-  3.46517481375486e-014, 9.08901492948644e-009, 0, !- X,Y,Z Vertex 2 {m}
-  3.46517481375486e-014, -9.89206907057851, 0, !- X,Y,Z Vertex 3 {m}
-  3.46517481375486e-014, -9.89206907057851, 7.3427511208222; !- X,Y,Z Vertex 4 {m}
+  3.46517481375486e-14, -2.02135197469033e-14, 7.3427511208222, !- X,Y,Z Vertex 1 {m}
+  3.46517481375486e-14, 9.08901492948644e-09, 0, !- X,Y,Z Vertex 2 {m}
+  3.46517481375486e-14, -9.89206907057851, 0, !- X,Y,Z Vertex 3 {m}
+  3.46517481375486e-14, -9.89206907057851, 7.3427511208222; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {77db6043-fc5b-4785-b0be-b94cd7baf8d1}, !- Handle
@@ -2137,8 +2135,8 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  3.46517481375486e-014, -9.89206907057851, 7.3427511208222, !- X,Y,Z Vertex 1 {m}
-  3.46517481375486e-014, -9.89206907057851, 0, !- X,Y,Z Vertex 2 {m}
+  3.46517481375486e-14, -9.89206907057851, 7.3427511208222, !- X,Y,Z Vertex 1 {m}
+  3.46517481375486e-14, -9.89206907057851, 0, !- X,Y,Z Vertex 2 {m}
   5.78534715300304, -9.89206907057851, 0, !- X,Y,Z Vertex 3 {m}
   5.78534694473738, -9.89206907057851, 4.9148993484292; !- X,Y,Z Vertex 4 {m}
 
@@ -2169,10 +2167,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  61.7219863212786, 129.08661, -1.6903663516482e-007, !- X,Y,Z Vertex 1 {m}
+  61.7219863212786, 129.08661, -1.6903663516482e-07, !- X,Y,Z Vertex 1 {m}
   61.7219863212786, 129.08661, -3.45439931457034, !- X,Y,Z Vertex 2 {m}
   61.7219863276882, 135.614156, -3.45439932347944, !- X,Y,Z Vertex 3 {m}
-  61.7219863276882, 135.614156, -2.24755467220449e-007; !- X,Y,Z Vertex 4 {m}
+  61.7219863276882, 135.614156, -2.24755467220449e-07; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {90ae01e4-8c80-4221-82a4-0f7745b02405}, !- Handle
@@ -2186,10 +2184,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  61.7219863276882, 135.614156, -2.24755467220449e-007, !- X,Y,Z Vertex 1 {m}
-  61.7219863276882, 135.614156, -3.45439932347944, !- X,Y,Z Vertex 2 {m}
-  13.3603863276882, 135.614156, -3.45439911839822, !- X,Y,Z Vertex 3 {m}
-  13.3603863276882, 135.614156, 8.82207040423411e-007; !- X,Y,Z Vertex 4 {m}
+  13.3603863276882, 135.614156, 8.82207040423411e-07, !- X,Y,Z Vertex 1 {m}
+  61.7219863276882, 135.614156, -2.24755467220449e-07, !- X,Y,Z Vertex 2 {m}
+  61.7219863276882, 135.614156, -3.45439932347944, !- X,Y,Z Vertex 3 {m}
+  13.3603863276882, 135.614156, -3.45439911839822; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {bcfd9bb6-5599-46dc-b7cb-d122b4bea0e1}, !- Handle
@@ -2203,10 +2201,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  75.0823542072365, 118.846600000006, -7.08056516711361e-007, !- X,Y,Z Vertex 1 {m}
-  75.0823542082805, 118.846600000006, -3.4544, !- X,Y,Z Vertex 2 {m}
-  75.0823542258465, 129.08661, -3.45440064499745, !- X,Y,Z Vertex 3 {m}
-  75.0823542248026, 129.08661, -6.57784348165007e-007; !- X,Y,Z Vertex 4 {m}
+  75.0823542248026, 129.08661, -6.57784348165007e-07, !- X,Y,Z Vertex 1 {m}
+  75.0823542072365, 118.846600000006, -7.08056516711361e-07, !- X,Y,Z Vertex 2 {m}
+  75.0823542082805, 118.846600000006, -3.4544, !- X,Y,Z Vertex 3 {m}
+  75.0823542258465, 129.08661, -3.45440064499745; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {508aa3c9-c575-4beb-873e-f86eba6c1b5d}, !- Handle
@@ -2220,10 +2218,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  13.3603863276882, 135.614156, 8.82207040423411e-007, !- X,Y,Z Vertex 1 {m}
-  13.3603863276882, 135.614156, -3.45439911839822, !- X,Y,Z Vertex 2 {m}
-  13.3603863276882, 129.08661, -3.45439910948912, !- X,Y,Z Vertex 3 {m}
-  13.3603863276882, 129.08661, 9.3792587233233e-007; !- X,Y,Z Vertex 4 {m}
+  13.3603863276882, 129.08661, 9.3792587233233e-07, !- X,Y,Z Vertex 1 {m}
+  13.3603863276882, 135.614156, 8.82207040423411e-07, !- X,Y,Z Vertex 2 {m}
+  13.3603863276882, 135.614156, -3.45439911839822, !- X,Y,Z Vertex 3 {m}
+  13.3603863276882, 129.08661, -3.45439910948912; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {0262bd17-5dda-4d9e-b2e5-fcbb6590f4df}, !- Handle
@@ -2237,10 +2235,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  75.0823542058633, -1.06712747434223e-013, -8.61101441600339e-008, !- X,Y,Z Vertex 1 {m}
-  75.0823542058633, -4.86205495869289e-014, -3.45439937266219, !- X,Y,Z Vertex 2 {m}
-  75.0823541776712, 27.9692099999999, -3.45439923321632, !- X,Y,Z Vertex 3 {m}
-  75.0823541776712, 27.9692099999999, 3.88287547649883e-007; !- X,Y,Z Vertex 4 {m}
+  75.0823541776712, 27.9692099999999, 3.88287547649883e-07, !- X,Y,Z Vertex 1 {m}
+  75.0823542058633, -1.06712747445866e-13, -8.61101441600339e-08, !- X,Y,Z Vertex 2 {m}
+  75.0823542058633, -4.86205495985715e-14, -3.45439937266219, !- X,Y,Z Vertex 3 {m}
+  75.0823541776712, 27.9692099999999, -3.45439923321632; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {fb85cf01-f937-4914-909c-f6d1d3b8eba6}, !- Handle
@@ -2254,10 +2252,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  13.3603863276882, 129.08661, 9.3792587233233e-007, !- X,Y,Z Vertex 1 {m}
-  13.3603863276882, 129.08661, -3.45439910948912, !- X,Y,Z Vertex 2 {m}
-  2.80080324549862e-008, 129.08661, -3.45439905283333, !- X,Y,Z Vertex 3 {m}
-  2.80080105337784e-008, 129.08661, 1.24373557923584e-006; !- X,Y,Z Vertex 4 {m}
+  2.80080105337784e-08, 129.08661, 1.24373557923584e-06, !- X,Y,Z Vertex 1 {m}
+  13.3603863276882, 129.08661, 9.3792587233233e-07, !- X,Y,Z Vertex 2 {m}
+  13.3603863276882, 129.08661, -3.45439910948912, !- X,Y,Z Vertex 3 {m}
+  2.80080324549862e-08, 129.08661, -3.45439905283333; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {bada4e1e-54d9-4a79-8021-840d37d067cd}, !- Handle
@@ -2271,10 +2269,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  75.0823541776712, 27.9692099999999, 3.88287547649883e-007, !- X,Y,Z Vertex 1 {m}
-  75.0823541776712, 27.9692099999999, -3.45439923321632, !- X,Y,Z Vertex 2 {m}
-  74.8537541764558, 27.9692099999999, -3.45439923224692, !- X,Y,Z Vertex 3 {m}
-  74.8537541776738, 27.9692099999999, 3.93520038494778e-007; !- X,Y,Z Vertex 4 {m}
+  74.8537541776738, 27.9692099999999, 3.93520038494778e-07, !- X,Y,Z Vertex 1 {m}
+  75.0823541776712, 27.9692099999999, 3.88287547649883e-07, !- X,Y,Z Vertex 2 {m}
+  75.0823541776712, 27.9692099999999, -3.45439923321632, !- X,Y,Z Vertex 3 {m}
+  74.8537541764558, 27.9692099999999, -3.45439923224692; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {c6b9c10b-2042-4d38-b539-96612faf71dc}, !- Handle
@@ -2288,10 +2286,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  2.80080109893547e-008, 129.08661, 1.24373557923584e-006, !- X,Y,Z Vertex 1 {m}
-  2.80080319994099e-008, 129.08661, -3.45439905283333, !- X,Y,Z Vertex 2 {m}
-  2.41700248728322e-013, 101.12121, -3.45439901466485, !- X,Y,Z Vertex 3 {m}
-  2.20690192368585e-013, 101.12121, 1.48244694581224e-006; !- X,Y,Z Vertex 4 {m}
+  2.20690192368585e-13, 101.12121, 1.48244694581224e-06, !- X,Y,Z Vertex 1 {m}
+  2.80080109893547e-08, 129.08661, 1.24373557923584e-06, !- X,Y,Z Vertex 2 {m}
+  2.80080319994099e-08, 129.08661, -3.45439905283333, !- X,Y,Z Vertex 3 {m}
+  2.41700248749837e-13, 101.12121, -3.45439901466485; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {1d6eda74-52e3-4064-86f4-6fc27e493b24}, !- Handle
@@ -2305,10 +2303,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  2.21145768676736e-013, 101.12121, 1.48244694581224e-006, !- X,Y,Z Vertex 1 {m}
-  2.41244672441686e-013, 101.12121, -3.45439901466485, !- X,Y,Z Vertex 2 {m}
+  2.21145768676736e-13, 101.12121, 1.48244694581224e-06, !- X,Y,Z Vertex 1 {m}
+  2.41244672441686e-13, 101.12121, -3.45439901466485, !- X,Y,Z Vertex 2 {m}
   0.228600000000237, 101.12121, -3.45439901563425, !- X,Y,Z Vertex 3 {m}
-  0.228600000000212, 101.12121, 1.47721445496729e-006; !- X,Y,Z Vertex 4 {m}
+  0.228600000000212, 101.12121, 1.47721445496729e-06; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {1fa4625c-6344-4a3e-b33b-10a21757de6a}, !- Handle
@@ -2322,10 +2320,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0.228600000000213, 101.12121, 1.47721445496729e-006, !- X,Y,Z Vertex 1 {m}
-  0.228600000000236, 101.12121, -3.45439901563425, !- X,Y,Z Vertex 2 {m}
-  0.228600000000141, 27.96921, -3.454398915793, !- X,Y,Z Vertex 3 {m}
-  0.228600000000119, 27.9692100000012, 2.10163655659647e-006; !- X,Y,Z Vertex 4 {m}
+  0.228600000000119, 27.9692100000012, 2.10163655659647e-06, !- X,Y,Z Vertex 1 {m}
+  0.228600000000213, 101.12121, 1.47721445496729e-06, !- X,Y,Z Vertex 2 {m}
+  0.228600000000236, 101.12121, -3.45439901563425, !- X,Y,Z Vertex 3 {m}
+  0.228600000000141, 27.96921, -3.454398915793; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {91b18eb1-5420-4bd7-bcd2-6e15fe2bf1d1}, !- Handle
@@ -2339,10 +2337,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0.22860000000012, 27.9692100000017, 2.10163655659647e-006, !- X,Y,Z Vertex 1 {m}
+  0.22860000000012, 27.9692100000017, 2.10163655659647e-06, !- X,Y,Z Vertex 1 {m}
   0.22860000000014, 27.9692099999994, -3.454398915793, !- X,Y,Z Vertex 2 {m}
-  4.48622405056781e-006, 27.9692100000012, -3.45439999999168, !- X,Y,Z Vertex 3 {m}
-  -4.48622384765778e-006, 27.9692100000035, 2.05603000912826e-006; !- X,Y,Z Vertex 4 {m}
+  4.48622405056781e-06, 27.9692100000012, -3.45439999999168, !- X,Y,Z Vertex 3 {m}
+  -4.48622384765778e-06, 27.9692100000035, 2.05603000912826e-06; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {f9d7ef60-7be3-4e7a-b3fd-0cbfc8b53f10}, !- Handle
@@ -2356,10 +2354,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  61.7219863212786, 129.08661, -1.6903663516482e-007, !- X,Y,Z Vertex 1 {m}
-  75.0823542248059, 129.08661, -6.57784348165006e-007, !- X,Y,Z Vertex 2 {m}
-  75.0823542258432, 129.08661, -3.45440064499745, !- X,Y,Z Vertex 3 {m}
-  61.7219863212786, 129.08661, -3.45439931457034; !- X,Y,Z Vertex 4 {m}
+  75.0823542248059, 129.08661, -6.57784348165006e-07, !- X,Y,Z Vertex 1 {m}
+  75.0823542258432, 129.08661, -3.45440064499745, !- X,Y,Z Vertex 2 {m}
+  61.7219863212786, 129.08661, -3.45439931457034, !- X,Y,Z Vertex 3 {m}
+  61.7219863212786, 129.08661, -1.6903663516482e-07; !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {2cfa91f0-f336-4b15-8108-94b7c8c253b8}, !- Handle
@@ -2388,10 +2386,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  61.7219863276882, 135.614156, -2.28593650787164e-007, !- X,Y,Z Vertex 1 {m}
-  61.7219863276882, 135.614156, -3.14960039052279, !- X,Y,Z Vertex 2 {m}
-  13.3603863276882, 135.614156, -3.14959996181096, !- X,Y,Z Vertex 3 {m}
-  13.3603863276882, 135.614156, 8.25779881374795e-008; !- X,Y,Z Vertex 4 {m}
+  13.3603863276882, 135.614156, 8.25779881374795e-08, !- X,Y,Z Vertex 1 {m}
+  61.7219863276882, 135.614156, -2.28593650787164e-07, !- X,Y,Z Vertex 2 {m}
+  61.7219863276882, 135.614156, -3.14960039052279, !- X,Y,Z Vertex 3 {m}
+  13.3603863276882, 135.614156, -3.14959996181096; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {cd875f72-2d9d-41a2-9ae3-ca947c6aec18}, !- Handle
@@ -2405,10 +2403,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  13.3603863276882, 129.08661, 1.26717690148742e-007, !- X,Y,Z Vertex 1 {m}
-  13.3603863276882, 135.614156, 8.25779881374795e-008, !- X,Y,Z Vertex 2 {m}
-  13.3603863276882, 135.614156, -3.14959996181096, !- X,Y,Z Vertex 3 {m}
-  13.3603863276882, 129.08661, -3.14959989421879; !- X,Y,Z Vertex 4 {m}
+  13.3603863276882, 135.614156, 8.25779881374795e-08, !- X,Y,Z Vertex 1 {m}
+  13.3603863276882, 135.614156, -3.14959996181096, !- X,Y,Z Vertex 2 {m}
+  13.3603863276882, 129.08661, -3.14959989421879, !- X,Y,Z Vertex 3 {m}
+  13.3603863276882, 129.08661, 1.26717690148742e-07; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {bd392081-7c7b-49ca-b719-163e048f00c2}, !- Handle
@@ -2422,10 +2420,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  2.80079865730235e-008, 129.08661, 2.12682035859757e-007, !- X,Y,Z Vertex 1 {m}
-  13.3603863276882, 129.08661, 1.26717690148742e-007, !- X,Y,Z Vertex 2 {m}
-  13.3603863276882, 129.08661, -3.14959989421879, !- X,Y,Z Vertex 3 {m}
-  2.80079870688342e-008, 129.08661, -3.14959977578276; !- X,Y,Z Vertex 4 {m}
+  13.3603863276882, 129.08661, 1.26717690148742e-07, !- X,Y,Z Vertex 1 {m}
+  13.3603863276882, 129.08661, -3.14959989421879, !- X,Y,Z Vertex 2 {m}
+  2.80079870688342e-08, 129.08661, -3.14959977578276, !- X,Y,Z Vertex 3 {m}
+  2.80079865730235e-08, 129.08661, 2.12682035859757e-07; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {3bf25c9c-95d0-46b6-8fe4-fa74d30d9604}, !- Handle
@@ -2439,10 +2437,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  74.8537541776738, 27.9692099999999, 4.1481531075757e-007, !- X,Y,Z Vertex 1 {m}
-  75.0823541776712, 27.9692099999999, 4.13344436413931e-007, !- X,Y,Z Vertex 2 {m}
-  75.0823541776712, 27.9692099999999, -3.14959939430456, !- X,Y,Z Vertex 3 {m}
-  74.8537541776738, 27.9692099999999, -3.14959939227809; !- X,Y,Z Vertex 4 {m}
+  75.0823541776712, 27.9692099999999, 4.13344436413931e-07, !- X,Y,Z Vertex 1 {m}
+  75.0823541776712, 27.9692099999999, -3.14959939430456, !- X,Y,Z Vertex 2 {m}
+  74.8537541776738, 27.9692099999999, -3.14959939227809, !- X,Y,Z Vertex 3 {m}
+  74.8537541776738, 27.9692099999999, 4.1481531075757e-07; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {89340fd8-8320-4165-8826-e35cacc5620d}, !- Handle
@@ -2456,10 +2454,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  1.9215480329158e-013, 101.12121, 4.01785938582478e-007, !- X,Y,Z Vertex 1 {m}
-  2.80079864934876e-008, 129.08661, 2.12682035859757e-007, !- X,Y,Z Vertex 2 {m}
-  2.80079871483701e-008, 129.08661, -3.14959977578276, !- X,Y,Z Vertex 3 {m}
-  1.92809685707264e-013, 101.12121, -3.14959948620347; !- X,Y,Z Vertex 4 {m}
+  2.80079864934876e-08, 129.08661, 2.12682035859757e-07, !- X,Y,Z Vertex 1 {m}
+  2.80079871483701e-08, 129.08661, -3.14959977578276, !- X,Y,Z Vertex 2 {m}
+  1.92809685728779e-13, 101.12121, -3.14959948620347, !- X,Y,Z Vertex 3 {m}
+  1.92154803270065e-13, 101.12121, 4.01785938582478e-07; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {1fd43d44-6bff-422e-9428-70ba4169932a}, !- Handle
@@ -2473,10 +2471,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  74.8537541781804, 27.9692099999999, 4.14815310757407e-007, !- X,Y,Z Vertex 1 {m}
+  74.8537541781804, 27.9692099999999, 4.14815310757407e-07, !- X,Y,Z Vertex 1 {m}
   74.8537541771672, 27.9692099999999, -3.14959939227809, !- X,Y,Z Vertex 2 {m}
   74.8537541929013, 110.265209996664, -3.14960024444604, !- X,Y,Z Vertex 3 {m}
-  74.8537541939146, 110.265209996664, -8.29941492936158e-009; !- X,Y,Z Vertex 4 {m}
+  74.8537541939146, 110.265209996664, -8.29941492936157e-09; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {32de56bb-80bb-4707-925f-5294cecaed60}, !- Handle
@@ -2490,10 +2488,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  1.92075267422654e-013, 101.12121, 4.01785938582478e-007, !- X,Y,Z Vertex 1 {m}
-  1.9288922157619e-013, 101.12121, -3.14959948620347, !- X,Y,Z Vertex 2 {m}
+  1.92075267422654e-13, 101.12121, 4.01785938582478e-07, !- X,Y,Z Vertex 1 {m}
+  1.9288922157619e-13, 101.12121, -3.14959948620347, !- X,Y,Z Vertex 2 {m}
   0.228600000000188, 101.12121, -3.14959948822994, !- X,Y,Z Vertex 3 {m}
-  0.228600000000186, 101.12121, 4.00315064238822e-007; !- X,Y,Z Vertex 4 {m}
+  0.228600000000186, 101.12121, 4.00315064238822e-07; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {2a39c4f7-3e47-4891-901b-bbe48e699af2}, !- Handle
@@ -2507,10 +2505,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0.228600000000081, 27.9692100000001, 8.94973773886807e-007, !- X,Y,Z Vertex 1 {m}
-  0.228600000000186, 101.12121, 4.00315064238822e-007, !- X,Y,Z Vertex 2 {m}
-  0.228600000000188, 101.12121, -3.14959948822994, !- X,Y,Z Vertex 3 {m}
-  0.228600000000084, 27.96921, -3.14959873074732; !- X,Y,Z Vertex 4 {m}
+  0.228600000000186, 101.12121, 4.00315064238822e-07, !- X,Y,Z Vertex 1 {m}
+  0.228600000000188, 101.12121, -3.14959948822994, !- X,Y,Z Vertex 2 {m}
+  0.228600000000084, 27.96921, -3.14959873074732, !- X,Y,Z Vertex 3 {m}
+  0.228600000000081, 27.9692100000001, 8.94973773886807e-07; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {9f61edec-c8da-494e-8f02-f8c81d91543b}, !- Handle
@@ -2524,10 +2522,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  75.0823541960533, 110.265209996165, 2.84459810181219e-010, !- X,Y,Z Vertex 1 {m}
+  75.0823541960533, 110.265209996165, 2.84459810181226e-10, !- X,Y,Z Vertex 1 {m}
   75.08235419504, 110.265209996165, -3.14960024647251, !- X,Y,Z Vertex 2 {m}
   75.0823542242993, 129.08661, -3.14960044136648, !- X,Y,Z Vertex 3 {m}
-  75.0823542253125, 129.08661, -3.21725345293252e-007; !- X,Y,Z Vertex 4 {m}
+  75.0823542253125, 129.08661, -3.21725345293252e-07; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {7c225f24-ad3a-4b65-af1a-ce4f466bb42a}, !- Handle
@@ -2541,10 +2539,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -4.27259345730069e-007, 27.9692100000001, 8.96444650979566e-007, !- X,Y,Z Vertex 1 {m}
-  0.228600000000081, 27.9692100000001, 8.94973773886807e-007, !- X,Y,Z Vertex 2 {m}
-  0.228600000000084, 27.96921, -3.14959873074732, !- X,Y,Z Vertex 3 {m}
-  4.27259523161485e-007, 27.9692099999999, -3.14959872872085; !- X,Y,Z Vertex 4 {m}
+  0.228600000000081, 27.9692100000001, 8.94973773886807e-07, !- X,Y,Z Vertex 1 {m}
+  0.228600000000084, 27.96921, -3.14959873074732, !- X,Y,Z Vertex 2 {m}
+  4.27259523161485e-07, 27.9692099999999, -3.14959872872085, !- X,Y,Z Vertex 3 {m}
+  -4.27259345730069e-07, 27.9692100000001, 8.96444650979566e-07; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {63617173-25f4-4d05-b3b9-cf643bc39a71}, !- Handle
@@ -2558,10 +2556,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  61.7219863212786, 129.08661, -1.8445394873466e-007, !- X,Y,Z Vertex 1 {m}
+  61.7219863212786, 129.08661, -1.8445394873466e-07, !- X,Y,Z Vertex 1 {m}
   61.7219863212786, 129.08661, -3.14960032293062, !- X,Y,Z Vertex 2 {m}
   61.7219863276882, 135.614156, -3.14960039052279, !- X,Y,Z Vertex 3 {m}
-  61.7219863276882, 135.614156, -2.28593650787164e-007; !- X,Y,Z Vertex 4 {m}
+  61.7219863276882, 135.614156, -2.28593650787164e-07; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {e9b16f03-3e89-4844-ae3b-180613ebbb2b}, !- Handle
@@ -2575,10 +2573,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -6.36492509613333e-007, -1.36684982965202e-013, 1.0855743183428e-006, !- X,Y,Z Vertex 1 {m}
-  1.06082087345904e-006, 3.46336188422396e-013, -3.14959843910211, !- X,Y,Z Vertex 2 {m}
-  75.0823542058633, 1.31778013888542e-013, -3.14959910468582, !- X,Y,Z Vertex 3 {m}
-  75.0823542058633, -3.51243189078855e-013, 5.94283562662667e-007; !- X,Y,Z Vertex 4 {m}
+  -6.36492509613333e-07, -1.36684982965202e-13, 1.0855743183428e-06, !- X,Y,Z Vertex 1 {m}
+  1.06082087345904e-06, 3.46336188422396e-13, -3.14959843910211, !- X,Y,Z Vertex 2 {m}
+  75.0823542058633, 1.31778013888542e-13, -3.14959910468582, !- X,Y,Z Vertex 3 {m}
+  75.0823542058633, -3.51243189078855e-13, 5.94283562662667e-07; !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {a4c44d3f-19db-4622-9461-87490721667d}, !- Handle
@@ -2608,9 +2606,9 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   19.4817863276952, -24.8662287296965, 0, !- X,Y,Z Vertex 1 {m}
-  19.4817863276952, 3.46517481375486e-014, 0, !- X,Y,Z Vertex 2 {m}
-  1.80477854883065e-016, 3.46517481375486e-014, 0, !- X,Y,Z Vertex 3 {m}
-  -3.69528407873076e-014, -24.8662287296965, 0; !- X,Y,Z Vertex 4 {m}
+  19.4817863276952, 3.46517481375486e-14, 0, !- X,Y,Z Vertex 2 {m}
+  1.80477854883065e-16, 3.46517481375486e-14, 0, !- X,Y,Z Vertex 3 {m}
+  -3.69528407873076e-14, -24.8662287296965, 0; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {49430a8b-563d-4e16-a66b-dec0015f4140}, !- Handle
@@ -2624,8 +2622,8 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -3.69528407873076e-014, -24.8662287296965, 0, !- X,Y,Z Vertex 1 {m}
-  -3.69528407873076e-014, -24.8662287296965, -3.1496, !- X,Y,Z Vertex 2 {m}
+  -3.69528407873076e-14, -24.8662287296965, 0, !- X,Y,Z Vertex 1 {m}
+  -3.69528407873076e-14, -24.8662287296965, -3.1496, !- X,Y,Z Vertex 2 {m}
   19.4817863276952, -24.8662287296965, -3.1496, !- X,Y,Z Vertex 3 {m}
   19.4817863276952, -24.8662287296965, 0; !- X,Y,Z Vertex 4 {m}
 
@@ -2641,10 +2639,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  19.4817863276952, 3.46517481375486e-014, -3.1496, !- X,Y,Z Vertex 1 {m}
+  19.4817863276952, 3.46517481375486e-14, -3.1496, !- X,Y,Z Vertex 1 {m}
   19.4817863276952, -24.8662287296965, -3.1496, !- X,Y,Z Vertex 2 {m}
-  -3.69528407873076e-014, -24.8662287296965, -3.1496, !- X,Y,Z Vertex 3 {m}
-  1.80477854883065e-016, 3.46517481375486e-014, -3.1496; !- X,Y,Z Vertex 4 {m}
+  -3.69528407873076e-14, -24.8662287296965, -3.1496, !- X,Y,Z Vertex 3 {m}
+  1.80477854883065e-16, 3.46517481375486e-14, -3.1496; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {8aadeb07-52f7-4578-98fd-eae8a838252c}, !- Handle
@@ -2658,10 +2656,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  1.80477854883069e-016, 3.46517481375486e-014, 0, !- X,Y,Z Vertex 1 {m}
-  1.80477854883069e-016, 3.46517481375486e-014, -3.1496, !- X,Y,Z Vertex 2 {m}
-  -3.69528407873076e-014, -24.8662287296965, -3.1496, !- X,Y,Z Vertex 3 {m}
-  -3.69528407873076e-014, -24.8662287296965, 0; !- X,Y,Z Vertex 4 {m}
+  1.8047785488307e-16, 3.46517481375486e-14, 0, !- X,Y,Z Vertex 1 {m}
+  1.8047785488307e-16, 3.46517481375486e-14, -3.1496, !- X,Y,Z Vertex 2 {m}
+  -3.69528407873076e-14, -24.8662287296965, -3.1496, !- X,Y,Z Vertex 3 {m}
+  -3.69528407873076e-14, -24.8662287296965, 0; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {c7de2e2b-6a63-4bda-aca5-5732e55f1602}, !- Handle
@@ -2677,8 +2675,8 @@ OS:Surface,
   ,                                       !- Number of Vertices
   19.4817863276952, -24.8662287296965, 0, !- X,Y,Z Vertex 1 {m}
   19.4817863276952, -24.8662287296965, -3.1496, !- X,Y,Z Vertex 2 {m}
-  19.4817863276952, 3.46517481375486e-014, -3.1496, !- X,Y,Z Vertex 3 {m}
-  19.4817863276952, 3.46517481375486e-014, 0; !- X,Y,Z Vertex 4 {m}
+  19.4817863276952, 3.46517481375486e-14, -3.1496, !- X,Y,Z Vertex 3 {m}
+  19.4817863276952, 3.46517481375486e-14, 0; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {fccca844-19d9-4b57-82fa-cca815092eb2}, !- Handle
@@ -2692,10 +2690,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  19.4817863276952, 3.46517481375486e-014, 0, !- X,Y,Z Vertex 1 {m}
-  19.4817863276952, 3.46517481375486e-014, -3.1496, !- X,Y,Z Vertex 2 {m}
-  1.80477854883065e-016, 3.46517481375486e-014, -3.1496, !- X,Y,Z Vertex 3 {m}
-  1.80477854883065e-016, 3.46517481375486e-014, 0; !- X,Y,Z Vertex 4 {m}
+  19.4817863276952, 3.46517481375486e-14, 0, !- X,Y,Z Vertex 1 {m}
+  19.4817863276952, 3.46517481375486e-14, -3.1496, !- X,Y,Z Vertex 2 {m}
+  1.80477854883065e-16, 3.46517481375486e-14, -3.1496, !- X,Y,Z Vertex 3 {m}
+  1.80477854883065e-16, 3.46517481375486e-14, 0; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {1b3078f7-6e59-478c-9d05-27a9472ca655}, !- Handle
@@ -2709,10 +2707,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  5.11633034987576, 18.3120595175827, 2.07219288890774e-006, !- X,Y,Z Vertex 1 {m}
-  5.11633974957729, 18.3120595175829, -3.45439892333932, !- X,Y,Z Vertex 2 {m}
-  5.1163380405447, 9.65852656110722, -3.45439891152857, !- X,Y,Z Vertex 3 {m}
-  5.11632864083468, 9.65852656110877, 5.20442471896359e-006; !- X,Y,Z Vertex 4 {m}
+  5.11632864083468, 9.65852656110877, 5.20442471896359e-06, !- X,Y,Z Vertex 1 {m}
+  5.11633034987576, 18.3120595175827, 2.07219288890774e-06, !- X,Y,Z Vertex 2 {m}
+  5.11633974957729, 18.3120595175829, -3.45439892333932, !- X,Y,Z Vertex 3 {m}
+  5.1163380405447, 9.65852656110722, -3.45439891152857; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {a8ae00f4-83f7-4a77-8fd0-ac2426ed4095}, !- Handle
@@ -2726,10 +2724,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -2.99081594596962e-006, 18.3120605280399, 9.61746957181609e-007, !- X,Y,Z Vertex 1 {m}
-  -4.27259345954989e-007, 27.9692100000001, 8.96444650979566e-007, !- X,Y,Z Vertex 2 {m}
-  4.27259523386404e-007, 27.9692099999999, -3.14959872872085, !- X,Y,Z Vertex 3 {m}
-  -2.13629708604169e-006, 18.3120605280401, -3.14959862872188; !- X,Y,Z Vertex 4 {m}
+  -4.27259345954988e-07, 27.9692100000001, 8.96444650979566e-07, !- X,Y,Z Vertex 1 {m}
+  4.27259523386403e-07, 27.9692099999999, -3.14959872872085, !- X,Y,Z Vertex 2 {m}
+  -2.13629708604169e-06, 18.3120605280401, -3.14959862872188, !- X,Y,Z Vertex 3 {m}
+  -2.99081594596962e-06, 18.3120605280399, 9.61746957181609e-07; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {98651747-948c-4843-a502-d338f2486b98}, !- Handle
@@ -2743,10 +2741,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  5.11633760156569, 9.65852604894428, 9.87342813533951e-007, !- X,Y,Z Vertex 1 {m}
-  5.11634015339792, 9.65852604894402, -3.1495985844702, !- X,Y,Z Vertex 2 {m}
-  -4.50234490312574e-006, 9.65852757156178, -3.14959853911528, !- X,Y,Z Vertex 3 {m}
-  -6.19965830437139e-006, 9.65852757156178, 1.02026274562874e-006; !- X,Y,Z Vertex 4 {m}
+  -6.19965830437139e-06, 9.65852757156178, 1.02026274562874e-06, !- X,Y,Z Vertex 1 {m}
+  5.11633760156569, 9.65852604894428, 9.87342813533951e-07, !- X,Y,Z Vertex 2 {m}
+  5.11634015339792, 9.65852604894402, -3.1495985844702, !- X,Y,Z Vertex 3 {m}
+  -4.50234490312574e-06, 9.65852757156178, -3.14959853911528; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {131f4038-2ab9-4ce8-88cf-f4875fa54705}, !- Handle
@@ -2760,10 +2758,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  5.11633760156569, 9.65852604894396, 9.87342813533954e-007, !- X,Y,Z Vertex 1 {m}
-  5.1163401768466, 18.3120590054224, 9.28827029163314e-007, !- X,Y,Z Vertex 2 {m}
-  5.11634272867884, 18.3120590054222, -3.14959867407681, !- X,Y,Z Vertex 3 {m}
-  5.11634015339792, 9.65852604894434, -3.1495985844702; !- X,Y,Z Vertex 4 {m}
+  5.1163401768466, 18.3120590054224, 9.28827029163305e-07, !- X,Y,Z Vertex 1 {m}
+  5.11634272867884, 18.3120590054222, -3.14959867407681, !- X,Y,Z Vertex 2 {m}
+  5.11634015339792, 9.65852604894434, -3.1495985844702, !- X,Y,Z Vertex 3 {m}
+  5.11633760156569, 9.65852604894396, 9.87342813533963e-07; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {a3cee5c6-a794-4605-b648-6bf2d6935fe7}, !- Handle
@@ -2777,10 +2775,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -2.99081594619455e-006, 18.3120605280399, 9.61746957181609e-007, !- X,Y,Z Vertex 1 {m}
-  -2.13629708581676e-006, 18.3120605280401, -3.14959862872188, !- X,Y,Z Vertex 2 {m}
+  -2.99081594619458e-06, 18.3120605280399, 9.61746957181609e-07, !- X,Y,Z Vertex 1 {m}
+  -2.13629708581673e-06, 18.3120605280401, -3.14959862872188, !- X,Y,Z Vertex 2 {m}
   5.11634272867884, 18.3120590054222, -3.14959867407681, !- X,Y,Z Vertex 3 {m}
-  5.1163401768466, 18.3120590054224, 9.28827029163317e-007; !- X,Y,Z Vertex 4 {m}
+  5.1163401768466, 18.3120590054224, 9.28827029163317e-07; !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {37cb42a6-fea1-4e0a-8549-add4555c8b3a}, !- Handle
@@ -2809,10 +2807,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -5.1163422838333, 8.65353447909603, -3.1089779848545e-006, !- X,Y,Z Vertex 1 {m}
-  4.20152446021458e-013, 8.65353447909553, -1.0363259949512e-006, !- X,Y,Z Vertex 2 {m}
-  -4.20152446021458e-013, 2.48337528232588e-013, 1.0363259949512e-006, !- X,Y,Z Vertex 3 {m}
-  -5.11634228383246, -2.48337528232588e-013, -1.03632599495119e-006; !- X,Y,Z Vertex 4 {m}
+  4.20152446021457e-13, 8.65353447909553, -1.0363259949512e-06, !- X,Y,Z Vertex 1 {m}
+  -4.20152446021457e-13, 2.48337528232587e-13, 1.0363259949512e-06, !- X,Y,Z Vertex 2 {m}
+  -5.11634228383246, -2.48337528232587e-13, -1.03632599495119e-06, !- X,Y,Z Vertex 3 {m}
+  -5.1163422838333, 8.65353447909603, -3.1089779848545e-06; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {516fd4cb-b4fb-4e96-8fc5-75204bec5762}, !- Handle
@@ -2826,10 +2824,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -5.11634355974789, 7.54375855478885e-007, 3.14959676746568, !- X,Y,Z Vertex 1 {m}
-  -5.11634355974823, 8.65353523347196, 3.1495933994062, !- X,Y,Z Vertex 2 {m}
-  -5.11634228383331, 8.65353447909603, -3.1089779848545e-006, !- X,Y,Z Vertex 3 {m}
-  -5.11634228383245, -2.48337528232587e-013, -1.03632599495119e-006; !- X,Y,Z Vertex 4 {m}
+  -5.11634355974823, 8.65353523347196, 3.1495933994062, !- X,Y,Z Vertex 1 {m}
+  -5.11634228383331, 8.65353447909603, -3.1089779848545e-06, !- X,Y,Z Vertex 2 {m}
+  -5.11634228383245, -2.48337528232587e-13, -1.03632599495119e-06, !- X,Y,Z Vertex 3 {m}
+  -5.11634355974789, 7.54375855478885e-07, 3.14959676746568; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {f8cb2ac2-9f24-4a2a-8b20-55555a30f129}, !- Handle
@@ -2843,10 +2841,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -1.27591598614517e-006, 7.54376593272353e-007, 3.14959909919917, !- X,Y,Z Vertex 1 {m}
-  -4.29911878088929e-013, 2.48337528232589e-013, 1.0363259949512e-006, !- X,Y,Z Vertex 2 {m}
-  4.2991188200123e-013, 8.65353447909553, -1.0363259949512e-006, !- X,Y,Z Vertex 3 {m}
-  -1.27591460154633e-006, 8.65353523347141, 3.14959573113968; !- X,Y,Z Vertex 4 {m}
+  -1.27591598614517e-06, 7.54376593272353e-07, 3.14959909919917, !- X,Y,Z Vertex 1 {m}
+  -4.29911877615609e-13, 2.48337528232589e-13, 1.0363259949512e-06, !- X,Y,Z Vertex 2 {m}
+  4.29911881051907e-13, 8.65353447909553, -1.0363259949512e-06, !- X,Y,Z Vertex 3 {m}
+  -1.27591460154633e-06, 8.65353523347141, 3.14959573113968; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {0e0ea117-0df5-446f-bae2-ea71733ba12a}, !- Handle
@@ -2860,9 +2858,9 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -1.27591459178689e-006, 8.65353523347144, 3.14959573113968, !- X,Y,Z Vertex 1 {m}
-  4.20152446021453e-013, 8.6535344790955, -1.03632599495119e-006, !- X,Y,Z Vertex 2 {m}
-  -5.1163422838333, 8.65353447909606, -3.10897798485451e-006, !- X,Y,Z Vertex 3 {m}
+  -1.27591459178689e-06, 8.65353523347144, 3.14959573113968, !- X,Y,Z Vertex 1 {m}
+  4.20152446021456e-13, 8.6535344790955, -1.03632599495119e-06, !- X,Y,Z Vertex 2 {m}
+  -5.1163422838333, 8.65353447909606, -3.10897798485451e-06, !- X,Y,Z Vertex 3 {m}
   -5.11634355974824, 8.65353523347193, 3.1495933994062; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
@@ -2877,10 +2875,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -1.2759159959046e-006, 7.54376548506234e-007, 3.14959909919917, !- X,Y,Z Vertex 1 {m}
-  -5.11634355974788, 7.54375900245008e-007, 3.14959676746568, !- X,Y,Z Vertex 2 {m}
-  -5.11634228383246, -2.93103650891579e-013, -1.03632599495118e-006, !- X,Y,Z Vertex 3 {m}
-  -4.2015244602146e-013, 2.93103647266656e-013, 1.03632599495119e-006; !- X,Y,Z Vertex 4 {m}
+  -5.11634355974788, 7.54375900245008e-07, 3.14959676746568, !- X,Y,Z Vertex 1 {m}
+  -5.11634228383246, -2.93103650519533e-13, -1.03632599495118e-06, !- X,Y,Z Vertex 2 {m}
+  -4.2015244602146e-13, 2.93103647255899e-13, 1.03632599495119e-06, !- X,Y,Z Vertex 3 {m}
+  -1.2759159959046e-06, 7.54376548506234e-07, 3.14959909919917; !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {9400acb4-ffee-4578-a128-3f6fd16b12c3}, !- Handle
@@ -2909,10 +2907,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -5.11634017684373, 8.65353396693777, -9.49227306980389e-006, !- X,Y,Z Vertex 1 {m}
-  3.91564753931169e-012, 8.65353396693314, -3.16409102085288e-006, !- X,Y,Z Vertex 2 {m}
-  -3.91131607079449e-012, 2.31733565656181e-012, 3.164091028072e-006, !- X,Y,Z Vertex 3 {m}
-  -5.11634017683591, -2.31156036520554e-012, -3.16409102085288e-006; !- X,Y,Z Vertex 4 {m}
+  3.91564753931169e-12, 8.65353396693314, -3.16409102085288e-06, !- X,Y,Z Vertex 1 {m}
+  -3.91131607079449e-12, 2.31733565656181e-12, 3.164091028072e-06, !- X,Y,Z Vertex 2 {m}
+  -5.11634017683591, -2.31156036520554e-12, -3.16409102085288e-06, !- X,Y,Z Vertex 3 {m}
+  -5.11634017684373, 8.65353396693777, -9.49227306980389e-06; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {d70252e4-5e0e-4307-9262-f1c47f53bcd8}, !- Handle
@@ -2926,10 +2924,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -4.27259435914919e-006, 2.52614063564351e-006, 3.45439551264764, !- X,Y,Z Vertex 1 {m}
-  -4.40059153908059e-012, 2.31733565669862e-012, 3.1640910282584e-006, !- X,Y,Z Vertex 2 {m}
-  4.40492300738388e-012, 8.65353396693314, -3.16409102103928e-006, !- X,Y,Z Vertex 3 {m}
-  -4.27258555363466e-006, 8.65353649307146, 3.4543891844656; !- X,Y,Z Vertex 4 {m}
+  -4.27259435914919e-06, 2.52614063564351e-06, 3.45439551264764, !- X,Y,Z Vertex 1 {m}
+  -4.40059153701518e-12, 2.31733565669862e-12, 3.1640910282584e-06, !- X,Y,Z Vertex 2 {m}
+  4.40492300569867e-12, 8.65353396693314, -3.16409102103928e-06, !- X,Y,Z Vertex 3 {m}
+  -4.27258555363466e-06, 8.65353649307146, 3.4543891844656; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {725dff6f-e4e5-45a6-ace7-0a82d5d6345b}, !- Handle
@@ -2943,10 +2941,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -4.27259484842466e-006, 2.52614063585394e-006, 3.45439551264764, !- X,Y,Z Vertex 1 {m}
-  -5.11634444942097, 2.52613369353287e-006, 3.45438602037458, !- X,Y,Z Vertex 2 {m}
-  -5.11634017683591, -2.31134993923109e-012, -3.16409102103989e-006, !- X,Y,Z Vertex 3 {m}
-  -3.91131607102579e-012, 2.31712523036907e-012, 3.16409102825901e-006; !- X,Y,Z Vertex 4 {m}
+  -5.11634444942097, 2.52613369353287e-06, 3.45438602037458, !- X,Y,Z Vertex 1 {m}
+  -5.11634017683591, -2.31134994276528e-12, -3.16409102103989e-06, !- X,Y,Z Vertex 2 {m}
+  -3.91131607102579e-12, 2.31712523372535e-12, 3.16409102825901e-06, !- X,Y,Z Vertex 3 {m}
+  -4.27259484842466e-06, 2.52614063585394e-06, 3.45439551264764; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {2d2a1135-6f47-44fb-bfca-991c5007058b}, !- Handle
@@ -2960,10 +2958,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -5.11634444943027, 8.65353649307378, 3.45437969219253, !- X,Y,Z Vertex 1 {m}
-  -5.11634017684422, 8.65353396693777, -9.4922730696175e-006, !- X,Y,Z Vertex 2 {m}
-  -5.11634017683542, -2.31156036534136e-012, -3.16409102103928e-006, !- X,Y,Z Vertex 3 {m}
-  -5.11634444942146, 2.5261336937433e-006, 3.45438602037458; !- X,Y,Z Vertex 4 {m}
+  -5.11634444942146, 2.5261336937433e-06, 3.45438602037458, !- X,Y,Z Vertex 1 {m}
+  -5.11634444943027, 8.65353649307378, 3.45437969219253, !- X,Y,Z Vertex 2 {m}
+  -5.11634017684422, 8.65353396693777, -9.4922730696175e-06, !- X,Y,Z Vertex 3 {m}
+  -5.11634017683542, -2.31156036534136e-12, -3.16409102103928e-06; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {ac80e7a8-8086-4a98-b740-e7bf8d50a5ef}, !- Handle
@@ -2977,9 +2975,9 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -4.27258506435919e-006, 8.65353649307146, 3.4543891844656, !- X,Y,Z Vertex 1 {m}
-  3.91564753954299e-012, 8.65353396693314, -3.16409102103989e-006, !- X,Y,Z Vertex 2 {m}
-  -5.11634017684373, 8.65353396693777, -9.49227306961689e-006, !- X,Y,Z Vertex 3 {m}
+  -4.27258506435919e-06, 8.65353649307146, 3.4543891844656, !- X,Y,Z Vertex 1 {m}
+  3.91564753954299e-12, 8.65353396693314, -3.16409102103989e-06, !- X,Y,Z Vertex 2 {m}
+  -5.11634017684373, 8.65353396693777, -9.49227306961689e-06, !- X,Y,Z Vertex 3 {m}
   -5.11634444943076, 8.65353649307378, 3.45437969219253; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
@@ -2994,10 +2992,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -7.60425077461119e-008, 2.22672356344125e-012, -1.10317326712187e-006, !- X,Y,Z Vertex 1 {m}
-  6.15175852140101e-006, 5.63988463255556e-012, -3.45439999999165, !- X,Y,Z Vertex 2 {m}
-  53.7971863276984, 1.63737821678346e-012, -3.45439923158713, !- X,Y,Z Vertex 3 {m}
-  53.7971863276983, -1.77578474738352e-012, 1.11423373613099e-006; !- X,Y,Z Vertex 4 {m}
+  53.7971863276983, -1.77578474738352e-12, 1.11423373613099e-06, !- X,Y,Z Vertex 1 {m}
+  -7.60425077461119e-08, 2.22672356344125e-12, -1.10317326712187e-06, !- X,Y,Z Vertex 2 {m}
+  6.15175852140101e-06, 5.63988463255556e-12, -3.45439999999165, !- X,Y,Z Vertex 3 {m}
+  53.7971863276984, 1.63737821678346e-12, -3.45439923158713; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {65085bdb-6b3a-4705-94ad-09c40be7b8ad}, !- Handle
@@ -3011,10 +3009,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  53.7971863276983, 4.49103750000716, 1.07589844694888e-006, !- X,Y,Z Vertex 1 {m}
+  53.7971863276983, 4.49103750000716, 1.07589844694888e-06, !- X,Y,Z Vertex 1 {m}
   53.7971863276984, 4.49103750000697, -3.4543992317878, !- X,Y,Z Vertex 2 {m}
   60.0868613276954, 4.491037500007, -3.45439852137212, !- X,Y,Z Vertex 3 {m}
-  60.0868613276954, 4.49103750000718, 9.31932275228718e-007; !- X,Y,Z Vertex 4 {m}
+  60.0868613276954, 4.49103750000718, 9.31932275228718e-07; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {57dca202-deca-4911-b535-0c07608b96fb}, !- Handle
@@ -3028,10 +3026,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  53.7971863276983, -7.12350525506708e-014, 1.11423373613099e-006, !- X,Y,Z Vertex 1 {m}
-  53.7971863276984, -6.71716753757298e-014, -3.45439923158713, !- X,Y,Z Vertex 2 {m}
+  53.7971863276983, -7.12350525506708e-14, 1.11423373613099e-06, !- X,Y,Z Vertex 1 {m}
+  53.7971863276984, -6.71716753757298e-14, -3.45439923158713, !- X,Y,Z Vertex 2 {m}
   53.7971863276984, 4.49103750000696, -3.4543992317878, !- X,Y,Z Vertex 3 {m}
-  53.7971863276983, 4.49103750000717, 1.07589844694888e-006; !- X,Y,Z Vertex 4 {m}
+  53.7971863276983, 4.49103750000717, 1.07589844694888e-06; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {44c1f590-fe5c-410a-aea5-250f72ba2529}, !- Handle
@@ -3045,10 +3043,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  60.0868613276954, 4.49103750000717, 9.31932275228718e-007, !- X,Y,Z Vertex 1 {m}
+  60.0868613276954, 4.49103750000717, 9.31932275228718e-07, !- X,Y,Z Vertex 1 {m}
   60.0868613276954, 4.49103750000701, -3.45439852137212, !- X,Y,Z Vertex 2 {m}
-  60.0868613276954, -1.48956408024223e-013, -3.4543997908874, !- X,Y,Z Vertex 3 {m}
-  60.0868613276954, -1.01232042458282e-013, 8.61101443412905e-008; !- X,Y,Z Vertex 4 {m}
+  60.0868613276954, -1.48956408024223e-13, -3.4543997908874, !- X,Y,Z Vertex 3 {m}
+  60.0868613276954, -1.01232042458282e-13, 8.61101443412905e-08; !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {8b396e48-99c3-4f49-8785-848fd2c03248}, !- Handle
@@ -3077,10 +3075,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -3.46517481375486e-014, -2.16573425859679e-015, 0, !- X,Y,Z Vertex 1 {m}
-  -3.46517481375486e-014, -4.49103750000702, 0, !- X,Y,Z Vertex 2 {m}
+  -3.46517481375486e-14, -2.16573425859679e-15, 0, !- X,Y,Z Vertex 1 {m}
+  -3.46517481375486e-14, -4.49103750000702, 0, !- X,Y,Z Vertex 2 {m}
   -6.28967499999708, -4.49103750000702, 0, !- X,Y,Z Vertex 3 {m}
-  -6.28967499999708, -2.16573425859679e-015, 0; !- X,Y,Z Vertex 4 {m}
+  -6.28967499999708, -2.16573425859679e-15, 0; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {ffa475aa-39b4-46c7-8508-f30043c707f4}, !- Handle
@@ -3094,9 +3092,9 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -3.46517481375486e-014, -4.49103750000702, 3.4544, !- X,Y,Z Vertex 1 {m}
-  -3.46517481375486e-014, -2.16573425859679e-015, 3.4544, !- X,Y,Z Vertex 2 {m}
-  -6.28967499999708, -2.16573425859679e-015, 3.4544, !- X,Y,Z Vertex 3 {m}
+  -3.46517481375486e-14, -4.49103750000702, 3.4544, !- X,Y,Z Vertex 1 {m}
+  -3.46517481375486e-14, -2.16573425859679e-15, 3.4544, !- X,Y,Z Vertex 2 {m}
+  -6.28967499999708, -2.16573425859679e-15, 3.4544, !- X,Y,Z Vertex 3 {m}
   -6.28967499999708, -4.49103750000702, 3.4544; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
@@ -3111,10 +3109,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -3.46517481375486e-014, -2.16573425859679e-015, 3.4544, !- X,Y,Z Vertex 1 {m}
-  -3.46517481375486e-014, -2.16573425859679e-015, 0, !- X,Y,Z Vertex 2 {m}
-  -6.28967499999708, -2.16573425859679e-015, 0, !- X,Y,Z Vertex 3 {m}
-  -6.28967499999708, -2.16573425859679e-015, 3.4544; !- X,Y,Z Vertex 4 {m}
+  -3.46517481375486e-14, -2.16573425859679e-15, 3.4544, !- X,Y,Z Vertex 1 {m}
+  -3.46517481375486e-14, -2.16573425859679e-15, 0, !- X,Y,Z Vertex 2 {m}
+  -6.28967499999708, -2.16573425859679e-15, 0, !- X,Y,Z Vertex 3 {m}
+  -6.28967499999708, -2.16573425859679e-15, 3.4544; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {3f723782-6169-4534-b474-122a93de9e40}, !- Handle
@@ -3128,8 +3126,8 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -6.28967499999708, -2.16573425859679e-015, 3.4544, !- X,Y,Z Vertex 1 {m}
-  -6.28967499999708, -2.16573425859679e-015, 0, !- X,Y,Z Vertex 2 {m}
+  -6.28967499999708, -2.16573425859679e-15, 3.4544, !- X,Y,Z Vertex 1 {m}
+  -6.28967499999708, -2.16573425859679e-15, 0, !- X,Y,Z Vertex 2 {m}
   -6.28967499999708, -4.49103750000702, 0, !- X,Y,Z Vertex 3 {m}
   -6.28967499999708, -4.49103750000702, 3.4544; !- X,Y,Z Vertex 4 {m}
 
@@ -3147,8 +3145,8 @@ OS:Surface,
   ,                                       !- Number of Vertices
   -6.28967499999708, -4.49103750000702, 3.4544, !- X,Y,Z Vertex 1 {m}
   -6.28967499999708, -4.49103750000702, 0, !- X,Y,Z Vertex 2 {m}
-  -3.46517481375486e-014, -4.49103750000702, 0, !- X,Y,Z Vertex 3 {m}
-  -3.46517481375486e-014, -4.49103750000702, 3.4544; !- X,Y,Z Vertex 4 {m}
+  -3.46517481375486e-14, -4.49103750000702, 0, !- X,Y,Z Vertex 3 {m}
+  -3.46517481375486e-14, -4.49103750000702, 3.4544; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {fdf9e35b-b388-492a-a6fa-0c07fd7f9beb}, !- Handle
@@ -3162,10 +3160,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -3.46517481375486e-014, -4.49103750000702, 3.4544, !- X,Y,Z Vertex 1 {m}
-  -3.46517481375486e-014, -4.49103750000702, 0, !- X,Y,Z Vertex 2 {m}
-  -3.46517481375486e-014, -2.16573425859679e-015, 0, !- X,Y,Z Vertex 3 {m}
-  -3.46517481375486e-014, -2.16573425859679e-015, 3.4544; !- X,Y,Z Vertex 4 {m}
+  -3.46517481375486e-14, -4.49103750000702, 3.4544, !- X,Y,Z Vertex 1 {m}
+  -3.46517481375486e-14, -4.49103750000702, 0, !- X,Y,Z Vertex 2 {m}
+  -3.46517481375486e-14, -2.16573425859679e-15, 0, !- X,Y,Z Vertex 3 {m}
+  -3.46517481375486e-14, -2.16573425859679e-15, 3.4544; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {40047ae1-b0a0-42b4-8a45-2c6422442c96}, !- Handle
@@ -3179,10 +3177,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  74.8537541785873, 27.9692099999999, 3.93520038493973e-007, !- X,Y,Z Vertex 1 {m}
+  74.8537541785873, 27.9692099999999, 3.93520038493973e-07, !- X,Y,Z Vertex 1 {m}
   74.8537541755423, 27.9692099999999, -3.45439923224692, !- X,Y,Z Vertex 2 {m}
   74.8537542010644, 107.490066342021, -3.45439934078069, !- X,Y,Z Vertex 3 {m}
-  74.8537542041095, 107.490066342021, -3.22064815528878e-007; !- X,Y,Z Vertex 4 {m}
+  74.8537542041095, 107.490066342021, -3.22064815528878e-07; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {10312e2e-78ec-4356-803a-defbfefa929a}, !- Handle
@@ -3196,10 +3194,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  75.0823541937047, 110.265209999979, -6.01995094400623e-007, !- X,Y,Z Vertex 1 {m}
+  75.0823541937047, 110.265209999979, -6.01995094400623e-07, !- X,Y,Z Vertex 1 {m}
   75.0823541965599, 110.265209995825, -3.45440030132934, !- X,Y,Z Vertex 2 {m}
   75.0823542038582, 115.604925000006, -3.4544003745299, !- X,Y,Z Vertex 3 {m}
-  75.0823542010031, 115.604925000006, -6.39516022986882e-007; !- X,Y,Z Vertex 4 {m}
+  75.0823542010031, 115.604925000006, -6.39516022986882e-07; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {8cbe4bad-a1b3-4ce2-b01c-2071f8dd0fb5}, !- Handle
@@ -3213,10 +3211,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  69.8547488309849, 110.26520999809, -4.47631794858506e-007, !- X,Y,Z Vertex 1 {m}
+  69.8547488309849, 110.26520999809, -4.47631794858506e-07, !- X,Y,Z Vertex 1 {m}
   69.8547488276173, 110.265209993936, -3.45440011341254, !- X,Y,Z Vertex 2 {m}
   74.8537541721111, 110.265209995742, -3.45440003092546, !- X,Y,Z Vertex 3 {m}
-  74.8537541776784, 110.265209999896, -5.94529218065703e-007; !- X,Y,Z Vertex 4 {m}
+  74.8537541776784, 110.265209999896, -5.94529218065703e-07; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {ebad770f-8c99-41da-bb41-bbddf4b5a543}, !- Handle
@@ -3230,10 +3228,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  69.8547488376234, 107.490066336269, -3.25167016974561e-007, !- X,Y,Z Vertex 1 {m}
+  69.8547488376234, 107.490066336269, -3.25167016974561e-07, !- X,Y,Z Vertex 1 {m}
   69.8547488342558, 107.490066336269, -3.45440009999938, !- X,Y,Z Vertex 2 {m}
   69.8547488276173, 110.265209993936, -3.45440011341254, !- X,Y,Z Vertex 3 {m}
-  69.8547488309849, 110.26520999809, -4.47631794858506e-007; !- X,Y,Z Vertex 4 {m}
+  69.8547488309849, 110.26520999809, -4.47631794858506e-07; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {eb2cf3c4-a102-48e1-9912-f169a49e4f64}, !- Handle
@@ -3247,10 +3245,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  74.853754205023, 107.490066342021, -3.22064815529683e-007, !- X,Y,Z Vertex 1 {m}
+  74.853754205023, 107.490066342021, -3.22064815529683e-07, !- X,Y,Z Vertex 1 {m}
   74.8537542001509, 107.490066342021, -3.45439934078069, !- X,Y,Z Vertex 2 {m}
   69.8547488342558, 107.490066336269, -3.45440009999938, !- X,Y,Z Vertex 3 {m}
-  69.8547488376234, 107.490066336269, -3.25167016974561e-007; !- X,Y,Z Vertex 4 {m}
+  69.8547488376234, 107.490066336269, -3.25167016974561e-07; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {90b61621-2c96-4fc4-807b-50c384bffffc}, !- Handle
@@ -3264,10 +3262,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  69.8547488331669, 118.84660000883, -4.4968492757132e-007, !- X,Y,Z Vertex 1 {m}
+  69.8547488331669, 118.84660000883, -4.4968492757132e-07, !- X,Y,Z Vertex 1 {m}
   69.8547488345962, 118.84660000883, -3.45439959137902, !- X,Y,Z Vertex 2 {m}
   75.0823542082838, 118.846600000006, -3.4544, !- X,Y,Z Vertex 3 {m}
-  75.0823542072332, 118.846600000006, -7.08056516711362e-007; !- X,Y,Z Vertex 4 {m}
+  75.0823542072332, 118.846600000006, -7.08056516711362e-07; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {4d9ecdd5-ba26-4958-bce4-c7f7ea623993}, !- Handle
@@ -3281,10 +3279,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  69.8547488276954, 115.60492500883, -4.85152723207397e-007, !- X,Y,Z Vertex 1 {m}
-  75.0823542010031, 115.604925000006, -6.39516022986882e-007, !- X,Y,Z Vertex 2 {m}
-  75.0823542038582, 115.604925000006, -3.4544003745299, !- X,Y,Z Vertex 3 {m}
-  69.8547488291247, 115.60492500883, -3.4544001866131; !- X,Y,Z Vertex 4 {m}
+  75.0823542010031, 115.604925000006, -6.39516022986882e-07, !- X,Y,Z Vertex 1 {m}
+  75.0823542038582, 115.604925000006, -3.4544003745299, !- X,Y,Z Vertex 2 {m}
+  69.8547488291247, 115.60492500883, -3.4544001866131, !- X,Y,Z Vertex 3 {m}
+  69.8547488276954, 115.60492500883, -4.85152723207397e-07; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {16b8b5ca-394b-4129-89ef-aa917ca008fe}, !- Handle
@@ -3298,10 +3296,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  69.8547488276954, 115.60492500883, -4.85152723207397e-007, !- X,Y,Z Vertex 1 {m}
-  69.8547488291247, 115.60492500883, -3.4544001866131, !- X,Y,Z Vertex 2 {m}
-  69.8547488345962, 118.84660000883, -3.45439959137902, !- X,Y,Z Vertex 3 {m}
-  69.8547488331669, 118.84660000883, -4.4968492757132e-007; !- X,Y,Z Vertex 4 {m}
+  69.8547488331669, 118.84660000883, -4.4968492757132e-07, !- X,Y,Z Vertex 1 {m}
+  69.8547488276954, 115.60492500883, -4.85152723207397e-07, !- X,Y,Z Vertex 2 {m}
+  69.8547488291247, 115.60492500883, -3.4544001866131, !- X,Y,Z Vertex 3 {m}
+  69.8547488345962, 118.84660000883, -3.45439959137902; !- X,Y,Z Vertex 4 {m}
 
 OS:Space,
   {dabb59b7-13b9-429c-b785-120270bd90cd}, !- Handle
@@ -3330,10 +3328,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  5.22760537402064, -8.82362874108367e-009, 1.62225606032962e-009, !- X,Y,Z Vertex 1 {m}
-  5.22760537402064, -3.24167499999998, 5.40750095012754e-010, !- X,Y,Z Vertex 2 {m}
-  -5.38012282049749e-009, -3.24167499999998, -5.40755870304111e-010, !- X,Y,Z Vertex 3 {m}
-  -5.38012282049749e-009, -8.82362874108367e-009, 5.40750095012754e-010; !- X,Y,Z Vertex 4 {m}
+  5.22760537402064, -8.82362874108367e-09, 1.62225606032962e-09, !- X,Y,Z Vertex 1 {m}
+  5.22760537402064, -3.24167499999998, 5.40750095012754e-10, !- X,Y,Z Vertex 2 {m}
+  -5.38012282049749e-09, -3.24167499999998, -5.40755870304111e-10, !- X,Y,Z Vertex 3 {m}
+  -5.38012282049749e-09, -8.82362874108367e-09, 5.40750095012754e-10; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {f3952210-6397-4814-9c74-93946e995a7b}, !- Handle
@@ -3347,10 +3345,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  5.22760537330603, -9.97589177145414e-009, 3.45440000270377, !- X,Y,Z Vertex 1 {m}
-  5.22760537402064, -8.82362874103858e-009, 1.62225606032962e-009, !- X,Y,Z Vertex 2 {m}
-  -5.38012282049749e-009, -8.82362874112876e-009, 5.40750095012753e-010, !- X,Y,Z Vertex 3 {m}
-  -6.09473427175544e-009, -9.97589177118358e-009, 3.45440000054075; !- X,Y,Z Vertex 4 {m}
+  5.22760537330603, -9.97589177145414e-09, 3.45440000270377, !- X,Y,Z Vertex 1 {m}
+  5.22760537402064, -8.82362874103858e-09, 1.62225606032962e-09, !- X,Y,Z Vertex 2 {m}
+  -5.38012282049749e-09, -8.82362874112876e-09, 5.40750095012753e-10, !- X,Y,Z Vertex 3 {m}
+  -6.09473427175544e-09, -9.97589177118358e-09, 3.45440000054075; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {b7464cf5-4419-4c8b-b628-d4e317bf183a}, !- Handle
@@ -3365,9 +3363,9 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   5.22760537330603, -3.24167500115224, 3.45440000158846, !- X,Y,Z Vertex 1 {m}
-  5.22760537330603, -9.97589177139777e-009, 3.45440000266997, !- X,Y,Z Vertex 2 {m}
-  -6.09473427176899e-009, -9.97589177123995e-009, 3.45440000057455, !- X,Y,Z Vertex 3 {m}
-  -6.09473427171567e-009, -3.24167500115224, 3.45439999949303; !- X,Y,Z Vertex 4 {m}
+  5.22760537330603, -9.97589177139777e-09, 3.45440000266997, !- X,Y,Z Vertex 2 {m}
+  -6.09473427176899e-09, -9.97589177123995e-09, 3.45440000057455, !- X,Y,Z Vertex 3 {m}
+  -6.09473427171567e-09, -3.24167500115224, 3.45439999949303; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {347ba9f2-ab3a-4a32-8089-4e03ae6db67a}, !- Handle
@@ -3381,10 +3379,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -6.09473427174539e-009, -9.97589177122867e-009, 3.45440000054075, !- X,Y,Z Vertex 1 {m}
-  -5.38012282050754e-009, -8.82362874108367e-009, 5.40750095012753e-010, !- X,Y,Z Vertex 2 {m}
-  -5.38012282048744e-009, -3.24167499999998, -5.4075587030411e-010, !- X,Y,Z Vertex 3 {m}
-  -6.09473427173927e-009, -3.24167500115224, 3.45439999952683; !- X,Y,Z Vertex 4 {m}
+  -6.09473427174539e-09, -9.97589177122867e-09, 3.45440000054075, !- X,Y,Z Vertex 1 {m}
+  -5.38012282050754e-09, -8.82362874108367e-09, 5.40750095012753e-10, !- X,Y,Z Vertex 2 {m}
+  -5.38012282048744e-09, -3.24167499999998, -5.4075587030411e-10, !- X,Y,Z Vertex 3 {m}
+  -6.09473427173927e-09, -3.24167500115224, 3.45439999952683; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {714ea8a1-5960-4ab4-b389-845dc34ca44b}, !- Handle
@@ -3398,10 +3396,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -6.09473427172922e-009, -3.24167500115224, 3.45439999952683, !- X,Y,Z Vertex 1 {m}
-  -5.38012282049749e-009, -3.24167499999998, -5.4075587030411e-010, !- X,Y,Z Vertex 2 {m}
-  5.22760537402064, -3.24167499999998, 5.40750095012753e-010, !- X,Y,Z Vertex 3 {m}
-  5.22760537330603, -3.24167500115224, 3.45440000155466; !- X,Y,Z Vertex 4 {m}
+  5.22760537330603, -3.24167500115224, 3.45440000155466, !- X,Y,Z Vertex 1 {m}
+  -6.09473427172922e-09, -3.24167500115224, 3.45439999952683, !- X,Y,Z Vertex 2 {m}
+  -5.38012282049749e-09, -3.24167499999998, -5.4075587030411e-10, !- X,Y,Z Vertex 3 {m}
+  5.22760537402064, -3.24167499999998, 5.40750095012753e-10; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {fc40f6ba-f5bb-4c7c-afc4-802df860c765}, !- Handle
@@ -3415,10 +3413,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  5.22760537330603, -3.24167500115224, 3.45440000155466, !- X,Y,Z Vertex 1 {m}
-  5.22760537402064, -3.24167499999998, 5.40750095012753e-010, !- X,Y,Z Vertex 2 {m}
-  5.22760537402064, -8.82362874108367e-009, 1.62225606032962e-009, !- X,Y,Z Vertex 3 {m}
-  5.22760537330603, -9.97589177140905e-009, 3.45440000270377; !- X,Y,Z Vertex 4 {m}
+  5.22760537330603, -9.97589177140905e-09, 3.45440000270377, !- X,Y,Z Vertex 1 {m}
+  5.22760537330603, -3.24167500115224, 3.45440000155466, !- X,Y,Z Vertex 2 {m}
+  5.22760537402064, -3.24167499999998, 5.40750095012753e-10, !- X,Y,Z Vertex 3 {m}
+  5.22760537402064, -8.82362874108367e-09, 1.62225606032962e-09; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {158b0cea-25e1-41d8-a900-8a04db2cd047}, !- Handle
@@ -3433,8 +3431,8 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   110.660140929629, 69.2970070000578, 7.62, !- X,Y,Z Vertex 1 {m}
-  110.660140928569, 69.2970070000579, -7.71758502939289e-009, !- X,Y,Z Vertex 2 {m}
-  110.660140946104, 75.0823541733274, 6.60177375510775e-017, !- X,Y,Z Vertex 3 {m}
+  110.660140928569, 69.2970070000579, -7.71758502939279e-09, !- X,Y,Z Vertex 2 {m}
+  110.660140946104, 75.0823541733274, 6.60176314557421e-17, !- X,Y,Z Vertex 3 {m}
   110.660140947165, 75.0823540289571, 7.62; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
@@ -3450,8 +3448,8 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   120.552209999994, 69.2970070000573, 7.62, !- X,Y,Z Vertex 1 {m}
-  120.552209999994, 69.2970070000574, -6.40232186815051e-009, !- X,Y,Z Vertex 2 {m}
-  110.660140929268, 69.2970070000579, -7.7175850294902e-009, !- X,Y,Z Vertex 3 {m}
+  120.552209999994, 69.2970070000574, -6.40232186815051e-09, !- X,Y,Z Vertex 2 {m}
+  110.660140929268, 69.2970070000579, -7.7175850294902e-09, !- X,Y,Z Vertex 3 {m}
   110.66014092893, 69.2970070000578, 7.62; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
@@ -3467,25 +3465,25 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   117.9583084912, 11.177539610068, 7.62,  !- X,Y,Z Vertex 1 {m}
-  117.9583084912, 11.177539610068, 1.59277904516636e-016, !- X,Y,Z Vertex 2 {m}
-  123.1399084912, 11.177539610068, 1.68655468820899e-016, !- X,Y,Z Vertex 3 {m}
+  117.9583084912, 11.177539610068, 1.59277904516636e-16, !- X,Y,Z Vertex 2 {m}
+  123.1399084912, 11.177539610068, 1.68655468820899e-16, !- X,Y,Z Vertex 3 {m}
   123.1399084912, 11.177539610068, 7.62;  !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {6f93d131-8958-4903-9b9e-03ebc0043189}, !- Handle
   Surface 34,                             !- Name
   Wall,                                   !- Surface Type
-  ,                                       !- Construction Name
+  {1e000a7c-851c-43bf-9021-1d2da9c1b615}, !- Construction Name
   {c9091985-9c4a-4786-abbc-ca57606cbc32}, !- Space Name
-  Surface,                                !- Outside Boundary Condition
-  {9f578051-6e5e-4e9c-9145-cee2c0f75a81}, !- Outside Boundary Condition Object
-  NoSun,                                  !- Sun Exposure
-  NoWind,                                 !- Wind Exposure
+  Adiabatic,                              !- Outside Boundary Condition
+  ,                                       !- Outside Boundary Condition Object
+  SunExposed,                             !- Sun Exposure
+  WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   110.77454947196, 5.11632946079759, 7.62, !- X,Y,Z Vertex 1 {m}
-  110.77454947196, 5.11632945681379, 1.44910252960872e-016, !- X,Y,Z Vertex 2 {m}
-  115.523009999993, 5.11632945067457, 1.56713497863144e-016, !- X,Y,Z Vertex 3 {m}
+  110.77454947196, 5.11632945681379, 1.44910257489932e-16, !- X,Y,Z Vertex 2 {m}
+  115.523009999993, 5.11632945067457, 1.56713491824396e-16, !- X,Y,Z Vertex 3 {m}
   115.523009999993, 5.11632945465838, 7.62; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
@@ -3518,8 +3516,8 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   119.428082428438, 5.11632945374419, 7.62, !- X,Y,Z Vertex 1 {m}
-  119.428082428438, -1.5718904642574e-006, 7.62, !- X,Y,Z Vertex 2 {m}
-  117.9583084912, -3.33098354233678e-006, 7.61999999999999, !- X,Y,Z Vertex 3 {m}
+  119.428082428438, -1.5718904642574e-06, 7.62, !- X,Y,Z Vertex 2 {m}
+  117.9583084912, -3.33098354233678e-06, 7.61999999999999, !- X,Y,Z Vertex 3 {m}
   117.9583084912, 5.11632945374419, 7.62; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
@@ -3569,8 +3567,8 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   120.552209999994, 37.5411784807575, 28.2892493272178, !- X,Y,Z Vertex 1 {m}
-  120.552209999994, 6.73278151615366e-008, 12.5349010303847, !- X,Y,Z Vertex 2 {m}
-  120.552209999994, -1.4088547167576e-007, 7.62, !- X,Y,Z Vertex 3 {m}
+  120.552209999994, 6.73278151615366e-08, 12.5349010303847, !- X,Y,Z Vertex 2 {m}
+  120.552209999994, -1.4088547167576e-07, 7.62, !- X,Y,Z Vertex 3 {m}
   120.552209999994, 69.2970070000573, 7.62, !- X,Y,Z Vertex 4 {m}
   120.552209999994, 69.2970066176937, 14.9627501227822; !- X,Y,Z Vertex 5 {m}
 
@@ -3588,8 +3586,8 @@ OS:Surface,
   ,                                       !- Number of Vertices
   117.9583084912, 5.11632945374419, 14.6819942357203, !- X,Y,Z Vertex 1 {m}
   117.9583084912, 5.11632945374419, 7.62, !- X,Y,Z Vertex 2 {m}
-  117.9583084912, -3.33098354233678e-006, 7.61999999999999, !- X,Y,Z Vertex 3 {m}
-  117.958308491199, -3.12277030527028e-006, 12.5348998555633; !- X,Y,Z Vertex 4 {m}
+  117.9583084912, -3.33098354233678e-06, 7.61999999999999, !- X,Y,Z Vertex 3 {m}
+  117.958308491199, -3.12277030527028e-06, 12.5348998555633; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {70ff3cbb-c5b0-4baf-80a2-92ef5ceea7d0}, !- Handle
@@ -3603,10 +3601,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -1.30314125238569e-005, 18.3120605280396, 2.1090147939465e-006, !- X,Y,Z Vertex 1 {m}
-  -4.05896448796136e-006, 18.3120605280404, -3.45440000000842, !- X,Y,Z Vertex 2 {m}
+  -1.30314125238569e-05, 18.3120605280396, 2.1090147939465e-06, !- X,Y,Z Vertex 1 {m}
+  -4.05896448796139e-06, 18.3120605280404, -3.45440000000842, !- X,Y,Z Vertex 2 {m}
   5.11633974957689, 18.3120595175831, -3.45439892333932, !- X,Y,Z Vertex 3 {m}
-  5.11633034987616, 18.3120595175825, 2.07219288890883e-006; !- X,Y,Z Vertex 4 {m}
+  5.11633034987616, 18.3120595175825, 2.07219288890883e-06; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {332b8b03-9f5c-4127-95ee-06afe1261670}, !- Handle
@@ -3620,10 +3618,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  5.11632864083428, 9.65852656110892, 5.2044247189625e-006, !- X,Y,Z Vertex 1 {m}
+  5.11632864083428, 9.65852656110892, 5.2044247189625e-06, !- X,Y,Z Vertex 1 {m}
   5.1163380405451, 9.65852656110706, -3.45439891152857, !- X,Y,Z Vertex 2 {m}
-  -7.36844940952202e-006, 9.65852757155797, -3.45440000000096, !- X,Y,Z Vertex 3 {m}
-  -1.35962602093636e-005, 9.6585275715592, 4.3163604563149e-006; !- X,Y,Z Vertex 4 {m}
+  -7.36844940952202e-06, 9.65852757155797, -3.45440000000096, !- X,Y,Z Vertex 3 {m}
+  -1.35962602093636e-05, 9.6585275715592, 4.3163604563149e-06; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {b8908859-c590-4fc0-b483-645e19ea4bd6}, !- Handle
@@ -3637,10 +3635,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -3.98453086826061e-009, -4.74846052803377, 7.06199423572032, !- X,Y,Z Vertex 1 {m}
-  3.98453086826055e-009, -4.74846052803378, -1.41844022935623e-015, !- X,Y,Z Vertex 2 {m}
-  -2.24934686379639e-008, -1.25426345648892e-016, -6.21097646890292e-014, !- X,Y,Z Vertex 3 {m}
-  -3.04625305168828e-008, 1.25426345648892e-016, 7.0619943619098; !- X,Y,Z Vertex 4 {m}
+  -3.04625305168828e-08, 1.25426345648892e-16, 7.0619943619098, !- X,Y,Z Vertex 1 {m}
+  -3.98453086826061e-09, -4.74846052803377, 7.06199423572032, !- X,Y,Z Vertex 2 {m}
+  3.98453086826058e-09, -4.74846052803378, -1.41844022935623e-15, !- X,Y,Z Vertex 3 {m}
+  -2.24934686379639e-08, -1.25426345648892e-16, -6.21097646890292e-14; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {bb285fb9-8aca-4adf-9187-19c30302ddf7}, !- Handle
@@ -3654,29 +3652,29 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -9.3848484539194e-015, -7.18375901923956, 7.62, !- X,Y,Z Vertex 1 {m}
-  -8.66293703438714e-015, 2.02135197469033e-014, 7.62, !- X,Y,Z Vertex 2 {m}
-  -5.11634312604592, 1.44382283906452e-014, 7.62, !- X,Y,Z Vertex 3 {m}
+  -9.3848484539194e-15, -7.18375901923956, 7.62, !- X,Y,Z Vertex 1 {m}
+  -8.66293703438714e-15, 2.02135197469033e-14, 7.62, !- X,Y,Z Vertex 2 {m}
+  -5.11634312604592, 1.44382283906452e-14, 7.62, !- X,Y,Z Vertex 3 {m}
   -5.11633230913287, -7.1837590192394, 7.62; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {9f578051-6e5e-4e9c-9145-cee2c0f75a81}, !- Handle
   Surface 216,                            !- Name
   Wall,                                   !- Surface Type
-  ,                                       !- Construction Name
+  {1e000a7c-851c-43bf-9021-1d2da9c1b615}, !- Construction Name
   {2068beb1-f72a-42a1-b012-d4c525765164}, !- Space Name
-  Surface,                                !- Outside Boundary Condition
-  {6f93d131-8958-4903-9b9e-03ebc0043189}, !- Outside Boundary Condition Object
-  NoSun,                                  !- Sun Exposure
-  NoWind,                                 !- Wind Exposure
+  Adiabatic,                              !- Outside Boundary Condition
+  ,                                       !- Outside Boundary Condition Object
+  SunExposed,                             !- Sun Exposure
+  WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  1.94914109341444e-014, -4.74846052803349, 7.62, !- X,Y,Z Vertex 1 {m}
-  -1.74810237988895e-014, -4.74846052803298, 6.64972109453693e-017, !- X,Y,Z Vertex 2 {m}
-  -1.89755092250242e-014, -4.60802856284304, 2.44710395140629e-016, !- X,Y,Z Vertex 3 {m}
-  -1.8975897608332e-014, -4.60799081783161, 2.74140678105425e-006, !- X,Y,Z Vertex 4 {m}
-  -6.80144239399645e-014, 4.9089976528194e-014, 5.37410929505693e-007, !- X,Y,Z Vertex 5 {m}
-  -3.10419918144673e-014, 2.02135197469031e-014, 7.62; !- X,Y,Z Vertex 6 {m}
+  1.94914109341444e-14, -4.74846052803349, 7.62, !- X,Y,Z Vertex 1 {m}
+  -1.74810237988895e-14, -4.74846052803298, 6.64972109453693e-17, !- X,Y,Z Vertex 2 {m}
+  -1.89755092250242e-14, -4.60802856284304, 2.44710395140629e-16, !- X,Y,Z Vertex 3 {m}
+  -1.8975897608332e-14, -4.60799081783161, 2.74140678105425e-06, !- X,Y,Z Vertex 4 {m}
+  -6.80144239399645e-14, 4.9089976528194e-14, 5.37410929505693e-07, !- X,Y,Z Vertex 5 {m}
+  -3.10419918144673e-14, 2.02135197469031e-14, 7.62; !- X,Y,Z Vertex 6 {m}
 
 OS:Surface,
   {d65513ea-d291-4135-a723-f2033c2ce095}, !- Handle
@@ -3690,8 +3688,8 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  2.88764567812905e-014, -5.94670150880041, 7.62, !- X,Y,Z Vertex 1 {m}
-  2.88764567812905e-014, 2.88764567812905e-015, 7.62, !- X,Y,Z Vertex 2 {m}
+  2.88764567812905e-14, -5.94670150880041, 7.62, !- X,Y,Z Vertex 1 {m}
+  2.88764567812905e-14, 2.88764567812905e-15, 7.62, !- X,Y,Z Vertex 2 {m}
   -11.1775397131258, 0, 7.62,             !- X,Y,Z Vertex 3 {m}
   -11.177539610068, -5.94670150880041, 7.62; !- X,Y,Z Vertex 4 {m}
 
@@ -3708,8 +3706,8 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   -6.06121015632376, 3.7118260627613, 7.62, !- X,Y,Z Vertex 1 {m}
-  -6.06121015632376, 3.7118260627613, 1.18559630718392e-016, !- X,Y,Z Vertex 2 {m}
-  -11.1775532823697, 3.7118260627613, 2.0432193157678e-016, !- X,Y,Z Vertex 3 {m}
+  -6.06121015632376, 3.7118260627613, 1.18559630718392e-16, !- X,Y,Z Vertex 2 {m}
+  -11.1775532823697, 3.7118260627613, 2.0432193157678e-16, !- X,Y,Z Vertex 3 {m}
   -11.1775532823697, 3.7118260627613, 7.62; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
@@ -3724,12 +3722,12 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -6.06121015632376, 3.7118260627613, 1.1621211127572e-016, !- X,Y,Z Vertex 1 {m}
-  -6.06121015632376, 2.88764567812905e-015, 9.99125628951865e-017, !- X,Y,Z Vertex 2 {m}
-  2.88764567812905e-014, 2.88764567812905e-015, -1.60920994503125e-018, !- X,Y,Z Vertex 3 {m}
-  2.88764567812905e-014, -5.94670150880041, -2.77226504210587e-017, !- X,Y,Z Vertex 4 {m}
-  -11.177539610068, -5.94670150880041, 1.59494688681091e-016, !- X,Y,Z Vertex 5 {m}
-  -11.1775532823697, 3.7118260627613, 2.01907906540816e-016; !- X,Y,Z Vertex 6 {m}
+  -6.06121015632376, 3.7118260627613, 1.1621211127572e-16, !- X,Y,Z Vertex 1 {m}
+  -6.06121015632376, 2.88764567812905e-15, 9.99125628951865e-17, !- X,Y,Z Vertex 2 {m}
+  2.88764567812905e-14, 2.88764567812905e-15, -1.60920994503127e-18, !- X,Y,Z Vertex 3 {m}
+  2.88764567812905e-14, -5.94670150880041, -2.77226504210584e-17, !- X,Y,Z Vertex 4 {m}
+  -11.177539610068, -5.94670150880041, 1.59494688681091e-16, !- X,Y,Z Vertex 5 {m}
+  -11.1775532823697, 3.7118260627613, 2.01907906540816e-16; !- X,Y,Z Vertex 6 {m}
 
 OS:Surface,
   {f1ff01c0-26de-448b-a9a6-87e5b8c01c63}, !- Handle
@@ -3743,10 +3741,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -4.13004000000012, 2.88764567812905e-015, 7.62, !- X,Y,Z Vertex 1 {m}
-  -4.13004000000012, 2.88764567812905e-015, 6.14877838383153e-017, !- X,Y,Z Vertex 2 {m}
-  -6.06121015632376, 2.88764567812905e-015, 9.02389274415323e-017, !- X,Y,Z Vertex 3 {m}
-  -6.06121015632376, 2.88764567812905e-015, 7.62; !- X,Y,Z Vertex 4 {m}
+  -4.13004000000012, 2.88764567812905e-15, 7.62, !- X,Y,Z Vertex 1 {m}
+  -4.13004000000012, 2.88764567812905e-15, 6.14877838383153e-17, !- X,Y,Z Vertex 2 {m}
+  -6.06121015632376, 2.88764567812905e-15, 9.02389274415323e-17, !- X,Y,Z Vertex 3 {m}
+  -6.06121015632376, 2.88764567812905e-15, 7.62; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {85a4beec-ac05-4455-a087-7f36daddf7eb}, !- Handle
@@ -3762,8 +3760,8 @@ OS:Surface,
   ,                                       !- Number of Vertices
   1.93117015632364, -3.7118260627613, 7.62, !- X,Y,Z Vertex 1 {m}
   1.93117015632364, -1.12412757155557, 7.62, !- X,Y,Z Vertex 2 {m}
-  1.44382283906452e-015, -1.12412757155568, 7.62, !- X,Y,Z Vertex 3 {m}
-  1.44382283906452e-015, -3.7118260627613, 7.62; !- X,Y,Z Vertex 4 {m}
+  1.44382283906452e-15, -1.12412757155568, 7.62, !- X,Y,Z Vertex 3 {m}
+  1.44382283906452e-15, -3.7118260627613, 7.62; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {fb7c9147-0890-4aa2-a6d1-8c363a03fb28}, !- Handle
@@ -3778,8 +3776,8 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   -2.55524000000012, -1.46977393723869, 7.62, !- X,Y,Z Vertex 1 {m}
-  -2.55524000000012, -1.46977393723869, 1.80477854883065e-016, !- X,Y,Z Vertex 2 {m}
-  -2.55524000000012, -2.59390150879426, 6.29167146568667e-017, !- X,Y,Z Vertex 3 {m}
+  -2.55524000000012, -1.46977393723869, 1.80477854883065e-16, !- X,Y,Z Vertex 2 {m}
+  -2.55524000000012, -2.59390150879426, 6.29167146568667e-17, !- X,Y,Z Vertex 3 {m}
   -2.55524000000012, -2.59390150879426, 7.62; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
@@ -3794,8 +3792,8 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  2.88764567812905e-014, -5.18159999999999, 7.62, !- X,Y,Z Vertex 1 {m}
-  2.88764567812905e-014, -2.59390150879442, 7.62, !- X,Y,Z Vertex 2 {m}
+  2.88764567812905e-14, -5.18159999999999, 7.62, !- X,Y,Z Vertex 1 {m}
+  2.88764567812905e-14, -2.59390150879442, 7.62, !- X,Y,Z Vertex 2 {m}
   -4.13004000000012, -2.59390150879426, 7.62, !- X,Y,Z Vertex 3 {m}
   -4.13004000000012, -5.18159999999999, 7.62; !- X,Y,Z Vertex 4 {m}
 
@@ -3811,9 +3809,9 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -1.1189627002749e-014, -2.43529849120712, 7.62, !- X,Y,Z Vertex 1 {m}
-  -2.88764567812905e-015, -4.8512447392568e-013, 7.62, !- X,Y,Z Vertex 2 {m}
-  -3.50597015632364, -4.8512447392568e-013, 7.62, !- X,Y,Z Vertex 3 {m}
+  -1.1189627002749e-14, -2.43529849120712, 7.62, !- X,Y,Z Vertex 1 {m}
+  -2.88764567812905e-15, -4.8512447392568e-13, 7.62, !- X,Y,Z Vertex 2 {m}
+  -3.50597015632364, -4.8512447392568e-13, 7.62, !- X,Y,Z Vertex 3 {m}
   -3.50597015632364, -2.43529849120656, 7.62; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
@@ -3828,10 +3826,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -1.17310605673991e-014, -2.43529849120712, 7.62, !- X,Y,Z Vertex 1 {m}
-  -9.92628201856844e-015, -2.43529849120659, 6.53352777633092e-017, !- X,Y,Z Vertex 2 {m}
-  -5.41433564650257e-016, -4.8512447392568e-013, 6.69702483824723e-017, !- X,Y,Z Vertex 3 {m}
-  -2.34621211347891e-015, -4.8512447392568e-013, 7.62; !- X,Y,Z Vertex 4 {m}
+  -1.17310605673991e-14, -2.43529849120712, 7.62, !- X,Y,Z Vertex 1 {m}
+  -9.92628201856843e-15, -2.43529849120659, 6.53352777633092e-17, !- X,Y,Z Vertex 2 {m}
+  -5.41433564650268e-16, -4.8512447392568e-13, 6.69702483824723e-17, !- X,Y,Z Vertex 3 {m}
+  -2.3462121134789e-15, -4.8512447392568e-13, 7.62; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {d5f7a1fc-2b74-48fd-950a-c5111835985b}, !- Handle
@@ -3845,10 +3843,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, -4.8512447392568e-013, 6.69702483824724e-017, !- X,Y,Z Vertex 1 {m}
-  4.26272958513899e-050, -3.90507242844529, 5.77675466816808e-017, !- X,Y,Z Vertex 2 {m}
-  -3.50597015632364, -3.90507242844529, 7.26849023161001e-017, !- X,Y,Z Vertex 3 {m}
-  -3.50597015632364, -4.8512447392568e-013, 8.18876040168917e-017; !- X,Y,Z Vertex 4 {m}
+  0, -4.8512447392568e-13, 6.69702483824724e-17, !- X,Y,Z Vertex 1 {m}
+  1.7050918340556e-49, -3.90507242844529, 5.77675466816808e-17, !- X,Y,Z Vertex 2 {m}
+  -3.50597015632364, -3.90507242844529, 7.26849023161001e-17, !- X,Y,Z Vertex 3 {m}
+  -3.50597015632364, -4.8512447392568e-13, 8.18876040168917e-17; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {62ec93cd-4203-4655-939e-3656fee0b593}, !- Handle
@@ -3862,10 +3860,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  75.0823542058633, -1.11288743500832e-013, 5.94283562662667e-007, !- X,Y,Z Vertex 1 {m}
-  75.0823542058633, -1.08176437113896e-013, -3.14959910468582, !- X,Y,Z Vertex 2 {m}
+  75.0823542058633, -1.11288743500832e-13, 5.94283562662667e-07, !- X,Y,Z Vertex 1 {m}
+  75.0823542058633, -1.08176437113896e-13, -3.14959910468582, !- X,Y,Z Vertex 2 {m}
   75.0823541776712, 27.9692099999999, -3.14959939430456, !- X,Y,Z Vertex 3 {m}
-  75.0823541776712, 27.9692099999999, 4.13344436413931e-007; !- X,Y,Z Vertex 4 {m}
+  75.0823541776712, 27.9692099999999, 4.13344436413931e-07; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {199929a2-d649-4b80-8b00-51517b13c6d8}, !- Handle
@@ -3879,10 +3877,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  61.7219863212786, 129.08661, -1.8445394873466e-007, !- X,Y,Z Vertex 1 {m}
-  75.0823542248059, 129.08661, -3.21725345293089e-007, !- X,Y,Z Vertex 2 {m}
-  75.0823542248059, 129.08661, -3.14960044136648, !- X,Y,Z Vertex 3 {m}
-  61.7219863212786, 129.08661, -3.14960032293062; !- X,Y,Z Vertex 4 {m}
+  75.0823542248059, 129.08661, -3.21725345293089e-07, !- X,Y,Z Vertex 1 {m}
+  75.0823542248059, 129.08661, -3.14960044136648, !- X,Y,Z Vertex 2 {m}
+  61.7219863212786, 129.08661, -3.14960032293062, !- X,Y,Z Vertex 3 {m}
+  61.7219863212786, 129.08661, -1.8445394873466e-07; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {16fc7487-942e-4533-9501-84db54dd2348}, !- Handle
@@ -3896,10 +3894,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  60.0868613276954, -1.27686181272261e-013, 8.61101443412905e-008, !- X,Y,Z Vertex 1 {m}
-  60.0868613276954, -1.22502269210244e-013, -3.4543997908874, !- X,Y,Z Vertex 2 {m}
-  75.0823542058633, -7.50746929109565e-014, -3.45439937266219, !- X,Y,Z Vertex 3 {m}
-  75.0823542058633, -8.02586040869098e-014, -8.61101441600339e-008; !- X,Y,Z Vertex 4 {m}
+  60.0868613276954, -1.27686181272261e-13, 8.61101443412905e-08, !- X,Y,Z Vertex 1 {m}
+  60.0868613276954, -1.22502269210244e-13, -3.4543997908874, !- X,Y,Z Vertex 2 {m}
+  75.0823542058633, -7.50746929109565e-14, -3.45439937266219, !- X,Y,Z Vertex 3 {m}
+  75.0823542058633, -8.02586040869098e-14, -8.61101441600339e-08; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {57bd9f4f-e368-45b4-a055-8bbeb6d3c961}, !- Handle
@@ -3914,8 +3912,8 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   129.08661, 75.0823542126357, 7.62,      !- X,Y,Z Vertex 1 {m}
-  129.08661, 75.0823542046541, 1.73582265979975e-016, !- X,Y,Z Vertex 2 {m}
-  120.552209999994, 75.0823541438696, 1.60143971150521e-016, !- X,Y,Z Vertex 3 {m}
+  129.08661, 75.0823542046541, 1.73582241782679e-16, !- X,Y,Z Vertex 2 {m}
+  120.552209999994, 75.0823541438696, 1.60143995347817e-16, !- X,Y,Z Vertex 3 {m}
   120.552209999994, 75.0823541518511, 7.62; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
@@ -3930,15 +3928,13 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  1.93687310713954e-014, 61.7219864419276, 18.1416498034648, !- X,Y,Z Vertex 1 {m}
-  5.40191863176374e-015, 75.0823546084023, 12.5349013144976, !- X,Y,Z Vertex 2 {m}
-  -5.40191869879807e-015, 75.0823543533066, -4.04951546079481e-015, !- X,Y,Z Vertex 3 {m}
-  3.73243442067137e-015, 61.7219863126815, 2.57985085007383e-017; !- X,Y,Z Vertex 4 {m}
+  1.93687310713954e-14, 61.7219864419276, 18.1416498034648, !- X,Y,Z Vertex 1 {m}
+  5.40191863176375e-15, 75.0823546084023, 12.5349013144976, !- X,Y,Z Vertex 2 {m}
+  -5.40191869879807e-15, 75.0823543533066, -4.04951546079481e-15, !- X,Y,Z Vertex 3 {m}
+  3.73243442067138e-15, 61.7219863126815, 2.57985085007383e-17; !- X,Y,Z Vertex 4 {m}
 
 OS:ClimateZones,
   {79eb4fa0-07fb-4be4-8712-d2e621c85b0f}, !- Handle
-  ,                                       !- Active Institution
-  ,                                       !- Active Year
   ASHRAE,                                 !- Climate Zone Institution Name 1
   ANSI/ASHRAE Standard 169,               !- Climate Zone Document Name 1
   2006,                                   !- Climate Zone Document Year 1
@@ -3973,7 +3969,6 @@ OS:YearDescription,
 
 OS:Connection,
   {8484f705-133c-4268-8efd-5df34b993961}, !- Handle
-  {5cd48ccd-ed00-4b57-9c88-9050256d3320}, !- Name
   ,                                       !- Source Object
   11,                                     !- Outlet Port
   ,                                       !- Target Object
@@ -3999,7 +3994,7 @@ OS:ThermalZone,
   {c875fb50-750c-44d8-8bd9-45b51a06e51e}, !- Zone Air Inlet Port List
   {f2b9fafd-9387-48c0-afc6-fa66d2df6a52}, !- Zone Air Exhaust Port List
   {35cac26b-a964-4c1e-8422-eb19c0b5d56f}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {5cd6c21c-f694-4bb0-a339-2c613f2f596c}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -4010,6 +4005,11 @@ OS:ThermalZone,
   No,                                     !- Use Ideal Air Loads
   ;                                       !- Humidistat Name
 
+OS:PortList,
+  {5cd6c21c-f694-4bb0-a339-2c613f2f596c}, !- Handle
+  {d0925ce4-271b-4301-958c-fd645a985c74}, !- HVAC Component
+  ;                                       !- Port 1
+
 OS:Node,
   {8f406f23-0601-485e-ad38-fe734243c9c1}, !- Handle
   Node 2,                                 !- Name
@@ -4018,7 +4018,6 @@ OS:Node,
 
 OS:Connection,
   {35cac26b-a964-4c1e-8422-eb19c0b5d56f}, !- Handle
-  {57f1ba73-88cb-4639-be04-2d7cdfd16dc6}, !- Name
   {d0925ce4-271b-4301-958c-fd645a985c74}, !- Source Object
   11,                                     !- Outlet Port
   {8f406f23-0601-485e-ad38-fe734243c9c1}, !- Target Object
@@ -4026,20 +4025,22 @@ OS:Connection,
 
 OS:PortList,
   {c875fb50-750c-44d8-8bd9-45b51a06e51e}, !- Handle
-  Port List 3,                            !- Name
   {d0925ce4-271b-4301-958c-fd645a985c74}; !- HVAC Component
 
 OS:PortList,
   {f2b9fafd-9387-48c0-afc6-fa66d2df6a52}, !- Handle
-  Port List 4,                            !- Name
   {d0925ce4-271b-4301-958c-fd645a985c74}, !- HVAC Component
   {7d7dbb58-5945-4a8d-9a29-df950c2c0f9d}; !- Port 1
 
 OS:Sizing:Zone,
   {c2419f4f-ff6e-4cd3-8b3a-38ccb044334d}, !- Handle
   {d0925ce4-271b-4301-958c-fd645a985c74}, !- Zone or ZoneList Name
+  SupplyAirTemperature,                   !- Zone Cooling Design Supply Air Temperature Input Method
   14,                                     !- Zone Cooling Design Supply Air Temperature {C}
+  11.11,                                  !- Zone Cooling Design Supply Air Temperature Difference {deltaC}
+  SupplyAirTemperature,                   !- Zone Heating Design Supply Air Temperature Input Method
   40,                                     !- Zone Heating Design Supply Air Temperature {C}
+  11.11,                                  !- Zone Heating Design Supply Air Temperature Difference {deltaC}
   0.0085,                                 !- Zone Cooling Design Supply Air Humidity Ratio {kg-H2O/kg-air}
   0.008,                                  !- Zone Heating Design Supply Air Humidity Ratio {kg-H2O/kg-air}
   ,                                       !- Zone Heating Sizing Factor
@@ -4054,16 +4055,28 @@ OS:Sizing:Zone,
   ,                                       !- Heating Maximum Air Flow per Zone Floor Area {m3/s-m2}
   ,                                       !- Heating Maximum Air Flow {m3/s}
   ,                                       !- Heating Maximum Air Flow Fraction
-  ,                                       !- Design Zone Air Distribution Effectiveness in Cooling Mode
-  ;                                       !- Design Zone Air Distribution Effectiveness in Heating Mode
+  No,                                     !- Account for Dedicated Outdoor Air System
+  NeutralSupplyAir,                       !- Dedicated Outdoor Air System Control Strategy
+  Autosize,                               !- Dedicated Outdoor Air Low Setpoint Temperature for Design {C}
+  Autosize,                               !- Dedicated Outdoor Air High Setpoint Temperature for Design {C}
+  Sensible Load Only No Latent Load,      !- Zone Load Sizing Method
+  HumidityRatioDifference,                !- Zone Latent Cooling Design Supply Air Humidity Ratio Input Method
+  ,                                       !- Zone Dehumidification Design Supply Air Humidity Ratio {kgWater/kgDryAir}
+  0.005,                                  !- Zone Cooling Design Supply Air Humidity Ratio Difference {kgWater/kgDryAir}
+  HumidityRatioDifference,                !- Zone Latent Heating Design Supply Air Humidity Ratio Input Method
+  ,                                       !- Zone Humidification Design Supply Air Humidity Ratio {kgWater/kgDryAir}
+  0.005;                                  !- Zone Humidification Design Supply Air Humidity Ratio Difference {kgWater/kgDryAir}
 
 OS:ZoneHVAC:EquipmentList,
   {b3ee06ba-4699-4f5a-aa3d-283b3c67ba39}, !- Handle
   Zone HVAC Equipment List 2,             !- Name
   {d0925ce4-271b-4301-958c-fd645a985c74}, !- Thermal Zone
+  ,                                       !- Load Distribution Scheme
   {a571e157-761c-44a3-a21c-9af0f89ae7f3}, !- Zone Equipment 1
   1,                                      !- Zone Equipment Cooling Sequence 1
-  1;                                      !- Zone Equipment Heating or No-Load Sequence 1
+  1,                                      !- Zone Equipment Heating or No-Load Sequence 1
+  ,                                       !- Zone Equipment Sequential Cooling Fraction Schedule Name 1
+  ;                                       !- Zone Equipment Sequential Heating Fraction Schedule Name 1
 
 OS:Rendering:Color,
   {c1a914c9-8ab2-411f-a117-2115659f35ee}, !- Handle
@@ -4085,7 +4098,7 @@ OS:ThermalZone,
   {0bb13971-e55d-44b4-a53b-abd5a0248059}, !- Zone Air Inlet Port List
   {73fbdcf0-4980-4bc9-9283-47a54fbd0cba}, !- Zone Air Exhaust Port List
   {7c2bb6cc-2799-4ad4-95f5-5576b72004e2}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {9d8146b7-5604-4aec-b45e-bdfe9c414454}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -4096,6 +4109,11 @@ OS:ThermalZone,
   No,                                     !- Use Ideal Air Loads
   ;                                       !- Humidistat Name
 
+OS:PortList,
+  {9d8146b7-5604-4aec-b45e-bdfe9c414454}, !- Handle
+  {a15b33bf-95a8-4c35-af8c-ddecb61c0f47}, !- HVAC Component
+  ;                                       !- Port 1
+
 OS:Node,
   {5f93fcd2-0a3c-4ca3-aa56-d80605fc69f8}, !- Handle
   Node 3,                                 !- Name
@@ -4104,7 +4122,6 @@ OS:Node,
 
 OS:Connection,
   {7c2bb6cc-2799-4ad4-95f5-5576b72004e2}, !- Handle
-  {f980bb64-f0a7-4b68-9918-c62fe7e73d92}, !- Name
   {a15b33bf-95a8-4c35-af8c-ddecb61c0f47}, !- Source Object
   11,                                     !- Outlet Port
   {5f93fcd2-0a3c-4ca3-aa56-d80605fc69f8}, !- Target Object
@@ -4112,20 +4129,22 @@ OS:Connection,
 
 OS:PortList,
   {0bb13971-e55d-44b4-a53b-abd5a0248059}, !- Handle
-  Port List 5,                            !- Name
   {a15b33bf-95a8-4c35-af8c-ddecb61c0f47}; !- HVAC Component
 
 OS:PortList,
   {73fbdcf0-4980-4bc9-9283-47a54fbd0cba}, !- Handle
-  Port List 6,                            !- Name
   {a15b33bf-95a8-4c35-af8c-ddecb61c0f47}, !- HVAC Component
   {ffdd9a9b-56af-458c-9535-c7ea815a547c}; !- Port 1
 
 OS:Sizing:Zone,
   {06bace78-727b-4896-ac98-f39e7acddf75}, !- Handle
   {a15b33bf-95a8-4c35-af8c-ddecb61c0f47}, !- Zone or ZoneList Name
+  SupplyAirTemperature,                   !- Zone Cooling Design Supply Air Temperature Input Method
   14,                                     !- Zone Cooling Design Supply Air Temperature {C}
+  11.11,                                  !- Zone Cooling Design Supply Air Temperature Difference {deltaC}
+  SupplyAirTemperature,                   !- Zone Heating Design Supply Air Temperature Input Method
   40,                                     !- Zone Heating Design Supply Air Temperature {C}
+  11.11,                                  !- Zone Heating Design Supply Air Temperature Difference {deltaC}
   0.0085,                                 !- Zone Cooling Design Supply Air Humidity Ratio {kg-H2O/kg-air}
   0.008,                                  !- Zone Heating Design Supply Air Humidity Ratio {kg-H2O/kg-air}
   ,                                       !- Zone Heating Sizing Factor
@@ -4140,16 +4159,28 @@ OS:Sizing:Zone,
   ,                                       !- Heating Maximum Air Flow per Zone Floor Area {m3/s-m2}
   ,                                       !- Heating Maximum Air Flow {m3/s}
   ,                                       !- Heating Maximum Air Flow Fraction
-  ,                                       !- Design Zone Air Distribution Effectiveness in Cooling Mode
-  ;                                       !- Design Zone Air Distribution Effectiveness in Heating Mode
+  No,                                     !- Account for Dedicated Outdoor Air System
+  NeutralSupplyAir,                       !- Dedicated Outdoor Air System Control Strategy
+  Autosize,                               !- Dedicated Outdoor Air Low Setpoint Temperature for Design {C}
+  Autosize,                               !- Dedicated Outdoor Air High Setpoint Temperature for Design {C}
+  Sensible Load Only No Latent Load,      !- Zone Load Sizing Method
+  HumidityRatioDifference,                !- Zone Latent Cooling Design Supply Air Humidity Ratio Input Method
+  ,                                       !- Zone Dehumidification Design Supply Air Humidity Ratio {kgWater/kgDryAir}
+  0.005,                                  !- Zone Cooling Design Supply Air Humidity Ratio Difference {kgWater/kgDryAir}
+  HumidityRatioDifference,                !- Zone Latent Heating Design Supply Air Humidity Ratio Input Method
+  ,                                       !- Zone Humidification Design Supply Air Humidity Ratio {kgWater/kgDryAir}
+  0.005;                                  !- Zone Humidification Design Supply Air Humidity Ratio Difference {kgWater/kgDryAir}
 
 OS:ZoneHVAC:EquipmentList,
   {7d2bfcf4-4cbd-4070-9746-65254cbb5517}, !- Handle
   Zone HVAC Equipment List 3,             !- Name
   {a15b33bf-95a8-4c35-af8c-ddecb61c0f47}, !- Thermal Zone
+  ,                                       !- Load Distribution Scheme
   {e212296b-762d-4822-a7f4-643b2cfeb2f7}, !- Zone Equipment 1
   1,                                      !- Zone Equipment Cooling Sequence 1
-  1;                                      !- Zone Equipment Heating or No-Load Sequence 1
+  1,                                      !- Zone Equipment Heating or No-Load Sequence 1
+  ,                                       !- Zone Equipment Sequential Cooling Fraction Schedule Name 1
+  ;                                       !- Zone Equipment Sequential Heating Fraction Schedule Name 1
 
 OS:Rendering:Color,
   {830a4cf5-94b9-4bab-9553-9045baf01a10}, !- Handle
@@ -4171,7 +4202,7 @@ OS:ThermalZone,
   {58603f0b-1cf7-4a0e-a3af-da38cee98e1c}, !- Zone Air Inlet Port List
   {ab7417a3-bb39-4c0a-abc0-64fb7ae49d18}, !- Zone Air Exhaust Port List
   {bc353dfd-1dab-429e-8d77-5dc3578ee7bc}, !- Zone Air Node Name
-  {6fa9ec0b-7d67-4ed3-b6a7-48f8a161216b}, !- Zone Return Air Node Name
+  {c0fa847c-d186-4c61-9d7a-774a168baa25}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -4182,6 +4213,11 @@ OS:ThermalZone,
   No,                                     !- Use Ideal Air Loads
   ;                                       !- Humidistat Name
 
+OS:PortList,
+  {c0fa847c-d186-4c61-9d7a-774a168baa25}, !- Handle
+  {6f6da13e-8cc0-4b66-ba77-f3f7916b1f52}, !- HVAC Component
+  {6fa9ec0b-7d67-4ed3-b6a7-48f8a161216b}; !- Port 1
+
 OS:Node,
   {1f678f5f-6eec-43e1-91ee-6a2f4045f699}, !- Handle
   Node 4,                                 !- Name
@@ -4190,7 +4226,6 @@ OS:Node,
 
 OS:Connection,
   {bc353dfd-1dab-429e-8d77-5dc3578ee7bc}, !- Handle
-  {d39d617b-481a-4cf8-bfd4-2ca51c9cd46e}, !- Name
   {6f6da13e-8cc0-4b66-ba77-f3f7916b1f52}, !- Source Object
   11,                                     !- Outlet Port
   {1f678f5f-6eec-43e1-91ee-6a2f4045f699}, !- Target Object
@@ -4198,20 +4233,22 @@ OS:Connection,
 
 OS:PortList,
   {58603f0b-1cf7-4a0e-a3af-da38cee98e1c}, !- Handle
-  Port List 7,                            !- Name
   {6f6da13e-8cc0-4b66-ba77-f3f7916b1f52}, !- HVAC Component
   {51cb9c5f-5b40-485c-b9a7-be4ffc36cfb6}; !- Port 1
 
 OS:PortList,
   {ab7417a3-bb39-4c0a-abc0-64fb7ae49d18}, !- Handle
-  Port List 8,                            !- Name
   {6f6da13e-8cc0-4b66-ba77-f3f7916b1f52}; !- HVAC Component
 
 OS:Sizing:Zone,
   {1fa68ecb-ea36-4fc6-890d-9ddc57e268d6}, !- Handle
   {6f6da13e-8cc0-4b66-ba77-f3f7916b1f52}, !- Zone or ZoneList Name
+  SupplyAirTemperature,                   !- Zone Cooling Design Supply Air Temperature Input Method
   12.78,                                  !- Zone Cooling Design Supply Air Temperature {C}
+  11.11,                                  !- Zone Cooling Design Supply Air Temperature Difference {deltaC}
+  SupplyAirTemperature,                   !- Zone Heating Design Supply Air Temperature Input Method
   32.22,                                  !- Zone Heating Design Supply Air Temperature {C}
+  11.11,                                  !- Zone Heating Design Supply Air Temperature Difference {deltaC}
   0.0085,                                 !- Zone Cooling Design Supply Air Humidity Ratio {kg-H2O/kg-air}
   0.008,                                  !- Zone Heating Design Supply Air Humidity Ratio {kg-H2O/kg-air}
   ,                                       !- Zone Heating Sizing Factor
@@ -4226,16 +4263,28 @@ OS:Sizing:Zone,
   ,                                       !- Heating Maximum Air Flow per Zone Floor Area {m3/s-m2}
   ,                                       !- Heating Maximum Air Flow {m3/s}
   ,                                       !- Heating Maximum Air Flow Fraction
-  ,                                       !- Design Zone Air Distribution Effectiveness in Cooling Mode
-  ;                                       !- Design Zone Air Distribution Effectiveness in Heating Mode
+  No,                                     !- Account for Dedicated Outdoor Air System
+  NeutralSupplyAir,                       !- Dedicated Outdoor Air System Control Strategy
+  Autosize,                               !- Dedicated Outdoor Air Low Setpoint Temperature for Design {C}
+  Autosize,                               !- Dedicated Outdoor Air High Setpoint Temperature for Design {C}
+  Sensible Load Only No Latent Load,      !- Zone Load Sizing Method
+  HumidityRatioDifference,                !- Zone Latent Cooling Design Supply Air Humidity Ratio Input Method
+  ,                                       !- Zone Dehumidification Design Supply Air Humidity Ratio {kgWater/kgDryAir}
+  0.005,                                  !- Zone Cooling Design Supply Air Humidity Ratio Difference {kgWater/kgDryAir}
+  HumidityRatioDifference,                !- Zone Latent Heating Design Supply Air Humidity Ratio Input Method
+  ,                                       !- Zone Humidification Design Supply Air Humidity Ratio {kgWater/kgDryAir}
+  0.005;                                  !- Zone Humidification Design Supply Air Humidity Ratio Difference {kgWater/kgDryAir}
 
 OS:ZoneHVAC:EquipmentList,
   {5b94e3d8-fae8-482e-bc67-80834e37c6ff}, !- Handle
   Zone HVAC Equipment List 4,             !- Name
   {6f6da13e-8cc0-4b66-ba77-f3f7916b1f52}, !- Thermal Zone
+  ,                                       !- Load Distribution Scheme
   {2a313c2a-c41b-440c-aafd-e4a806e28289}, !- Zone Equipment 1
   1,                                      !- Zone Equipment Cooling Sequence 1
-  1;                                      !- Zone Equipment Heating or No-Load Sequence 1
+  1,                                      !- Zone Equipment Heating or No-Load Sequence 1
+  ,                                       !- Zone Equipment Sequential Cooling Fraction Schedule Name 1
+  ;                                       !- Zone Equipment Sequential Heating Fraction Schedule Name 1
 
 OS:Rendering:Color,
   {8df23e0d-8e1e-44de-93f6-38b1ded98338}, !- Handle
@@ -4257,7 +4306,7 @@ OS:ThermalZone,
   {3f5723bf-ce91-4ebd-83ae-00bcc2cb8afd}, !- Zone Air Inlet Port List
   {d5bb0843-3d13-4519-a3b3-6aa651fb5af9}, !- Zone Air Exhaust Port List
   {110289f7-eb7f-4e15-8c20-984c03ff9935}, !- Zone Air Node Name
-  ,                                       !- Zone Return Air Node Name
+  {0b49fae4-21c9-46b9-91a4-4326472e4de5}, !- Zone Return Air Port List
   ,                                       !- Primary Daylighting Control Name
   ,                                       !- Fraction of Zone Controlled by Primary Daylighting Control
   ,                                       !- Secondary Daylighting Control Name
@@ -4268,6 +4317,11 @@ OS:ThermalZone,
   No,                                     !- Use Ideal Air Loads
   ;                                       !- Humidistat Name
 
+OS:PortList,
+  {0b49fae4-21c9-46b9-91a4-4326472e4de5}, !- Handle
+  {55cace87-0ec6-41e9-b1b6-9a51b675d042}, !- HVAC Component
+  ;                                       !- Port 1
+
 OS:Node,
   {a318f1c7-3539-471b-8866-b3656896fb0e}, !- Handle
   Node 5,                                 !- Name
@@ -4276,7 +4330,6 @@ OS:Node,
 
 OS:Connection,
   {110289f7-eb7f-4e15-8c20-984c03ff9935}, !- Handle
-  {96f58acf-681a-4f14-ad7e-b00e7a13f6df}, !- Name
   {55cace87-0ec6-41e9-b1b6-9a51b675d042}, !- Source Object
   11,                                     !- Outlet Port
   {a318f1c7-3539-471b-8866-b3656896fb0e}, !- Target Object
@@ -4284,19 +4337,21 @@ OS:Connection,
 
 OS:PortList,
   {3f5723bf-ce91-4ebd-83ae-00bcc2cb8afd}, !- Handle
-  Port List 9,                            !- Name
   {55cace87-0ec6-41e9-b1b6-9a51b675d042}; !- HVAC Component
 
 OS:PortList,
   {d5bb0843-3d13-4519-a3b3-6aa651fb5af9}, !- Handle
-  Port List 10,                           !- Name
   {55cace87-0ec6-41e9-b1b6-9a51b675d042}; !- HVAC Component
 
 OS:Sizing:Zone,
   {d68d0c3a-5729-4e12-9ec8-92bc88e68513}, !- Handle
   {55cace87-0ec6-41e9-b1b6-9a51b675d042}, !- Zone or ZoneList Name
+  SupplyAirTemperature,                   !- Zone Cooling Design Supply Air Temperature Input Method
   14,                                     !- Zone Cooling Design Supply Air Temperature {C}
+  11.11,                                  !- Zone Cooling Design Supply Air Temperature Difference {deltaC}
+  SupplyAirTemperature,                   !- Zone Heating Design Supply Air Temperature Input Method
   40,                                     !- Zone Heating Design Supply Air Temperature {C}
+  11.11,                                  !- Zone Heating Design Supply Air Temperature Difference {deltaC}
   0.0085,                                 !- Zone Cooling Design Supply Air Humidity Ratio {kg-H2O/kg-air}
   0.008,                                  !- Zone Heating Design Supply Air Humidity Ratio {kg-H2O/kg-air}
   ,                                       !- Zone Heating Sizing Factor
@@ -4311,8 +4366,17 @@ OS:Sizing:Zone,
   ,                                       !- Heating Maximum Air Flow per Zone Floor Area {m3/s-m2}
   ,                                       !- Heating Maximum Air Flow {m3/s}
   ,                                       !- Heating Maximum Air Flow Fraction
-  ,                                       !- Design Zone Air Distribution Effectiveness in Cooling Mode
-  ;                                       !- Design Zone Air Distribution Effectiveness in Heating Mode
+  No,                                     !- Account for Dedicated Outdoor Air System
+  NeutralSupplyAir,                       !- Dedicated Outdoor Air System Control Strategy
+  Autosize,                               !- Dedicated Outdoor Air Low Setpoint Temperature for Design {C}
+  Autosize,                               !- Dedicated Outdoor Air High Setpoint Temperature for Design {C}
+  Sensible Load Only No Latent Load,      !- Zone Load Sizing Method
+  HumidityRatioDifference,                !- Zone Latent Cooling Design Supply Air Humidity Ratio Input Method
+  ,                                       !- Zone Dehumidification Design Supply Air Humidity Ratio {kgWater/kgDryAir}
+  0.005,                                  !- Zone Cooling Design Supply Air Humidity Ratio Difference {kgWater/kgDryAir}
+  HumidityRatioDifference,                !- Zone Latent Heating Design Supply Air Humidity Ratio Input Method
+  ,                                       !- Zone Humidification Design Supply Air Humidity Ratio {kgWater/kgDryAir}
+  0.005;                                  !- Zone Humidification Design Supply Air Humidity Ratio Difference {kgWater/kgDryAir}
 
 OS:ZoneHVAC:EquipmentList,
   {b80bd05c-f1de-49a2-b524-85b601f26d3f}, !- Handle
@@ -4368,21 +4432,23 @@ OS:SizingPeriod:DesignDay,
   Denver Intl Ap Ann Htg 99.6% Condns DB, !- Name
   -17.4,                                  !- Maximum Dry-Bulb Temperature {C}
   0,                                      !- Daily Dry-Bulb Temperature Range {deltaC}
-  -17.4,                                  !- Humidity Indicating Conditions at Maximum Dry-Bulb {BasedOnField A3}
   83011,                                  !- Barometric Pressure {Pa}
   3.3,                                    !- Wind Speed {m/s}
   160,                                    !- Wind Direction {deg}
   0,                                      !- Sky Clearness
-  0,                                      !- Rain Indicator
-  0,                                      !- Snow Indicator
+  No,                                     !- Rain Indicator
+  No,                                     !- Snow Indicator
   21,                                     !- Day of Month
   12,                                     !- Month
   WinterDesignDay,                        !- Day Type
-  0,                                      !- Daylight Saving Time Indicator
-  Wetbulb,                                !- Humidity Indicating Type
-  ,                                       !- Humidity Indicating Day Schedule Name
+  No,                                     !- Daylight Saving Time Indicator
+  Wetbulb,                                !- Humidity Condition Type
+  ,                                       !- Humidity Condition Day Schedule Name
+  -17.4,                                  !- Wetbulb or DewPoint at Maximum Dry-Bulb {C}
+  ,                                       !- Humidity Ratio at Maximum Dry-Bulb {kgWater/kgDryAir}
+  ,                                       !- Enthalpy at Maximum Dry-Bulb {J/kg}
   DefaultMultipliers,                     !- Dry-Bulb Temperature Range Modifier Type
-  ,                                       !- Dry-Bulb Temperature Range Modifier Schedule Name
+  ,                                       !- Dry-Bulb Temperature Range Modifier Day Schedule Name
   ASHRAEClearSky;                         !- Solar Model Indicator
 
 OS:SizingPeriod:DesignDay,
@@ -4390,47 +4456,51 @@ OS:SizingPeriod:DesignDay,
   Denver Intl Ap Ann Clg .4% Condns WB=>MDB, !- Name
   27.3,                                   !- Maximum Dry-Bulb Temperature {C}
   15.2,                                   !- Daily Dry-Bulb Temperature Range {deltaC}
-  18.3,                                   !- Humidity Indicating Conditions at Maximum Dry-Bulb {BasedOnField A3}
   83011,                                  !- Barometric Pressure {Pa}
   4.2,                                    !- Wind Speed {m/s}
   80,                                     !- Wind Direction {deg}
   0,                                      !- Sky Clearness
-  0,                                      !- Rain Indicator
-  0,                                      !- Snow Indicator
+  No,                                     !- Rain Indicator
+  No,                                     !- Snow Indicator
   21,                                     !- Day of Month
   7,                                      !- Month
   SummerDesignDay,                        !- Day Type
-  0,                                      !- Daylight Saving Time Indicator
-  Wetbulb,                                !- Humidity Indicating Type
-  ,                                       !- Humidity Indicating Day Schedule Name
+  No,                                     !- Daylight Saving Time Indicator
+  Wetbulb,                                !- Humidity Condition Type
+  ,                                       !- Humidity Condition Day Schedule Name
+  18.3,                                   !- Wetbulb or DewPoint at Maximum Dry-Bulb {C}
+  ,                                       !- Humidity Ratio at Maximum Dry-Bulb {kgWater/kgDryAir}
+  ,                                       !- Enthalpy at Maximum Dry-Bulb {J/kg}
   DefaultMultipliers,                     !- Dry-Bulb Temperature Range Modifier Type
-  ,                                       !- Dry-Bulb Temperature Range Modifier Schedule Name
+  ,                                       !- Dry-Bulb Temperature Range Modifier Day Schedule Name
   ASHRAETau,                              !- Solar Model Indicator
   ,                                       !- Beam Solar Day Schedule Name
   ,                                       !- Diffuse Solar Day Schedule Name
-  0.424,                                  !- ASHRAE Taub {dimensionless}
-  2.012;                                  !- ASHRAE Taud {dimensionless}
+  0.424,                                  !- ASHRAE Clear Sky Optical Depth for Beam Irradiance {dimensionless}
+  2.012;                                  !- ASHRAE Clear Sky Optical Depth for Diffuse Irradiance {dimensionless}
 
 OS:SizingPeriod:DesignDay,
   {149468d0-af65-40a6-a9f0-1578aaf86c69}, !- Handle
   Denver Intl Ap Ann Hum_n 99.6% Condns DP=>MCDB, !- Name
   -11.7,                                  !- Maximum Dry-Bulb Temperature {C}
   0,                                      !- Daily Dry-Bulb Temperature Range {deltaC}
-  -21.5,                                  !- Humidity Indicating Conditions at Maximum Dry-Bulb {BasedOnField A3}
   83011,                                  !- Barometric Pressure {Pa}
   3.3,                                    !- Wind Speed {m/s}
   160,                                    !- Wind Direction {deg}
   0,                                      !- Sky Clearness
-  0,                                      !- Rain Indicator
-  0,                                      !- Snow Indicator
+  No,                                     !- Rain Indicator
+  No,                                     !- Snow Indicator
   21,                                     !- Day of Month
   12,                                     !- Month
   WinterDesignDay,                        !- Day Type
-  0,                                      !- Daylight Saving Time Indicator
-  Dewpoint,                               !- Humidity Indicating Type
-  ,                                       !- Humidity Indicating Day Schedule Name
+  No,                                     !- Daylight Saving Time Indicator
+  Dewpoint,                               !- Humidity Condition Type
+  ,                                       !- Humidity Condition Day Schedule Name
+  -21.5,                                  !- Wetbulb or DewPoint at Maximum Dry-Bulb {C}
+  ,                                       !- Humidity Ratio at Maximum Dry-Bulb {kgWater/kgDryAir}
+  ,                                       !- Enthalpy at Maximum Dry-Bulb {J/kg}
   DefaultMultipliers,                     !- Dry-Bulb Temperature Range Modifier Type
-  ,                                       !- Dry-Bulb Temperature Range Modifier Schedule Name
+  ,                                       !- Dry-Bulb Temperature Range Modifier Day Schedule Name
   ASHRAEClearSky;                         !- Solar Model Indicator
 
 OS:SizingPeriod:DesignDay,
@@ -4438,21 +4508,23 @@ OS:SizingPeriod:DesignDay,
   Denver Intl Ap Ann Htg Wind 99.6% Condns WS=>MCDB, !- Name
   1.8,                                    !- Maximum Dry-Bulb Temperature {C}
   0,                                      !- Daily Dry-Bulb Temperature Range {deltaC}
-  1.8,                                    !- Humidity Indicating Conditions at Maximum Dry-Bulb {BasedOnField A3}
   83011,                                  !- Barometric Pressure {Pa}
   14.1,                                   !- Wind Speed {m/s}
   160,                                    !- Wind Direction {deg}
   0,                                      !- Sky Clearness
-  0,                                      !- Rain Indicator
-  0,                                      !- Snow Indicator
+  No,                                     !- Rain Indicator
+  No,                                     !- Snow Indicator
   21,                                     !- Day of Month
   12,                                     !- Month
   WinterDesignDay,                        !- Day Type
-  0,                                      !- Daylight Saving Time Indicator
-  Wetbulb,                                !- Humidity Indicating Type
-  ,                                       !- Humidity Indicating Day Schedule Name
+  No,                                     !- Daylight Saving Time Indicator
+  Wetbulb,                                !- Humidity Condition Type
+  ,                                       !- Humidity Condition Day Schedule Name
+  1.8,                                    !- Wetbulb or DewPoint at Maximum Dry-Bulb {C}
+  ,                                       !- Humidity Ratio at Maximum Dry-Bulb {kgWater/kgDryAir}
+  ,                                       !- Enthalpy at Maximum Dry-Bulb {J/kg}
   DefaultMultipliers,                     !- Dry-Bulb Temperature Range Modifier Type
-  ,                                       !- Dry-Bulb Temperature Range Modifier Schedule Name
+  ,                                       !- Dry-Bulb Temperature Range Modifier Day Schedule Name
   ASHRAEClearSky;                         !- Solar Model Indicator
 
 OS:SizingPeriod:DesignDay,
@@ -4460,78 +4532,84 @@ OS:SizingPeriod:DesignDay,
   Denver Intl Ap Ann Clg .4% Condns Enth=>MDB, !- Name
   27,                                     !- Maximum Dry-Bulb Temperature {C}
   15.2,                                   !- Daily Dry-Bulb Temperature Range {deltaC}
-  58300,                                  !- Humidity Indicating Conditions at Maximum Dry-Bulb {BasedOnField A3}
   83011,                                  !- Barometric Pressure {Pa}
   4.2,                                    !- Wind Speed {m/s}
   80,                                     !- Wind Direction {deg}
   0,                                      !- Sky Clearness
-  0,                                      !- Rain Indicator
-  0,                                      !- Snow Indicator
+  No,                                     !- Rain Indicator
+  No,                                     !- Snow Indicator
   21,                                     !- Day of Month
   7,                                      !- Month
   SummerDesignDay,                        !- Day Type
-  0,                                      !- Daylight Saving Time Indicator
-  Enthalpy,                               !- Humidity Indicating Type
-  ,                                       !- Humidity Indicating Day Schedule Name
+  No,                                     !- Daylight Saving Time Indicator
+  Enthalpy,                               !- Humidity Condition Type
+  ,                                       !- Humidity Condition Day Schedule Name
+  ,                                       !- Wetbulb or DewPoint at Maximum Dry-Bulb {C}
+  ,                                       !- Humidity Ratio at Maximum Dry-Bulb {kgWater/kgDryAir}
+  58300,                                  !- Enthalpy at Maximum Dry-Bulb {J/kg}
   DefaultMultipliers,                     !- Dry-Bulb Temperature Range Modifier Type
-  ,                                       !- Dry-Bulb Temperature Range Modifier Schedule Name
+  ,                                       !- Dry-Bulb Temperature Range Modifier Day Schedule Name
   ASHRAETau,                              !- Solar Model Indicator
   ,                                       !- Beam Solar Day Schedule Name
   ,                                       !- Diffuse Solar Day Schedule Name
-  0.424,                                  !- ASHRAE Taub {dimensionless}
-  2.012;                                  !- ASHRAE Taud {dimensionless}
+  0.424,                                  !- ASHRAE Clear Sky Optical Depth for Beam Irradiance {dimensionless}
+  2.012;                                  !- ASHRAE Clear Sky Optical Depth for Diffuse Irradiance {dimensionless}
 
 OS:SizingPeriod:DesignDay,
   {a78571de-7346-43ad-84d5-81f7d444b719}, !- Handle
   Denver Intl Ap Ann Clg .4% Condns DP=>MDB, !- Name
   19.9,                                   !- Maximum Dry-Bulb Temperature {C}
   15.2,                                   !- Daily Dry-Bulb Temperature Range {deltaC}
-  16,                                     !- Humidity Indicating Conditions at Maximum Dry-Bulb {BasedOnField A3}
   83011,                                  !- Barometric Pressure {Pa}
   4.2,                                    !- Wind Speed {m/s}
   80,                                     !- Wind Direction {deg}
   0,                                      !- Sky Clearness
-  0,                                      !- Rain Indicator
-  0,                                      !- Snow Indicator
+  No,                                     !- Rain Indicator
+  No,                                     !- Snow Indicator
   21,                                     !- Day of Month
   7,                                      !- Month
   SummerDesignDay,                        !- Day Type
-  0,                                      !- Daylight Saving Time Indicator
-  Dewpoint,                               !- Humidity Indicating Type
-  ,                                       !- Humidity Indicating Day Schedule Name
+  No,                                     !- Daylight Saving Time Indicator
+  Dewpoint,                               !- Humidity Condition Type
+  ,                                       !- Humidity Condition Day Schedule Name
+  16,                                     !- Wetbulb or DewPoint at Maximum Dry-Bulb {C}
+  ,                                       !- Humidity Ratio at Maximum Dry-Bulb {kgWater/kgDryAir}
+  ,                                       !- Enthalpy at Maximum Dry-Bulb {J/kg}
   DefaultMultipliers,                     !- Dry-Bulb Temperature Range Modifier Type
-  ,                                       !- Dry-Bulb Temperature Range Modifier Schedule Name
+  ,                                       !- Dry-Bulb Temperature Range Modifier Day Schedule Name
   ASHRAETau,                              !- Solar Model Indicator
   ,                                       !- Beam Solar Day Schedule Name
   ,                                       !- Diffuse Solar Day Schedule Name
-  0.424,                                  !- ASHRAE Taub {dimensionless}
-  2.012;                                  !- ASHRAE Taud {dimensionless}
+  0.424,                                  !- ASHRAE Clear Sky Optical Depth for Beam Irradiance {dimensionless}
+  2.012;                                  !- ASHRAE Clear Sky Optical Depth for Diffuse Irradiance {dimensionless}
 
 OS:SizingPeriod:DesignDay,
   {bdfee646-f624-4121-8336-abc0c8cc2f5b}, !- Handle
   Denver Intl Ap Ann Clg .4% Condns DB=>MWB, !- Name
   34.6,                                   !- Maximum Dry-Bulb Temperature {C}
   15.2,                                   !- Daily Dry-Bulb Temperature Range {deltaC}
-  15.7,                                   !- Humidity Indicating Conditions at Maximum Dry-Bulb {BasedOnField A3}
   83011,                                  !- Barometric Pressure {Pa}
   4.2,                                    !- Wind Speed {m/s}
   80,                                     !- Wind Direction {deg}
   0,                                      !- Sky Clearness
-  0,                                      !- Rain Indicator
-  0,                                      !- Snow Indicator
+  No,                                     !- Rain Indicator
+  No,                                     !- Snow Indicator
   21,                                     !- Day of Month
   7,                                      !- Month
   SummerDesignDay,                        !- Day Type
-  0,                                      !- Daylight Saving Time Indicator
-  Wetbulb,                                !- Humidity Indicating Type
-  ,                                       !- Humidity Indicating Day Schedule Name
+  No,                                     !- Daylight Saving Time Indicator
+  Wetbulb,                                !- Humidity Condition Type
+  ,                                       !- Humidity Condition Day Schedule Name
+  15.7,                                   !- Wetbulb or DewPoint at Maximum Dry-Bulb {C}
+  ,                                       !- Humidity Ratio at Maximum Dry-Bulb {kgWater/kgDryAir}
+  ,                                       !- Enthalpy at Maximum Dry-Bulb {J/kg}
   DefaultMultipliers,                     !- Dry-Bulb Temperature Range Modifier Type
-  ,                                       !- Dry-Bulb Temperature Range Modifier Schedule Name
+  ,                                       !- Dry-Bulb Temperature Range Modifier Day Schedule Name
   ASHRAETau,                              !- Solar Model Indicator
   ,                                       !- Beam Solar Day Schedule Name
   ,                                       !- Diffuse Solar Day Schedule Name
-  0.424,                                  !- ASHRAE Taub {dimensionless}
-  2.012;                                  !- ASHRAE Taud {dimensionless}
+  0.424,                                  !- ASHRAE Clear Sky Optical Depth for Beam Irradiance {dimensionless}
+  2.012;                                  !- ASHRAE Clear Sky Optical Depth for Diffuse Irradiance {dimensionless}
 
 OS:Material,
   {e60bad88-e075-4cc2-83eb-f13e6000c0cb}, !- Handle
@@ -4625,12 +4703,12 @@ OS:StandardsInformation:Material,
 
 OS:Material,
   {4eb27784-29e6-4799-9c55-bd8b340d011d}, !- Handle
-  Clay Roof Tile - Lightweight Concrete - 1 in. - 80 lb/ft3, ! Name
-  MediumRough,                            ! Roughness
-  0.0254,                                 ! Thickness {m}
-  0.53,                                   ! Conductivity {W/m-K}
-  1281.47706991681,                       ! Density {kg/m3}
-  840;                                    ! Specific Heat {J/kg-K}
+  Clay Roof Tile - Lightweight Concrete - 1 in. - 80 lb/ft3, !- Name
+  MediumRough,                            !- Roughness
+  0.0254,                                 !- Thickness {m}
+  0.53,                                   !- Conductivity {W/m-K}
+  1281.47706991681,                       !- Density {kg/m3}
+  840;                                    !- Specific Heat {J/kg-K}
 
 OS:StandardsInformation:Material,
   {216683d8-5e72-4389-83c5-3a703f9ffb4f}, !- Handle
@@ -4654,12 +4732,12 @@ OS:StandardsInformation:Material,
 
 OS:Material,
   {c5241ab9-dfd5-4666-8968-7ddfa31e19be}, !- Handle
-  Sandstone - 3 in. - 120 lb/ft3,         ! Name
-  MediumRough,                            ! Roughness
-  0.0762,                                 ! Thickness {m}
-  1.89999993983096,                       ! Conductivity {W/m-K}
-  1922.21560487522,                       ! Density {kg/m3}
-  790;                                    ! Specific Heat {J/kg-K}
+  Sandstone - 3 in. - 120 lb/ft3,         !- Name
+  MediumRough,                            !- Roughness
+  0.0762,                                 !- Thickness {m}
+  1.89999993983096,                       !- Conductivity {W/m-K}
+  1922.21560487522,                       !- Density {kg/m3}
+  790;                                    !- Specific Heat {J/kg-K}
 
 OS:StandardsInformation:Material,
   {e9df9a5a-2734-4e4e-8a1c-17b4ae14b1f2}, !- Handle
@@ -4667,12 +4745,12 @@ OS:StandardsInformation:Material,
 
 OS:Material,
   {eab167c3-ff9a-4e27-bf6c-8877d994210f}, !- Handle
-  Wood Sheathing - 0.5 in. - 35 lb/ft3,   ! Name
-  MediumRough,                            ! Roughness
-  0.0127,                                 ! Thickness {m}
-  0.519739620311329,                      ! Conductivity {W/m-K}
-  560.646218088605,                       ! Density {kg/m3}
-  1632.852,                               ! Specific Heat {J/kg-K}
+  Wood Sheathing - 0.5 in. - 35 lb/ft3,   !- Name
+  MediumRough,                            !- Roughness
+  0.0127,                                 !- Thickness {m}
+  0.519739620311329,                      !- Conductivity {W/m-K}
+  560.646218088605,                       !- Density {kg/m3}
+  1632.852,                               !- Specific Heat {J/kg-K}
   0.9;                                    !- Thermal Absorptance
 
 OS:StandardsInformation:Material,
@@ -4730,28 +4808,28 @@ OS:StandardsInformation:Material,
   {80ccc228-54bc-4cb7-b7f2-3a544ccb0760}; !- Material Name
 
 OS:Material,
-  {77a65c04-ad1c-4c41-8d77-ae75b61fb463}, ! Handle
-  Roof Membrane,                          ! Name
-  VeryRough,                              ! Roughness
-  0.0095,                                 ! Thickness {m}
-  0.16,                                   ! Conductivity {W/m-K}
-  1121.29,                                ! Density {kg/m3}
-  1460,                                   ! Specific Heat {J/kg-K}
-  0.9,                                    ! Thermal Absorptance
-  0.7,                                    ! Solar Absorptance
-  0.7;                                    ! Visible Absorptance
+  {77a65c04-ad1c-4c41-8d77-ae75b61fb463}, !- Handle
+  Roof Membrane,                          !- Name
+  VeryRough,                              !- Roughness
+  0.0095,                                 !- Thickness {m}
+  0.16,                                   !- Conductivity {W/m-K}
+  1121.29,                                !- Density {kg/m3}
+  1460,                                   !- Specific Heat {J/kg-K}
+  0.9,                                    !- Thermal Absorptance
+  0.7,                                    !- Solar Absorptance
+  0.7;                                    !- Visible Absorptance
 
 OS:Material,
-  {73c62f33-9823-4c10-92a7-aec9fdcdf342}, ! Handle
-  Roof Insulation [14],                   ! Name
-  MediumRough,                            ! Roughness
-  0.167335,                               ! Thickness {m}
-  0.049,                                  ! Conductivity {W/m-K}
-  265,                                    ! Density {kg/m3}
-  836.8,                                  ! Specific Heat {J/kg-K}
-  0.9,                                    ! Thermal Absorptance
-  0.7,                                    ! Solar Absorptance
-  0.7;                                    ! Visible Absorptance
+  {73c62f33-9823-4c10-92a7-aec9fdcdf342}, !- Handle
+  Roof Insulation [14],                   !- Name
+  MediumRough,                            !- Roughness
+  0.167335,                               !- Thickness {m}
+  0.049,                                  !- Conductivity {W/m-K}
+  265,                                    !- Density {kg/m3}
+  836.8,                                  !- Specific Heat {J/kg-K}
+  0.9,                                    !- Thermal Absorptance
+  0.7,                                    !- Solar Absorptance
+  0.7;                                    !- Visible Absorptance
 
 OS:StandardsInformation:Material,
   {5102684b-b039-45ff-96e7-889bdd7b1181}, !- Handle
@@ -4762,16 +4840,16 @@ OS:StandardsInformation:Material,
   {73c62f33-9823-4c10-92a7-aec9fdcdf342}; !- Material Name
 
 OS:Material,
-  {0705558e-02a9-4c8f-b524-d7681feff022}, ! Handle
-  Metal Decking,                          ! Name
-  MediumSmooth,                           ! Roughness
-  0.001524,                               ! Thickness {m}
-  45.006,                                 ! Conductivity {W/m-K}
-  7680,                                   ! Density {kg/m3}
-  418.4,                                  ! Specific Heat {J/kg-K}
-  0.9,                                    ! Thermal Absorptance
-  0.7,                                    ! Solar Absorptance
-  0.3;                                    ! Visible Absorptance
+  {0705558e-02a9-4c8f-b524-d7681feff022}, !- Handle
+  Metal Decking,                          !- Name
+  MediumSmooth,                           !- Roughness
+  0.001524,                               !- Thickness {m}
+  45.006,                                 !- Conductivity {W/m-K}
+  7680,                                   !- Density {kg/m3}
+  418.4,                                  !- Specific Heat {J/kg-K}
+  0.9,                                    !- Thermal Absorptance
+  0.7,                                    !- Solar Absorptance
+  0.3;                                    !- Visible Absorptance
 
 OS:StandardsInformation:Material,
   {b165a500-499c-4d30-9fa7-3d4d082be660}, !- Handle
@@ -5313,9 +5391,9 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  18.8214, 74.8537541776737, 13.7159999974148, !- X,Y,Z Vertex 1 {m}
-  18.8214, 74.8537541776738, 12.6308338470245, !- X,Y,Z Vertex 2 {m}
-  18.8214, 72.2679025706399, 13.7160002855163; !- X,Y,Z Vertex 3 {m}
+  18.8214, 72.2679025706399, 13.7160002855163, !- X,Y,Z Vertex 1 {m}
+  18.8214, 74.8537541776737, 13.7159999974148, !- X,Y,Z Vertex 2 {m}
+  18.8214, 74.8537541776738, 12.6308338470245; !- X,Y,Z Vertex 3 {m}
 
 OS:Surface,
   {482cb5aa-cbaa-4132-8d8b-0ced5c2bfa57}, !- Handle
@@ -5330,8 +5408,8 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   18.8214, 74.8537541776738, 12.6308338470245, !- X,Y,Z Vertex 1 {m}
-  18.8214, 74.8537541776786, 4.12387507100872e-017, !- X,Y,Z Vertex 2 {m}
-  18.8214, 75.0823543008404, 7.6821543312422e-016, !- X,Y,Z Vertex 3 {m}
+  18.8214, 74.8537541776786, 4.12387507100872e-17, !- X,Y,Z Vertex 2 {m}
+  18.8214, 75.0823543008404, 7.6821543312422e-16, !- X,Y,Z Vertex 3 {m}
   18.8214, 75.0823545559361, 12.5349009954621; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
@@ -5346,10 +5424,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  18.8214, 74.8537541776737, 13.7159999974148, !- X,Y,Z Vertex 1 {m}
-  101.1174, 74.8537541776688, 13.7159998634124, !- X,Y,Z Vertex 2 {m}
-  101.1174, 74.8537541776736, 1.26297410906228e-016, !- X,Y,Z Vertex 3 {m}
-  18.8214, 74.8537541776786, 4.12387507019262e-017; !- X,Y,Z Vertex 4 {m}
+  101.1174, 74.8537541776688, 13.7159998634124, !- X,Y,Z Vertex 1 {m}
+  101.1174, 74.8537541776736, 1.26297410918469e-16, !- X,Y,Z Vertex 2 {m}
+  18.8214, 74.8537541776786, 4.12387506937652e-17, !- X,Y,Z Vertex 3 {m}
+  18.8214, 74.8537541776737, 13.7159999974148; !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {e2ab307b-b94b-40c4-a769-e361b4a2a2fa}, !- Handle
@@ -5359,7 +5437,6 @@ OS:SubSurface,
   {4930fe44-8112-4027-839c-42f5f96747cd}, !- Surface Name
   ,                                       !- Outside Boundary Condition Object
   ,                                       !- View Factor to Ground
-  ,                                       !- Shading Control Name
   ,                                       !- Frame and Divider Name
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
@@ -5376,7 +5453,6 @@ OS:SubSurface,
   {4930fe44-8112-4027-839c-42f5f96747cd}, !- Surface Name
   ,                                       !- Outside Boundary Condition Object
   ,                                       !- View Factor to Ground
-  ,                                       !- Shading Control Name
   ,                                       !- Frame and Divider Name
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
@@ -5393,7 +5469,6 @@ OS:SubSurface,
   {4930fe44-8112-4027-839c-42f5f96747cd}, !- Surface Name
   ,                                       !- Outside Boundary Condition Object
   ,                                       !- View Factor to Ground
-  ,                                       !- Shading Control Name
   ,                                       !- Frame and Divider Name
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
@@ -5410,7 +5485,6 @@ OS:SubSurface,
   {4930fe44-8112-4027-839c-42f5f96747cd}, !- Surface Name
   ,                                       !- Outside Boundary Condition Object
   ,                                       !- View Factor to Ground
-  ,                                       !- Shading Control Name
   ,                                       !- Frame and Divider Name
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
@@ -5427,7 +5501,6 @@ OS:SubSurface,
   {4930fe44-8112-4027-839c-42f5f96747cd}, !- Surface Name
   ,                                       !- Outside Boundary Condition Object
   ,                                       !- View Factor to Ground
-  ,                                       !- Shading Control Name
   ,                                       !- Frame and Divider Name
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
@@ -5444,7 +5517,6 @@ OS:SubSurface,
   {4930fe44-8112-4027-839c-42f5f96747cd}, !- Surface Name
   ,                                       !- Outside Boundary Condition Object
   ,                                       !- View Factor to Ground
-  ,                                       !- Shading Control Name
   ,                                       !- Frame and Divider Name
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
@@ -5461,7 +5533,6 @@ OS:SubSurface,
   {4930fe44-8112-4027-839c-42f5f96747cd}, !- Surface Name
   ,                                       !- Outside Boundary Condition Object
   ,                                       !- View Factor to Ground
-  ,                                       !- Shading Control Name
   ,                                       !- Frame and Divider Name
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
@@ -5478,7 +5549,6 @@ OS:SubSurface,
   {4930fe44-8112-4027-839c-42f5f96747cd}, !- Surface Name
   ,                                       !- Outside Boundary Condition Object
   ,                                       !- View Factor to Ground
-  ,                                       !- Shading Control Name
   ,                                       !- Frame and Divider Name
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
@@ -5495,7 +5565,6 @@ OS:SubSurface,
   {4930fe44-8112-4027-839c-42f5f96747cd}, !- Surface Name
   ,                                       !- Outside Boundary Condition Object
   ,                                       !- View Factor to Ground
-  ,                                       !- Shading Control Name
   ,                                       !- Frame and Divider Name
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
@@ -5512,7 +5581,6 @@ OS:SubSurface,
   {4930fe44-8112-4027-839c-42f5f96747cd}, !- Surface Name
   ,                                       !- Outside Boundary Condition Object
   ,                                       !- View Factor to Ground
-  ,                                       !- Shading Control Name
   ,                                       !- Frame and Divider Name
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
@@ -5529,7 +5597,6 @@ OS:SubSurface,
   {4930fe44-8112-4027-839c-42f5f96747cd}, !- Surface Name
   ,                                       !- Outside Boundary Condition Object
   ,                                       !- View Factor to Ground
-  ,                                       !- Shading Control Name
   ,                                       !- Frame and Divider Name
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
@@ -5546,7 +5613,6 @@ OS:SubSurface,
   {4930fe44-8112-4027-839c-42f5f96747cd}, !- Surface Name
   ,                                       !- Outside Boundary Condition Object
   ,                                       !- View Factor to Ground
-  ,                                       !- Shading Control Name
   ,                                       !- Frame and Divider Name
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
@@ -5563,7 +5629,6 @@ OS:SubSurface,
   {4930fe44-8112-4027-839c-42f5f96747cd}, !- Surface Name
   ,                                       !- Outside Boundary Condition Object
   ,                                       !- View Factor to Ground
-  ,                                       !- Shading Control Name
   ,                                       !- Frame and Divider Name
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
@@ -5580,7 +5645,6 @@ OS:SubSurface,
   {4930fe44-8112-4027-839c-42f5f96747cd}, !- Surface Name
   ,                                       !- Outside Boundary Condition Object
   ,                                       !- View Factor to Ground
-  ,                                       !- Shading Control Name
   ,                                       !- Frame and Divider Name
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
@@ -5597,7 +5661,6 @@ OS:SubSurface,
   {4930fe44-8112-4027-839c-42f5f96747cd}, !- Surface Name
   ,                                       !- Outside Boundary Condition Object
   ,                                       !- View Factor to Ground
-  ,                                       !- Shading Control Name
   ,                                       !- Frame and Divider Name
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
@@ -5614,7 +5677,6 @@ OS:SubSurface,
   {4930fe44-8112-4027-839c-42f5f96747cd}, !- Surface Name
   ,                                       !- Outside Boundary Condition Object
   ,                                       !- View Factor to Ground
-  ,                                       !- Shading Control Name
   ,                                       !- Frame and Divider Name
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
@@ -5650,10 +5712,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  4.99900534005499, -1.24535247595082e-031, -1.51060141949697e-009, !- X,Y,Z Vertex 1 {m}
-  4.99900534005499, 2.77514366373091, -3.57796824382182e-008, !- X,Y,Z Vertex 2 {m}
-  -1.32734905891538e-032, 2.77514366373091, -2.87302091472324e-008, !- X,Y,Z Vertex 3 {m}
-  2.58672597070553e-018, 1.24488589691083e-031, 5.53887187148881e-009; !- X,Y,Z Vertex 4 {m}
+  4.99900534005499, -3.07186944067869e-31, -1.51060141949698e-09, !- X,Y,Z Vertex 1 {m}
+  4.99900534005499, 2.77514366373091, -3.57796824382182e-08, !- X,Y,Z Vertex 2 {m}
+  -1.70659164717693e-32, 2.77514366373091, -2.87302091472324e-08, !- X,Y,Z Vertex 3 {m}
+  2.58672597070554e-18, 2.07512088087804e-31, 5.53887187148882e-09; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {7c02528b-0906-4d04-b5e4-adaf5922f6b7}, !- Handle
@@ -5667,10 +5729,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  2.58672597070552e-018, -4.73675617206344e-018, 5.5388718714888e-009, !- X,Y,Z Vertex 1 {m}
-  -5.56730001158855e-009, -3.88963331577944e-008, -3.45439975249707, !- X,Y,Z Vertex 2 {m}
-  4.99900533448769, -3.88963331763154e-008, -3.45439976203274, !- X,Y,Z Vertex 3 {m}
-  4.99900534005499, 4.73675789672879e-018, -1.51060141949696e-009; !- X,Y,Z Vertex 4 {m}
+  2.58672597070552e-18, -4.73671919378133e-18, 5.5388718714888e-09, !- X,Y,Z Vertex 1 {m}
+  -5.56730001158855e-09, -3.88963331577944e-08, -3.45439975249707, !- X,Y,Z Vertex 2 {m}
+  4.99900533448769, -3.88963331763154e-08, -3.45439976203274, !- X,Y,Z Vertex 3 {m}
+  4.99900534005499, 4.73672141459054e-18, -1.51060141949696e-09; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {5b8ca52c-6b18-4448-b9f1-3bf5009ab830}, !- Handle
@@ -5684,10 +5746,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -2.0390022043683e-018, 2.77514366373091, -2.87302091472324e-008, !- X,Y,Z Vertex 1 {m}
-  -5.56730001131482e-009, 2.77514362483458, -3.45439978119581, !- X,Y,Z Vertex 2 {m}
-  -5.56730001362755e-009, -3.88963331625312e-008, -3.45439975249707, !- X,Y,Z Vertex 3 {m}
-  4.62572958082534e-018, -8.23406021333969e-035, 5.5388718714888e-009; !- X,Y,Z Vertex 4 {m}
+  4.62573142973944e-18, -8.23406344895143e-35, 5.5388718714888e-09, !- X,Y,Z Vertex 1 {m}
+  -2.03900488453533e-18, 2.77514366373091, -2.87302091472324e-08, !- X,Y,Z Vertex 2 {m}
+  -5.56730001131482e-09, 2.77514362483458, -3.45439978119581, !- X,Y,Z Vertex 3 {m}
+  -5.56730001362755e-09, -3.88963331625312e-08, -3.45439975249707; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {bb538491-92d6-4818-95ac-f559af171278}, !- Handle
@@ -5702,9 +5764,9 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   4.99900533448769, 2.77514362483458, -3.45439979264334, !- X,Y,Z Vertex 1 {m}
-  4.99900533448769, -3.88963331784617e-008, -3.45439976267002, !- X,Y,Z Vertex 2 {m}
-  -5.56730001021043e-009, -3.88963331556481e-008, -3.45439975185978, !- X,Y,Z Vertex 3 {m}
-  -5.56730001473193e-009, 2.77514362483458, -3.45439978183309; !- X,Y,Z Vertex 4 {m}
+  4.99900533448769, -3.88963331784617e-08, -3.45439976267002, !- X,Y,Z Vertex 2 {m}
+  -5.56730001021043e-09, -3.88963331556481e-08, -3.45439975185978, !- X,Y,Z Vertex 3 {m}
+  -5.56730001473196e-09, 2.77514362483458, -3.45439978183309; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {32fc781d-6fa7-4bbe-85d1-6e9d5f9104b1}, !- Handle
@@ -5718,10 +5780,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 2.77514366373091, -2.87302091472324e-008, !- X,Y,Z Vertex 1 {m}
-  4.99900534005499, 2.77514366373091, -3.57796824382182e-008, !- X,Y,Z Vertex 2 {m}
-  4.99900533448769, 2.77514362483458, -3.45439979328062, !- X,Y,Z Vertex 3 {m}
-  -5.56730001335382e-009, 2.77514362483458, -3.45439978119581; !- X,Y,Z Vertex 4 {m}
+  4.99900534005499, 2.77514366373091, -3.57796824382182e-08, !- X,Y,Z Vertex 1 {m}
+  4.99900533448769, 2.77514362483458, -3.45439979328062, !- X,Y,Z Vertex 2 {m}
+  -5.56730001335382e-09, 2.77514362483458, -3.45439978119581, !- X,Y,Z Vertex 3 {m}
+  0, 2.77514366373091, -2.87302091472324e-08; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {516419fc-4924-4951-b597-2e7add228194}, !- Handle
@@ -5735,10 +5797,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  4.99900534005499, 0, -1.51060141949696e-009, !- X,Y,Z Vertex 1 {m}
-  4.99900533448769, -3.88963331715786e-008, -3.45439976203274, !- X,Y,Z Vertex 2 {m}
+  4.99900534005499, 0, -1.51060141949696e-09, !- X,Y,Z Vertex 1 {m}
+  4.99900533448769, -3.88963331715786e-08, -3.45439976203274, !- X,Y,Z Vertex 2 {m}
   4.99900533448769, 2.77514362483458, -3.45439979328062, !- X,Y,Z Vertex 3 {m}
-  4.99900534005499, 2.77514366373091, -3.57796824382182e-008; !- X,Y,Z Vertex 4 {m}
+  4.99900534005499, 2.77514366373091, -3.57796824382182e-08; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {c7c2004f-ab58-4241-97a5-45a0223ed342}, !- Handle
@@ -5752,10 +5814,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  21.5965436591073, 74.8537541776782, 3.65124399588244e-016, !- X,Y,Z Vertex 1 {m}
-  21.5965436637309, 69.8547488376232, 5.27678500331465e-016, !- X,Y,Z Vertex 2 {m}
-  18.8214, 69.8547488365458, 2.03792850948738e-016, !- X,Y,Z Vertex 3 {m}
-  18.8214, 74.8537541776786, 4.12387507100874e-017; !- X,Y,Z Vertex 4 {m}
+  18.8214, 74.8537541776786, 4.12387507100878e-17, !- X,Y,Z Vertex 1 {m}
+  21.5965436591073, 74.8537541776782, 3.65124399588244e-16, !- X,Y,Z Vertex 2 {m}
+  21.5965436637309, 69.8547488376232, 5.27678500331464e-16, !- X,Y,Z Vertex 3 {m}
+  18.8214, 69.8547488365458, 2.03792850948738e-16; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {59b0a4a8-8c73-417d-9b0d-2cd1d48e0e7b}, !- Handle
@@ -5769,10 +5831,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  0, 75.0823546084023, 12.5349013144976,  !- X,Y,Z Vertex 1 {m}
-  18.8214, 75.0823545559361, 12.5349009954621, !- X,Y,Z Vertex 2 {m}
-  18.8214, 75.0823543008404, 7.6821543312422e-016, !- X,Y,Z Vertex 3 {m}
-  -3.21981971974164e-023, 75.0823543533066, -4.04951522573081e-015; !- X,Y,Z Vertex 4 {m}
+  18.8214, 75.0823545559361, 12.5349009954621, !- X,Y,Z Vertex 1 {m}
+  18.8214, 75.0823543008404, 7.6821543312422e-16, !- X,Y,Z Vertex 2 {m}
+  -6.43963943948328e-23, 75.0823543533066, -4.04951499066681e-15, !- X,Y,Z Vertex 3 {m}
+  0, 75.0823546084023, 12.5349013144976;  !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {fead9d21-2fb1-4635-8085-241bef15e67e}, !- Handle
@@ -5786,10 +5848,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  13.4816849923221, 75.0823542078563, -1.6222596698857e-009, !- X,Y,Z Vertex 1 {m}
-  13.4816849923221, 69.8547488365455, -1.6222596698857e-009, !- X,Y,Z Vertex 2 {m}
-  10.2400099999939, 69.8547488365458, -5.01091738662699e-007, !- X,Y,Z Vertex 3 {m}
-  10.2400099999939, 75.0823542072333, -5.01091738662699e-007; !- X,Y,Z Vertex 4 {m}
+  13.4816849923221, 75.0823542078563, -1.6222596698857e-09, !- X,Y,Z Vertex 1 {m}
+  13.4816849923221, 69.8547488365455, -1.6222596698857e-09, !- X,Y,Z Vertex 2 {m}
+  10.2400099999939, 69.8547488365458, -5.01091738662699e-07, !- X,Y,Z Vertex 3 {m}
+  10.2400099999939, 75.0823542072333, -5.01091738662699e-07; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {8af60e99-ff55-493b-a497-83051add45df}, !- Handle
@@ -5803,10 +5865,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  74.8537541944212, 110.265209996664, -8.29941492952457e-009, !- X,Y,Z Vertex 1 {m}
-  74.8537541923947, 110.265209996664, -3.14960024444604, !- X,Y,Z Vertex 2 {m}
-  75.0823541945334, 110.265209996165, -3.14960024647251, !- X,Y,Z Vertex 3 {m}
-  75.0823541965599, 110.265209996165, 2.84459810018234e-010; !- X,Y,Z Vertex 4 {m}
+  75.0823541965599, 110.265209996165, 2.84459810018234e-10, !- X,Y,Z Vertex 1 {m}
+  74.8537541944212, 110.265209996664, -8.29941492952457e-09, !- X,Y,Z Vertex 2 {m}
+  74.8537541923947, 110.265209996664, -3.14960024444604, !- X,Y,Z Vertex 3 {m}
+  75.0823541945334, 110.265209996165, -3.14960024647251; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {e84da201-32d6-4281-a3b8-ed26c4f27f5b}, !- Handle
@@ -5820,10 +5882,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  75.0823542038582, 115.604925000006, -9.32375332532779e-008, !- X,Y,Z Vertex 1 {m}
-  75.0823542085711, 118.846600000006, -8.62684613756479e-008, !- X,Y,Z Vertex 2 {m}
-  69.8547488342558, 118.846600000006, -9.61266032626376e-008, !- X,Y,Z Vertex 3 {m}
-  69.8547488342558, 115.604925000006, -1.0309567513138e-007; !- X,Y,Z Vertex 4 {m}
+  75.0823542038582, 115.604925000006, -9.3237533253278e-08, !- X,Y,Z Vertex 1 {m}
+  75.0823542085711, 118.846600000006, -8.62684613756482e-08, !- X,Y,Z Vertex 2 {m}
+  69.8547488342558, 118.846600000006, -9.61266032626377e-08, !- X,Y,Z Vertex 3 {m}
+  69.8547488342558, 115.604925000006, -1.0309567513138e-07; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {58e39232-3655-43fc-aa3d-11065b000c49}, !- Handle
@@ -5837,10 +5899,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  60.0868613276954, -8.82796409249995e-014, 5.59392044641527e-007, !- X,Y,Z Vertex 1 {m}
-  60.0868613276954, 4.49103750000693, 5.42459988412248e-007, !- X,Y,Z Vertex 2 {m}
-  53.7971863276983, 4.49103750000693, 7.15013305415369e-007, !- X,Y,Z Vertex 3 {m}
-  53.7971863276983, -7.67343272808744e-014, 7.31945361644648e-007; !- X,Y,Z Vertex 4 {m}
+  60.0868613276954, -8.82796409249995e-14, 5.59392044641527e-07, !- X,Y,Z Vertex 1 {m}
+  60.0868613276954, 4.49103750000693, 5.42459988412248e-07, !- X,Y,Z Vertex 2 {m}
+  53.7971863276983, 4.49103750000693, 7.15013305415369e-07, !- X,Y,Z Vertex 3 {m}
+  53.7971863276983, -7.67343272808744e-14, 7.31945361644648e-07; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {b676164d-cbdd-4cf1-9ffd-3488e54b9ed7}, !- Handle
@@ -5854,10 +5916,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  129.08661, 60.0868613276954, 1.79990743277269e-016, !- X,Y,Z Vertex 1 {m}
-  129.08661, 53.7971863276983, 1.77242547001588e-016, !- X,Y,Z Vertex 2 {m}
-  124.595572499993, 53.7971863276983, 1.7011561661846e-016, !- X,Y,Z Vertex 3 {m}
-  124.595572499993, 60.0868613276954, 1.72863812894142e-016; !- X,Y,Z Vertex 4 {m}
+  129.08661, 60.0868613276954, 1.79990743277269e-16, !- X,Y,Z Vertex 1 {m}
+  129.08661, 53.7971863276983, 1.77242547001588e-16, !- X,Y,Z Vertex 2 {m}
+  124.595572499993, 53.7971863276983, 1.7011561661846e-16, !- X,Y,Z Vertex 3 {m}
+  124.595572499993, 60.0868613276954, 1.72863812894142e-16; !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {508f9417-d326-4b98-9372-1b587623176a}, !- Handle
@@ -5867,7 +5929,6 @@ OS:SubSurface,
   {4930fe44-8112-4027-839c-42f5f96747cd}, !- Surface Name
   ,                                       !- Outside Boundary Condition Object
   ,                                       !- View Factor to Ground
-  ,                                       !- Shading Control Name
   ,                                       !- Frame and Divider Name
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
@@ -5884,7 +5945,6 @@ OS:SubSurface,
   {4930fe44-8112-4027-839c-42f5f96747cd}, !- Surface Name
   ,                                       !- Outside Boundary Condition Object
   ,                                       !- View Factor to Ground
-  ,                                       !- Shading Control Name
   ,                                       !- Frame and Divider Name
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
@@ -5905,10 +5965,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  3.46515863295473e-014, -4.18014149954569e-011, 7.3427511208222, !- X,Y,Z Vertex 1 {m}
-  5.78534694473738, -1.94141001860974e-008, 4.9148993484292, !- X,Y,Z Vertex 2 {m}
-  5.78534715300304, -1.32743867426206e-008, -7.79755809965009e-020, !- X,Y,Z Vertex 3 {m}
-  3.46519099455412e-014, 9.1307961287151e-009, 5.21932609606337e-020; !- X,Y,Z Vertex 4 {m}
+  3.46515863295473e-14, -4.18014149954717e-11, 7.3427511208222, !- X,Y,Z Vertex 1 {m}
+  5.78534694473738, -1.94141001860974e-08, 4.9148993484292, !- X,Y,Z Vertex 2 {m}
+  5.78534715300304, -1.32743867426206e-08, -7.79755809965194e-20, !- X,Y,Z Vertex 3 {m}
+  3.46519099455412e-14, 9.13079612871511e-09, 5.21932609606522e-20; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {4f810aeb-c21d-42a6-b647-e3e9bdcbd9c8}, !- Handle
@@ -5922,10 +5982,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  3.46517481375486e-014, -9.89206907057851, 7.3427511208222, !- X,Y,Z Vertex 1 {m}
+  3.46517481375486e-14, -9.89206907057851, 7.3427511208222, !- X,Y,Z Vertex 1 {m}
   5.78534694473738, -9.89206907057851, 4.9148993484292, !- X,Y,Z Vertex 2 {m}
-  5.78534694473738, -1.94765203787028e-008, 4.9148993484292, !- X,Y,Z Vertex 3 {m}
-  3.46517481375486e-014, -2.02135197469033e-014, 7.3427511208222; !- X,Y,Z Vertex 4 {m}
+  5.78534694473738, -1.94765203787028e-08, 4.9148993484292, !- X,Y,Z Vertex 3 {m}
+  3.46517481375486e-14, -2.02135197469033e-14, 7.3427511208222; !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {6026b9fa-04fe-4842-8490-fbc4a1949039}, !- Handle
@@ -5935,14 +5995,13 @@ OS:SubSurface,
   {0f52e282-4118-47e0-a41d-017ed0365b7a}, !- Surface Name
   ,                                       !- Outside Boundary Condition Object
   ,                                       !- View Factor to Ground
-  ,                                       !- Shading Control Name
   ,                                       !- Frame and Divider Name
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
-  104.550209999994, 37.5177580694247, 28.2794206516473, !- X,Y,Z Vertex 1 {m}
-  12.3482099999941, 37.5177611997503, 28.2794204515845, !- X,Y,Z Vertex 2 {m}
-  12.3482099071332, 34.707213801487, 27.0999598451563, !- X,Y,Z Vertex 3 {m}
-  104.550209907133, 34.7072106711614, 27.0999600452191; !- X,Y,Z Vertex 4 {m}
+  104.550209999994, 37.517758061846, 28.2794206697067, !- X,Y,Z Vertex 1 {m}
+  12.3482099999941, 37.5177612079473, 28.2794204320518, !- X,Y,Z Vertex 2 {m}
+  12.3482099071332, 34.7072138092727, 27.0999598266036, !- X,Y,Z Vertex 3 {m}
+  104.550209907133, 34.7072106631714, 27.0999600642585; !- X,Y,Z Vertex 4 {m}
 
 OS:RadianceParameters,
   {d7752f07-b213-4d67-8b61-38272f6831ca}, !- Handle
@@ -5991,8 +6050,16 @@ OS:ConvergenceLimits,
 
 OS:ShadowCalculation,
   {92affde5-30c6-4b7c-add3-2d3e1d12a09c}, !- Handle
-  7,                                      !- Calculation Frequency
-  15000;                                  !- Maximum Figures in Shadow Overlap Calculations
+  PolygonClipping,                        !- Shading Calculation Method
+  ,                                       !- Shading Calculation Update Frequency Method
+  7,                                      !- Shading Calculation Update Frequency
+  15000,                                  !- Maximum Figures in Shadow Overlap Calculations
+  ,                                       !- Polygon Clipping Algorithm
+  512,                                    !- Pixel Counting Resolution
+  ,                                       !- Sky Diffuse Modeling Algorithm
+  No,                                     !- Output External Shading Calculation Results
+  No,                                     !- Disable Self-Shading Within Shading Zone Groups
+  No;                                     !- Disable Self-Shading From Shading Zone Groups to Other Zones
 
 OS:SurfaceConvectionAlgorithm:Inside,
   {75de7418-4963-461e-b16d-625d7e26ab9a}, !- Handle
@@ -6009,7 +6076,9 @@ OS:HeatBalanceAlgorithm,
 
 OS:ZoneAirHeatBalanceAlgorithm,
   {b7c54704-9c23-41e9-96bc-3965d3028c2d}, !- Handle
-  AnalyticalSolution;                     !- Algorithm
+  AnalyticalSolution,                     !- Algorithm
+  ,                                       !- Do Space Heat Balance for Sizing
+  ;                                       !- Do Space Heat Balance for Simulation
 
 OS:ZoneAirContaminantBalance,
   {52c5ef3a-fc45-422a-97c0-8cf7a18b076c}; !- Handle
@@ -6083,10 +6152,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  75.0823541388985, 8.53440000000614, 5.23303860772842e-007, !- X,Y,Z Vertex 1 {m}
-  75.0823541388985, 18.4264690705844, 6.24915447772093e-007, !- X,Y,Z Vertex 2 {m}
-  69.2970070000573, 18.4264690705844, 9.15537184391572e-007, !- X,Y,Z Vertex 3 {m}
-  69.2970070000574, 8.53440000000614, 8.13925597392316e-007; !- X,Y,Z Vertex 4 {m}
+  75.0823541388985, 8.53440000000614, 5.23303860772842e-07, !- X,Y,Z Vertex 1 {m}
+  75.0823541388985, 18.4264690705844, 6.24915447772093e-07, !- X,Y,Z Vertex 2 {m}
+  69.2970070000573, 18.4264690705844, 9.15537184391572e-07, !- X,Y,Z Vertex 3 {m}
+  69.2970070000574, 8.53440000000614, 8.13925597392316e-07; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {91908804-90d0-40f5-92bb-67cdf72fd7de}, !- Handle
@@ -6100,10 +6169,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  74.8537541977863, 107.490066341603, -1.20205952435915e-007, !- X,Y,Z Vertex 1 {m}
-  74.8537541944212, 110.265209996664, -1.10034934579309e-008, !- X,Y,Z Vertex 2 {m}
-  69.8547488342558, 110.265209996664, 1.57533048096128e-008, !- X,Y,Z Vertex 3 {m}
-  69.8547488342558, 107.490066336269, -9.34491543602539e-008; !- X,Y,Z Vertex 4 {m}
+  69.8547488342558, 107.490066336269, -9.34491543602518e-08, !- X,Y,Z Vertex 1 {m}
+  74.8537541977863, 107.490066341603, -1.20205952435913e-07, !- X,Y,Z Vertex 2 {m}
+  74.8537541944212, 110.265209996664, -1.10034934579309e-08, !- X,Y,Z Vertex 3 {m}
+  69.8547488342558, 110.265209996664, 1.57533048096142e-08; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {2b05cfdf-5a66-4d27-8e92-a705fc8027f8}, !- Handle
@@ -6117,10 +6186,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  129.08661, 75.0823542046541, 1.73510569577e-016, !- X,Y,Z Vertex 1 {m}
-  129.08661, 60.0868613276954, 1.8006246387754e-016, !- X,Y,Z Vertex 2 {m}
-  120.552209999994, 60.0868613276954, 1.66767561827768e-016, !- X,Y,Z Vertex 3 {m}
-  120.552209999994, 75.0823541438696, 1.60215667553787e-016; !- X,Y,Z Vertex 4 {m}
+  129.08661, 75.0823542046541, 1.73510569577e-16, !- X,Y,Z Vertex 1 {m}
+  129.08661, 60.0868613276954, 1.8006246387754e-16, !- X,Y,Z Vertex 2 {m}
+  120.552209999994, 60.0868613276954, 1.66767561827768e-16, !- X,Y,Z Vertex 3 {m}
+  120.552209999994, 75.0823541438696, 1.60215667553787e-16; !- X,Y,Z Vertex 4 {m}
 
 OS:Material:NoMass,
   {f4b3c9f1-9f76-4ec4-b6bb-b3acf10115dc}, !- Handle
@@ -6176,10 +6245,10 @@ OS:ShadingSurface,
   {5c045807-e28d-48d0-a355-85e788126903}, !- Shading Surface Group Name
   ,                                       !- Transmittance Schedule Name
   ,                                       !- Number of Vertices
-  -0.101553841277634, -1.15505827125162e-013, 13.1952999082863, !- X,Y,Z Vertex 1 {m}
-  -0.101555632856128, -1.15505827125162e-013, -6.20843820797745e-014, !- X,Y,Z Vertex 2 {m}
-  -9.88334358824695, -1.15505827125162e-013, -3.60955709766131e-014, !- X,Y,Z Vertex 3 {m}
-  -9.88334358824695, -1.15505827125162e-013, 13.1952999082863; !- X,Y,Z Vertex 4 {m}
+  -0.101553851282077, -1.15432974506899e-13, 13.1952999082863, !- X,Y,Z Vertex 1 {m}
+  -0.101555632856128, -1.15505827125162e-13, -4.66804269162606e-14, !- X,Y,Z Vertex 2 {m}
+  -9.88334358824695, -1.15505827125162e-13, -3.99408956334045e-14, !- X,Y,Z Vertex 3 {m}
+  -9.88334358824695, -1.15505827125162e-13, 13.1952999082863; !- X,Y,Z Vertex 4 {m}
 
 OS:ShadingSurface,
   {9b276293-ccd4-4b8a-880c-50cbce188c53}, !- Handle
@@ -6188,10 +6257,10 @@ OS:ShadingSurface,
   {5c045807-e28d-48d0-a355-85e788126903}, !- Shading Surface Group Name
   ,                                       !- Transmittance Schedule Name
   ,                                       !- Number of Vertices
-  -9.88334358824679, -1.15505827125162e-013, 7.62, !- X,Y,Z Vertex 1 {m}
-  -9.88334358824695, -1.15505827125162e-013, -3.60955709766131e-014, !- X,Y,Z Vertex 2 {m}
-  -9.88334358824695, -3.66354049127708, -3.46517481375486e-014, !- X,Y,Z Vertex 3 {m}
-  -9.88334358824674, -3.66354049127708, 7.62; !- X,Y,Z Vertex 4 {m}
+  -9.88334358824683, -1.15505827125162e-13, 7.62, !- X,Y,Z Vertex 1 {m}
+  -9.88334358824695, -1.15505827125162e-13, -3.99408956334045e-14, !- X,Y,Z Vertex 2 {m}
+  -9.88334358824695, -3.66354049127708, -3.73861732803723e-14, !- X,Y,Z Vertex 3 {m}
+  -9.88334358824674, -3.66354049127709, 7.62; !- X,Y,Z Vertex 4 {m}
 
 OS:ShadingSurface,
   {51f2d65b-13a8-4f53-91f5-100ddc89b31f}, !- Handle
@@ -6200,8 +6269,8 @@ OS:ShadingSurface,
   {5c045807-e28d-48d0-a355-85e788126903}, !- Shading Surface Group Name
   ,                                       !- Transmittance Schedule Name
   ,                                       !- Number of Vertices
-  -9.88334358824695, -1.15505827125162e-013, 13.1952999082863, !- X,Y,Z Vertex 1 {m}
-  -9.88334358824679, -1.15505827125162e-013, 7.62, !- X,Y,Z Vertex 2 {m}
+  -9.88334358824695, -1.15505827125162e-13, 13.1952999082863, !- X,Y,Z Vertex 1 {m}
+  -9.88334358824683, -1.15505827125162e-13, 7.62, !- X,Y,Z Vertex 2 {m}
   -9.88334358824695, -9.95100409270849, 7.62, !- X,Y,Z Vertex 3 {m}
   -9.88334358824695, -9.95100409270849, 13.1952999082863; !- X,Y,Z Vertex 4 {m}
 
@@ -6212,9 +6281,9 @@ OS:ShadingSurface,
   {5c045807-e28d-48d0-a355-85e788126903}, !- Shading Surface Group Name
   ,                                       !- Transmittance Schedule Name
   ,                                       !- Number of Vertices
-  -0.101553925358014, -9.95100409270849, 13.1952999082863, !- X,Y,Z Vertex 1 {m}
-  -0.101553841277634, -1.15505827125162e-013, 13.1952999082863, !- X,Y,Z Vertex 2 {m}
-  -9.88334358824695, -1.15505827125162e-013, 13.1952999082863, !- X,Y,Z Vertex 3 {m}
+  -0.101553923745553, -9.95100409270849, 13.1952999082863, !- X,Y,Z Vertex 1 {m}
+  -0.101553851282077, -1.15432974506899e-13, 13.1952999082863, !- X,Y,Z Vertex 2 {m}
+  -9.88334358824695, -1.15505827125162e-13, 13.1952999082863, !- X,Y,Z Vertex 3 {m}
   -9.88334358824695, -9.95100409270849, 13.1952999082863; !- X,Y,Z Vertex 4 {m}
 
 OS:ShadingSurface,
@@ -6225,9 +6294,9 @@ OS:ShadingSurface,
   ,                                       !- Transmittance Schedule Name
   ,                                       !- Number of Vertices
   -23.0532690562169, -3.6635404912771, 7.62000000000002, !- X,Y,Z Vertex 1 {m}
-  -9.88334358824674, -3.66354049127708, 7.62, !- X,Y,Z Vertex 2 {m}
-  -9.88334358824695, -3.66354049127708, -3.46517481375486e-014, !- X,Y,Z Vertex 3 {m}
-  -23.0532690562169, -3.66354049127708, -2.59888111031614e-014; !- X,Y,Z Vertex 4 {m}
+  -9.88334358824674, -3.66354049127709, 7.62, !- X,Y,Z Vertex 2 {m}
+  -9.88334358824695, -3.66354049127708, -3.73861732803723e-14, !- X,Y,Z Vertex 3 {m}
+  -23.0532690562169, -3.66354049127708, -2.83122570301892e-14; !- X,Y,Z Vertex 4 {m}
 
 OS:ShadingSurface,
   {ca24b9a9-a9af-49d0-8bc4-11adbc8afbbb}, !- Handle
@@ -6237,8 +6306,8 @@ OS:ShadingSurface,
   ,                                       !- Transmittance Schedule Name
   ,                                       !- Number of Vertices
   -23.0532690562169, -3.6635404912771, 7.62000000000002, !- X,Y,Z Vertex 1 {m}
-  -23.0532690562169, -3.66354049127708, -2.59888111031614e-014, !- X,Y,Z Vertex 2 {m}
-  -23.0532690562169, -10.2679500000032, -2.16573425859679e-014, !- X,Y,Z Vertex 3 {m}
+  -23.0532690562169, -3.66354049127708, -2.83122570301892e-14, !- X,Y,Z Vertex 2 {m}
+  -23.0532690562169, -10.2679500000032, -2.3706757885115e-14, !- X,Y,Z Vertex 3 {m}
   -23.0532690562169, -10.2679500000032, 7.61999999999999; !- X,Y,Z Vertex 4 {m}
 
 OS:ShadingSurface,
@@ -6250,8 +6319,8 @@ OS:ShadingSurface,
   ,                                       !- Number of Vertices
   -34.5372001869833, -10.2679500000032, 7.62, !- X,Y,Z Vertex 1 {m}
   -23.0532690562169, -10.2679500000032, 7.61999999999999, !- X,Y,Z Vertex 2 {m}
-  -23.0532690562169, -10.2679500000032, -2.16573425859679e-014, !- X,Y,Z Vertex 3 {m}
-  -34.5372001869833, -10.2679500000032, -1.44382283906452e-015; !- X,Y,Z Vertex 4 {m}
+  -23.0532690562169, -10.2679500000032, -2.3706757885115e-14, !- X,Y,Z Vertex 3 {m}
+  -34.5372001869833, -10.2679500000032, -1.57944709434101e-14; !- X,Y,Z Vertex 4 {m}
 
 OS:ShadingSurface,
   {372be631-fc20-467b-9d2c-a6f5a7dfd75b}, !- Handle
@@ -6261,8 +6330,8 @@ OS:ShadingSurface,
   ,                                       !- Transmittance Schedule Name
   ,                                       !- Number of Vertices
   -23.7079371198328, -95.1267290927076, 7.61999999999993, !- X,Y,Z Vertex 1 {m}
-  -23.7079371198328, -95.1267290927076, 3.3207925298484e-014, !- X,Y,Z Vertex 2 {m}
-  -0.101556300465748, -94.6163394747809, 2.74326339422259e-014, !- X,Y,Z Vertex 3 {m}
+  -23.7079371198328, -95.1267290927076, 3.59194671788073e-14, !- X,Y,Z Vertex 2 {m}
+  -0.101556300465748, -94.6163394747809, 1.92990483151391e-14, !- X,Y,Z Vertex 3 {m}
   -0.101555303297755, -94.6163394691509, 7.61999999999991; !- X,Y,Z Vertex 4 {m}
 
 OS:ShadingSurface,
@@ -6273,8 +6342,8 @@ OS:ShadingSurface,
   ,                                       !- Transmittance Schedule Name
   ,                                       !- Number of Vertices
   -23.7079371198328, -47.6763540927007, 7.62000000000007, !- X,Y,Z Vertex 1 {m}
-  -23.7079371198328, -47.6763540927007, 2.88764567812905e-015, !- X,Y,Z Vertex 2 {m}
-  -23.7079371198328, -95.1267290927076, 3.3207925298484e-014, !- X,Y,Z Vertex 3 {m}
+  -23.7079371198328, -47.6763540927007, 2.8305648011997e-15, !- X,Y,Z Vertex 2 {m}
+  -23.7079371198328, -95.1267290927076, 3.59194671788073e-14, !- X,Y,Z Vertex 3 {m}
   -23.7079371198328, -95.1267290927076, 7.61999999999993; !- X,Y,Z Vertex 4 {m}
 
 OS:ShadingSurface,
@@ -6286,8 +6355,8 @@ OS:ShadingSurface,
   ,                                       !- Number of Vertices
   -23.7079371198328, -47.6763540927007, 7.62000000000007, !- X,Y,Z Vertex 1 {m}
   -46.8308896656869, -47.6763540927007, 7.62, !- X,Y,Z Vertex 2 {m}
-  -46.8308896656869, -47.6763540927007, 1.58820512297098e-014, !- X,Y,Z Vertex 3 {m}
-  -23.7079371198328, -47.6763540927007, 2.88764567812905e-015; !- X,Y,Z Vertex 4 {m}
+  -46.8308896656869, -47.6763540927007, 1.87619939781016e-14, !- X,Y,Z Vertex 3 {m}
+  -23.7079371198328, -47.6763540927007, 2.8305648011997e-15; !- X,Y,Z Vertex 4 {m}
 
 OS:ShadingSurface,
   {1cecd766-1e7b-453f-a224-15a4286ac5ff}, !- Handle
@@ -6297,8 +6366,8 @@ OS:ShadingSurface,
   ,                                       !- Transmittance Schedule Name
   ,                                       !- Number of Vertices
   -46.8308896656869, -47.6763540927007, 7.5692, !- X,Y,Z Vertex 1 {m}
-  -46.8308896656869, -47.6763540927007, 1.58820512297098e-014, !- X,Y,Z Vertex 2 {m}
-  -46.8308896656869, -45.1231437510848, 1.44382283906452e-014, !- X,Y,Z Vertex 3 {m}
+  -46.8308896656869, -47.6763540927007, 1.87619939781016e-14, !- X,Y,Z Vertex 2 {m}
+  -46.8308896656869, -45.1231437510848, 1.69815459259373e-14, !- X,Y,Z Vertex 3 {m}
   -46.8308896656869, -45.1231437510848, 7.5692; !- X,Y,Z Vertex 4 {m}
 
 OS:ShadingSurface,
@@ -6309,8 +6378,8 @@ OS:ShadingSurface,
   ,                                       !- Transmittance Schedule Name
   ,                                       !- Number of Vertices
   -72.2331343284259, -44.304504092708, 34.8234, !- X,Y,Z Vertex 1 {m}
-  -72.2331343284259, -44.304504092708, -1.44382283906452e-015, !- X,Y,Z Vertex 2 {m}
-  -34.5372001869833, -45.1231437510848, -1.44382283906452e-015, !- X,Y,Z Vertex 3 {m}
+  -72.2331343284259, -44.304504092708, -1.44382283906452e-15, !- X,Y,Z Vertex 2 {m}
+  -34.5372001869833, -45.1231437510848, -1.44382283906452e-15, !- X,Y,Z Vertex 3 {m}
   -34.5372001869833, -45.1231437510848, 34.8234; !- X,Y,Z Vertex 4 {m}
 
 OS:ShadingSurface,
@@ -6323,8 +6392,8 @@ OS:ShadingSurface,
   -34.5372001869833, -45.1231437510848, 34.8234, !- X,Y,Z Vertex 1 {m}
   -34.5372001869833, -45.1231437510848, 7.62, !- X,Y,Z Vertex 2 {m}
   -34.5372001869833, -10.2679500000032, 7.62, !- X,Y,Z Vertex 3 {m}
-  -34.5372001869833, -10.2679500000032, -1.44382283906452e-015, !- X,Y,Z Vertex 4 {m}
-  -34.5372001869833, 3.02839590729218, -1.44382283906452e-015, !- X,Y,Z Vertex 5 {m}
+  -34.5372001869833, -10.2679500000032, -1.57944709434101e-14, !- X,Y,Z Vertex 4 {m}
+  -34.5372001869833, 3.02839590729218, -1.44382283906452e-15, !- X,Y,Z Vertex 5 {m}
   -34.5372001869833, 3.02839590729218, 34.8234; !- X,Y,Z Vertex 6 {m}
 
 OS:ShadingSurface,
@@ -6335,8 +6404,8 @@ OS:ShadingSurface,
   ,                                       !- Transmittance Schedule Name
   ,                                       !- Number of Vertices
   -34.5372001869833, 3.02839590729218, 34.8234, !- X,Y,Z Vertex 1 {m}
-  -34.5372001869833, 3.02839590729218, -1.44382283906452e-015, !- X,Y,Z Vertex 2 {m}
-  -32.1559501869833, 3.02839590729218, -1.44382283906452e-015, !- X,Y,Z Vertex 3 {m}
+  -34.5372001869833, 3.02839590729218, -1.44382283906452e-15, !- X,Y,Z Vertex 2 {m}
+  -32.1559501869833, 3.02839590729218, -1.44382283906452e-15, !- X,Y,Z Vertex 3 {m}
   -32.1559501869833, 3.02839590729218, 34.8234; !- X,Y,Z Vertex 4 {m}
 
 OS:ShadingSurface,
@@ -6347,8 +6416,8 @@ OS:ShadingSurface,
   ,                                       !- Transmittance Schedule Name
   ,                                       !- Number of Vertices
   -32.1559501869833, 3.02839590729218, 34.8234, !- X,Y,Z Vertex 1 {m}
-  -32.1559501869833, 3.02839590729218, -1.44382283906452e-015, !- X,Y,Z Vertex 2 {m}
-  -32.1559501869833, 12.1257914653982, -1.44382283906452e-015, !- X,Y,Z Vertex 3 {m}
+  -32.1559501869833, 3.02839590729218, -1.44382283906452e-15, !- X,Y,Z Vertex 2 {m}
+  -32.1559501869833, 12.1257914653982, -1.44382283906452e-15, !- X,Y,Z Vertex 3 {m}
   -32.1559501869833, 12.1257914653982, 34.8234; !- X,Y,Z Vertex 4 {m}
 
 OS:ShadingSurface,
@@ -6359,8 +6428,8 @@ OS:ShadingSurface,
   ,                                       !- Transmittance Schedule Name
   ,                                       !- Number of Vertices
   -32.1559501869833, 12.1257914653982, 34.8234, !- X,Y,Z Vertex 1 {m}
-  -32.1559501869833, 12.1257914653982, -1.44382283906452e-015, !- X,Y,Z Vertex 2 {m}
-  -94.1554496803807, 12.1257914653983, -1.44382283906452e-015, !- X,Y,Z Vertex 3 {m}
+  -32.1559501869833, 12.1257914653982, -1.44382283906452e-15, !- X,Y,Z Vertex 2 {m}
+  -94.1554496803807, 12.1257914653983, -1.44382283906452e-15, !- X,Y,Z Vertex 3 {m}
   -94.1554496803807, 12.1257914653984, 34.8234; !- X,Y,Z Vertex 4 {m}
 
 OS:ShadingSurface,
@@ -6371,8 +6440,8 @@ OS:ShadingSurface,
   ,                                       !- Transmittance Schedule Name
   ,                                       !- Number of Vertices
   -94.1554496803807, 12.1257914653984, 34.8234, !- X,Y,Z Vertex 1 {m}
-  -94.1554496803807, 12.1257914653983, -1.44382283906452e-015, !- X,Y,Z Vertex 2 {m}
-  -101.122585309077, -8.89790873129625, -1.44382283906452e-015, !- X,Y,Z Vertex 3 {m}
+  -94.1554496803807, 12.1257914653983, -1.44382283906452e-15, !- X,Y,Z Vertex 2 {m}
+  -101.122585309077, -8.89790873129625, -1.44382283906452e-15, !- X,Y,Z Vertex 3 {m}
   -101.122585309077, -8.89790873129622, 34.8234; !- X,Y,Z Vertex 4 {m}
 
 OS:ShadingSurface,
@@ -6383,8 +6452,8 @@ OS:ShadingSurface,
   ,                                       !- Transmittance Schedule Name
   ,                                       !- Number of Vertices
   -101.122585309077, -8.89790873129622, 34.8234, !- X,Y,Z Vertex 1 {m}
-  -101.122585309077, -8.89790873129625, -1.44382283906452e-015, !- X,Y,Z Vertex 2 {m}
-  -72.2331343284259, -44.304504092708, -1.44382283906452e-015, !- X,Y,Z Vertex 3 {m}
+  -101.122585309077, -8.89790873129625, -1.44382283906452e-15, !- X,Y,Z Vertex 2 {m}
+  -72.2331343284259, -44.304504092708, -1.44382283906452e-15, !- X,Y,Z Vertex 3 {m}
   -72.2331343284259, -44.304504092708, 34.8234; !- X,Y,Z Vertex 4 {m}
 
 OS:ShadingSurface,
@@ -6394,13 +6463,13 @@ OS:ShadingSurface,
   {5c045807-e28d-48d0-a355-85e788126903}, !- Shading Surface Group Name
   ,                                       !- Transmittance Schedule Name
   ,                                       !- Number of Vertices
-  -94.1554496803807, 12.1257914653983, -1.44382283906452e-015, !- X,Y,Z Vertex 1 {m}
-  -32.1559501869833, 12.1257914653982, -1.44382283906452e-015, !- X,Y,Z Vertex 2 {m}
-  -32.1559501869833, 3.02839590729218, -1.44382283906452e-015, !- X,Y,Z Vertex 3 {m}
-  -34.5372001869833, 3.02839590729218, -1.44382283906452e-015, !- X,Y,Z Vertex 4 {m}
-  -34.5372001869833, -45.1231437510848, -1.44382283906452e-015, !- X,Y,Z Vertex 5 {m}
-  -72.2331343284259, -44.304504092708, -1.44382283906452e-015, !- X,Y,Z Vertex 6 {m}
-  -101.122585309077, -8.89790873129625, -1.44382283906452e-015; !- X,Y,Z Vertex 7 {m}
+  -94.1554496803807, 12.1257914653983, -1.44382283906452e-15, !- X,Y,Z Vertex 1 {m}
+  -32.1559501869833, 12.1257914653982, -1.44382283906452e-15, !- X,Y,Z Vertex 2 {m}
+  -32.1559501869833, 3.02839590729218, -1.44382283906452e-15, !- X,Y,Z Vertex 3 {m}
+  -34.5372001869833, 3.02839590729218, -1.44382283906452e-15, !- X,Y,Z Vertex 4 {m}
+  -34.5372001869833, -45.1231437510848, -1.44382283906452e-15, !- X,Y,Z Vertex 5 {m}
+  -72.2331343284259, -44.304504092708, -1.44382283906452e-15, !- X,Y,Z Vertex 6 {m}
+  -101.122585309077, -8.89790873129625, -1.44382283906452e-15; !- X,Y,Z Vertex 7 {m}
 
 OS:ShadingSurface,
   {06e2cafc-26ee-4ec2-a561-97708fb0c43d}, !- Handle
@@ -6423,8 +6492,8 @@ OS:ShadingSurface,
   ,                                       !- Transmittance Schedule Name
   ,                                       !- Number of Vertices
   -30.8002251869833, -197.880331251084, 46.609, !- X,Y,Z Vertex 1 {m}
-  -30.8002251869833, -197.880331251084, -1.01067598734517e-014, !- X,Y,Z Vertex 2 {m}
-  -30.8002251869833, -53.1003312510846, -1.44382283906452e-015, !- X,Y,Z Vertex 3 {m}
+  -30.8002251869833, -197.880331251084, -7.94102561485491e-15, !- X,Y,Z Vertex 2 {m}
+  -30.8002251869833, -53.1003312510846, -3.60955709766132e-15, !- X,Y,Z Vertex 3 {m}
   -30.8002251869833, -53.1003312510846, 46.609; !- X,Y,Z Vertex 4 {m}
 
 OS:ShadingSurface,
@@ -6460,7 +6529,7 @@ OS:ShadingSurface,
   ,                                       !- Number of Vertices
   -56.7082251869833, -197.880331251084, 46.609, !- X,Y,Z Vertex 1 {m}
   -56.7082251869833, -197.880331251084, 21.3857870167291, !- X,Y,Z Vertex 2 {m}
-  -30.8002251869833, -197.880331251084, -1.01067598734517e-014, !- X,Y,Z Vertex 3 {m}
+  -30.8002251869833, -197.880331251084, -7.94102561485491e-15, !- X,Y,Z Vertex 3 {m}
   -30.8002251869833, -197.880331251084, 46.609; !- X,Y,Z Vertex 4 {m}
 
 OS:ShadingSurface,
@@ -6471,8 +6540,8 @@ OS:ShadingSurface,
   ,                                       !- Transmittance Schedule Name
   ,                                       !- Number of Vertices
   -110.466380820439, -53.1003312510846, 4.21194974500286, !- X,Y,Z Vertex 1 {m}
-  -110.466380820439, -53.1003312510846, -1.44382283906452e-015, !- X,Y,Z Vertex 2 {m}
-  -110.466380820439, -197.880331251084, -1.44382283906452e-015, !- X,Y,Z Vertex 3 {m}
+  -110.466380820439, -53.1003312510846, 7.21911419532276e-16, !- X,Y,Z Vertex 2 {m}
+  -110.466380820439, -197.880331251084, -3.60955709766132e-15, !- X,Y,Z Vertex 3 {m}
   -110.466380820439, -197.880331251084, 4.21194974500286; !- X,Y,Z Vertex 4 {m}
 
 OS:ShadingSurface,
@@ -6494,10 +6563,10 @@ OS:ShadingSurface,
   {5c045807-e28d-48d0-a355-85e788126903}, !- Shading Surface Group Name
   ,                                       !- Transmittance Schedule Name
   ,                                       !- Number of Vertices
-  -30.8002251869833, -53.1003312510846, -1.44382283906452e-015, !- X,Y,Z Vertex 1 {m}
-  -30.8002251869833, -197.880331251084, -1.01067598734517e-014, !- X,Y,Z Vertex 2 {m}
-  -110.466380820439, -197.880331251084, -1.44382283906452e-015, !- X,Y,Z Vertex 3 {m}
-  -110.466380820439, -53.1003312510846, -1.44382283906452e-015; !- X,Y,Z Vertex 4 {m}
+  -30.8002251869833, -53.1003312510846, -3.60955709766132e-15, !- X,Y,Z Vertex 1 {m}
+  -30.8002251869833, -197.880331251084, -7.94102561485491e-15, !- X,Y,Z Vertex 2 {m}
+  -110.466380820439, -197.880331251084, -3.60955709766132e-15, !- X,Y,Z Vertex 3 {m}
+  -110.466380820439, -53.1003312510846, 7.21911419532276e-16; !- X,Y,Z Vertex 4 {m}
 
 OS:ShadingSurface,
   {acbacd78-fde6-43c2-a88b-e159a3342811}, !- Handle
@@ -6507,8 +6576,8 @@ OS:ShadingSurface,
   ,                                       !- Transmittance Schedule Name
   ,                                       !- Number of Vertices
   -56.7082251869833, -53.1003312510846, 21.3857870167291, !- X,Y,Z Vertex 1 {m}
-  -30.8002251869833, -53.1003312510846, -1.44382283906452e-015, !- X,Y,Z Vertex 2 {m}
-  -110.466380820439, -53.1003312510846, -1.44382283906452e-015, !- X,Y,Z Vertex 3 {m}
+  -30.8002251869833, -53.1003312510846, -3.60955709766132e-15, !- X,Y,Z Vertex 2 {m}
+  -110.466380820439, -53.1003312510846, 7.21911419532276e-16, !- X,Y,Z Vertex 3 {m}
   -110.466380820439, -53.1003312510846, 4.21194974500286; !- X,Y,Z Vertex 4 {m}
 
 OS:ShadingSurface,
@@ -6519,8 +6588,8 @@ OS:ShadingSurface,
   ,                                       !- Transmittance Schedule Name
   ,                                       !- Number of Vertices
   -109.453176363395, -15.3062085346015, 30.2514, !- X,Y,Z Vertex 1 {m}
-  -109.453176363395, -15.3062085346015, -1.44382283906452e-015, !- X,Y,Z Vertex 2 {m}
-  -109.453176363395, 16.6977914653985, -1.44382283906452e-015, !- X,Y,Z Vertex 3 {m}
+  -109.453176363395, -15.3062085346015, -1.44382283906452e-15, !- X,Y,Z Vertex 2 {m}
+  -109.453176363395, 16.6977914653985, -1.44382283906452e-15, !- X,Y,Z Vertex 3 {m}
   -109.453176363395, 16.6977914653985, 30.2514; !- X,Y,Z Vertex 4 {m}
 
 OS:ShadingSurface,
@@ -6543,8 +6612,8 @@ OS:ShadingSurface,
   ,                                       !- Transmittance Schedule Name
   ,                                       !- Number of Vertices
   -152.125176363395, 16.6977914653985, 36.3474, !- X,Y,Z Vertex 1 {m}
-  -152.125176363395, 16.6977914653985, -1.44382283906452e-015, !- X,Y,Z Vertex 2 {m}
-  -173.461176363395, 16.6977914653985, -1.44382283906452e-015, !- X,Y,Z Vertex 3 {m}
+  -152.125176363395, 16.6977914653985, -1.44382283906452e-15, !- X,Y,Z Vertex 2 {m}
+  -173.461176363395, 16.6977914653985, -1.44382283906452e-15, !- X,Y,Z Vertex 3 {m}
   -173.461176363395, 16.6977914653985, 30.2514; !- X,Y,Z Vertex 4 {m}
 
 OS:ShadingSurface,
@@ -6603,8 +6672,8 @@ OS:ShadingSurface,
   ,                                       !- Transmittance Schedule Name
   ,                                       !- Number of Vertices
   -173.461176363395, 16.6977914653985, 30.2514, !- X,Y,Z Vertex 1 {m}
-  -173.461176363395, 16.6977914653985, -1.44382283906452e-015, !- X,Y,Z Vertex 2 {m}
-  -173.461176363395, -15.3062085346015, -1.44382283906452e-015, !- X,Y,Z Vertex 3 {m}
+  -173.461176363395, 16.6977914653985, -1.44382283906452e-15, !- X,Y,Z Vertex 2 {m}
+  -173.461176363395, -15.3062085346015, -1.44382283906452e-15, !- X,Y,Z Vertex 3 {m}
   -173.461176363395, -15.3062085346015, 30.2514; !- X,Y,Z Vertex 4 {m}
 
 OS:ShadingSurface,
@@ -6614,10 +6683,10 @@ OS:ShadingSurface,
   {5c045807-e28d-48d0-a355-85e788126903}, !- Shading Surface Group Name
   ,                                       !- Transmittance Schedule Name
   ,                                       !- Number of Vertices
-  -109.453176363395, 16.6977914653985, -1.44382283906452e-015, !- X,Y,Z Vertex 1 {m}
-  -109.453176363395, -15.3062085346015, -1.44382283906452e-015, !- X,Y,Z Vertex 2 {m}
-  -173.461176363395, -15.3062085346015, -1.44382283906452e-015, !- X,Y,Z Vertex 3 {m}
-  -173.461176363395, 16.6977914653985, -1.44382283906452e-015; !- X,Y,Z Vertex 4 {m}
+  -109.453176363395, 16.6977914653985, -1.44382283906452e-15, !- X,Y,Z Vertex 1 {m}
+  -109.453176363395, -15.3062085346015, -1.44382283906452e-15, !- X,Y,Z Vertex 2 {m}
+  -173.461176363395, -15.3062085346015, -1.44382283906452e-15, !- X,Y,Z Vertex 3 {m}
+  -173.461176363395, 16.6977914653985, -1.44382283906452e-15; !- X,Y,Z Vertex 4 {m}
 
 OS:ShadingSurface,
   {4da2ed51-75b6-45d3-99b3-024202ca5e6e}, !- Handle
@@ -6627,8 +6696,8 @@ OS:ShadingSurface,
   ,                                       !- Transmittance Schedule Name
   ,                                       !- Number of Vertices
   -130.789176363395, -15.3062085346015, 36.3474, !- X,Y,Z Vertex 1 {m}
-  -130.789176363395, -15.3062085346015, -1.44382283906452e-015, !- X,Y,Z Vertex 2 {m}
-  -109.453176363395, -15.3062085346015, -1.44382283906452e-015, !- X,Y,Z Vertex 3 {m}
+  -130.789176363395, -15.3062085346015, -1.44382283906452e-15, !- X,Y,Z Vertex 2 {m}
+  -109.453176363395, -15.3062085346015, -1.44382283906452e-15, !- X,Y,Z Vertex 3 {m}
   -109.453176363395, -15.3062085346015, 30.2514; !- X,Y,Z Vertex 4 {m}
 
 OS:ShadingSurface,
@@ -6639,8 +6708,8 @@ OS:ShadingSurface,
   ,                                       !- Transmittance Schedule Name
   ,                                       !- Number of Vertices
   -201.69478623008, -8.90375087961891, 46.609, !- X,Y,Z Vertex 1 {m}
-  -201.69478623008, -8.90375087961891, -1.44382283906452e-015, !- X,Y,Z Vertex 2 {m}
-  -201.69478623008, -136.913908731296, -1.44382283906452e-015, !- X,Y,Z Vertex 3 {m}
+  -201.69478623008, -8.90375087961891, -1.44382283906452e-15, !- X,Y,Z Vertex 2 {m}
+  -201.69478623008, -136.913908731296, -1.44382283906452e-15, !- X,Y,Z Vertex 3 {m}
   -201.69478623008, -136.913908731296, 46.609; !- X,Y,Z Vertex 4 {m}
 
 OS:ShadingSurface,
@@ -6651,8 +6720,8 @@ OS:ShadingSurface,
   ,                                       !- Transmittance Schedule Name
   ,                                       !- Number of Vertices
   -34.5372001869833, -10.2679500000032, 7.62, !- X,Y,Z Vertex 1 {m}
-  -34.5372001869833, -10.2679500000032, -1.44382283906452e-015, !- X,Y,Z Vertex 2 {m}
-  -34.5372001869833, -45.1231437510848, -1.44382283906452e-015, !- X,Y,Z Vertex 3 {m}
+  -34.5372001869833, -10.2679500000032, -1.57944709434101e-14, !- X,Y,Z Vertex 2 {m}
+  -34.5372001869833, -45.1231437510848, -1.44382283906452e-15, !- X,Y,Z Vertex 3 {m}
   -34.5372001869833, -45.1231437510848, 7.62; !- X,Y,Z Vertex 4 {m}
 
 OS:ShadingSurface,
@@ -6665,7 +6734,7 @@ OS:ShadingSurface,
   -9.88334358824695, -9.95100409270849, 13.1952999082863, !- X,Y,Z Vertex 1 {m}
   -9.88334358824695, -9.95100409270849, 7.62, !- X,Y,Z Vertex 2 {m}
   -0.101554674324896, -9.95100409270849, 7.6200000000001, !- X,Y,Z Vertex 3 {m}
-  -0.101553925358014, -9.95100409270849, 13.1952999082863; !- X,Y,Z Vertex 4 {m}
+  -0.101553923745553, -9.95100409270849, 13.1952999082863; !- X,Y,Z Vertex 4 {m}
 
 OS:ShadingSurface,
   {bac1565f-d977-4d68-a44d-2bb838851890}, !- Handle
@@ -6686,12 +6755,12 @@ OS:ShadingSurface,
   {5c045807-e28d-48d0-a355-85e788126903}, !- Shading Surface Group Name
   ,                                       !- Transmittance Schedule Name
   ,                                       !- Number of Vertices
-  -0.101553841277634, -1.15505827125162e-013, 13.1952999082863, !- X,Y,Z Vertex 1 {m}
-  -0.101553925358014, -9.95100409270849, 13.1952999082863, !- X,Y,Z Vertex 2 {m}
-  -0.101554674324896, -9.95100409270849, 7.6200000000001, !- X,Y,Z Vertex 3 {m}
-  -0.101555303297755, -94.6163394691509, 7.61999999999991, !- X,Y,Z Vertex 4 {m}
-  -0.101556300465748, -94.6163394747809, 2.74326339422259e-014, !- X,Y,Z Vertex 5 {m}
-  -0.101555632856128, -1.15505827125162e-013, -6.20843820797745e-014; !- X,Y,Z Vertex 6 {m}
+  -0.101553923745553, -9.95100409270849, 13.1952999082863, !- X,Y,Z Vertex 1 {m}
+  -0.101554674324896, -9.95100409270849, 7.6200000000001, !- X,Y,Z Vertex 2 {m}
+  -0.101555303297755, -94.6163394691509, 7.61999999999991, !- X,Y,Z Vertex 3 {m}
+  -0.101556300465748, -94.6163394747809, 1.92990483151391e-14, !- X,Y,Z Vertex 4 {m}
+  -0.101555632856128, -1.15505827125162e-13, -4.66804269162606e-14, !- X,Y,Z Vertex 5 {m}
+  -0.101553851282077, -1.15432974506899e-13, 13.1952999082863; !- X,Y,Z Vertex 6 {m}
 
 OS:ShadingSurface,
   {dd3c2a59-309e-43fb-a6b6-fea446407fb8}, !- Handle
@@ -6700,18 +6769,18 @@ OS:ShadingSurface,
   {5c045807-e28d-48d0-a355-85e788126903}, !- Shading Surface Group Name
   ,                                       !- Transmittance Schedule Name
   ,                                       !- Number of Vertices
-  -0.101555632856128, -1.15505827125162e-013, -6.20843820797745e-014, !- X,Y,Z Vertex 1 {m}
-  -0.101556300465748, -94.6163394747809, 2.74326339422259e-014, !- X,Y,Z Vertex 2 {m}
-  -23.7079371198328, -95.1267290927076, 3.3207925298484e-014, !- X,Y,Z Vertex 3 {m}
-  -23.7079371198328, -47.6763540927007, 2.88764567812905e-015, !- X,Y,Z Vertex 4 {m}
-  -46.8308896656869, -47.6763540927007, 1.58820512297098e-014, !- X,Y,Z Vertex 5 {m}
-  -46.8308896656869, -45.1231437510848, 1.44382283906452e-014, !- X,Y,Z Vertex 6 {m}
-  -34.5372001869833, -45.1231437510848, -1.44382283906452e-015, !- X,Y,Z Vertex 7 {m}
-  -34.5372001869833, -10.2679500000032, -1.44382283906452e-015, !- X,Y,Z Vertex 8 {m}
-  -23.0532690562169, -10.2679500000032, -2.16573425859679e-014, !- X,Y,Z Vertex 9 {m}
-  -23.0532690562169, -3.66354049127708, -2.59888111031614e-014, !- X,Y,Z Vertex 10 {m}
-  -9.88334358824695, -3.66354049127708, -3.46517481375486e-014, !- X,Y,Z Vertex 11 {m}
-  -9.88334358824695, -1.15505827125162e-013, -3.60955709766131e-014; !- X,Y,Z Vertex 12 {m}
+  -0.101555632856128, -1.15505827125162e-13, -4.66804269162606e-14, !- X,Y,Z Vertex 1 {m}
+  -0.101556300465748, -94.6163394747809, 1.92990483151391e-14, !- X,Y,Z Vertex 2 {m}
+  -23.7079371198328, -95.1267290927076, 3.59194671788073e-14, !- X,Y,Z Vertex 3 {m}
+  -23.7079371198328, -47.6763540927007, 2.8305648011997e-15, !- X,Y,Z Vertex 4 {m}
+  -46.8308896656869, -47.6763540927007, 1.87619939781016e-14, !- X,Y,Z Vertex 5 {m}
+  -46.8308896656869, -45.1231437510848, 1.69815459259373e-14, !- X,Y,Z Vertex 6 {m}
+  -34.5372001869833, -45.1231437510848, -1.44382283906452e-15, !- X,Y,Z Vertex 7 {m}
+  -34.5372001869833, -10.2679500000032, -1.57944709434101e-14, !- X,Y,Z Vertex 8 {m}
+  -23.0532690562169, -10.2679500000032, -2.3706757885115e-14, !- X,Y,Z Vertex 9 {m}
+  -23.0532690562169, -3.66354049127708, -2.83122570301892e-14, !- X,Y,Z Vertex 10 {m}
+  -9.88334358824695, -3.66354049127708, -3.73861732803723e-14, !- X,Y,Z Vertex 11 {m}
+  -9.88334358824695, -1.15505827125162e-13, -3.99408956334045e-14; !- X,Y,Z Vertex 12 {m}
 
 OS:Construction,
   {78b1161b-e22c-411f-94ae-3387bad1b992}, !- Handle
@@ -7529,7 +7598,6 @@ OS:Schedule:Rule,
   ,                                       !- Apply Thursday
   ,                                       !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   1,                                      !- Start Month
   1,                                      !- Start Day
@@ -7939,7 +8007,6 @@ OS:Schedule:Rule,
   ,                                       !- Apply Thursday
   ,                                       !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   1,                                      !- Start Month
   1,                                      !- Start Day
@@ -7974,7 +8041,6 @@ OS:Schedule:Rule,
   Yes,                                    !- Apply Thursday
   Yes,                                    !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   12,                                     !- Start Month
   18,                                     !- Start Day
@@ -8003,7 +8069,6 @@ OS:Schedule:Rule,
   Yes,                                    !- Apply Thursday
   Yes,                                    !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   5,                                      !- Start Month
   1,                                      !- Start Day
@@ -8103,7 +8168,6 @@ OS:Schedule:Rule,
   ,                                       !- Apply Thursday
   ,                                       !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   1,                                      !- Start Month
   1,                                      !- Start Day
@@ -8138,7 +8202,6 @@ OS:Schedule:Rule,
   Yes,                                    !- Apply Thursday
   Yes,                                    !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   12,                                     !- Start Month
   18,                                     !- Start Day
@@ -8167,7 +8230,6 @@ OS:Schedule:Rule,
   Yes,                                    !- Apply Thursday
   Yes,                                    !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   5,                                      !- Start Month
   1,                                      !- Start Day
@@ -8261,7 +8323,6 @@ OS:Schedule:Rule,
   ,                                       !- Apply Thursday
   ,                                       !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   1,                                      !- Start Month
   1,                                      !- Start Day
@@ -8296,7 +8357,6 @@ OS:Schedule:Rule,
   Yes,                                    !- Apply Thursday
   Yes,                                    !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   12,                                     !- Start Month
   18,                                     !- Start Day
@@ -8325,7 +8385,6 @@ OS:Schedule:Rule,
   Yes,                                    !- Apply Thursday
   Yes,                                    !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   5,                                      !- Start Month
   1,                                      !- Start Day
@@ -8413,7 +8472,6 @@ OS:Schedule:Rule,
   ,                                       !- Apply Thursday
   ,                                       !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   1,                                      !- Start Month
   1,                                      !- Start Day
@@ -8448,7 +8506,6 @@ OS:Schedule:Rule,
   Yes,                                    !- Apply Thursday
   Yes,                                    !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   12,                                     !- Start Month
   18,                                     !- Start Day
@@ -8477,7 +8534,6 @@ OS:Schedule:Rule,
   Yes,                                    !- Apply Thursday
   Yes,                                    !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   5,                                      !- Start Month
   1,                                      !- Start Day
@@ -8583,7 +8639,6 @@ OS:Schedule:Rule,
   ,                                       !- Apply Thursday
   ,                                       !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   1,                                      !- Start Month
   1,                                      !- Start Day
@@ -8618,7 +8673,6 @@ OS:Schedule:Rule,
   Yes,                                    !- Apply Thursday
   Yes,                                    !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   12,                                     !- Start Month
   18,                                     !- Start Day
@@ -8647,7 +8701,6 @@ OS:Schedule:Rule,
   Yes,                                    !- Apply Thursday
   Yes,                                    !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   5,                                      !- Start Month
   1,                                      !- Start Day
@@ -8676,7 +8729,6 @@ OS:Schedule:Rule,
   Yes,                                    !- Apply Thursday
   Yes,                                    !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   2,                                      !- Start Month
   1,                                      !- Start Day
@@ -8717,7 +8769,6 @@ OS:Schedule:Rule,
   Yes,                                    !- Apply Thursday
   Yes,                                    !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   4,                                      !- Start Month
   1,                                      !- Start Day
@@ -8758,7 +8809,6 @@ OS:Schedule:Rule,
   Yes,                                    !- Apply Thursday
   Yes,                                    !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   1,                                      !- Start Month
   22,                                     !- Start Day
@@ -8802,7 +8852,6 @@ OS:Schedule:Rule,
   Yes,                                    !- Apply Thursday
   Yes,                                    !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   3,                                      !- Start Month
   12,                                     !- Start Day
@@ -8846,7 +8895,6 @@ OS:Schedule:Rule,
   Yes,                                    !- Apply Thursday
   Yes,                                    !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   8,                                      !- Start Month
   10,                                     !- Start Day
@@ -8890,7 +8938,6 @@ OS:Schedule:Rule,
   Yes,                                    !- Apply Thursday
   Yes,                                    !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   10,                                     !- Start Month
   15,                                     !- Start Day
@@ -8934,7 +8981,6 @@ OS:Schedule:Rule,
   Yes,                                    !- Apply Thursday
   Yes,                                    !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   11,                                     !- Start Month
   19,                                     !- Start Day
@@ -8978,7 +9024,6 @@ OS:Schedule:Rule,
   Yes,                                    !- Apply Thursday
   Yes,                                    !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   1,                                      !- Start Month
   22,                                     !- Start Day
@@ -9081,7 +9126,6 @@ OS:Schedule:Rule,
   ,                                       !- Apply Thursday
   ,                                       !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   1,                                      !- Start Month
   1,                                      !- Start Day
@@ -9116,7 +9160,6 @@ OS:Schedule:Rule,
   Yes,                                    !- Apply Thursday
   Yes,                                    !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   12,                                     !- Start Month
   18,                                     !- Start Day
@@ -9145,7 +9188,6 @@ OS:Schedule:Rule,
   Yes,                                    !- Apply Thursday
   Yes,                                    !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   5,                                      !- Start Month
   1,                                      !- Start Day
@@ -9245,7 +9287,6 @@ OS:Schedule:Rule,
   ,                                       !- Apply Thursday
   ,                                       !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   1,                                      !- Start Month
   1,                                      !- Start Day
@@ -9280,7 +9321,6 @@ OS:Schedule:Rule,
   Yes,                                    !- Apply Thursday
   Yes,                                    !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   12,                                     !- Start Month
   18,                                     !- Start Day
@@ -9309,7 +9349,6 @@ OS:Schedule:Rule,
   Yes,                                    !- Apply Thursday
   Yes,                                    !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   5,                                      !- Start Month
   1,                                      !- Start Day
@@ -9338,7 +9377,6 @@ OS:Schedule:Rule,
   Yes,                                    !- Apply Thursday
   Yes,                                    !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   2,                                      !- Start Month
   1,                                      !- Start Day
@@ -9379,7 +9417,6 @@ OS:Schedule:Rule,
   Yes,                                    !- Apply Thursday
   Yes,                                    !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   4,                                      !- Start Month
   1,                                      !- Start Day
@@ -9420,7 +9457,6 @@ OS:Schedule:Rule,
   Yes,                                    !- Apply Thursday
   Yes,                                    !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   1,                                      !- Start Month
   22,                                     !- Start Day
@@ -9464,7 +9500,6 @@ OS:Schedule:Rule,
   Yes,                                    !- Apply Thursday
   Yes,                                    !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   3,                                      !- Start Month
   12,                                     !- Start Day
@@ -9508,7 +9543,6 @@ OS:Schedule:Rule,
   Yes,                                    !- Apply Thursday
   Yes,                                    !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   8,                                      !- Start Month
   10,                                     !- Start Day
@@ -9552,7 +9586,6 @@ OS:Schedule:Rule,
   Yes,                                    !- Apply Thursday
   Yes,                                    !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   10,                                     !- Start Month
   15,                                     !- Start Day
@@ -9596,7 +9629,6 @@ OS:Schedule:Rule,
   Yes,                                    !- Apply Thursday
   Yes,                                    !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   11,                                     !- Start Month
   19,                                     !- Start Day
@@ -9640,7 +9672,6 @@ OS:Schedule:Rule,
   Yes,                                    !- Apply Thursday
   Yes,                                    !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   1,                                      !- Start Month
   22,                                     !- Start Day
@@ -9815,16 +9846,16 @@ OS:DefaultScheduleSet,
 OS:ScheduleTypeLimits,
   {132022d6-dc00-415c-9335-0b9c743b77a3}, !- Handle
   ActivityLevel 15,                       !- Name
-  0,                                      !- Lower Limit Value {BasedOnField A4}
-  ,                                       !- Upper Limit Value {BasedOnField A4}
+  0,                                      !- Lower Limit Value
+  ,                                       !- Upper Limit Value
   Continuous,                             !- Numeric Type
   ActivityLevel;                          !- Unit Type
 
 OS:ScheduleTypeLimits,
   {84abc437-9572-4b79-8a9f-3c494eb23b1a}, !- Handle
   ActivityLevel 16,                       !- Name
-  0,                                      !- Lower Limit Value {BasedOnField A4}
-  ,                                       !- Upper Limit Value {BasedOnField A4}
+  0,                                      !- Lower Limit Value
+  ,                                       !- Upper Limit Value
   Continuous,                             !- Numeric Type
   ActivityLevel;                          !- Unit Type
 
@@ -9835,6 +9866,7 @@ OS:SpaceType,
   {6fc58f5d-9d6f-4593-8f8f-5c13bc42d724}, !- Default Schedule Set Name
   {33388140-1bc0-4c38-9822-4ddda42cbfe1}, !- Group Rendering Name
   {1f4430a4-5cae-4680-a593-c5c71f9dca60}, !- Design Specification Outdoor Air Object Name
+  ,                                       !- Standards Template
   PrimarySchool,                          !- Standards Building Type
   Gym;                                    !- Standards Space Type
 
@@ -9889,6 +9921,7 @@ OS:SpaceType,
   {d1337075-1725-4366-a353-83ec77eb8096}, !- Default Schedule Set Name
   {1fee440c-892b-4b38-b588-cc9b0704a65e}, !- Group Rendering Name
   {12fc2b76-1eda-4fe9-a0e1-02560a9ace07}, !- Design Specification Outdoor Air Object Name
+  ,                                       !- Standards Template
   Office,                                 !- Standards Building Type
   Stair;                                  !- Standards Space Type
 
@@ -9930,6 +9963,7 @@ OS:SpaceType,
   {f91a7e47-fdd8-4e46-9ae9-9af11d7a47d2}, !- Default Schedule Set Name
   {dd6b11da-7dc2-4c30-b48a-57180416c72d}, !- Group Rendering Name
   {945620ad-3537-42c9-bd02-e2af7650b0cf}, !- Design Specification Outdoor Air Object Name
+  ,                                       !- Standards Template
   Office,                                 !- Standards Building Type
   Restroom;                               !- Standards Space Type
 
@@ -9984,6 +10018,7 @@ OS:SpaceType,
   {4bed341d-85f7-4c98-bb23-23c590c3d260}, !- Default Schedule Set Name
   {401e60c2-76e1-4d0c-873c-54e7e5bd8fc8}, !- Group Rendering Name
   {ea6556d1-5629-46bf-b5a5-cfa1e5592c9b}, !- Design Specification Outdoor Air Object Name
+  ,                                       !- Standards Template
   Office,                                 !- Standards Building Type
   Elec/MechRoom;                          !- Standards Space Type
 
@@ -10031,6 +10066,7 @@ OS:SpaceType,
   {647b7782-7350-4853-822b-76c70faf406f}, !- Default Schedule Set Name
   {6f54763d-2499-4d7e-8d1b-31d1c0671f60}, !- Group Rendering Name
   {cbc03601-5810-4e29-9d3c-c96206593a3c}, !- Design Specification Outdoor Air Object Name
+  ,                                       !- Standards Template
   Office,                                 !- Standards Building Type
   Storage;                                !- Standards Space Type
 
@@ -10073,6 +10109,7 @@ OS:SpaceType,
   {2c23c9f3-9efb-4cf8-a8da-2fea2eb561ac}, !- Default Schedule Set Name
   {33388140-1bc0-4c38-9822-4ddda42cbfe1}, !- Group Rendering Name
   {aaa676ab-19c8-4a3e-ad55-8912c388f014}, !- Design Specification Outdoor Air Object Name
+  ,                                       !- Standards Template
   Office,                                 !- Standards Building Type
   Attic;                                  !- Standards Space Type
 
@@ -10126,6 +10163,7 @@ OS:SpaceType,
   {6fa99081-ff00-4b63-8bcb-3e91824b6d6e}, !- Default Schedule Set Name
   {1fee440c-892b-4b38-b588-cc9b0704a65e}, !- Group Rendering Name
   {121b2f3f-4bf1-456b-bc60-37696cae66da}, !- Design Specification Outdoor Air Object Name
+  ,                                       !- Standards Template
   Office,                                 !- Standards Building Type
   Stair;                                  !- Standards Space Type
 
@@ -10167,6 +10205,7 @@ OS:SpaceType,
   {d9551c1e-02d2-4e87-af90-c291fc3fa7d1}, !- Default Schedule Set Name
   {22358db0-6d9a-4dba-8471-0c5f807d1c35}, !- Group Rendering Name
   {5bede928-6f92-4170-b784-949fa8c2963d}, !- Design Specification Outdoor Air Object Name
+  ,                                       !- Standards Template
   Office,                                 !- Standards Building Type
   IT_Room;                                !- Standards Space Type
 
@@ -10220,6 +10259,7 @@ OS:SpaceType,
   {2e08553c-3d79-4dc2-8cfb-f2441d7a4645}, !- Default Schedule Set Name
   {401e60c2-76e1-4d0c-873c-54e7e5bd8fc8}, !- Group Rendering Name
   {d05e25c1-f605-4aa5-8bb4-c36501827ff4}, !- Design Specification Outdoor Air Object Name
+  ,                                       !- Standards Template
   Office,                                 !- Standards Building Type
   Elec/MechRoom;                          !- Standards Space Type
 
@@ -10267,6 +10307,7 @@ OS:SpaceType,
   {2c23c9f3-9efb-4cf8-a8da-2fea2eb561ac}, !- Default Schedule Set Name
   {33388140-1bc0-4c38-9822-4ddda42cbfe1}, !- Group Rendering Name
   {678b7693-55b4-4f71-b47c-cbf720e25d90}, !- Design Specification Outdoor Air Object Name
+  ,                                       !- Standards Template
   Office,                                 !- Standards Building Type
   Attic;                                  !- Standards Space Type
 
@@ -10320,6 +10361,7 @@ OS:SpaceType,
   {6fa99081-ff00-4b63-8bcb-3e91824b6d6e}, !- Default Schedule Set Name
   {1fee440c-892b-4b38-b588-cc9b0704a65e}, !- Group Rendering Name
   {7a266e48-cf76-4b76-b0d1-1bc80c31a4f2}, !- Design Specification Outdoor Air Object Name
+  ,                                       !- Standards Template
   Office,                                 !- Standards Building Type
   Stair;                                  !- Standards Space Type
 
@@ -10376,6 +10418,7 @@ OS:PlantLoop,
   {7b1643c6-ef94-4f26-ae12-779b8c3dc5ff}, !- Handle
   DHW-Loop,                               !- Name
   ,                                       !- Fluid Type
+  0,                                      !- Glycol Concentration
   ,                                       !- User Defined Fluid Type
   ,                                       !- Plant Equipment Operation Heating Load
   ,                                       !- Plant Equipment Operation Cooling Load
@@ -10394,10 +10437,23 @@ OS:PlantLoop,
   ,                                       !- Demand Side Branch List Name
   ,                                       !- Demand Side Connector List Name
   Optimal,                                !- Load Distribution Scheme
-  ,                                       !- Availability Manager List Name
+  {4262a318-e5c7-4cee-be79-379dbb0104ef}, !- Availability Manager List Name
   ,                                       !- Plant Loop Demand Calculation Scheme
   ,                                       !- Common Pipe Simulation
-  ;                                       !- Pressure Simulation Type
+  ,                                       !- Pressure Simulation Type
+  ,                                       !- Plant Equipment Operation Heating Load Schedule
+  ,                                       !- Plant Equipment Operation Cooling Load Schedule
+  ,                                       !- Primary Plant Equipment Operation Scheme Schedule
+  ,                                       !- Component Setpoint Operation Scheme Schedule
+  ,                                       !- Demand Mixer Name
+  ,                                       !- Demand Splitter Name
+  ,                                       !- Supply Mixer Name
+  ;                                       !- Supply Splitter Name
+
+OS:AvailabilityManagerAssignmentList,
+  {4262a318-e5c7-4cee-be79-379dbb0104ef}, !- Handle
+  DHW-Loop AvailabilityManagerAssignmentList, !- Name
+  ;                                       !- Availability Manager Name 1
 
 OS:Sizing:Plant,
   {2a1eec0c-d12d-43e1-a9b2-469059e2e558}, !- Handle
@@ -10443,7 +10499,6 @@ OS:Connector:Splitter,
 
 OS:Connection,
   {0a3a6691-efc7-48ea-a6cf-07e907e32cb9}, !- Handle
-  {4641d8d0-3d08-435b-aa22-cb36ce481f1d}, !- Name
   {7b1643c6-ef94-4f26-ae12-779b8c3dc5ff}, !- Source Object
   11,                                     !- Outlet Port
   {285a7025-1166-41ee-b347-6d08db8b324e}, !- Target Object
@@ -10451,7 +10506,6 @@ OS:Connection,
 
 OS:Connection,
   {1c53d8ec-2e44-4e9c-9874-9b35c4e7679d}, !- Handle
-  {0d039df4-b091-4e90-8139-2b648a99a1c2}, !- Name
   {81a0c891-32a5-4975-b638-a7a7b59e55b0}, !- Source Object
   3,                                      !- Outlet Port
   {61eea198-b53e-4189-8294-2af1a010508f}, !- Target Object
@@ -10459,7 +10513,6 @@ OS:Connection,
 
 OS:Connection,
   {16025f62-4bf8-4608-a061-c2c7fd7069e7}, !- Handle
-  {269192f9-66c5-4b0e-9f5a-932a67ad59d2}, !- Name
   {0fd50a5d-4396-43cd-b93f-ff09f44f684a}, !- Source Object
   3,                                      !- Outlet Port
   {7b1643c6-ef94-4f26-ae12-779b8c3dc5ff}, !- Target Object
@@ -10499,7 +10552,6 @@ OS:Connector:Splitter,
 
 OS:Connection,
   {9814f8c6-40c7-47d1-8240-f120bdbe06ac}, !- Handle
-  {5eee9094-7448-434a-adad-0b5d31e9cf31}, !- Name
   {7b1643c6-ef94-4f26-ae12-779b8c3dc5ff}, !- Source Object
   14,                                     !- Outlet Port
   {1130642a-2290-46db-ab2b-9ffa020b209e}, !- Target Object
@@ -10507,7 +10559,6 @@ OS:Connection,
 
 OS:Connection,
   {38109028-21e8-4799-8905-871b4dad331e}, !- Handle
-  {ac7b4153-0181-43e2-805c-471f97067a24}, !- Name
   {3989f983-000a-48db-a592-f365eaae1992}, !- Source Object
   3,                                      !- Outlet Port
   {f55d9cbc-cf67-4d33-b878-810b14313137}, !- Target Object
@@ -10515,7 +10566,6 @@ OS:Connection,
 
 OS:Connection,
   {b41bc0da-b070-44d0-89bf-e262c6df9d30}, !- Handle
-  {5905b5a0-e4bf-47ee-8704-99f7c81ce0ad}, !- Name
   {90da0ec6-bb01-4d14-9cc5-5f64913a25b2}, !- Source Object
   3,                                      !- Outlet Port
   {7b1643c6-ef94-4f26-ae12-779b8c3dc5ff}, !- Target Object
@@ -10536,14 +10586,44 @@ OS:Pump:VariableSpeed,
   -4.7443,                                !- Coefficient 3 of the Part Load Performance Curve
   2.5294,                                 !- Coefficient 4 of the Part Load Performance Curve
   ,                                       !- Minimum Flow Rate {m3/s}
-  Intermittent;                           !- Pump Control Type
+  Intermittent,                           !- Pump Control Type
+  ,                                       !- Pump Flow Rate Schedule Name
+  ,                                       !- Pump Curve Name
+  ,                                       !- Impeller Diameter {m}
+  ,                                       !- VFD Control Type
+  ,                                       !- Pump RPM Schedule Name
+  ,                                       !- Minimum Pressure Schedule {Pa}
+  ,                                       !- Maximum Pressure Schedule {Pa}
+  ,                                       !- Minimum RPM Schedule {rev/min}
+  ,                                       !- Maximum RPM Schedule {rev/min}
+  ,                                       !- Zone Name
+  0.5,                                    !- Skin Loss Radiative Fraction
+  PowerPerFlowPerPressure,                !- Design Power Sizing Method
+  348701.1,                               !- Design Electric Power per Unit Flow Rate {W/(m3/s)}
+  1.282051282,                            !- Design Shaft Power per Unit Flow Rate per Unit Head {W-s/m3-Pa}
+  0.0;                                    !- Design Minimum Flow Rate Fraction
 
-OS:DistrictHeating,
+OS:Schedule:Constant,
+  {b5dfd00d-9733-424e-924c-94bce471bca3}, !- Handle
+  Always On Continuous,                   !- Name
+  {443798aa-55a3-4490-8d15-bc8627a4fa5f}, !- Schedule Type Limits Name
+  1;                                      !- Value
+
+OS:ScheduleTypeLimits,
+  {443798aa-55a3-4490-8d15-bc8627a4fa5f}, !- Handle
+  Always On Continuous Limits,            !- Name
+  0,                                      !- Lower Limit Value
+  1,                                      !- Upper Limit Value
+  Continuous,                             !- Numeric Type
+  ;                                       !- Unit Type
+
+OS:DistrictHeating:Water,
   {119ce34f-5eef-41af-993c-529de2496542}, !- Handle
   DHW-Loop District Heating,              !- Name
   {e125420f-5da1-49aa-9f02-ed6f554685bd}, !- Hot Water Inlet Node Name
   {5f1c3b4e-f17e-4808-95f3-7c491d9d33eb}, !- Hot Water Outlet Node Name
-  1000000000;                             !- Nominal Capacity {W}
+  1000000000,                             !- Nominal Capacity {W}
+  {b5dfd00d-9733-424e-924c-94bce471bca3}; !- Capacity Fraction Schedule
 
 OS:Schedule:Ruleset,
   {cc9ca07c-4a24-482a-9705-23e401a5a2dc}, !- Handle
@@ -10570,8 +10650,8 @@ OS:SetpointManager:Scheduled,
 OS:ScheduleTypeLimits,
   {8ac546ae-2a68-47ed-8937-059477082563}, !- Handle
   Temperature,                            !- Name
-  ,                                       !- Lower Limit Value {BasedOnField A4}
-  ,                                       !- Upper Limit Value {BasedOnField A4}
+  ,                                       !- Lower Limit Value
+  ,                                       !- Upper Limit Value
   Continuous,                             !- Numeric Type
   Temperature;                            !- Unit Type
 
@@ -10613,7 +10693,6 @@ OS:Node,
 
 OS:Connection,
   {e125420f-5da1-49aa-9f02-ed6f554685bd}, !- Handle
-  {52a5b87e-d3e7-4021-95d0-cb093260cde0}, !- Name
   {61eea198-b53e-4189-8294-2af1a010508f}, !- Source Object
   3,                                      !- Outlet Port
   {119ce34f-5eef-41af-993c-529de2496542}, !- Target Object
@@ -10621,7 +10700,6 @@ OS:Connection,
 
 OS:Connection,
   {5f1c3b4e-f17e-4808-95f3-7c491d9d33eb}, !- Handle
-  {e359a5de-3f99-4f5d-8bdf-b5e9f3208abe}, !- Name
   {119ce34f-5eef-41af-993c-529de2496542}, !- Source Object
   3,                                      !- Outlet Port
   {71db1967-4d62-4b2c-9ea9-b143d0e47f96}, !- Target Object
@@ -10629,7 +10707,6 @@ OS:Connection,
 
 OS:Connection,
   {5f07437b-eee8-4113-9f7a-a8431cc02613}, !- Handle
-  {125d9099-045f-41df-9e14-78f2e02de9fe}, !- Name
   {71db1967-4d62-4b2c-9ea9-b143d0e47f96}, !- Source Object
   3,                                      !- Outlet Port
   {120b418e-2de0-4906-ad1c-c9aab4319d87}, !- Target Object
@@ -10643,7 +10720,6 @@ OS:Node,
 
 OS:Connection,
   {743e54e1-d6a3-49c9-83fe-7d2d8536eb0e}, !- Handle
-  {2c16f165-917f-4b78-ac04-d4fd5abb2d98}, !- Name
   {81a0c891-32a5-4975-b638-a7a7b59e55b0}, !- Source Object
   4,                                      !- Outlet Port
   {14e3c4d3-8d11-470b-b034-0093ed1fdc55}, !- Target Object
@@ -10657,7 +10733,6 @@ OS:Node,
 
 OS:Connection,
   {57f7b0dc-8ce1-496b-a862-41771020040a}, !- Handle
-  {f2a18220-822d-47f2-9746-a40a3ef77a2f}, !- Name
   {14e3c4d3-8d11-470b-b034-0093ed1fdc55}, !- Source Object
   3,                                      !- Outlet Port
   {69ea8fe0-0ec3-4e77-955f-00083ec02c11}, !- Target Object
@@ -10665,7 +10740,6 @@ OS:Connection,
 
 OS:Connection,
   {14191531-b1ca-4d41-9e07-74bfdfb3938f}, !- Handle
-  {2207adbb-a68c-4dd0-a21e-07bd558e5866}, !- Name
   {69ea8fe0-0ec3-4e77-955f-00083ec02c11}, !- Source Object
   3,                                      !- Outlet Port
   {2bf2612b-5097-4455-b3e7-3e1787d672ba}, !- Target Object
@@ -10673,7 +10747,6 @@ OS:Connection,
 
 OS:Connection,
   {f80a3ca1-5e37-439d-b9b7-b506bcf61bfe}, !- Handle
-  {255de936-949c-4116-a0d2-83d195aaf95b}, !- Name
   {2bf2612b-5097-4455-b3e7-3e1787d672ba}, !- Source Object
   3,                                      !- Outlet Port
   {120b418e-2de0-4906-ad1c-c9aab4319d87}, !- Target Object
@@ -10687,7 +10760,6 @@ OS:Node,
 
 OS:Connection,
   {eb966e3d-e008-411d-a043-736c9d02ba40}, !- Handle
-  {a8047a6d-da7c-4de5-967d-f67fbfa9f8ff}, !- Name
   {285a7025-1166-41ee-b347-6d08db8b324e}, !- Source Object
   3,                                      !- Outlet Port
   {36df77e9-a6bd-4e6e-b061-b2b62f389293}, !- Target Object
@@ -10695,7 +10767,6 @@ OS:Connection,
 
 OS:Connection,
   {ab51a014-b667-41fd-bce4-9260d07effb5}, !- Handle
-  {03498874-20e1-4342-9d5a-659152f06dcc}, !- Name
   {36df77e9-a6bd-4e6e-b061-b2b62f389293}, !- Source Object
   3,                                      !- Outlet Port
   {82ad52fe-cf90-40b5-bc1d-46cb5c75e79c}, !- Target Object
@@ -10703,7 +10774,6 @@ OS:Connection,
 
 OS:Connection,
   {b4aead28-daec-409e-bfe6-77fa7d4cbb6c}, !- Handle
-  {b51fb9c8-d4ea-40d1-af41-fe9107bbcefa}, !- Name
   {82ad52fe-cf90-40b5-bc1d-46cb5c75e79c}, !- Source Object
   3,                                      !- Outlet Port
   {81a0c891-32a5-4975-b638-a7a7b59e55b0}, !- Target Object
@@ -10717,7 +10787,6 @@ OS:Node,
 
 OS:Connection,
   {de8a311b-a8a2-4654-8c4a-caf7ddb135d8}, !- Handle
-  {ad733435-50f3-4d26-93e8-d6fb24e095be}, !- Name
   {120b418e-2de0-4906-ad1c-c9aab4319d87}, !- Source Object
   2,                                      !- Outlet Port
   {ce67b18e-8115-4001-9a4d-04f71f5b3d45}, !- Target Object
@@ -10725,7 +10794,6 @@ OS:Connection,
 
 OS:Connection,
   {1d36cd24-cc62-4fb8-9713-a4eb74807fb7}, !- Handle
-  {2828507d-48bd-4b1b-aed9-1e7ff67fa7b7}, !- Name
   {ce67b18e-8115-4001-9a4d-04f71f5b3d45}, !- Source Object
   3,                                      !- Outlet Port
   {497c518f-3495-4043-bcef-0c2d583b900b}, !- Target Object
@@ -10733,7 +10801,6 @@ OS:Connection,
 
 OS:Connection,
   {7627cd5a-afa1-4a55-bd83-5dcf209f4571}, !- Handle
-  {dd2dc729-7673-4208-b8df-5e4856df6af8}, !- Name
   {497c518f-3495-4043-bcef-0c2d583b900b}, !- Source Object
   3,                                      !- Outlet Port
   {0fd50a5d-4396-43cd-b93f-ff09f44f684a}, !- Target Object
@@ -10747,7 +10814,6 @@ OS:Node,
 
 OS:Connection,
   {78bf0585-2122-4652-a411-148cb6bc5c3e}, !- Handle
-  {b4459c20-d269-4826-a369-c954c92453e7}, !- Name
   {f55d9cbc-cf67-4d33-b878-810b14313137}, !- Source Object
   3,                                      !- Outlet Port
   {f80121b1-a2f9-4007-b689-0ce44f436664}, !- Target Object
@@ -10755,7 +10821,6 @@ OS:Connection,
 
 OS:Connection,
   {bf0c8206-f0a4-4a12-846c-2a425f1cbbe4}, !- Handle
-  {aacfdb32-d748-43bd-8695-28e1384e79be}, !- Name
   {f80121b1-a2f9-4007-b689-0ce44f436664}, !- Source Object
   3,                                      !- Outlet Port
   {aee1d837-9a64-48fd-8e4b-7b1782435ae5}, !- Target Object
@@ -10763,7 +10828,6 @@ OS:Connection,
 
 OS:Connection,
   {c6428b87-a79d-48f2-a896-7d65acf2f09c}, !- Handle
-  {4b011911-43e3-4d9e-b41c-6a80202d5aee}, !- Name
   {aee1d837-9a64-48fd-8e4b-7b1782435ae5}, !- Source Object
   3,                                      !- Outlet Port
   {8caf3cf2-ab3a-4fba-b51a-31c4757f1de5}, !- Target Object
@@ -10777,7 +10841,6 @@ OS:Node,
 
 OS:Connection,
   {6d6e4254-fa1f-41e3-a244-c832fa2fd082}, !- Handle
-  {f95c86b2-bc04-484b-b355-adbae5b33479}, !- Name
   {1130642a-2290-46db-ab2b-9ffa020b209e}, !- Source Object
   3,                                      !- Outlet Port
   {6b32e647-a175-4377-aa2e-a2c1817910b1}, !- Target Object
@@ -10785,7 +10848,6 @@ OS:Connection,
 
 OS:Connection,
   {6f1a891c-42a7-4e63-bd8f-6d391f834125}, !- Handle
-  {e92bcfe6-e9eb-4b86-96b1-7f77e5610349}, !- Name
   {6b32e647-a175-4377-aa2e-a2c1817910b1}, !- Source Object
   3,                                      !- Outlet Port
   {9462dc57-3f8e-42d0-a13d-e15201d43240}, !- Target Object
@@ -10793,7 +10855,6 @@ OS:Connection,
 
 OS:Connection,
   {e069da0c-12e8-4d3b-992f-57b85332c639}, !- Handle
-  {fdf6359f-9a9d-4d56-8a90-bf9613369f69}, !- Name
   {9462dc57-3f8e-42d0-a13d-e15201d43240}, !- Source Object
   3,                                      !- Outlet Port
   {3989f983-000a-48db-a592-f365eaae1992}, !- Target Object
@@ -10807,7 +10868,6 @@ OS:Node,
 
 OS:Connection,
   {3fb2a1b0-0456-4922-8b4f-5b484df050d8}, !- Handle
-  {92aa7a2f-d435-45fd-8c25-e9bf2d20d2f5}, !- Name
   {8caf3cf2-ab3a-4fba-b51a-31c4757f1de5}, !- Source Object
   2,                                      !- Outlet Port
   {fe9bed6b-7aca-46b2-b5d6-bb29f5d95e64}, !- Target Object
@@ -10815,7 +10875,6 @@ OS:Connection,
 
 OS:Connection,
   {aefac168-cd5e-4ceb-ae3a-3c25d6b55182}, !- Handle
-  {5796aaa1-683f-4c89-aa29-b8b21985e29f}, !- Name
   {fe9bed6b-7aca-46b2-b5d6-bb29f5d95e64}, !- Source Object
   3,                                      !- Outlet Port
   {f0375d18-3014-4858-b3bd-e547d0ca34da}, !- Target Object
@@ -10823,7 +10882,6 @@ OS:Connection,
 
 OS:Connection,
   {1b8117b2-26d4-4382-a777-a275516fa4cb}, !- Handle
-  {06e54f22-561c-4bb0-b845-fed5ad58784c}, !- Name
   {f0375d18-3014-4858-b3bd-e547d0ca34da}, !- Source Object
   3,                                      !- Outlet Port
   {90da0ec6-bb01-4d14-9cc5-5f64913a25b2}, !- Target Object
@@ -10927,7 +10985,6 @@ OS:SubSurface,
   {b6a6eec5-bf8e-42c2-a43b-ba56d5edd776}, !- Surface Name
   ,                                       !- Outside Boundary Condition Object
   ,                                       !- View Factor to Ground
-  ,                                       !- Shading Control Name
   ,                                       !- Frame and Divider Name
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
@@ -10948,10 +11005,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  110.660140930164, 69.2970067567256, 14.9627505869168, !- X,Y,Z Vertex 1 {m}
-  110.660140948892, 75.0823539429401, 12.534899344047, !- X,Y,Z Vertex 2 {m}
-  101.1174, 75.0823539813864, 12.5348995256462, !- X,Y,Z Vertex 3 {m}
-  101.1174, 69.29700682728, 14.9627507550415; !- X,Y,Z Vertex 4 {m}
+  101.1174, 69.29700682728, 14.9627507550415, !- X,Y,Z Vertex 1 {m}
+  110.660140930164, 69.2970067567256, 14.9627505869168, !- X,Y,Z Vertex 2 {m}
+  110.660140948892, 75.0823539429401, 12.534899344047, !- X,Y,Z Vertex 3 {m}
+  101.1174, 75.0823539813864, 12.5348995256462; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {e101b773-2680-4dbc-9079-859de88b5a35}, !- Handle
@@ -10965,10 +11022,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -6.06121015632376, 2.88764567812905e-015, 7.62, !- X,Y,Z Vertex 1 {m}
-  -6.06121015632376, 2.58769849120562, 7.62, !- X,Y,Z Vertex 2 {m}
-  -11.1775397579712, 2.58769849120541, 7.62, !- X,Y,Z Vertex 3 {m}
-  -11.1775397131258, 0, 7.62;             !- X,Y,Z Vertex 4 {m}
+  -11.1775397131258, 0, 7.62,             !- X,Y,Z Vertex 1 {m}
+  -6.06121015632376, 2.88764567812905e-15, 7.62, !- X,Y,Z Vertex 2 {m}
+  -6.06121015632376, 2.58769849120562, 7.62, !- X,Y,Z Vertex 3 {m}
+  -11.1775397579712, 2.58769849120541, 7.62; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {ed09fb85-2076-4794-b81e-ff5f6bcc567c}, !- Handle
@@ -10982,10 +11039,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -4.27259484842467e-006, 2.52614063564351e-006, 3.45439551264764, !- X,Y,Z Vertex 1 {m}
-  -4.27258506435919e-006, 8.65353649307146, 3.4543891844656, !- X,Y,Z Vertex 2 {m}
+  -4.27259484842467e-06, 2.52614063564351e-06, 3.45439551264764, !- X,Y,Z Vertex 1 {m}
+  -4.27258506435919e-06, 8.65353649307146, 3.4543891844656, !- X,Y,Z Vertex 2 {m}
   -5.11634444943076, 8.65353649307378, 3.45437969219253, !- X,Y,Z Vertex 3 {m}
-  -5.11634444942097, 2.5261336937433e-006, 3.45438602037458; !- X,Y,Z Vertex 4 {m}
+  -5.11634444942097, 2.5261336937433e-06, 3.45438602037458; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {fcd8bc72-58d1-45e4-84aa-2660a06c8069}, !- Handle
@@ -10999,10 +11056,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -1.2759159959046e-006, 7.54376593272352e-007, 3.14959909919917, !- X,Y,Z Vertex 1 {m}
-  -1.27591459178689e-006, 8.65353523347141, 3.14959573113968, !- X,Y,Z Vertex 2 {m}
+  -1.2759159959046e-06, 7.54376593272349e-07, 3.14959909919917, !- X,Y,Z Vertex 1 {m}
+  -1.27591459178689e-06, 8.65353523347141, 3.14959573113968, !- X,Y,Z Vertex 2 {m}
   -5.11634355974824, 8.65353523347196, 3.1495933994062, !- X,Y,Z Vertex 3 {m}
-  -5.11634355974788, 7.54375855478886e-007, 3.14959676746568; !- X,Y,Z Vertex 4 {m}
+  -5.11634355974788, 7.54375855478889e-07, 3.14959676746568; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {13f9780e-37ad-4247-9f2a-5c5259f8fd23}, !- Handle
@@ -11016,28 +11073,28 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  53.7971863276983, -7.66853532906571e-014, 7.39190020621299e-007, !- X,Y,Z Vertex 1 {m}
-  53.7971863276983, 4.49103750000693, 7.0883054789806e-007, !- X,Y,Z Vertex 2 {m}
-  75.0823542013365, 4.49103750000693, 5.71836508559117e-007, !- X,Y,Z Vertex 3 {m}
-  75.0823541776712, 27.9692099999999, 4.13123753005444e-007, !- X,Y,Z Vertex 4 {m}
-  74.8537541776738, 27.9692099999999, 4.14595051591316e-007, !- X,Y,Z Vertex 5 {m}
-  74.8537541977863, 107.490066341603, -1.22966986046772e-007, !- X,Y,Z Vertex 6 {m}
-  69.8547488342558, 107.490066336269, -9.07927536300877e-008, !- X,Y,Z Vertex 7 {m}
-  69.8547488342558, 129.08661, -2.36785673589953e-007, !- X,Y,Z Vertex 8 {m}
-  61.7219863212786, 129.08661, -1.8444218284319e-007, !- X,Y,Z Vertex 9 {m}
-  61.7219863276882, 135.614156, -2.28568479923017e-007, !- X,Y,Z Vertex 10 {m}
-  13.3603863276882, 135.614156, 8.26929098027199e-008, !- X,Y,Z Vertex 11 {m}
-  13.3603863276882, 129.08661, 1.26819206841294e-007, !- X,Y,Z Vertex 12 {m}
-  2.80079865738365e-008, 129.08661, 2.12808347128447e-007, !- X,Y,Z Vertex 13 {m}
-  1.92075710752756e-013, 101.12121, 4.0185482008769e-007, !- X,Y,Z Vertex 14 {m}
-  0.228600000000186, 101.12121, 4.00383521501802e-007, !- X,Y,Z Vertex 15 {m}
-  0.228600000000081, 27.9692100000001, 8.94892006155269e-007, !- X,Y,Z Vertex 16 {m}
-  -4.27259345730593e-007, 27.9692100000001, 8.96363307491053e-007, !- X,Y,Z Vertex 17 {m}
-  -2.99081594619519e-006, 18.3120605280399, 9.61645781769451e-007, !- X,Y,Z Vertex 18 {m}
-  5.1163401768466, 18.3120590054224, 9.28716358696215e-007, !- X,Y,Z Vertex 19 {m}
-  5.11633760156569, 9.65852604894396, 9.87214372170751e-007, !- X,Y,Z Vertex 20 {m}
-  -6.19965830437207e-006, 9.6585275715621, 1.02014379932166e-006, !- X,Y,Z Vertex 21 {m}
-  -6.36492509614226e-007, -3.7664037998376e-013, 1.08543553726693e-006; !- X,Y,Z Vertex 22 {m}
+  -6.36492509614226e-07, -3.7664037998376e-13, 1.08543553726693e-06, !- X,Y,Z Vertex 1 {m}
+  53.7971863276983, -7.66853532906571e-14, 7.39190020621297e-07, !- X,Y,Z Vertex 2 {m}
+  53.7971863276983, 4.49103750000693, 7.08830547898058e-07, !- X,Y,Z Vertex 3 {m}
+  75.0823542013365, 4.49103750000693, 5.71836508559115e-07, !- X,Y,Z Vertex 4 {m}
+  75.0823541776712, 27.9692099999999, 4.13123753005443e-07, !- X,Y,Z Vertex 5 {m}
+  74.8537541776738, 27.9692099999999, 4.14595051591315e-07, !- X,Y,Z Vertex 6 {m}
+  74.8537541977863, 107.490066341603, -1.22966986046772e-07, !- X,Y,Z Vertex 7 {m}
+  69.8547488342558, 107.490066336269, -9.0792753630087e-08, !- X,Y,Z Vertex 8 {m}
+  69.8547488342558, 129.08661, -2.36785673589952e-07, !- X,Y,Z Vertex 9 {m}
+  61.7219863212786, 129.08661, -1.84442182843189e-07, !- X,Y,Z Vertex 10 {m}
+  61.7219863276882, 135.614156, -2.28568479923016e-07, !- X,Y,Z Vertex 11 {m}
+  13.3603863276882, 135.614156, 8.26929098027207e-08, !- X,Y,Z Vertex 12 {m}
+  13.3603863276882, 129.08661, 1.26819206841295e-07, !- X,Y,Z Vertex 13 {m}
+  2.80079865738365e-08, 129.08661, 2.12808347128448e-07, !- X,Y,Z Vertex 14 {m}
+  1.92075710752756e-13, 101.12121, 4.0185482008769e-07, !- X,Y,Z Vertex 15 {m}
+  0.228600000000186, 101.12121, 4.00383521501802e-07, !- X,Y,Z Vertex 16 {m}
+  0.228600000000081, 27.9692100000001, 8.94892006155267e-07, !- X,Y,Z Vertex 17 {m}
+  -4.27259345730593e-07, 27.9692100000001, 8.96363307491051e-07, !- X,Y,Z Vertex 18 {m}
+  -2.99081594619519e-06, 18.3120605280399, 9.61645781769449e-07, !- X,Y,Z Vertex 19 {m}
+  5.1163401768466, 18.3120590054224, 9.28716358696213e-07, !- X,Y,Z Vertex 20 {m}
+  5.11633760156569, 9.65852604894396, 9.87214372170749e-07, !- X,Y,Z Vertex 21 {m}
+  -6.19965830437207e-06, 9.6585275715621, 1.02014379932166e-06; !- X,Y,Z Vertex 22 {m}
 
 OS:Surface,
   {2a67ad86-56a8-4ae8-8e72-b55c3e1c49e0}, !- Handle
@@ -11058,17 +11115,17 @@ OS:Surface,
   74.8537541923947, 110.265209996664, -3.14960024444604, !- X,Y,Z Vertex 5 {m}
   74.8537541776738, 27.9692099999999, -3.14959939227809, !- X,Y,Z Vertex 6 {m}
   75.0823541776712, 27.9692099999999, -3.14959939430456, !- X,Y,Z Vertex 7 {m}
-  75.0823542058633, -1.0817643709147e-013, -3.14959910468582, !- X,Y,Z Vertex 8 {m}
-  1.06082087345904e-006, 5.86290652699728e-013, -3.14959843910211, !- X,Y,Z Vertex 9 {m}
-  -4.50234490312583e-006, 9.65852757156146, -3.14959853911528, !- X,Y,Z Vertex 10 {m}
+  75.0823542058633, -1.08176437069044e-13, -3.14959910468582, !- X,Y,Z Vertex 8 {m}
+  1.06082087345904e-06, 5.8629065269599e-13, -3.14959843910211, !- X,Y,Z Vertex 9 {m}
+  -4.50234490312583e-06, 9.65852757156146, -3.14959853911528, !- X,Y,Z Vertex 10 {m}
   5.11634015339792, 9.65852604894434, -3.1495985844702, !- X,Y,Z Vertex 11 {m}
   5.11634272867884, 18.3120590054222, -3.14959867407681, !- X,Y,Z Vertex 12 {m}
-  -2.13629708581677e-006, 18.3120605280401, -3.14959862872188, !- X,Y,Z Vertex 13 {m}
-  4.27259523161485e-007, 27.9692099999999, -3.14959872872085, !- X,Y,Z Vertex 14 {m}
+  -2.13629708581677e-06, 18.3120605280401, -3.14959862872188, !- X,Y,Z Vertex 13 {m}
+  4.27259523161485e-07, 27.9692099999999, -3.14959872872085, !- X,Y,Z Vertex 14 {m}
   0.228600000000084, 27.96921, -3.14959873074732, !- X,Y,Z Vertex 15 {m}
   0.228600000000188, 101.12121, -3.14959948822994, !- X,Y,Z Vertex 16 {m}
-  1.92889221592189e-013, 101.12121, -3.14959948620347, !- X,Y,Z Vertex 17 {m}
-  2.80079870688342e-008, 129.08661, -3.14959977578276, !- X,Y,Z Vertex 18 {m}
+  1.92889221608188e-13, 101.12121, -3.14959948620347, !- X,Y,Z Vertex 17 {m}
+  2.80079870688342e-08, 129.08661, -3.14959977578276, !- X,Y,Z Vertex 18 {m}
   13.3603863276882, 129.08661, -3.14959989421879, !- X,Y,Z Vertex 19 {m}
   13.3603863276882, 135.614156, -3.14959996181096; !- X,Y,Z Vertex 20 {m}
 
@@ -11084,10 +11141,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -6.36492509481219e-007, -3.76639441745761e-013, 1.0855743183428e-006, !- X,Y,Z Vertex 1 {m}
-  -6.19965830450341e-006, 9.6585275715621, 1.02026274562874e-006, !- X,Y,Z Vertex 2 {m}
-  -4.50234490299372e-006, 9.65852757156146, -3.14959853911528, !- X,Y,Z Vertex 3 {m}
-  1.06082087332693e-006, 5.86290652627371e-013, -3.14959843910211; !- X,Y,Z Vertex 4 {m}
+  -6.19965830450341e-06, 9.6585275715621, 1.02026274562874e-06, !- X,Y,Z Vertex 1 {m}
+  -4.50234490299372e-06, 9.65852757156146, -3.14959853911528, !- X,Y,Z Vertex 2 {m}
+  1.06082087332693e-06, 5.8629065262737e-13, -3.14959843910211, !- X,Y,Z Vertex 3 {m}
+  -6.36492509481216e-07, -3.76639441745759e-13, 1.0855743183428e-06; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {b0a6c195-b9e9-4d4b-bb78-a8733f23ccdb}, !- Handle
@@ -11101,10 +11158,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -1.35962602093636e-005, 9.65852757155936, 4.3163604563149e-006, !- X,Y,Z Vertex 1 {m}
-  -7.36844940952205e-006, 9.65852757155782, -3.45440000000096, !- X,Y,Z Vertex 2 {m}
-  6.151758521401e-006, 7.34443523971514e-012, -3.45439999999165, !- X,Y,Z Vertex 3 {m}
-  -7.60425077461087e-008, 5.22173153608005e-013, -1.10317326712187e-006; !- X,Y,Z Vertex 4 {m}
+  -1.35962602093636e-05, 9.65852757155936, 4.3163604563149e-06, !- X,Y,Z Vertex 1 {m}
+  -7.36844940952205e-06, 9.65852757155782, -3.45440000000096, !- X,Y,Z Vertex 2 {m}
+  6.151758521401e-06, 7.34443523971514e-12, -3.45439999999165, !- X,Y,Z Vertex 3 {m}
+  -7.60425077461061e-08, 5.22173153608009e-13, -1.10317326712187e-06; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {5af39922-898b-4466-8d71-008acc4aa0b6}, !- Handle
@@ -11118,12 +11175,12 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  7.04749961006203, 5.94670150880538, 3.32080754720976e-006, !- X,Y,Z Vertex 1 {m}
-  7.04749961007586, 8.53439999999926, 4.3146717831823e-006, !- X,Y,Z Vertex 2 {m}
-  8.62229961006613, 8.53440000000677, 3.94118393564223e-006, !- X,Y,Z Vertex 3 {m}
-  8.62229961007077, 9.65852757156783, 4.3729305992694e-006, !- X,Y,Z Vertex 4 {m}
-  5.11632864083428, 9.65852656110877, 5.2044247189625e-006, !- X,Y,Z Vertex 5 {m}
-  5.11632945374406, 5.94670150879974, 3.77881401464909e-006; !- X,Y,Z Vertex 6 {m}
+  5.11632945374406, 5.94670150879974, 3.77881401464909e-06, !- X,Y,Z Vertex 1 {m}
+  7.04749961006203, 5.94670150880538, 3.32080754720976e-06, !- X,Y,Z Vertex 2 {m}
+  7.04749961007586, 8.53439999999926, 4.3146717831823e-06, !- X,Y,Z Vertex 3 {m}
+  8.62229961006613, 8.53440000000677, 3.94118393564222e-06, !- X,Y,Z Vertex 4 {m}
+  8.62229961007077, 9.65852757156783, 4.3729305992694e-06, !- X,Y,Z Vertex 5 {m}
+  5.11632864083428, 9.65852656110877, 5.2044247189625e-06; !- X,Y,Z Vertex 6 {m}
 
 OS:Surface,
   {2a84fd74-0f50-4a75-8c18-e74a8245fc48}, !- Handle
@@ -11137,12 +11194,12 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.1775396100682, 3.37435210697411e-013, 1.65889012971977e-006, !- X,Y,Z Vertex 1 {m}
-  11.1775396100672, 5.94670150879841, 4.90498113120196e-006, !- X,Y,Z Vertex 2 {m}
-  5.11632945374414, 5.94670150879992, 3.45427719845153e-006, !- X,Y,Z Vertex 3 {m}
-  5.11632864083421, 9.65852656110862, 5.4804291293224e-006, !- X,Y,Z Vertex 4 {m}
-  -1.35962601948863e-005, 9.65852757155939, 4.25587260182159e-006, !- X,Y,Z Vertex 5 {m}
-  -7.60425285223216e-008, 4.74789185679833e-013, -1.01636784070511e-006; !- X,Y,Z Vertex 6 {m}
+  -7.60425285223216e-08, 4.74789185679833e-13, -1.01636784070511e-06, !- X,Y,Z Vertex 1 {m}
+  11.1775396100682, 3.37435210697408e-13, 1.65889012971977e-06, !- X,Y,Z Vertex 2 {m}
+  11.1775396100672, 5.94670150879841, 4.90498113120196e-06, !- X,Y,Z Vertex 3 {m}
+  5.11632945374414, 5.94670150879992, 3.45427719845154e-06, !- X,Y,Z Vertex 4 {m}
+  5.11632864083421, 9.65852656110862, 5.4804291293224e-06, !- X,Y,Z Vertex 5 {m}
+  -1.35962601948863e-05, 9.65852757155939, 4.25587260182159e-06; !- X,Y,Z Vertex 6 {m}
 
 OS:Surface,
   {a38346f3-b0d1-4a0a-96c9-8e1da8bde5f7}, !- Handle
@@ -11156,10 +11213,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  75.0823542058633, -1.0661624743896e-013, -8.74556151701163e-008, !- X,Y,Z Vertex 1 {m}
-  75.0823541388985, 8.53440000000614, 5.24649331788933e-007, !- X,Y,Z Vertex 2 {m}
-  60.0868613276954, 8.53440000000615, 6.99560561529327e-007, !- X,Y,Z Vertex 3 {m}
-  60.0868613276954, -1.01328542441902e-013, 8.74556153513727e-008; !- X,Y,Z Vertex 4 {m}
+  75.0823542058633, -1.0661624743896e-13, -8.74556151701158e-08, !- X,Y,Z Vertex 1 {m}
+  75.0823541388985, 8.53440000000614, 5.24649331788933e-07, !- X,Y,Z Vertex 2 {m}
+  60.0868613276954, 8.53440000000615, 6.99560561529327e-07, !- X,Y,Z Vertex 3 {m}
+  60.0868613276954, -1.01328542441902e-13, 8.74556153513723e-08; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {8cf55f73-8ee0-42fe-aac8-8c347cc77a29}, !- Handle
@@ -11173,12 +11230,12 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  11.1775396100672, 5.9467015087983, 4.66124333036227e-006, !- X,Y,Z Vertex 1 {m}
-  11.1775396100676, 11.1283015088012, 2.7910578336655e-006, !- X,Y,Z Vertex 2 {m}
-  8.62229961006774, 11.1283015088007, 2.56205757759387e-006, !- X,Y,Z Vertex 3 {m}
-  8.62229961006617, 8.53440000000661, 3.49826974788937e-006, !- X,Y,Z Vertex 4 {m}
-  7.04749961007595, 8.53439999999892, 3.35713638928015e-006, !- X,Y,Z Vertex 5 {m}
-  7.04749961006194, 5.94670150880573, 4.29110971567441e-006; !- X,Y,Z Vertex 6 {m}
+  11.1775396100672, 5.9467015087983, 4.66124333036227e-06, !- X,Y,Z Vertex 1 {m}
+  11.1775396100676, 11.1283015088012, 2.79105783366551e-06, !- X,Y,Z Vertex 2 {m}
+  8.62229961006774, 11.1283015088007, 2.56205757759386e-06, !- X,Y,Z Vertex 3 {m}
+  8.62229961006617, 8.53440000000661, 3.49826974788937e-06, !- X,Y,Z Vertex 4 {m}
+  7.04749961007595, 8.53439999999892, 3.35713638928016e-06, !- X,Y,Z Vertex 5 {m}
+  7.04749961006194, 5.94670150880573, 4.29110971567441e-06; !- X,Y,Z Vertex 6 {m}
 
 OS:Surface,
   {b445d3cd-0809-49f0-bbce-01bf904f011d}, !- Handle
@@ -11192,10 +11249,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -1.30314125238569e-005, 18.3120605280394, 2.1090147939465e-006, !- X,Y,Z Vertex 1 {m}
-  -4.48622384765779e-006, 27.969210000004, 2.05603000912826e-006, !- X,Y,Z Vertex 2 {m}
-  4.48622405056781e-006, 27.9692100000006, -3.45439999999168, !- X,Y,Z Vertex 3 {m}
-  -4.05896448796132e-006, 18.3120605280406, -3.45440000000842; !- X,Y,Z Vertex 4 {m}
+  -4.48622384765779e-06, 27.969210000004, 2.05603000912826e-06, !- X,Y,Z Vertex 1 {m}
+  4.48622405056781e-06, 27.9692100000006, -3.45439999999168, !- X,Y,Z Vertex 2 {m}
+  -4.05896448796131e-06, 18.3120605280406, -3.45440000000842, !- X,Y,Z Vertex 3 {m}
+  -1.30314125238569e-05, 18.3120605280394, 2.1090147939465e-06; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {0a5a252f-657d-4e82-b261-7c274966a31c}, !- Handle
@@ -11209,10 +11266,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  8.62229961007079, 9.65852757156791, 4.48684143534332e-006, !- X,Y,Z Vertex 1 {m}
-  8.62229961006405, 13.5636000000031, 1.63141995749832e-006, !- X,Y,Z Vertex 2 {m}
-  5.11632945374811, 13.5636000000109, 2.23509155568515e-006, !- X,Y,Z Vertex 3 {m}
-  5.11632864083426, 9.65852656110869, 5.09051391236386e-006; !- X,Y,Z Vertex 4 {m}
+  5.11632864083426, 9.65852656110869, 5.09051391236387e-06, !- X,Y,Z Vertex 1 {m}
+  8.62229961007079, 9.65852757156791, 4.48684143534331e-06, !- X,Y,Z Vertex 2 {m}
+  8.62229961006405, 13.5636000000031, 1.63141995749832e-06, !- X,Y,Z Vertex 3 {m}
+  5.11632945374811, 13.5636000000109, 2.23509155568514e-06; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {7b9ea12f-ee2c-4540-a7fa-bcb808c2333f}, !- Handle
@@ -11226,10 +11283,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  60.0868613276954, 4.49103750000701, -3.45439852137212, !- X,Y,Z Vertex 1 {m}
-  75.0823542013365, 4.49103750000689, -3.45439810314692, !- X,Y,Z Vertex 2 {m}
-  75.0823542058633, -4.86205489630819e-014, -3.45439937266219, !- X,Y,Z Vertex 3 {m}
-  60.0868613276954, -1.48956408840495e-013, -3.4543997908874; !- X,Y,Z Vertex 4 {m}
+  75.0823542013365, 4.49103750000689, -3.45439810314692, !- X,Y,Z Vertex 1 {m}
+  75.0823542058633, -4.86205471264687e-14, -3.45439937266219, !- X,Y,Z Vertex 2 {m}
+  60.0868613276954, -1.48956411289311e-13, -3.4543997908874, !- X,Y,Z Vertex 3 {m}
+  60.0868613276954, 4.49103750000701, -3.45439852137212; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {fc249476-aa89-4ed0-bb2a-51f3b2f41c86}, !- Handle
@@ -11243,10 +11300,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -5.86525662476296e-008, -6.14896369724897e-016, 7.06199437548422, !- X,Y,Z Vertex 1 {m}
-  -5.11633614684951, 6.39018772598299e-015, 4.91490031589021, !- X,Y,Z Vertex 2 {m}
+  -5.86525651302212e-08, -6.14896249110084e-16, 7.06199437548422, !- X,Y,Z Vertex 1 {m}
+  -5.11633614684951, 6.39018760536818e-15, 4.91490031589021, !- X,Y,Z Vertex 2 {m}
   -5.11633588354459, -7.18375901923991, 4.91490010097616, !- X,Y,Z Vertex 3 {m}
-  5.06835039221816e-008, -7.18375901923986, 7.06199409595642; !- X,Y,Z Vertex 4 {m}
+  5.06835033634774e-08, -7.18375901923986, 7.06199409595642; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {51b2e21f-6643-4cda-9b09-c8afa2c3b3ec}, !- Handle
@@ -11260,9 +11317,9 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -5.11633615254608, 5.77529141146806e-015, 4.91490032946463, !- X,Y,Z Vertex 1 {m}
-  -5.11633321819841, -5.77529141146806e-015, -8.37417255277493e-014, !- X,Y,Z Vertex 2 {m}
-  -5.1163329435005, -7.18375901923985, 8.22979026886847e-014, !- X,Y,Z Vertex 3 {m}
+  -5.11633615254608, 5.77529146667803e-15, 4.91490032946463, !- X,Y,Z Vertex 1 {m}
+  -5.11633321819841, -5.77529146667803e-15, -8.37417263897562e-14, !- X,Y,Z Vertex 2 {m}
+  -5.1163329435005, -7.18375901923985, 8.22979035506916e-14, !- X,Y,Z Vertex 3 {m}
   -5.11633587784802, -7.18375901923991, 4.91490008740174; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
@@ -11277,10 +11334,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  101.117400000004, 2.93870247097353e-006, 12.5349019894117, !- X,Y,Z Vertex 1 {m}
-  101.117399999999, -8.61397499360345e-007, 2.61559989478031e-013, !- X,Y,Z Vertex 2 {m}
-  110.774549471961, -1.28109040018722e-005, -2.61284106899374e-013, !- X,Y,Z Vertex 3 {m}
-  110.774549471956, -9.0108054912936e-006, 12.5348971742631; !- X,Y,Z Vertex 4 {m}
+  101.117400000004, 2.93870247097355e-06, 12.5349019894117, !- X,Y,Z Vertex 1 {m}
+  101.117399999999, -8.61397499360323e-07, 2.61559989478024e-13, !- X,Y,Z Vertex 2 {m}
+  110.774549471961, -1.28109040018722e-05, -2.61284106899374e-13, !- X,Y,Z Vertex 3 {m}
+  110.774549471956, -9.0108054912936e-06, 12.5348971742631; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {44e451cf-367e-428b-a432-7d5215b99ee4}, !- Handle
@@ -11294,10 +11351,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  3.38986250550928e-007, 37.5411848512915, 28.2892501313594, !- X,Y,Z Vertex 1 {m}
-  -6.52754599999974, 37.5411853086858, 28.2892498781722, !- X,Y,Z Vertex 2 {m}
-  -6.52754599999976, 13.3603865729976, 18.1416542660795, !- X,Y,Z Vertex 3 {m}
-  -3.21682300010595e-015, 13.3603864321697, 18.1416546521153; !- X,Y,Z Vertex 4 {m}
+  -6.52754599999974, 37.5411853086858, 28.2892498781722, !- X,Y,Z Vertex 1 {m}
+  -6.52754599999976, 13.3603865729976, 18.1416542660795, !- X,Y,Z Vertex 2 {m}
+  -3.21682427114733e-15, 13.3603864321697, 18.1416546521153, !- X,Y,Z Vertex 3 {m}
+  3.38986250550929e-07, 37.5411848512915, 28.2892501313594; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {bc7abcfd-f194-4d38-a4a1-50f89bfd7c58}, !- Handle
@@ -11311,10 +11368,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  101.1174, 8.62229953474035, 16.1532930056059, !- X,Y,Z Vertex 1 {m}
-  27.9654, 8.62229981262081, 16.1532923434419, !- X,Y,Z Vertex 2 {m}
-  27.9654, 2.8144539748575, 13.7160000616083, !- X,Y,Z Vertex 3 {m}
-  101.1174, 2.81445215667057, 13.7160000773748; !- X,Y,Z Vertex 4 {m}
+  27.9654, 8.62229981262081, 16.1532923434419, !- X,Y,Z Vertex 1 {m}
+  27.9654, 2.8144539748575, 13.7160000616083, !- X,Y,Z Vertex 2 {m}
+  101.1174, 2.81445215667057, 13.7160000773748, !- X,Y,Z Vertex 3 {m}
+  101.1174, 8.62229953474035, 16.1532930056059; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {300093b7-de41-46f7-80c9-2fb65423b4f0}, !- Handle
@@ -11329,8 +11386,8 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   117.9583084912, 8.62229934942076, 16.1532935942122, !- X,Y,Z Vertex 1 {m}
-  117.958308491199, -3.09791214052461e-006, 12.5348997963286, !- X,Y,Z Vertex 2 {m}
-  120.552209999994, 4.24696403591757e-008, 12.5349010896195, !- X,Y,Z Vertex 3 {m}
+  117.958308491199, -3.0979121394072e-06, 12.5348997963286, !- X,Y,Z Vertex 2 {m}
+  120.552209999994, 4.2469639241766e-08, 12.5349010896195, !- X,Y,Z Vertex 3 {m}
   120.552209999994, 8.62229934829231, 16.1532935691521; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
@@ -11345,10 +11402,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  120.552209999994, 37.5411785944252, 28.2892495980775, !- X,Y,Z Vertex 1 {m}
-  120.552209999994, 69.297006504026, 14.9627498519225, !- X,Y,Z Vertex 2 {m}
-  1.4507630389278e-013, 69.2970074840136, 14.9627523199778, !- X,Y,Z Vertex 3 {m}
-  3.38986240864794e-007, 37.5411847178278, 28.2892499076718; !- X,Y,Z Vertex 4 {m}
+  3.38986240864794e-07, 37.5411847178278, 28.2892499076718, !- X,Y,Z Vertex 1 {m}
+  120.552209999994, 37.5411785944252, 28.2892495980775, !- X,Y,Z Vertex 2 {m}
+  120.552209999994, 69.297006504026, 14.9627498519225, !- X,Y,Z Vertex 3 {m}
+  1.45076304147166e-13, 69.2970074840136, 14.9627523199778; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {ba9b8ca1-9215-42f2-aad2-2b021e3b3d4c}, !- Handle
@@ -11362,10 +11419,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  115.523009999993, 8.62229951922025, 16.1532930148397, !- X,Y,Z Vertex 1 {m}
-  115.523009999993, 8.62229968253845, 7.62, !- X,Y,Z Vertex 2 {m}
-  117.9583084912, 8.62229953759712, 7.62, !- X,Y,Z Vertex 3 {m}
-  117.9583084912, 8.62229937427892, 16.1532935349775; !- X,Y,Z Vertex 4 {m}
+  117.9583084912, 8.62229937427892, 16.1532935349775, !- X,Y,Z Vertex 1 {m}
+  115.523009999993, 8.62229951922025, 16.1532930148397, !- X,Y,Z Vertex 2 {m}
+  115.523009999993, 8.62229968253845, 7.62, !- X,Y,Z Vertex 3 {m}
+  117.9583084912, 8.62229953759712, 7.62; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {40b8d1a1-c1f5-4140-9f4c-79ce8fc1aaff}, !- Handle
@@ -11379,10 +11436,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  18.8214, 69.2970072903639, 14.9627518585274, !- X,Y,Z Vertex 1 {m}
-  101.1174, 69.2970068211595, 14.9627507404568, !- X,Y,Z Vertex 2 {m}
-  101.1174, 72.2678993753734, 13.7160002942985, !- X,Y,Z Vertex 3 {m}
-  18.8214, 72.2679025645194, 13.7160002709316; !- X,Y,Z Vertex 4 {m}
+  101.1174, 69.2970068211595, 14.9627507404568, !- X,Y,Z Vertex 1 {m}
+  101.1174, 72.2678993753734, 13.7160002942985, !- X,Y,Z Vertex 2 {m}
+  18.8214, 72.2679025645194, 13.7160002709316, !- X,Y,Z Vertex 3 {m}
+  18.8214, 69.2970072903639, 14.9627518585274; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {ef54f233-31d5-4f00-ac66-e9b6ce55a983}, !- Handle
@@ -11396,10 +11453,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  120.552209999994, 6.73278151616027e-008, 12.5349010303847, !- X,Y,Z Vertex 1 {m}
-  117.958308491199, -3.12277030527032e-006, 12.5348998555633, !- X,Y,Z Vertex 2 {m}
-  117.9583084912, -3.33098354233671e-006, 7.61999999999999, !- X,Y,Z Vertex 3 {m}
-  120.552209999994, -1.40885471675804e-007, 7.62; !- X,Y,Z Vertex 4 {m}
+  117.958308491199, -3.12277030527032e-06, 12.5348998555633, !- X,Y,Z Vertex 1 {m}
+  117.9583084912, -3.33098354233671e-06, 7.61999999999999, !- X,Y,Z Vertex 2 {m}
+  120.552209999994, -1.40885471675804e-07, 7.62, !- X,Y,Z Vertex 3 {m}
+  120.552209999994, 6.73278151616027e-08, 12.5349010303847; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {73f5ade8-de16-45d5-a763-0ac8e053d28a}, !- Handle
@@ -11413,10 +11470,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  1.38935005906724e-013, 69.2970073792435, 14.9627520703203, !- X,Y,Z Vertex 1 {m}
-  18.8214, 69.2970072753457, 14.9627518227405, !- X,Y,Z Vertex 2 {m}
-  18.8214, 75.0823545648337, 12.5349010166643, !- X,Y,Z Vertex 3 {m}
-  -3.28013438917635e-016, 75.0823545995047, 12.5349012932954; !- X,Y,Z Vertex 4 {m}
+  18.8214, 69.2970072753457, 14.9627518227405, !- X,Y,Z Vertex 1 {m}
+  18.8214, 75.0823545648337, 12.5349010166643, !- X,Y,Z Vertex 2 {m}
+  -3.28013191755342e-16, 75.0823545995047, 12.5349012932954, !- X,Y,Z Vertex 3 {m}
+  1.38935005659562e-13, 69.2970073792435, 14.9627520703203; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {8602c5f3-4997-4141-b1b2-634aaaf02c46}, !- Handle
@@ -11430,10 +11487,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  27.9654, 8.62229982719988, 16.1532923087013, !- X,Y,Z Vertex 1 {m}
-  -3.30755765374464e-016, 8.62229991168174, 16.1532921073891, !- X,Y,Z Vertex 2 {m}
-  3.30755776646104e-016, 8.93249485782333e-008, 12.5348997871468, !- X,Y,Z Vertex 3 {m}
-  27.9654, 5.10666192075973e-008, 12.5349000078569; !- X,Y,Z Vertex 4 {m}
+  -3.30755844275943e-16, 8.62229991168173, 16.1532921073891, !- X,Y,Z Vertex 1 {m}
+  3.30755855547583e-16, 8.93249524891668e-08, 12.5348997871468, !- X,Y,Z Vertex 2 {m}
+  27.9654, 5.10666152966638e-08, 12.5349000078569, !- X,Y,Z Vertex 3 {m}
+  27.9654, 8.62229982719988, 16.1532923087013; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {1b42814b-c95f-4f9b-9305-6e865fe4a06e}, !- Handle
@@ -11447,8 +11504,8 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  3.38986247577454e-007, 37.5411848132044, 28.2892501349455, !- X,Y,Z Vertex 1 {m}
-  2.28578161936147e-014, 61.7219864602187, 18.1416498470508, !- X,Y,Z Vertex 2 {m}
+  3.38986247577454e-07, 37.5411848132044, 28.2892501349455, !- X,Y,Z Vertex 1 {m}
+  2.28578161638821e-14, 61.7219864602187, 18.1416498470508, !- X,Y,Z Vertex 2 {m}
   -6.52754599999974, 61.7219864232282, 18.1416498261295, !- X,Y,Z Vertex 3 {m}
   -6.52754599999974, 37.5411853467729, 28.2892498745861; !- X,Y,Z Vertex 4 {m}
 
@@ -11464,8 +11521,8 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  3.38986247334105e-007, 37.5411848314955, 28.2892501785315, !- X,Y,Z Vertex 1 {m}
-  -6.00934000218799e-023, 8.62229992807641, 16.1532920683221, !- X,Y,Z Vertex 2 {m}
+  3.38986247334105e-07, 37.5411848314955, 28.2892501785315, !- X,Y,Z Vertex 1 {m}
+  -1.2018680004376e-22, 8.62229992807641, 16.1532920683221, !- X,Y,Z Vertex 2 {m}
   120.552209999994, 8.62229932343414, 16.1532936283869, !- X,Y,Z Vertex 3 {m}
   120.552209999994, 37.5411784807575, 28.2892493272178; !- X,Y,Z Vertex 4 {m}
 
@@ -11477,7 +11534,6 @@ OS:SubSurface,
   {dc719711-7a2a-4a72-a9a8-0d263ac0bbab}, !- Surface Name
   ,                                       !- Outside Boundary Condition Object
   ,                                       !- View Factor to Ground
-  ,                                       !- Shading Control Name
   ,                                       !- Frame and Divider Name
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
@@ -11493,14 +11549,13 @@ OS:SubSurface,
   {1b25914b-5f8c-4bff-b058-2bda4b410e0a}, !- Surface Name
   ,                                       !- Outside Boundary Condition Object
   ,                                       !- View Factor to Ground
-  ,                                       !- Shading Control Name
   ,                                       !- Frame and Divider Name
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
-  -6.52754599999977, 48.971186327688, 11.72845, !- X,Y,Z Vertex 1 {m}
-  -6.52754599999977, 48.971186327688, 5.04825, !- X,Y,Z Vertex 2 {m}
-  -6.52754599999977, 26.111186327688, 5.04825, !- X,Y,Z Vertex 3 {m}
-  -6.52754599999977, 26.111186327688, 11.72845; !- X,Y,Z Vertex 4 {m}
+  -6.52754599999976, 48.971186327688, 11.72845, !- X,Y,Z Vertex 1 {m}
+  -6.52754599999976, 48.971186327688, 5.04825, !- X,Y,Z Vertex 2 {m}
+  -6.52754599999976, 26.111186327688, 5.04825, !- X,Y,Z Vertex 3 {m}
+  -6.52754599999976, 26.111186327688, 11.72845; !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {f00aacbb-22da-4baf-9d6e-8b040da3ce02}, !- Handle
@@ -11510,7 +11565,6 @@ OS:SubSurface,
   {dc719711-7a2a-4a72-a9a8-0d263ac0bbab}, !- Surface Name
   ,                                       !- Outside Boundary Condition Object
   ,                                       !- View Factor to Ground
-  ,                                       !- Shading Control Name
   ,                                       !- Frame and Divider Name
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
@@ -11526,14 +11580,13 @@ OS:SubSurface,
   {1b25914b-5f8c-4bff-b058-2bda4b410e0a}, !- Surface Name
   ,                                       !- Outside Boundary Condition Object
   ,                                       !- View Factor to Ground
-  ,                                       !- Shading Control Name
   ,                                       !- Frame and Divider Name
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
-  -6.52754599999977, 30.784786327688, 5.02285, !- X,Y,Z Vertex 1 {m}
-  -6.52754599999977, 30.784786327688, 3.21945, !- X,Y,Z Vertex 2 {m}
-  -6.52754599999977, 26.111186327688, 3.21945, !- X,Y,Z Vertex 3 {m}
-  -6.52754599999977, 26.111186327688, 5.02285; !- X,Y,Z Vertex 4 {m}
+  -6.52754599999976, 30.784786327688, 5.02285, !- X,Y,Z Vertex 1 {m}
+  -6.52754599999976, 30.784786327688, 3.21945, !- X,Y,Z Vertex 2 {m}
+  -6.52754599999976, 26.111186327688, 3.21945, !- X,Y,Z Vertex 3 {m}
+  -6.52754599999976, 26.111186327688, 5.02285; !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {179bd356-179f-4df0-9a8a-008dd93f45f1}, !- Handle
@@ -11543,7 +11596,6 @@ OS:SubSurface,
   {dc719711-7a2a-4a72-a9a8-0d263ac0bbab}, !- Surface Name
   ,                                       !- Outside Boundary Condition Object
   ,                                       !- View Factor to Ground
-  ,                                       !- Shading Control Name
   ,                                       !- Frame and Divider Name
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
@@ -11559,7 +11611,6 @@ OS:SubSurface,
   {dc719711-7a2a-4a72-a9a8-0d263ac0bbab}, !- Surface Name
   ,                                       !- Outside Boundary Condition Object
   ,                                       !- View Factor to Ground
-  ,                                       !- Shading Control Name
   ,                                       !- Frame and Divider Name
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
@@ -11576,7 +11627,6 @@ OS:SubSurface,
   {dc719711-7a2a-4a72-a9a8-0d263ac0bbab}, !- Surface Name
   ,                                       !- Outside Boundary Condition Object
   ,                                       !- View Factor to Ground
-  ,                                       !- Shading Control Name
   ,                                       !- Frame and Divider Name
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
@@ -11592,7 +11642,6 @@ OS:SubSurface,
   {dc719711-7a2a-4a72-a9a8-0d263ac0bbab}, !- Surface Name
   ,                                       !- Outside Boundary Condition Object
   ,                                       !- View Factor to Ground
-  ,                                       !- Shading Control Name
   ,                                       !- Frame and Divider Name
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
@@ -11608,13 +11657,12 @@ OS:SubSurface,
   {1b25914b-5f8c-4bff-b058-2bda4b410e0a}, !- Surface Name
   ,                                       !- Outside Boundary Condition Object
   ,                                       !- View Factor to Ground
-  ,                                       !- Shading Control Name
   ,                                       !- Frame and Divider Name
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
-  -6.52754599999977, 27.6863166152717, 17.3798310288324, !- X,Y,Z Vertex 1 {m}
-  -6.52754599999977, 37.4507754187936, 11.75385, !- X,Y,Z Vertex 2 {m}
-  -6.52754599999977, 26.111186327688, 11.75385; !- X,Y,Z Vertex 3 {m}
+  -6.52754599999976, 27.6863166152717, 17.3798310288324, !- X,Y,Z Vertex 1 {m}
+  -6.52754599999976, 37.4507754187936, 11.75385, !- X,Y,Z Vertex 2 {m}
+  -6.52754599999976, 26.111186327688, 11.75385; !- X,Y,Z Vertex 3 {m}
 
 OS:SubSurface,
   {d2aa39a2-cc20-4e65-a293-552445afa038}, !- Handle
@@ -11624,13 +11672,12 @@ OS:SubSurface,
   {1b25914b-5f8c-4bff-b058-2bda4b410e0a}, !- Surface Name
   ,                                       !- Outside Boundary Condition Object
   ,                                       !- View Factor to Ground
-  ,                                       !- Shading Control Name
   ,                                       !- Frame and Divider Name
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
-  -6.52754599999977, 47.3960560401043, 17.3798310288324, !- X,Y,Z Vertex 1 {m}
-  -6.52754599999977, 48.971186327688, 11.75385, !- X,Y,Z Vertex 2 {m}
-  -6.52754599999977, 37.6315972365824, 11.75385; !- X,Y,Z Vertex 3 {m}
+  -6.52754599999976, 47.3960560401043, 17.3798310288324, !- X,Y,Z Vertex 1 {m}
+  -6.52754599999976, 48.971186327688, 11.75385, !- X,Y,Z Vertex 2 {m}
+  -6.52754599999976, 37.6315972365824, 11.75385; !- X,Y,Z Vertex 3 {m}
 
 OS:SubSurface,
   {bd3c776f-5722-4062-bb2e-22165982b09d}, !- Handle
@@ -11640,13 +11687,12 @@ OS:SubSurface,
   {1b25914b-5f8c-4bff-b058-2bda4b410e0a}, !- Surface Name
   ,                                       !- Outside Boundary Condition Object
   ,                                       !- View Factor to Ground
-  ,                                       !- Shading Control Name
   ,                                       !- Frame and Divider Name
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
-  -6.52754599999977, 31.8519405555003, 21.5076160545741, !- X,Y,Z Vertex 1 {m}
-  -6.52754599999977, 37.5000752832492, 11.75385, !- X,Y,Z Vertex 2 {m}
-  -6.52754599999977, 27.6931646332249, 17.4042904779291; !- X,Y,Z Vertex 3 {m}
+  -6.52754599999976, 31.8519405555003, 21.5076160545741, !- X,Y,Z Vertex 1 {m}
+  -6.52754599999976, 37.5000752832492, 11.75385, !- X,Y,Z Vertex 2 {m}
+  -6.52754599999976, 27.6931646332249, 17.4042904779291; !- X,Y,Z Vertex 3 {m}
 
 OS:SubSurface,
   {a0ea6fd0-7499-406e-9f2f-6b3c016e45cc}, !- Handle
@@ -11656,13 +11702,12 @@ OS:SubSurface,
   {1b25914b-5f8c-4bff-b058-2bda4b410e0a}, !- Surface Name
   ,                                       !- Outside Boundary Condition Object
   ,                                       !- View Factor to Ground
-  ,                                       !- Shading Control Name
   ,                                       !- Frame and Divider Name
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
-  -6.52754599999977, 43.2304320998757, 21.5076160545741, !- X,Y,Z Vertex 1 {m}
-  -6.52754599999977, 47.3892080221511, 17.4042904779291, !- X,Y,Z Vertex 2 {m}
-  -6.52754599999977, 37.5822973721268, 11.75385; !- X,Y,Z Vertex 3 {m}
+  -6.52754599999976, 43.2304320998757, 21.5076160545741, !- X,Y,Z Vertex 1 {m}
+  -6.52754599999976, 47.3892080221511, 17.4042904779291, !- X,Y,Z Vertex 2 {m}
+  -6.52754599999976, 37.5822973721268, 11.75385; !- X,Y,Z Vertex 3 {m}
 
 OS:SubSurface,
   {e754bc53-f4ef-465c-a8e2-2b0bdb08b477}, !- Handle
@@ -11672,7 +11717,6 @@ OS:SubSurface,
   {dc719711-7a2a-4a72-a9a8-0d263ac0bbab}, !- Surface Name
   ,                                       !- Outside Boundary Condition Object
   ,                                       !- View Factor to Ground
-  ,                                       !- Shading Control Name
   ,                                       !- Frame and Divider Name
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
@@ -11688,7 +11732,6 @@ OS:SubSurface,
   {dc719711-7a2a-4a72-a9a8-0d263ac0bbab}, !- Surface Name
   ,                                       !- Outside Boundary Condition Object
   ,                                       !- View Factor to Ground
-  ,                                       !- Shading Control Name
   ,                                       !- Frame and Divider Name
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
@@ -11705,14 +11748,13 @@ OS:SubSurface,
   {1b25914b-5f8c-4bff-b058-2bda4b410e0a}, !- Surface Name
   ,                                       !- Outside Boundary Condition Object
   ,                                       !- View Factor to Ground
-  ,                                       !- Shading Control Name
   ,                                       !- Frame and Divider Name
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
-  -6.52754599999977, 48.971186327688, 5.02285, !- X,Y,Z Vertex 1 {m}
-  -6.52754599999977, 48.971186327688, 3.21945, !- X,Y,Z Vertex 2 {m}
-  -6.52754599999977, 44.297586327688, 3.21945, !- X,Y,Z Vertex 3 {m}
-  -6.52754599999977, 44.297586327688, 5.02285; !- X,Y,Z Vertex 4 {m}
+  -6.52754599999976, 48.971186327688, 5.02285, !- X,Y,Z Vertex 1 {m}
+  -6.52754599999976, 48.971186327688, 3.21945, !- X,Y,Z Vertex 2 {m}
+  -6.52754599999976, 44.297586327688, 3.21945, !- X,Y,Z Vertex 3 {m}
+  -6.52754599999976, 44.297586327688, 5.02285; !- X,Y,Z Vertex 4 {m}
 
 OS:SubSurface,
   {c5f2332a-b7f0-4db9-b519-86d3c9005927}, !- Handle
@@ -11722,13 +11764,12 @@ OS:SubSurface,
   {1b25914b-5f8c-4bff-b058-2bda4b410e0a}, !- Surface Name
   ,                                       !- Outside Boundary Condition Object
   ,                                       !- View Factor to Ground
-  ,                                       !- Shading Control Name
   ,                                       !- Frame and Divider Name
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
-  -6.52754599999977, 37.528486327688, 23.0280774781039, !- X,Y,Z Vertex 1 {m}
-  -6.52754599999977, 37.528486327688, 11.75385, !- X,Y,Z Vertex 2 {m}
-  -6.52754599999977, 31.8700212008942, 21.5254556246961; !- X,Y,Z Vertex 3 {m}
+  -6.52754599999976, 37.528486327688, 23.0280774781039, !- X,Y,Z Vertex 1 {m}
+  -6.52754599999976, 37.528486327688, 11.75385, !- X,Y,Z Vertex 2 {m}
+  -6.52754599999976, 31.8700212008942, 21.5254556246961; !- X,Y,Z Vertex 3 {m}
 
 OS:SubSurface,
   {075810d2-f403-42ef-8736-dc12af21e9fa}, !- Handle
@@ -11738,13 +11779,12 @@ OS:SubSurface,
   {1b25914b-5f8c-4bff-b058-2bda4b410e0a}, !- Surface Name
   ,                                       !- Outside Boundary Condition Object
   ,                                       !- View Factor to Ground
-  ,                                       !- Shading Control Name
   ,                                       !- Frame and Divider Name
   ,                                       !- Multiplier
   ,                                       !- Number of Vertices
-  -6.52754599999977, 37.553886327688, 23.0280774781039, !- X,Y,Z Vertex 1 {m}
-  -6.52754599999977, 43.2123514544818, 21.5254556246961, !- X,Y,Z Vertex 2 {m}
-  -6.52754599999977, 37.553886327688, 11.75385; !- X,Y,Z Vertex 3 {m}
+  -6.52754599999976, 37.553886327688, 23.0280774781039, !- X,Y,Z Vertex 1 {m}
+  -6.52754599999976, 43.2123514544818, 21.5254556246961, !- X,Y,Z Vertex 2 {m}
+  -6.52754599999976, 37.553886327688, 11.75385; !- X,Y,Z Vertex 3 {m}
 
 OS:ShadingSurface,
   {4b23eec0-04ca-47f1-9986-156f3f3d77b9}, !- Handle
@@ -11778,7 +11818,7 @@ OS:ShadingSurface,
   ,                                       !- Transmittance Schedule Name
   ,                                       !- Number of Vertices
   -9.88334358824695, -9.95100409270849, 7.62, !- X,Y,Z Vertex 1 {m}
-  -9.88334358824674, -3.66354049127708, 7.62, !- X,Y,Z Vertex 2 {m}
+  -9.88334358824674, -3.66354049127709, 7.62, !- X,Y,Z Vertex 2 {m}
   -23.0532690562169, -3.6635404912771, 7.62000000000002, !- X,Y,Z Vertex 3 {m}
   -23.0532690562169, -9.95100409270849, 7.62000000000003; !- X,Y,Z Vertex 4 {m}
 
@@ -11802,7 +11842,7 @@ OS:ShadingSurface,
   ,                                       !- Transmittance Schedule Name
   ,                                       !- Number of Vertices
   -30.8002251869833, -53.1003312510846, 46.609, !- X,Y,Z Vertex 1 {m}
-  -30.8002251869833, -53.1003312510846, -1.44382283906452e-015, !- X,Y,Z Vertex 2 {m}
+  -30.8002251869833, -53.1003312510846, -3.60955709766132e-15, !- X,Y,Z Vertex 2 {m}
   -56.7082251869833, -53.1003312510846, 21.3857870167291, !- X,Y,Z Vertex 3 {m}
   -56.7082251869833, -53.1003312510846, 46.609; !- X,Y,Z Vertex 4 {m}
 
@@ -11814,8 +11854,8 @@ OS:ShadingSurface,
   ,                                       !- Transmittance Schedule Name
   ,                                       !- Number of Vertices
   -56.7082251869833, -53.1003312510846, 21.3857870167291, !- X,Y,Z Vertex 1 {m}
-  -30.8002251869833, -53.1003312510846, -1.44382283906452e-015, !- X,Y,Z Vertex 2 {m}
-  -30.8002251869833, -197.880331251084, -1.01067598734517e-014, !- X,Y,Z Vertex 3 {m}
+  -30.8002251869833, -53.1003312510846, -3.60955709766132e-15, !- X,Y,Z Vertex 2 {m}
+  -30.8002251869833, -197.880331251084, -7.94102561485491e-15, !- X,Y,Z Vertex 3 {m}
   -56.7082251869833, -197.880331251084, 21.3857870167291; !- X,Y,Z Vertex 4 {m}
 
 OS:ShadingSurface,
@@ -11827,8 +11867,8 @@ OS:ShadingSurface,
   ,                                       !- Number of Vertices
   -56.7082251869833, -197.880331251084, 21.3857870167291, !- X,Y,Z Vertex 1 {m}
   -110.466380820439, -197.880331251084, 4.21194974500286, !- X,Y,Z Vertex 2 {m}
-  -110.466380820439, -197.880331251084, -1.44382283906452e-015, !- X,Y,Z Vertex 3 {m}
-  -30.8002251869833, -197.880331251084, -1.01067598734517e-014; !- X,Y,Z Vertex 4 {m}
+  -110.466380820439, -197.880331251084, -3.60955709766132e-15, !- X,Y,Z Vertex 3 {m}
+  -30.8002251869833, -197.880331251084, -7.94102561485491e-15; !- X,Y,Z Vertex 4 {m}
 
 OS:ShadingSurface,
   {3ccf0645-5e2f-476f-aff7-12408695c0ee}, !- Handle
@@ -11850,8 +11890,8 @@ OS:ShadingSurface,
   ,                                       !- Transmittance Schedule Name
   ,                                       !- Number of Vertices
   -152.125176363395, -15.3062085346015, 30.2514, !- X,Y,Z Vertex 1 {m}
-  -152.125176363395, -15.3062085346015, -1.44382283906452e-015, !- X,Y,Z Vertex 2 {m}
-  -130.789176363395, -15.3062085346015, -1.44382283906452e-015, !- X,Y,Z Vertex 3 {m}
+  -152.125176363395, -15.3062085346015, -1.44382283906452e-15, !- X,Y,Z Vertex 2 {m}
+  -130.789176363395, -15.3062085346015, -1.44382283906452e-15, !- X,Y,Z Vertex 3 {m}
   -130.789176363395, -15.3062085346015, 30.2514; !- X,Y,Z Vertex 4 {m}
 
 OS:ShadingSurface,
@@ -11863,8 +11903,8 @@ OS:ShadingSurface,
   ,                                       !- Number of Vertices
   -152.125176363395, -15.3062085346015, 36.3474, !- X,Y,Z Vertex 1 {m}
   -173.461176363395, -15.3062085346015, 30.2514, !- X,Y,Z Vertex 2 {m}
-  -173.461176363395, -15.3062085346015, -1.44382283906452e-015, !- X,Y,Z Vertex 3 {m}
-  -152.125176363395, -15.3062085346015, -1.44382283906452e-015; !- X,Y,Z Vertex 4 {m}
+  -173.461176363395, -15.3062085346015, -1.44382283906452e-15, !- X,Y,Z Vertex 3 {m}
+  -152.125176363395, -15.3062085346015, -1.44382283906452e-15; !- X,Y,Z Vertex 4 {m}
 
 OS:ShadingSurface,
   {60e0765d-7dca-4fc6-8434-1194d2d89cba}, !- Handle
@@ -11874,8 +11914,8 @@ OS:ShadingSurface,
   ,                                       !- Transmittance Schedule Name
   ,                                       !- Number of Vertices
   -130.789176363395, 16.6977914653985, 30.2514, !- X,Y,Z Vertex 1 {m}
-  -130.789176363395, 16.6977914653985, -1.44382283906452e-015, !- X,Y,Z Vertex 2 {m}
-  -152.125176363395, 16.6977914653985, -1.44382283906452e-015, !- X,Y,Z Vertex 3 {m}
+  -130.789176363395, 16.6977914653985, -1.44382283906452e-15, !- X,Y,Z Vertex 2 {m}
+  -152.125176363395, 16.6977914653985, -1.44382283906452e-15, !- X,Y,Z Vertex 3 {m}
   -152.125176363395, 16.6977914653985, 30.2514; !- X,Y,Z Vertex 4 {m}
 
 OS:ShadingSurface,
@@ -11887,8 +11927,8 @@ OS:ShadingSurface,
   ,                                       !- Number of Vertices
   -130.789176363395, 16.6977914653985, 36.3474, !- X,Y,Z Vertex 1 {m}
   -109.453176363395, 16.6977914653985, 30.2514, !- X,Y,Z Vertex 2 {m}
-  -109.453176363395, 16.6977914653985, -1.44382283906452e-015, !- X,Y,Z Vertex 3 {m}
-  -130.789176363395, 16.6977914653985, -1.44382283906452e-015; !- X,Y,Z Vertex 4 {m}
+  -109.453176363395, 16.6977914653985, -1.44382283906452e-15, !- X,Y,Z Vertex 3 {m}
+  -130.789176363395, 16.6977914653985, -1.44382283906452e-15; !- X,Y,Z Vertex 4 {m}
 
 OS:Schedule:Day,
   {61945529-267c-446e-a4e4-3dace0c2dd24}, !- Handle
@@ -11974,10 +12014,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  18.8214, 75.0823543008404, 6.27109789954172e-016, !- X,Y,Z Vertex 1 {m}
-  18.8214, 69.8547488365458, 3.44898494118786e-016, !- X,Y,Z Vertex 2 {m}
-  13.4816849923221, 69.8547488365455, -1.62225981099169e-009, !- X,Y,Z Vertex 3 {m}
-  13.4816849923221, 75.0823542078563, -1.6222595287804e-009; !- X,Y,Z Vertex 4 {m}
+  18.8214, 75.0823543008404, 6.2710978928184e-16, !- X,Y,Z Vertex 1 {m}
+  18.8214, 69.8547488365458, 3.44898495463451e-16, !- X,Y,Z Vertex 2 {m}
+  13.4816849923221, 69.8547488365455, -1.62225981099169e-09, !- X,Y,Z Vertex 3 {m}
+  13.4816849923221, 75.0823542078563, -1.6222595287804e-09; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {a7507131-e99b-4d45-ae94-3e290926414b}, !- Handle
@@ -11991,10 +12031,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  -1.16303655990015e-015, 75.0823543533066, -2.65888210750417e-008, !- X,Y,Z Vertex 1 {m}
-  10.2400099999939, 75.0823542072333, -4.74502920894207e-007, !- X,Y,Z Vertex 2 {m}
-  10.2400099999939, 69.8547488365458, -5.27680556431191e-007, !- X,Y,Z Vertex 3 {m}
-  1.16303655990016e-015, 69.8547488365453, -7.97664580979557e-008; !- X,Y,Z Vertex 4 {m}
+  10.2400099999939, 75.0823542072333, -4.74502920894207e-07, !- X,Y,Z Vertex 1 {m}
+  10.2400099999939, 69.8547488365458, -5.27680556431191e-07, !- X,Y,Z Vertex 2 {m}
+  1.16303655990012e-15, 69.8547488365453, -7.97664580979564e-08, !- X,Y,Z Vertex 3 {m}
+  -1.16303655990014e-15, 75.0823543533066, -2.65888210750415e-08; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {a104ec8f-2db3-4660-8841-de4b7b326312}, !- Handle
@@ -12008,34 +12048,34 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  110.660140945405, 75.0823541733274, -6.71071753970999e-009, !- X,Y,Z Vertex 1 {m}
-  110.660140929268, 69.2970070000579, -5.85676472314207e-009, !- X,Y,Z Vertex 2 {m}
-  120.552209999994, 69.2970070000574, -4.87408540722006e-009, !- X,Y,Z Vertex 3 {m}
-  120.552209999994, 60.0868613276954, -3.51461127072949e-009, !- X,Y,Z Vertex 4 {m}
-  124.595572499993, 60.0868613276954, -3.11294315993134e-009, !- X,Y,Z Vertex 5 {m}
-  124.595572499993, 53.7971863276983, -2.18454845331053e-009, !- X,Y,Z Vertex 6 {m}
-  129.08661, 53.7971863276983, -1.73840825486136e-009, !- X,Y,Z Vertex 7 {m}
-  129.08661, 11.177539610068, 4.55251367842055e-009, !- X,Y,Z Vertex 8 {m}
-  117.9583084912, 11.177539610068, 3.44702688532864e-009, !- X,Y,Z Vertex 9 {m}
-  117.9583084912, 8.62229957027117, 3.82419602794634e-009, !- X,Y,Z Vertex 10 {m}
-  115.523009999993, 8.62229964986439, 3.58227317495054e-009, !- X,Y,Z Vertex 11 {m}
-  115.523009999993, 5.11632945067457, 4.09977593534748e-009, !- X,Y,Z Vertex 12 {m}
-  110.77454947196, 5.11632945681379, 3.62806330182547e-009, !- X,Y,Z Vertex 13 {m}
-  110.774549471961, -1.28109040018718e-005, 4.383266882076e-009, !- X,Y,Z Vertex 14 {m}
-  101.117399999999, -8.61397499359686e-007, 3.42392274316547e-009, !- X,Y,Z Vertex 15 {m}
-  101.117399999996, 0.228599999999995, 3.39017985030498e-009, !- X,Y,Z Vertex 16 {m}
-  27.9654, 0.228599999999997, -3.87674851466666e-009, !- X,Y,Z Vertex 17 {m}
-  27.9654, -2.12705253537996e-008, -3.84300574581437e-009, !- X,Y,Z Vertex 18 {m}
-  6.57740051016457e-019, 2.80077544631105e-008, -6.62109190928058e-009, !- X,Y,Z Vertex 19 {m}
-  8.53646269026571e-019, 13.3603862893464, -8.59316707746365e-009, !- X,Y,Z Vertex 20 {m}
-  -6.52754599999976, 13.3603863660296, -9.24161428340551e-009, !- X,Y,Z Vertex 21 {m}
-  -6.52754599999976, 61.7219863360121, -1.6380083825292e-008, !- X,Y,Z Vertex 22 {m}
-  1.56278265285013e-018, 61.7219863126815, -1.57316366272254e-008, !- X,Y,Z Vertex 23 {m}
-  -8.88331058331828e-018, 69.8547488365453, -1.69320823859271e-008, !- X,Y,Z Vertex 24 {m}
-  21.5965436637309, 69.8547488376232, -1.47866791744813e-008, !- X,Y,Z Vertex 25 {m}
-  21.5965436591073, 74.8537541776782, -1.5524563103137e-008, !- X,Y,Z Vertex 26 {m}
-  101.1174, 74.8537541776736, -7.62495179311744e-009, !- X,Y,Z Vertex 27 {m}
-  101.1174, 75.0823542114224, -7.65869456381161e-009; !- X,Y,Z Vertex 28 {m}
+  101.1174, 75.0823542114224, -7.6586945638116e-09, !- X,Y,Z Vertex 1 {m}
+  110.660140945405, 75.0823541733274, -6.71071753970998e-09, !- X,Y,Z Vertex 2 {m}
+  110.660140929268, 69.2970070000579, -5.85676472314207e-09, !- X,Y,Z Vertex 3 {m}
+  120.552209999994, 69.2970070000574, -4.87408540722006e-09, !- X,Y,Z Vertex 4 {m}
+  120.552209999994, 60.0868613276954, -3.51461127072949e-09, !- X,Y,Z Vertex 5 {m}
+  124.595572499993, 60.0868613276954, -3.11294315993134e-09, !- X,Y,Z Vertex 6 {m}
+  124.595572499993, 53.7971863276983, -2.18454845331053e-09, !- X,Y,Z Vertex 7 {m}
+  129.08661, 53.7971863276983, -1.73840825486136e-09, !- X,Y,Z Vertex 8 {m}
+  129.08661, 11.177539610068, 4.55251367842054e-09, !- X,Y,Z Vertex 9 {m}
+  117.9583084912, 11.177539610068, 3.44702688532863e-09, !- X,Y,Z Vertex 10 {m}
+  117.9583084912, 8.62229957027117, 3.82419602794633e-09, !- X,Y,Z Vertex 11 {m}
+  115.523009999993, 8.62229964986439, 3.58227317495054e-09, !- X,Y,Z Vertex 12 {m}
+  115.523009999993, 5.11632945067457, 4.09977593534747e-09, !- X,Y,Z Vertex 13 {m}
+  110.77454947196, 5.11632945681379, 3.62806330182546e-09, !- X,Y,Z Vertex 14 {m}
+  110.774549471961, -1.28109040018718e-05, 4.38326688207599e-09, !- X,Y,Z Vertex 15 {m}
+  101.117399999999, -8.61397499359686e-07, 3.42392274316547e-09, !- X,Y,Z Vertex 16 {m}
+  101.117399999996, 0.228599999999995, 3.39017985030497e-09, !- X,Y,Z Vertex 17 {m}
+  27.9654, 0.228599999999997, -3.87674851466665e-09, !- X,Y,Z Vertex 18 {m}
+  27.9654, -2.12705253537996e-08, -3.84300574581436e-09, !- X,Y,Z Vertex 19 {m}
+  6.57740051016455e-19, 2.80077544631105e-08, -6.62109190928056e-09, !- X,Y,Z Vertex 20 {m}
+  8.53646269026568e-19, 13.3603862893464, -8.59316707746362e-09, !- X,Y,Z Vertex 21 {m}
+  -6.52754599999976, 13.3603863660296, -9.24161428340548e-09, !- X,Y,Z Vertex 22 {m}
+  -6.52754599999976, 61.7219863360121, -1.6380083825292e-08, !- X,Y,Z Vertex 23 {m}
+  1.56278265285011e-18, 61.7219863126815, -1.57316366272253e-08, !- X,Y,Z Vertex 24 {m}
+  -8.88331058331828e-18, 69.8547488365453, -1.69320823859271e-08, !- X,Y,Z Vertex 25 {m}
+  21.5965436637309, 69.8547488376232, -1.47866791744813e-08, !- X,Y,Z Vertex 26 {m}
+  21.5965436591073, 74.8537541776782, -1.5524563103137e-08, !- X,Y,Z Vertex 27 {m}
+  101.1174, 74.8537541776736, -7.62495179311744e-09; !- X,Y,Z Vertex 28 {m}
 
 OS:Surface,
   {9bdfd394-16f9-4458-b76a-65a39cc2f843}, !- Handle
@@ -12049,34 +12089,34 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  53.7971863276983, -7.10989867349319e-014, 1.12995337620113e-006, !- X,Y,Z Vertex 1 {m}
-  53.7971863276983, 4.49103750000717, 1.09107992374128e-006, !- X,Y,Z Vertex 2 {m}
-  60.0868613276954, 4.49103750000717, 9.51379078277106e-007, !- X,Y,Z Vertex 3 {m}
-  60.0868613276954, 8.53440000000615, 9.16380604111309e-007, !- X,Y,Z Vertex 4 {m}
-  69.2970070000574, 8.53440000000614, 7.11812778702558e-007, !- X,Y,Z Vertex 5 {m}
-  69.2970070000573, 18.4264690705844, 6.26189161276966e-007, !- X,Y,Z Vertex 6 {m}
-  75.0823541388985, 18.4264690705844, 4.97690012020408e-007, !- X,Y,Z Vertex 7 {m}
-  75.0823541776712, 27.9692099999999, 4.150901028183e-007, !- X,Y,Z Vertex 8 {m}
-  74.8537541776738, 27.9692099999999, 4.20167569185443e-007, !- X,Y,Z Vertex 9 {m}
-  74.853754205023, 107.490066342021, -2.68147821478917e-007, !- X,Y,Z Vertex 10 {m}
-  69.8547488376234, 107.490066336269, -1.57114218531364e-007, !- X,Y,Z Vertex 11 {m}
-  69.8547488331669, 129.08661, -3.44049244783784e-007, !- X,Y,Z Vertex 12 {m}
-  61.7219863212786, 129.08661, -1.63411326469932e-007, !- X,Y,Z Vertex 13 {m}
-  61.7219863276882, 135.614156, -2.19912357634647e-007, !- X,Y,Z Vertex 14 {m}
-  13.3603863276882, 135.614156, 8.54253860493223e-007, !- X,Y,Z Vertex 15 {m}
-  13.3603863276882, 129.08661, 9.10754891515574e-007, !- X,Y,Z Vertex 16 {m}
-  2.80080097290402e-008, 129.08661, 1.20750428823228e-006, !- X,Y,Z Vertex 17 {m}
-  2.20415462360638e-013, 101.12121, 1.44956676270786e-006, !- X,Y,Z Vertex 18 {m}
-  0.228600000000211, 101.12121, 1.44448929634065e-006, !- X,Y,Z Vertex 19 {m}
-  0.228600000000119, 27.9692100000012, 2.07767723884568e-006, !- X,Y,Z Vertex 20 {m}
-  -4.48622384706419e-006, 27.969210000004, 2.082754804857e-006, !- X,Y,Z Vertex 21 {m}
-  -1.30314125225835e-005, 18.3120605280394, 2.16634519867737e-006, !- X,Y,Z Vertex 22 {m}
-  5.11633034987616, 18.3120595175827, 2.05270539359363e-006, !- X,Y,Z Vertex 23 {m}
-  5.11632945374809, 13.5636000000108, 2.09380705544866e-006, !- X,Y,Z Vertex 24 {m}
-  8.62229961006408, 13.5636000000032, 2.01593546510268e-006, !- X,Y,Z Vertex 25 {m}
-  8.62229961006778, 11.1283015088005, 2.03701488386122e-006, !- X,Y,Z Vertex 26 {m}
-  11.1775396100676, 11.1283015088011, 1.9802600931345e-006, !- X,Y,Z Vertex 27 {m}
-  11.1775396100682, 3.67510238887548e-013, 2.07658427204871e-006; !- X,Y,Z Vertex 28 {m}
+  53.7971863276983, -7.10989867349319e-14, 1.12995337620113e-06, !- X,Y,Z Vertex 1 {m}
+  53.7971863276983, 4.49103750000717, 1.09107992374128e-06, !- X,Y,Z Vertex 2 {m}
+  60.0868613276954, 4.49103750000717, 9.51379078277107e-07, !- X,Y,Z Vertex 3 {m}
+  60.0868613276954, 8.53440000000615, 9.1638060411131e-07, !- X,Y,Z Vertex 4 {m}
+  69.2970070000574, 8.53440000000614, 7.11812778702559e-07, !- X,Y,Z Vertex 5 {m}
+  69.2970070000573, 18.4264690705844, 6.26189161276966e-07, !- X,Y,Z Vertex 6 {m}
+  75.0823541388985, 18.4264690705844, 4.97690012020408e-07, !- X,Y,Z Vertex 7 {m}
+  75.0823541776712, 27.9692099999999, 4.150901028183e-07, !- X,Y,Z Vertex 8 {m}
+  74.8537541776738, 27.9692099999999, 4.20167569185443e-07, !- X,Y,Z Vertex 9 {m}
+  74.853754205023, 107.490066342021, -2.68147821478918e-07, !- X,Y,Z Vertex 10 {m}
+  69.8547488376234, 107.490066336269, -1.57114218531366e-07, !- X,Y,Z Vertex 11 {m}
+  69.8547488331669, 129.08661, -3.44049244783786e-07, !- X,Y,Z Vertex 12 {m}
+  61.7219863212786, 129.08661, -1.63411326469934e-07, !- X,Y,Z Vertex 13 {m}
+  61.7219863276882, 135.614156, -2.19912357634649e-07, !- X,Y,Z Vertex 14 {m}
+  13.3603863276882, 135.614156, 8.54253860493222e-07, !- X,Y,Z Vertex 15 {m}
+  13.3603863276882, 129.08661, 9.10754891515572e-07, !- X,Y,Z Vertex 16 {m}
+  2.80080097290402e-08, 129.08661, 1.20750428823228e-06, !- X,Y,Z Vertex 17 {m}
+  2.20415462360638e-13, 101.12121, 1.44956676270786e-06, !- X,Y,Z Vertex 18 {m}
+  0.228600000000211, 101.12121, 1.44448929634065e-06, !- X,Y,Z Vertex 19 {m}
+  0.228600000000119, 27.9692100000012, 2.07767723884568e-06, !- X,Y,Z Vertex 20 {m}
+  -4.48622384706419e-06, 27.969210000004, 2.082754804857e-06, !- X,Y,Z Vertex 21 {m}
+  -1.30314125225835e-05, 18.3120605280394, 2.16634519867737e-06, !- X,Y,Z Vertex 22 {m}
+  5.11633034987616, 18.3120595175827, 2.05270539359363e-06, !- X,Y,Z Vertex 23 {m}
+  5.11632945374809, 13.5636000000108, 2.09380705544866e-06, !- X,Y,Z Vertex 24 {m}
+  8.62229961006408, 13.5636000000032, 2.01593546510268e-06, !- X,Y,Z Vertex 25 {m}
+  8.62229961006778, 11.1283015088005, 2.03701488386122e-06, !- X,Y,Z Vertex 26 {m}
+  11.1775396100676, 11.1283015088011, 1.9802600931345e-06, !- X,Y,Z Vertex 27 {m}
+  11.1775396100682, 3.67510238887548e-13, 2.07658427204871e-06; !- X,Y,Z Vertex 28 {m}
 
 OS:Surface,
   {b76d3b79-12ed-4400-bf96-7e7200dcbcf8}, !- Handle
@@ -12090,10 +12130,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  75.0823541937047, 110.265209999979, -6.01995094400624e-007, !- X,Y,Z Vertex 1 {m}
-  75.0823542010031, 115.604925000006, -6.39516022986882e-007, !- X,Y,Z Vertex 2 {m}
-  69.8547488276954, 115.60492500883, -4.85152723207398e-007, !- X,Y,Z Vertex 3 {m}
-  69.8547488309849, 110.26520999809, -4.47631794858506e-007; !- X,Y,Z Vertex 4 {m}
+  69.8547488309849, 110.26520999809, -4.47631794858506e-07, !- X,Y,Z Vertex 1 {m}
+  75.0823541937047, 110.265209999979, -6.01995094400623e-07, !- X,Y,Z Vertex 2 {m}
+  75.0823542010031, 115.604925000006, -6.39516022986882e-07, !- X,Y,Z Vertex 3 {m}
+  69.8547488276954, 115.60492500883, -4.85152723207397e-07; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {eec42761-eec0-4f3c-a284-a58024a04f22}, !- Handle
@@ -12107,10 +12147,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  75.0823542072332, 118.846600000006, -7.1911226511265e-007, !- X,Y,Z Vertex 1 {m}
-  75.0823542248059, 129.08661, -6.46728599800882e-007, !- X,Y,Z Vertex 2 {m}
-  69.8547488331669, 129.08661, -3.66245512968263e-007, !- X,Y,Z Vertex 3 {m}
-  69.8547488331669, 118.84660000883, -4.38629179160505e-007; !- X,Y,Z Vertex 4 {m}
+  75.0823542072332, 118.846600000006, -7.1911226511265e-07, !- X,Y,Z Vertex 1 {m}
+  75.0823542248059, 129.08661, -6.46728599800882e-07, !- X,Y,Z Vertex 2 {m}
+  69.8547488331669, 129.08661, -3.66245512968263e-07, !- X,Y,Z Vertex 3 {m}
+  69.8547488331669, 118.84660000883, -4.38629179160505e-07; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {e0d2b940-33ca-4751-98fe-ace802613ed7}, !- Handle
@@ -12124,10 +12164,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  75.0823542058633, -1.11294454209959e-013, 5.92972037746423e-007, !- X,Y,Z Vertex 1 {m}
-  75.0823542013365, 4.49103750000693, 5.7341693167452e-007, !- X,Y,Z Vertex 2 {m}
-  60.0868613276954, 4.49103750000693, 5.41148463495608e-007, !- X,Y,Z Vertex 3 {m}
-  60.0868613276954, -8.82739302158726e-014, 5.60703569557771e-007; !- X,Y,Z Vertex 4 {m}
+  75.0823542058633, -1.11294454209959e-13, 5.92972037746423e-07, !- X,Y,Z Vertex 1 {m}
+  75.0823542013365, 4.49103750000693, 5.7341693167452e-07, !- X,Y,Z Vertex 2 {m}
+  60.0868613276954, 4.49103750000693, 5.41148463495608e-07, !- X,Y,Z Vertex 3 {m}
+  60.0868613276954, -8.82739302158726e-14, 5.60703569557771e-07; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {4bbd172f-1a67-4773-9760-5e20ee7ef00f}, !- Handle
@@ -12141,10 +12181,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  75.0823541965599, 110.265209996165, 5.94018690528004e-009, !- X,Y,Z Vertex 1 {m}
-  75.0823542038582, 115.604925000006, -9.88932603406443e-008, !- X,Y,Z Vertex 2 {m}
-  69.8547488342558, 115.604925000006, -9.74399480434858e-008, !- X,Y,Z Vertex 3 {m}
-  69.8547488342558, 110.265209996664, 7.39349919061245e-009; !- X,Y,Z Vertex 4 {m}
+  75.0823541965599, 110.265209996165, 5.94018690528004e-09, !- X,Y,Z Vertex 1 {m}
+  75.0823542038582, 115.604925000006, -9.88932603406443e-08, !- X,Y,Z Vertex 2 {m}
+  69.8547488342558, 115.604925000006, -9.74399480434854e-08, !- X,Y,Z Vertex 3 {m}
+  69.8547488342558, 110.265209996664, 7.3934991906128e-09; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {1241f049-143c-49bf-97b1-ab427a1f0f0c}, !- Handle
@@ -12158,10 +12198,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  75.0823542085711, 118.846600000006, -1.09968746559629e-007, !- X,Y,Z Vertex 1 {m}
-  75.0823542248059, 129.08661, -2.98025060182711e-007, !- X,Y,Z Vertex 2 {m}
-  69.8547488342558, 129.08661, -2.60482631585147e-007, !- X,Y,Z Vertex 3 {m}
-  69.8547488342558, 118.846600000006, -7.24263180786565e-008; !- X,Y,Z Vertex 4 {m}
+  75.0823542085711, 118.846600000006, -1.09968746559629e-07, !- X,Y,Z Vertex 1 {m}
+  75.0823542248059, 129.08661, -2.98025060182711e-07, !- X,Y,Z Vertex 2 {m}
+  69.8547488342558, 129.08661, -2.60482631585147e-07, !- X,Y,Z Vertex 3 {m}
+  69.8547488342558, 118.846600000006, -7.24263180786568e-08; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {e8d5e24c-ed47-4eeb-ac5c-886294285c21}, !- Handle
@@ -12192,10 +12232,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  75.0823542038582, 115.604925000006, -3.4544003745299, !- X,Y,Z Vertex 1 {m}
-  75.0823541965599, 110.265209995825, -3.45440030132934, !- X,Y,Z Vertex 2 {m}
-  69.8547488276173, 110.265209993936, -3.45440011341254, !- X,Y,Z Vertex 3 {m}
-  69.8547488291247, 115.60492500883, -3.4544001866131; !- X,Y,Z Vertex 4 {m}
+  69.8547488291247, 115.60492500883, -3.4544001866131, !- X,Y,Z Vertex 1 {m}
+  75.0823542038582, 115.604925000006, -3.4544003745299, !- X,Y,Z Vertex 2 {m}
+  75.0823541965599, 110.265209995825, -3.45440030132934, !- X,Y,Z Vertex 3 {m}
+  69.8547488276173, 110.265209993936, -3.45440011341254; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {14bee695-e966-4917-9569-f8ccaef8c904}, !- Handle
@@ -12209,10 +12249,10 @@ OS:Surface,
   NoWind,                                 !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  74.8537541776784, 110.265209999896, -5.94529218065703e-007, !- X,Y,Z Vertex 1 {m}
+  74.8537541776784, 110.265209999896, -5.94529218065703e-07, !- X,Y,Z Vertex 1 {m}
   74.8537541721111, 110.265209995742, -3.45440003092546, !- X,Y,Z Vertex 2 {m}
   75.0823541965599, 110.265209995825, -3.45440030132934, !- X,Y,Z Vertex 3 {m}
-  75.0823541937047, 110.265209999979, -6.01995094400623e-007; !- X,Y,Z Vertex 4 {m}
+  75.0823541937047, 110.265209999979, -6.01995094400623e-07; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {9db87316-dcb6-4389-b67a-c38331c9c342}, !- Handle
@@ -12235,17 +12275,17 @@ OS:Surface,
   75.0823541776712, 27.9692099999999, -3.45439923717403, !- X,Y,Z Vertex 7 {m}
   75.0823542013365, 4.49103750000689, -3.45439923571585, !- X,Y,Z Vertex 8 {m}
   53.7971863276984, 4.49103750000696, -3.45439927071593, !- X,Y,Z Vertex 9 {m}
-  53.7971863276984, -6.7174088270446e-014, -3.454399270437, !- X,Y,Z Vertex 10 {m}
-  6.15175852034683e-006, 7.34447505687538e-012, -3.45439935889794, !- X,Y,Z Vertex 11 {m}
-  -7.36844941057526e-006, 9.65852757155782, -3.45439935949784, !- X,Y,Z Vertex 12 {m}
+  53.7971863276984, -6.71740882708495e-14, -3.454399270437, !- X,Y,Z Vertex 10 {m}
+  6.15175852034683e-06, 7.34447505687499e-12, -3.45439935889794, !- X,Y,Z Vertex 11 {m}
+  -7.36844941057526e-06, 9.65852757155782, -3.45439935949784, !- X,Y,Z Vertex 12 {m}
   5.1163380405451, 9.65852656110722, -3.45439935108482, !- X,Y,Z Vertex 13 {m}
   5.11633974957689, 18.3120595175829, -3.45439935162227, !- X,Y,Z Vertex 14 {m}
-  -4.05896448901365e-006, 18.3120605280406, -3.45439936003529, !- X,Y,Z Vertex 15 {m}
-  4.48622404951649e-006, 27.9692100000006, -3.45439936063506, !- X,Y,Z Vertex 16 {m}
+  -4.05896448901365e-06, 18.3120605280406, -3.45439936003529, !- X,Y,Z Vertex 15 {m}
+  4.48622404951649e-06, 27.9692100000006, -3.45439936063506, !- X,Y,Z Vertex 16 {m}
   0.228600000000141, 27.96921, -3.45439936025917, !- X,Y,Z Vertex 17 {m}
   0.228600000000238, 101.12121, -3.45439936480251, !- X,Y,Z Vertex 18 {m}
-  2.41821036440677e-013, 101.12121, -3.45439936517841, !- X,Y,Z Vertex 19 {m}
-  2.80080329714442e-008, 129.08661, -3.45439936691529, !- X,Y,Z Vertex 20 {m}
+  2.41821036426433e-13, 101.12121, -3.45439936517841, !- X,Y,Z Vertex 19 {m}
+  2.80080329714442e-08, 129.08661, -3.45439936691529, !- X,Y,Z Vertex 20 {m}
   13.3603863276882, 129.08661, -3.45439934494625, !- X,Y,Z Vertex 21 {m}
   13.3603863276882, 135.614156, -3.45439934535166; !- X,Y,Z Vertex 22 {m}
 
@@ -12261,10 +12301,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  110.774549471957, 8.62229950038425, 16.1532930874734, !- X,Y,Z Vertex 1 {m}
-  101.1174, 8.6222995482298, 16.1532929734618, !- X,Y,Z Vertex 2 {m}
-  101.117400000004, 2.92702861838856e-006, 12.5349020172294, !- X,Y,Z Vertex 3 {m}
-  110.774549471956, -8.99913165491111e-006, 12.5348971464454; !- X,Y,Z Vertex 4 {m}
+  101.1174, 8.6222995482298, 16.1532929734618, !- X,Y,Z Vertex 1 {m}
+  101.117400000004, 2.92702861503633e-06, 12.5349020172294, !- X,Y,Z Vertex 2 {m}
+  110.774549471956, -8.99913165155888e-06, 12.5348971464454, !- X,Y,Z Vertex 3 {m}
+  110.774549471957, 8.62229950038425, 16.1532930874734; !- X,Y,Z Vertex 4 {m}
 
 OS:Surface,
   {977b585f-1eb9-449c-871d-5a9325ba45a7}, !- Handle
@@ -12278,10 +12318,10 @@ OS:Surface,
   WindExposed,                            !- Wind Exposure
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
-  110.774549471957, 8.6222995203975, 16.1532930397836, !- X,Y,Z Vertex 1 {m}
-  110.774549471957, 5.11632927533494, 14.6819946557171, !- X,Y,Z Vertex 2 {m}
-  115.523009999993, 5.11632928434237, 14.6819946584189, !- X,Y,Z Vertex 3 {m}
-  115.523009999993, 8.62229951088083, 16.1532930347118; !- X,Y,Z Vertex 4 {m}
+  110.774549471957, 8.62229952039749, 16.1532930397836, !- X,Y,Z Vertex 1 {m}
+  110.774549471957, 5.11632927533495, 14.6819946557171, !- X,Y,Z Vertex 2 {m}
+  115.523009999993, 5.11632928434236, 14.6819946584189, !- X,Y,Z Vertex 3 {m}
+  115.523009999993, 8.62229951088084, 16.1532930347118; !- X,Y,Z Vertex 4 {m}
 
 OS:Material:NoMass,
   {69a86da4-dfc7-49fb-80d2-7bae60a25c2e}, !- Handle
@@ -12339,28 +12379,28 @@ OS:StandardsInformation:Material,
   {92adce11-6945-4364-808c-64211180a8fa}; !- Material Name
 
 OS:Material,
-  {965b9c03-7b72-4851-991f-b8ce42cbf6f5}, ! Handle
-  Floor Insulation [4],                   ! Name
-  MediumRough,                            ! Roughness
-  0.0795397,                              ! Thickness {m}
-  0.045,                                  ! Conductivity {W/m-K}
-  265,                                    ! Density {kg/m3}
-  836.8,                                  ! Specific Heat {J/kg-K}
-  0.9,                                    ! Thermal Absorptance
-  0.7,                                    ! Solar Absorptance
-  0.7;                                    ! Visible Absorptance
+  {965b9c03-7b72-4851-991f-b8ce42cbf6f5}, !- Handle
+  Floor Insulation [4],                   !- Name
+  MediumRough,                            !- Roughness
+  0.0795397,                              !- Thickness {m}
+  0.045,                                  !- Conductivity {W/m-K}
+  265,                                    !- Density {kg/m3}
+  836.8,                                  !- Specific Heat {J/kg-K}
+  0.9,                                    !- Thermal Absorptance
+  0.7,                                    !- Solar Absorptance
+  0.7;                                    !- Visible Absorptance
 
 OS:Material,
-  {2f747ace-dbc9-4498-9280-fb026abc979a}, ! Handle
-  MAT-CC05 8 HW CONCRETE,                 ! Name
-  Rough,                                  ! Roughness
-  0.20321,                                ! Thickness {m}
-  1.311,                                  ! Conductivity {W/m-K}
-  2240,                                   ! Density {kg/m3}
-  836.8,                                  ! Specific Heat {J/kg-K}
-  0.9,                                    ! Thermal Absorptance
-  0.7,                                    ! Solar Absorptance
-  0.7;                                    ! Visible Absorptance
+  {2f747ace-dbc9-4498-9280-fb026abc979a}, !- Handle
+  MAT-CC05 8 HW CONCRETE,                 !- Name
+  Rough,                                  !- Roughness
+  0.20321,                                !- Thickness {m}
+  1.311,                                  !- Conductivity {W/m-K}
+  2240,                                   !- Density {kg/m3}
+  836.8,                                  !- Specific Heat {J/kg-K}
+  0.9,                                    !- Thermal Absorptance
+  0.7,                                    !- Solar Absorptance
+  0.7;                                    !- Visible Absorptance
 
 OS:Material:NoMass,
   {89cb39e2-89d9-4a0f-b8fd-944e8226d19c}, ! Handle
@@ -12526,7 +12566,6 @@ OS:Schedule:Rule,
   ,                                       !- Apply Thursday
   ,                                       !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   1,                                      !- Start Month
   1,                                      !- Start Day
@@ -12561,7 +12600,6 @@ OS:Schedule:Rule,
   ,                                       !- Apply Thursday
   ,                                       !- Apply Friday
   ,                                       !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   1,                                      !- Start Month
   1,                                      !- Start Day
@@ -12679,7 +12717,6 @@ OS:Schedule:Rule,
   ,                                       !- Apply Thursday
   ,                                       !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   1,                                      !- Start Month
   1,                                      !- Start Day
@@ -12714,7 +12751,6 @@ OS:Schedule:Rule,
   Yes,                                    !- Apply Thursday
   Yes,                                    !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   12,                                     !- Start Month
   18,                                     !- Start Day
@@ -12743,7 +12779,6 @@ OS:Schedule:Rule,
   Yes,                                    !- Apply Thursday
   Yes,                                    !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   5,                                      !- Start Month
   1,                                      !- Start Day
@@ -12772,7 +12807,6 @@ OS:Schedule:Rule,
   Yes,                                    !- Apply Thursday
   Yes,                                    !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   2,                                      !- Start Month
   1,                                      !- Start Day
@@ -12813,7 +12847,6 @@ OS:Schedule:Rule,
   Yes,                                    !- Apply Thursday
   Yes,                                    !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   4,                                      !- Start Month
   1,                                      !- Start Day
@@ -12854,7 +12887,6 @@ OS:Schedule:Rule,
   Yes,                                    !- Apply Thursday
   Yes,                                    !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   1,                                      !- Start Month
   22,                                     !- Start Day
@@ -12895,7 +12927,6 @@ OS:Schedule:Rule,
   Yes,                                    !- Apply Thursday
   Yes,                                    !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   3,                                      !- Start Month
   12,                                     !- Start Day
@@ -12936,7 +12967,6 @@ OS:Schedule:Rule,
   Yes,                                    !- Apply Thursday
   Yes,                                    !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   8,                                      !- Start Month
   10,                                     !- Start Day
@@ -12977,7 +13007,6 @@ OS:Schedule:Rule,
   Yes,                                    !- Apply Thursday
   Yes,                                    !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   10,                                     !- Start Month
   15,                                     !- Start Day
@@ -13018,7 +13047,6 @@ OS:Schedule:Rule,
   Yes,                                    !- Apply Thursday
   Yes,                                    !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   11,                                     !- Start Month
   19,                                     !- Start Day
@@ -13059,7 +13087,6 @@ OS:Schedule:Rule,
   Yes,                                    !- Apply Thursday
   Yes,                                    !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   1,                                      !- Start Month
   22,                                     !- Start Day
@@ -13159,7 +13186,6 @@ OS:Schedule:Rule,
   ,                                       !- Apply Thursday
   ,                                       !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   1,                                      !- Start Month
   1,                                      !- Start Day
@@ -13188,7 +13214,6 @@ OS:Schedule:Rule,
   Yes,                                    !- Apply Thursday
   Yes,                                    !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   12,                                     !- Start Month
   18,                                     !- Start Day
@@ -13217,7 +13242,6 @@ OS:Schedule:Rule,
   Yes,                                    !- Apply Thursday
   Yes,                                    !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   5,                                      !- Start Month
   1,                                      !- Start Day
@@ -13246,7 +13270,6 @@ OS:Schedule:Rule,
   Yes,                                    !- Apply Thursday
   Yes,                                    !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   2,                                      !- Start Month
   1,                                      !- Start Day
@@ -13275,7 +13298,6 @@ OS:Schedule:Rule,
   Yes,                                    !- Apply Thursday
   Yes,                                    !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   4,                                      !- Start Month
   1,                                      !- Start Day
@@ -13304,7 +13326,6 @@ OS:Schedule:Rule,
   Yes,                                    !- Apply Thursday
   Yes,                                    !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   1,                                      !- Start Month
   22,                                     !- Start Day
@@ -13339,7 +13360,6 @@ OS:Schedule:Rule,
   Yes,                                    !- Apply Thursday
   Yes,                                    !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   3,                                      !- Start Month
   12,                                     !- Start Day
@@ -13374,7 +13394,6 @@ OS:Schedule:Rule,
   Yes,                                    !- Apply Thursday
   Yes,                                    !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   8,                                      !- Start Month
   10,                                     !- Start Day
@@ -13409,7 +13428,6 @@ OS:Schedule:Rule,
   Yes,                                    !- Apply Thursday
   Yes,                                    !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   10,                                     !- Start Month
   15,                                     !- Start Day
@@ -13444,7 +13462,6 @@ OS:Schedule:Rule,
   Yes,                                    !- Apply Thursday
   Yes,                                    !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   11,                                     !- Start Month
   19,                                     !- Start Day
@@ -13479,7 +13496,6 @@ OS:Schedule:Rule,
   Yes,                                    !- Apply Thursday
   Yes,                                    !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   1,                                      !- Start Month
   22,                                     !- Start Day
@@ -13576,7 +13592,6 @@ OS:Schedule:Rule,
   ,                                       !- Apply Thursday
   ,                                       !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   1,                                      !- Start Month
   1,                                      !- Start Day
@@ -13611,7 +13626,6 @@ OS:Schedule:Rule,
   ,                                       !- Apply Thursday
   ,                                       !- Apply Friday
   ,                                       !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   1,                                      !- Start Month
   1,                                      !- Start Day
@@ -13640,7 +13654,6 @@ OS:Schedule:Rule,
   Yes,                                    !- Apply Thursday
   Yes,                                    !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   12,                                     !- Start Month
   18,                                     !- Start Day
@@ -13669,7 +13682,6 @@ OS:Schedule:Rule,
   Yes,                                    !- Apply Thursday
   Yes,                                    !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   5,                                      !- Start Month
   1,                                      !- Start Day
@@ -13712,8 +13724,8 @@ OS:Surface,
   ,                                       !- View Factor to Ground
   ,                                       !- Number of Vertices
   27.9654, 0.228599999999997, 6.9596,     !- X,Y,Z Vertex 1 {m}
-  27.9654, 0.228599999999997, -3.15937125270842e-018, !- X,Y,Z Vertex 2 {m}
-  101.117399999996, 0.228599999999995, 1.29229774521356e-016, !- X,Y,Z Vertex 3 {m}
+  27.9654, 0.228599999999997, -3.1593712527084e-18, !- X,Y,Z Vertex 2 {m}
+  101.117399999996, 0.228599999999995, 1.29229774521356e-16, !- X,Y,Z Vertex 3 {m}
   101.117399999998, 0.228599999999996, 6.9596; !- X,Y,Z Vertex 4 {m}
 
 OS:Exterior:Lights:Definition,
@@ -13902,8 +13914,8 @@ OS:Schedule:Constant,
 OS:ScheduleTypeLimits,
   {d1848abf-71db-4e61-aaec-ed1a1017a2c3}, !- Handle
   Schedule Type Limits 1,                 !- Name
-  0,                                      !- Lower Limit Value {BasedOnField A4}
-  1,                                      !- Upper Limit Value {BasedOnField A4}
+  0,                                      !- Lower Limit Value
+  1,                                      !- Upper Limit Value
   Discrete,                               !- Numeric Type
   Availability;                           !- Unit Type
 
@@ -13996,16 +14008,16 @@ OS:ThermostatSetpoint:DualSetpoint,
 OS:ScheduleTypeLimits,
   {75a43c79-3f47-470a-92b8-f92f4e2721ec}, !- Handle
   Temperature 38,                         !- Name
-  ,                                       !- Lower Limit Value {BasedOnField A4}
-  ,                                       !- Upper Limit Value {BasedOnField A4}
+  ,                                       !- Lower Limit Value
+  ,                                       !- Upper Limit Value
   Continuous,                             !- Numeric Type
   Temperature;                            !- Unit Type
 
 OS:ScheduleTypeLimits,
   {3d8bc51b-173e-405d-8426-28cad7249731}, !- Handle
   Temperature 39,                         !- Name
-  ,                                       !- Lower Limit Value {BasedOnField A4}
-  ,                                       !- Upper Limit Value {BasedOnField A4}
+  ,                                       !- Lower Limit Value
+  ,                                       !- Upper Limit Value
   Continuous,                             !- Numeric Type
   Temperature;                            !- Unit Type
 
@@ -14013,6 +14025,7 @@ OS:PlantLoop,
   {abc7bf81-c2c2-49fe-8780-3b7f458fb968}, !- Handle
   Hot Water Loop,                         !- Name
   ,                                       !- Fluid Type
+  0,                                      !- Glycol Concentration
   ,                                       !- User Defined Fluid Type
   ,                                       !- Plant Equipment Operation Heating Load
   ,                                       !- Plant Equipment Operation Cooling Load
@@ -14031,10 +14044,23 @@ OS:PlantLoop,
   ,                                       !- Demand Side Branch List Name
   ,                                       !- Demand Side Connector List Name
   Optimal,                                !- Load Distribution Scheme
-  ,                                       !- Availability Manager List Name
+  {4b150659-78f7-4170-9c4e-acbff07e2a50}, !- Availability Manager List Name
   ,                                       !- Plant Loop Demand Calculation Scheme
   ,                                       !- Common Pipe Simulation
-  ;                                       !- Pressure Simulation Type
+  ,                                       !- Pressure Simulation Type
+  ,                                       !- Plant Equipment Operation Heating Load Schedule
+  ,                                       !- Plant Equipment Operation Cooling Load Schedule
+  ,                                       !- Primary Plant Equipment Operation Scheme Schedule
+  ,                                       !- Component Setpoint Operation Scheme Schedule
+  ,                                       !- Demand Mixer Name
+  ,                                       !- Demand Splitter Name
+  ,                                       !- Supply Mixer Name
+  ;                                       !- Supply Splitter Name
+
+OS:AvailabilityManagerAssignmentList,
+  {4b150659-78f7-4170-9c4e-acbff07e2a50}, !- Handle
+  Hot Water Loop AvailabilityManagerAssignmentList, !- Name
+  ;                                       !- Availability Manager Name 1
 
 OS:Sizing:Plant,
   {e3632743-2e78-4539-9033-dfbfef67bc04}, !- Handle
@@ -14080,7 +14106,6 @@ OS:Connector:Splitter,
 
 OS:Connection,
   {6330372e-b586-449b-a650-787f31f821e6}, !- Handle
-  {3cdf8c26-0f56-47c3-9468-b60e5bf11e67}, !- Name
   {abc7bf81-c2c2-49fe-8780-3b7f458fb968}, !- Source Object
   11,                                     !- Outlet Port
   {e4ce73d1-d291-4c6f-8832-10a8320093dc}, !- Target Object
@@ -14088,7 +14113,6 @@ OS:Connection,
 
 OS:Connection,
   {735a43b1-9770-4754-8b70-830c235e4d35}, !- Handle
-  {23fa1ff2-f30f-4c1c-8335-4b3e6d237d64}, !- Name
   {e5621e66-2aef-4d5c-ad36-512d3193b7db}, !- Source Object
   3,                                      !- Outlet Port
   {782a3b94-b78a-45b8-87ed-106ede00f378}, !- Target Object
@@ -14096,7 +14120,6 @@ OS:Connection,
 
 OS:Connection,
   {02083fc0-84ec-47c9-8709-5b8ae7df4a10}, !- Handle
-  {e44c891a-d1ae-4692-af24-3876700f297e}, !- Name
   {9782239d-4855-4b17-b5e8-f4fe037253e0}, !- Source Object
   3,                                      !- Outlet Port
   {abc7bf81-c2c2-49fe-8780-3b7f458fb968}, !- Target Object
@@ -14138,7 +14161,6 @@ OS:Connector:Splitter,
 
 OS:Connection,
   {c4bafe27-1331-4012-bb26-e53a2b77b2bf}, !- Handle
-  {7a383e8c-24c9-4a85-aa08-62d0d73b7952}, !- Name
   {abc7bf81-c2c2-49fe-8780-3b7f458fb968}, !- Source Object
   14,                                     !- Outlet Port
   {8e651786-9ab8-4043-aa05-d993ebc91d9d}, !- Target Object
@@ -14146,7 +14168,6 @@ OS:Connection,
 
 OS:Connection,
   {f512ca9a-6d05-40bb-987a-4fad6c0b1d4d}, !- Handle
-  {47bdaaf3-8820-4233-ada8-5fdf931f42e3}, !- Name
   {a36df825-f51c-4ac6-8a14-13ebbedde89b}, !- Source Object
   3,                                      !- Outlet Port
   {8f369355-7744-4a42-9783-cb68bc76b4b5}, !- Target Object
@@ -14154,7 +14175,6 @@ OS:Connection,
 
 OS:Connection,
   {5f97eea2-cb9b-4a75-9570-0b384830882c}, !- Handle
-  {0f6c49dc-922e-4272-81ef-9f8375bed004}, !- Name
   {c63d1954-d23c-4528-9d41-6b31536a31ff}, !- Source Object
   3,                                      !- Outlet Port
   {abc7bf81-c2c2-49fe-8780-3b7f458fb968}, !- Target Object
@@ -14175,14 +14195,30 @@ OS:Pump:VariableSpeed,
   -0.301,                                 !- Coefficient 3 of the Part Load Performance Curve
   0.7347,                                 !- Coefficient 4 of the Part Load Performance Curve
   ,                                       !- Minimum Flow Rate {m3/s}
-  Intermittent;                           !- Pump Control Type
+  Intermittent,                           !- Pump Control Type
+  ,                                       !- Pump Flow Rate Schedule Name
+  ,                                       !- Pump Curve Name
+  ,                                       !- Impeller Diameter {m}
+  ,                                       !- VFD Control Type
+  ,                                       !- Pump RPM Schedule Name
+  ,                                       !- Minimum Pressure Schedule {Pa}
+  ,                                       !- Maximum Pressure Schedule {Pa}
+  ,                                       !- Minimum RPM Schedule {rev/min}
+  ,                                       !- Maximum RPM Schedule {rev/min}
+  ,                                       !- Zone Name
+  0.5,                                    !- Skin Loss Radiative Fraction
+  PowerPerFlowPerPressure,                !- Design Power Sizing Method
+  348701.1,                               !- Design Electric Power per Unit Flow Rate {W/(m3/s)}
+  1.282051282,                            !- Design Shaft Power per Unit Flow Rate per Unit Head {W-s/m3-Pa}
+  0.0;                                    !- Design Minimum Flow Rate Fraction
 
-OS:DistrictHeating,
+OS:DistrictHeating:Water,
   {81039e35-72c8-40ea-9d3c-7419602d5c63}, !- Handle
   Hot Water Loop District Heating,        !- Name
   {89e364c8-251c-4c73-b924-643c66e2e4df}, !- Hot Water Inlet Node Name
   {608e2614-8981-4838-ad0a-f592ba610914}, !- Hot Water Outlet Node Name
-  1000000000;                             !- Nominal Capacity {W}
+  1000000000,                             !- Nominal Capacity {W}
+  {b5dfd00d-9733-424e-924c-94bce471bca3}; !- Capacity Fraction Schedule
 
 OS:SetpointManager:OutdoorAirReset,
   {f0f29b7b-b8c8-4b8a-a996-ef22dad9e940}, !- Handle
@@ -14237,7 +14273,6 @@ OS:Node,
 
 OS:Connection,
   {89e364c8-251c-4c73-b924-643c66e2e4df}, !- Handle
-  {96879974-0773-48c1-b85c-a689cf2d1e09}, !- Name
   {782a3b94-b78a-45b8-87ed-106ede00f378}, !- Source Object
   3,                                      !- Outlet Port
   {81039e35-72c8-40ea-9d3c-7419602d5c63}, !- Target Object
@@ -14245,7 +14280,6 @@ OS:Connection,
 
 OS:Connection,
   {608e2614-8981-4838-ad0a-f592ba610914}, !- Handle
-  {639072e1-32f0-43b1-adcf-50734a4b50e9}, !- Name
   {81039e35-72c8-40ea-9d3c-7419602d5c63}, !- Source Object
   3,                                      !- Outlet Port
   {3b4f3971-0091-4b1b-b306-998ed4b7af6b}, !- Target Object
@@ -14253,7 +14287,6 @@ OS:Connection,
 
 OS:Connection,
   {54e62c3d-79d0-4ce8-a8fd-abf58d61eb60}, !- Handle
-  {692ba496-3892-4728-9cf5-6b6fe30fb921}, !- Name
   {3b4f3971-0091-4b1b-b306-998ed4b7af6b}, !- Source Object
   3,                                      !- Outlet Port
   {59084dc8-35de-4959-8769-a0586291ec2a}, !- Target Object
@@ -14267,7 +14300,6 @@ OS:Node,
 
 OS:Connection,
   {3ab59374-3a7f-4e3c-950b-d82c909b272d}, !- Handle
-  {0ececbdb-2b0d-4ff2-bd15-88576e2f0330}, !- Name
   {e5621e66-2aef-4d5c-ad36-512d3193b7db}, !- Source Object
   4,                                      !- Outlet Port
   {45f69ae6-c789-4e21-a4c7-8ca930405426}, !- Target Object
@@ -14281,7 +14313,6 @@ OS:Node,
 
 OS:Connection,
   {8bb16193-6c9c-4307-9566-c2cb16de3fcc}, !- Handle
-  {cb1a74c2-6d7a-42d5-bd6e-2a3f9c12228d}, !- Name
   {45f69ae6-c789-4e21-a4c7-8ca930405426}, !- Source Object
   3,                                      !- Outlet Port
   {7b5e1bdd-43f0-4292-a0bd-6640e81f8d7c}, !- Target Object
@@ -14289,7 +14320,6 @@ OS:Connection,
 
 OS:Connection,
   {2be0b97e-308b-498e-a15c-ad115ce2f5c3}, !- Handle
-  {42e9dca7-77ab-4562-af7d-21c35a8dc47a}, !- Name
   {7b5e1bdd-43f0-4292-a0bd-6640e81f8d7c}, !- Source Object
   3,                                      !- Outlet Port
   {6c27465d-8637-4da3-a59e-bab1b76b8a6e}, !- Target Object
@@ -14297,7 +14327,6 @@ OS:Connection,
 
 OS:Connection,
   {6f3a8e54-8f61-4b1b-a525-bbabdec607b6}, !- Handle
-  {44ed8972-e89d-4d03-a5ac-9a99db6a14c7}, !- Name
   {6c27465d-8637-4da3-a59e-bab1b76b8a6e}, !- Source Object
   3,                                      !- Outlet Port
   {59084dc8-35de-4959-8769-a0586291ec2a}, !- Target Object
@@ -14311,7 +14340,6 @@ OS:Node,
 
 OS:Connection,
   {617c4745-d6a9-4a64-9a19-b3f3152fa951}, !- Handle
-  {3a0ffcbf-4a1c-41d2-84e4-7a48c04c1310}, !- Name
   {e4ce73d1-d291-4c6f-8832-10a8320093dc}, !- Source Object
   3,                                      !- Outlet Port
   {bba59b69-c763-4a99-91e8-e03047f616de}, !- Target Object
@@ -14319,7 +14347,6 @@ OS:Connection,
 
 OS:Connection,
   {a2721838-5c53-490e-9643-dac82f65e320}, !- Handle
-  {13fac348-ac0c-4d91-abfb-2e54146783b8}, !- Name
   {bba59b69-c763-4a99-91e8-e03047f616de}, !- Source Object
   3,                                      !- Outlet Port
   {9031eae7-9188-49fe-8c7b-c85153ee24be}, !- Target Object
@@ -14327,7 +14354,6 @@ OS:Connection,
 
 OS:Connection,
   {b65bbb1b-a40e-4eee-916a-30e13c9ae94e}, !- Handle
-  {685285d0-8803-46a7-99a4-4567d7161964}, !- Name
   {9031eae7-9188-49fe-8c7b-c85153ee24be}, !- Source Object
   3,                                      !- Outlet Port
   {e5621e66-2aef-4d5c-ad36-512d3193b7db}, !- Target Object
@@ -14341,7 +14367,6 @@ OS:Node,
 
 OS:Connection,
   {f2fc1b0d-0a5d-450e-999e-708388a078f6}, !- Handle
-  {b4c6fc1c-0045-4f62-85bc-fa33a488898b}, !- Name
   {59084dc8-35de-4959-8769-a0586291ec2a}, !- Source Object
   2,                                      !- Outlet Port
   {1d699179-ce5b-42dc-a1dc-1bd2e3cac27b}, !- Target Object
@@ -14349,7 +14374,6 @@ OS:Connection,
 
 OS:Connection,
   {541a3a60-0e63-4aca-a71d-9c2cc737fae5}, !- Handle
-  {18fa0583-e52d-4b42-80f3-1345f6a582fe}, !- Name
   {1d699179-ce5b-42dc-a1dc-1bd2e3cac27b}, !- Source Object
   3,                                      !- Outlet Port
   {d00f3571-71f6-4b7a-ba67-7aa6da5f97a8}, !- Target Object
@@ -14357,7 +14381,6 @@ OS:Connection,
 
 OS:Connection,
   {9d763bd7-c997-4d18-8930-0b13a29c3eed}, !- Handle
-  {8ba8fc12-91dd-45c2-9869-ae78a3f7b3f8}, !- Name
   {d00f3571-71f6-4b7a-ba67-7aa6da5f97a8}, !- Source Object
   3,                                      !- Outlet Port
   {9782239d-4855-4b17-b5e8-f4fe037253e0}, !- Target Object
@@ -14371,7 +14394,6 @@ OS:Node,
 
 OS:Connection,
   {ce70b2c5-8253-405a-bc49-754a6e2889df}, !- Handle
-  {66e55020-9f50-4a67-b709-8393a1ca6e07}, !- Name
   {8f369355-7744-4a42-9783-cb68bc76b4b5}, !- Source Object
   3,                                      !- Outlet Port
   {9fbc5cd0-b43a-4efe-bcf4-a899ae133bb1}, !- Target Object
@@ -14379,7 +14401,6 @@ OS:Connection,
 
 OS:Connection,
   {3cc761a7-b181-4bb3-b0d1-603ec3cad0da}, !- Handle
-  {6a08d18f-a7ba-4bbe-b726-b6ce4c84c55f}, !- Name
   {9fbc5cd0-b43a-4efe-bcf4-a899ae133bb1}, !- Source Object
   3,                                      !- Outlet Port
   {921a3173-defb-4790-80e1-88f25abed1da}, !- Target Object
@@ -14387,7 +14408,6 @@ OS:Connection,
 
 OS:Connection,
   {755181ba-f1df-42fd-9253-0190c3b5dd77}, !- Handle
-  {5f89000c-d708-4abe-bd26-2c591e5a0f99}, !- Name
   {921a3173-defb-4790-80e1-88f25abed1da}, !- Source Object
   3,                                      !- Outlet Port
   {a4665836-a18e-404f-9ad1-796d355dce76}, !- Target Object
@@ -14401,7 +14421,6 @@ OS:Node,
 
 OS:Connection,
   {563215b1-0bb7-4970-9cfe-31155228f03c}, !- Handle
-  {4021abf6-bf09-4db7-b8fb-a5a1257d7251}, !- Name
   {8e651786-9ab8-4043-aa05-d993ebc91d9d}, !- Source Object
   3,                                      !- Outlet Port
   {f0c5bbb0-2dfd-44eb-b263-df7a666b0e5e}, !- Target Object
@@ -14409,7 +14428,6 @@ OS:Connection,
 
 OS:Connection,
   {40b3ad61-ebbc-4e91-ae47-aac833947151}, !- Handle
-  {437a818c-e9e9-4f24-b62d-f9805ba0d4d9}, !- Name
   {f0c5bbb0-2dfd-44eb-b263-df7a666b0e5e}, !- Source Object
   3,                                      !- Outlet Port
   {3e3be7b6-d5a0-4a4f-a24b-cc5a551a42b3}, !- Target Object
@@ -14417,7 +14435,6 @@ OS:Connection,
 
 OS:Connection,
   {aadbfb48-6519-439f-88bc-3c8e3b6e7036}, !- Handle
-  {83374277-326c-4421-9ec3-ac2b10555914}, !- Name
   {3e3be7b6-d5a0-4a4f-a24b-cc5a551a42b3}, !- Source Object
   3,                                      !- Outlet Port
   {a36df825-f51c-4ac6-8a14-13ebbedde89b}, !- Target Object
@@ -14431,7 +14448,6 @@ OS:Node,
 
 OS:Connection,
   {d8002b87-2e2b-44c3-8a47-8cdf39d86daf}, !- Handle
-  {e30f3c59-b540-4def-b9ee-1dc2c3dff85f}, !- Name
   {a4665836-a18e-404f-9ad1-796d355dce76}, !- Source Object
   2,                                      !- Outlet Port
   {eab82a0f-1918-4da6-840f-1da8bb253586}, !- Target Object
@@ -14439,7 +14455,6 @@ OS:Connection,
 
 OS:Connection,
   {44365af2-98fc-4fa9-8a5f-6e634d53d26f}, !- Handle
-  {92ad1e3d-7e91-4783-94c7-5727e504d71c}, !- Name
   {eab82a0f-1918-4da6-840f-1da8bb253586}, !- Source Object
   3,                                      !- Outlet Port
   {d8976f92-b68f-4ba9-ade3-0493ece6f8f1}, !- Target Object
@@ -14447,7 +14462,6 @@ OS:Connection,
 
 OS:Connection,
   {1568b42c-c145-4d47-8c9d-a894bd1783cb}, !- Handle
-  {5a12df4c-f8a1-4f78-9d5d-f6d4bc2c5b1b}, !- Name
   {d8976f92-b68f-4ba9-ade3-0493ece6f8f1}, !- Source Object
   3,                                      !- Outlet Port
   {c63d1954-d23c-4528-9d41-6b31536a31ff}, !- Target Object
@@ -14458,8 +14472,9 @@ OS:AirLoopHVAC,
   Air Loop HVAC AHU-1-02-03_VAV,          !- Name
   ,                                       !- Controller List Name
   {42cc1368-3c9c-4bc1-a9dc-6d5cfb99a530}, !- Availability Schedule
-  {1918613e-931b-498f-9163-f9cd5c2f5aa5}, !- Availability Manager
+  {ca2cc6f8-9bc7-483c-88bb-d514e354dd09}, !- Availability Manager List Name
   56.63369316,                            !- Design Supply Air Flow Rate {m3/s}
+  1,                                      !- Design Return Air Flow Fraction of Supply Air Flow
   ,                                       !- Branch List Name
   ,                                       !- Connector List Name
   {336a6cd5-1172-447a-a30c-41cfd86c2bd3}, !- Supply Side Inlet Node Name
@@ -14467,16 +14482,47 @@ OS:AirLoopHVAC,
   {4de501ba-0c4c-487f-92e5-643ded841019}, !- Demand Side Inlet Node A
   {6d9197c5-2a77-44c1-8454-372eb5017d5a}, !- Supply Side Outlet Node A
   ,                                       !- Demand Side Inlet Node B
-  ;                                       !- Supply Side Outlet Node B
+  ,                                       !- Supply Side Outlet Node B
+  ,                                       !- Return Air Bypass Flow Temperature Setpoint Schedule Name
+  ,                                       !- Demand Mixer Name
+  ,                                       !- Demand Splitter A Name
+  ,                                       !- Demand Splitter B Name
+  ;                                       !- Supply Splitter Name
+
+OS:AvailabilityManagerAssignmentList,
+  {ca2cc6f8-9bc7-483c-88bb-d514e354dd09}, !- Handle
+  Air Loop HVAC AHU-1-02-03_VAV AvailabilityManagerAssignmentList, !- Name
+  {1918613e-931b-498f-9163-f9cd5c2f5aa5}; !- Availability Manager Name 1
 
 OS:AvailabilityManager:NightCycle,
   {1918613e-931b-498f-9163-f9cd5c2f5aa5}, !- Handle
   Availability Manager Night Cycle 1,     !- Name
-  ,                                       !- Applicability Schedule
+  {06311442-8cda-4a5f-80af-b0aae6a52dc1}, !- Applicability Schedule
   ,                                       !- Fan Schedule
   CycleOnAny,                             !- Control Type
   ,                                       !- Thermostat Tolerance {deltaC}
-  ;                                       !- Cycling Run Time {s}
+  ,                                       !- Cycling Run Time Control Type
+  ,                                       !- Cycling Run Time {s}
+  {94d6e058-f8a5-42f0-93fa-049e1aafe776}, !- Control Zone or Zone List Name
+  {f557cc97-0a65-4cb5-b2c0-639dddf69261}, !- Cooling Control Zone or Zone List Name
+  {ec98c773-dd0e-4609-863e-16f91d86a661}, !- Heating Control Zone or Zone List Name
+  {b78ec97d-a31e-4998-af1e-b5e8b9e827f2}; !- Heating Zone Fans Only Zone or Zone List Name
+
+OS:ModelObjectList,
+  {94d6e058-f8a5-42f0-93fa-049e1aafe776}, !- Handle
+  Availability Manager Night Cycle 1 Control Zone List; !- Name
+
+OS:ModelObjectList,
+  {f557cc97-0a65-4cb5-b2c0-639dddf69261}, !- Handle
+  Availability Manager Night Cycle 1 Cooling Control Zone List; !- Name
+
+OS:ModelObjectList,
+  {ec98c773-dd0e-4609-863e-16f91d86a661}, !- Handle
+  Availability Manager Night Cycle 1 Heating Control Zone List; !- Name
+
+OS:ModelObjectList,
+  {b78ec97d-a31e-4998-af1e-b5e8b9e827f2}, !- Handle
+  Availability Manager Night Cycle 1 Heating Zone Fans Only Zone List; !- Name
 
 OS:Node,
   {6758b186-eb15-4630-b9e2-44eafcc23764}, !- Handle
@@ -14492,7 +14538,6 @@ OS:Node,
 
 OS:Connection,
   {336a6cd5-1172-447a-a30c-41cfd86c2bd3}, !- Handle
-  {98a484a8-1ec7-49a3-a436-a393fb4a0ba2}, !- Name
   {80b6d89c-f4f0-4bee-bef3-6a5da3c0d98b}, !- Source Object
   7,                                      !- Outlet Port
   {6758b186-eb15-4630-b9e2-44eafcc23764}, !- Target Object
@@ -14500,7 +14545,6 @@ OS:Connection,
 
 OS:Connection,
   {6d9197c5-2a77-44c1-8454-372eb5017d5a}, !- Handle
-  {6faa5f5c-4f1e-45ef-acb6-91f8c58cb40a}, !- Name
   {6be041e2-6a32-4530-96d1-202975b5ef23}, !- Source Object
   3,                                      !- Outlet Port
   {80b6d89c-f4f0-4bee-bef3-6a5da3c0d98b}, !- Target Object
@@ -14526,7 +14570,6 @@ OS:Node,
 
 OS:Connection,
   {4de501ba-0c4c-487f-92e5-643ded841019}, !- Handle
-  {1529ea40-60eb-4816-85cf-9427e90afedc}, !- Name
   {80b6d89c-f4f0-4bee-bef3-6a5da3c0d98b}, !- Source Object
   9,                                      !- Outlet Port
   {15dbee40-b308-4bac-9e46-99a0f20f4960}, !- Target Object
@@ -14534,7 +14577,6 @@ OS:Connection,
 
 OS:Connection,
   {31ae91f3-0408-4514-a0bb-8fbd4ff25c69}, !- Handle
-  {83e54cb8-c2eb-4e0b-bc6f-719b423e1308}, !- Name
   {5acca883-3e53-48e6-a75e-2af6a41c5a0f}, !- Source Object
   3,                                      !- Outlet Port
   {80b6d89c-f4f0-4bee-bef3-6a5da3c0d98b}, !- Target Object
@@ -14554,7 +14596,6 @@ OS:AirLoopHVAC:ZoneMixer,
 
 OS:Connection,
   {a69553d3-16a2-465d-882e-cc0a92ad249d}, !- Handle
-  {90557ef4-ccbd-49e7-9b9f-7f4997a98fc2}, !- Name
   {15dbee40-b308-4bac-9e46-99a0f20f4960}, !- Source Object
   3,                                      !- Outlet Port
   {35ce775b-f149-4fe0-bd75-3d969e4f57d6}, !- Target Object
@@ -14562,7 +14603,6 @@ OS:Connection,
 
 OS:Connection,
   {31326885-305b-4dee-9d8b-d736b7655532}, !- Handle
-  {2677f51e-e85b-48c1-a599-b183b40d99a2}, !- Name
   {331bb0d6-91b5-46c1-ada7-4f1773b9a70f}, !- Source Object
   2,                                      !- Outlet Port
   {5acca883-3e53-48e6-a75e-2af6a41c5a0f}, !- Target Object
@@ -14573,7 +14613,7 @@ OS:Sizing:System,
   {80b6d89c-f4f0-4bee-bef3-6a5da3c0d98b}, !- AirLoop Name
   Sensible,                               !- Type of Load to Size On
   Autosize,                               !- Design Outdoor Air Flow Rate {m3/s}
-  0.3,                                    !- Minimum System Air Flow Ratio
+  0.3,                                    !- Central Heating Maximum System Air Flow Ratio
   7,                                      !- Preheat Design Temperature {C}
   0.008,                                  !- Preheat Design Humidity Ratio {kg-H2O/kg-Air}
   12.8,                                   !- Precool Design Temperature {C}
@@ -14606,13 +14646,14 @@ OS:Sizing:System,
   Autosize,                               !- Heating Design Capacity {W}
   157,                                    !- Heating Design Capacity Per Floor Area {W/m2}
   1,                                      !- Fraction of Autosized Heating Design Capacity
-  OnOff;                                  !- Central Cooling Capacity Control Method
+  OnOff,                                  !- Central Cooling Capacity Control Method
+  ;                                       !- Occupant Diversity
 
 OS:Fan:VariableVolume,
   {71b68fcf-4b50-4830-b039-2bdafe034e2c}, !- Handle
   Air Loop HVAC AHU-1-02-03_VAV Central Supply Fan, !- Name
   {06311442-8cda-4a5f-80af-b0aae6a52dc1}, !- Availability Schedule Name
-  0.7,                                    !- Fan Efficiency
+  0.7,                                    !- Fan Total Efficiency
   1743.7,                                 !- Pressure Rise {Pa}
   56.63369316,                            !- Maximum Flow Rate {m3/s}
   FixedFlowRate,                          !- Fan Power Minimum Flow Rate Input Method
@@ -14674,7 +14715,8 @@ OS:Controller:OutdoorAir,
   ,                                       !- Humidistat Control Zone Name
   ,                                       !- High Humidity Outdoor Air Flow Ratio
   ,                                       !- Control High Indoor Humidity Based on Outdoor Humidity Ratio
-  BypassWhenWithinEconomizerLimits;       !- Heat Recovery Bypass Control Type
+  BypassWhenWithinEconomizerLimits,       !- Heat Recovery Bypass Control Type
+  InterlockedWithMechanicalCooling;       !- Economizer Operation Staging
 
 OS:Controller:MechanicalVentilation,
   {6697044d-05f4-4ceb-a71b-01bee3ce5a8f}, !- Handle
@@ -14708,7 +14750,6 @@ OS:Node,
 
 OS:Connection,
   {c5a8f725-a6fc-4f2b-98db-a78f9873b602}, !- Handle
-  {4e8b8b62-ff6b-4740-aeb1-857c61b3a0a0}, !- Name
   {0ac486c1-48d0-48ff-bd0b-52d28671b095}, !- Source Object
   7,                                      !- Outlet Port
   {00773e48-6f32-4770-af75-3d370dde74c0}, !- Target Object
@@ -14725,7 +14766,6 @@ OS:SetpointManager:Warmest,
 
 OS:Connection,
   {a50a2b58-9ffe-480d-a1b2-c1b5629a641d}, !- Handle
-  {50e942f3-9f5b-414d-b112-d89acf9f969b}, !- Name
   {71b68fcf-4b50-4830-b039-2bdafe034e2c}, !- Source Object
   17,                                     !- Outlet Port
   {6be041e2-6a32-4530-96d1-202975b5ef23}, !- Target Object
@@ -14739,7 +14779,6 @@ OS:Node,
 
 OS:Connection,
   {ea6a71a0-5ea7-46e0-bf9d-ea96da37c191}, !- Handle
-  {83a8034a-f1ab-47af-989f-382a4cb6c57e}, !- Name
   {aeca487d-9133-4740-97ab-5fdf14e5f330}, !- Source Object
   8,                                      !- Outlet Port
   {6fe60bde-b5fe-4985-9fc6-b972c4a1d689}, !- Target Object
@@ -14747,7 +14786,6 @@ OS:Connection,
 
 OS:Connection,
   {49f55670-b420-4534-acc0-ae09a9da53ee}, !- Handle
-  {5d7284aa-7a0e-4df6-b5c9-88bcb41e37cc}, !- Name
   {6fe60bde-b5fe-4985-9fc6-b972c4a1d689}, !- Source Object
   3,                                      !- Outlet Port
   {71b68fcf-4b50-4830-b039-2bdafe034e2c}, !- Target Object
@@ -14761,7 +14799,6 @@ OS:Node,
 
 OS:Connection,
   {7fd20003-cc5f-4f2a-886f-7a147ed8c4d9}, !- Handle
-  {093df6a6-6cd1-4f2f-99f5-8cf52a352ea3}, !- Name
   {a36df825-f51c-4ac6-8a14-13ebbedde89b}, !- Source Object
   4,                                      !- Outlet Port
   {9d19adbb-727e-4cfb-959d-04565c03297c}, !- Target Object
@@ -14775,7 +14812,6 @@ OS:Node,
 
 OS:Connection,
   {25243987-3725-4372-a92c-2fec8e93a8b6}, !- Handle
-  {a2235312-d306-4ba0-abca-0005914c700a}, !- Name
   {9d19adbb-727e-4cfb-959d-04565c03297c}, !- Source Object
   3,                                      !- Outlet Port
   {aeca487d-9133-4740-97ab-5fdf14e5f330}, !- Target Object
@@ -14783,7 +14819,6 @@ OS:Connection,
 
 OS:Connection,
   {f7f1af62-853b-42e5-ba32-263d301fe9b3}, !- Handle
-  {9758381f-ba16-4438-8948-cc4ad74a3748}, !- Name
   {aeca487d-9133-4740-97ab-5fdf14e5f330}, !- Source Object
   6,                                      !- Outlet Port
   {aeec6326-2c0f-4b9f-9c2f-a442b48a8fcb}, !- Target Object
@@ -14791,7 +14826,6 @@ OS:Connection,
 
 OS:Connection,
   {23257039-588b-4529-99e9-41c1bb6cd6f5}, !- Handle
-  {5739ae9b-50ae-4d3b-b8ff-03e5c37e31b5}, !- Name
   {aeec6326-2c0f-4b9f-9c2f-a442b48a8fcb}, !- Source Object
   3,                                      !- Outlet Port
   {a4665836-a18e-404f-9ad1-796d355dce76}, !- Target Object
@@ -14818,7 +14852,6 @@ OS:Node,
 
 OS:Connection,
   {5e006cb5-8f3a-45a3-9d53-0288f79ed7be}, !- Handle
-  {d9686efd-1309-46ae-838a-7e977ee8aefb}, !- Name
   {6758b186-eb15-4630-b9e2-44eafcc23764}, !- Source Object
   3,                                      !- Outlet Port
   {0ac486c1-48d0-48ff-bd0b-52d28671b095}, !- Target Object
@@ -14826,7 +14859,6 @@ OS:Connection,
 
 OS:Connection,
   {d0324ce6-b599-4f47-8a19-76c10a4534d6}, !- Handle
-  {12cd1e9f-ddc8-40e9-9e06-64eddb532ff4}, !- Name
   {0ac486c1-48d0-48ff-bd0b-52d28671b095}, !- Source Object
   5,                                      !- Outlet Port
   {ec210cee-40cb-4688-9aff-32b515fc22ff}, !- Target Object
@@ -14834,7 +14866,6 @@ OS:Connection,
 
 OS:Connection,
   {8b3837ca-843c-458d-9711-3e2278c80762}, !- Handle
-  {92e76716-bbbb-42ba-b389-51ba29348ce3}, !- Name
   {ec210cee-40cb-4688-9aff-32b515fc22ff}, !- Source Object
   3,                                      !- Outlet Port
   {aeca487d-9133-4740-97ab-5fdf14e5f330}, !- Target Object
@@ -14850,7 +14881,7 @@ OS:EvaporativeCooler:Direct:ResearchSpecial,
   {a639f7dd-d58b-49bb-bd9a-c861bf72a60d}, !- Handle
   Air Loop HVAC AHU-1-02-03_VAV Direct Evaporative Cooler, !- Name
   {8d6eb783-5848-48f0-9589-acd1be7a3840}, !- Availability Schedule Name
-  0.95,                                   !- Cooler Effectiveness
+  0.95,                                   !- Cooler Design Effectiveness
   180,                                    !- Recirculating Water Pump Power Consumption {W}
   Autosize,                               !- Primary Air Design Flow Rate {m3/s}
   {e4347bbf-e914-4097-8100-43ee9923f10c}, !- Air Inlet Node Name
@@ -14859,7 +14890,11 @@ OS:EvaporativeCooler:Direct:ResearchSpecial,
   0,                                      !- Drift Loss Fraction
   3,                                      !- Blowdown Concentration Ratio
   ,                                       !- Effectiveness Flow Ratio Modifier Curve Name
-  0.1;                                    !- Water Pump Power Sizing Factor {W/(m3/s)}
+  0.1,                                    !- Water Pump Power Sizing Factor {W/(m3/s)}
+  ,                                       !- Water Pump Power Modifier Curve Name
+  -99,                                    !- Evaporative Operation Minimum Drybulb Temperature
+  99,                                     !- Evaporative Operation Maximum Limit Wetbulb Temperature
+  99;                                     !- Evaporative Operation Maximum Limit Drybulb Temperature
 
 OS:Node,
   {54cf1dcc-a204-4e4d-9003-8931103afb80}, !- Handle
@@ -14869,7 +14904,6 @@ OS:Node,
 
 OS:Connection,
   {e4347bbf-e914-4097-8100-43ee9923f10c}, !- Handle
-  {4439656c-2dc8-4fef-8e34-b847fad62172}, !- Name
   {d6f0c38a-c1c7-4607-8d28-33f2d8e1ff8f}, !- Source Object
   3,                                      !- Outlet Port
   {a639f7dd-d58b-49bb-bd9a-c861bf72a60d}, !- Target Object
@@ -14877,7 +14911,6 @@ OS:Connection,
 
 OS:Connection,
   {324fd55c-e963-4760-a15e-95efd10e0806}, !- Handle
-  {95bc2167-556c-44b3-9408-9c862172374b}, !- Name
   {a639f7dd-d58b-49bb-bd9a-c861bf72a60d}, !- Source Object
   6,                                      !- Outlet Port
   {54cf1dcc-a204-4e4d-9003-8931103afb80}, !- Target Object
@@ -14885,7 +14918,6 @@ OS:Connection,
 
 OS:Connection,
   {954cf7e1-b7eb-4bf8-bbae-e8f6155ff644}, !- Handle
-  {2112d14b-ef21-4bb7-8991-85fa4694f595}, !- Name
   {54cf1dcc-a204-4e4d-9003-8931103afb80}, !- Source Object
   3,                                      !- Outlet Port
   {0ac486c1-48d0-48ff-bd0b-52d28671b095}, !- Target Object
@@ -14972,7 +15004,6 @@ OS:Schedule:Rule,
   Yes,                                    !- Apply Thursday
   Yes,                                    !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   5,                                      !- Start Month
   1,                                      !- Start Day
@@ -15001,7 +15032,6 @@ OS:Schedule:Rule,
   Yes,                                    !- Apply Thursday
   Yes,                                    !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   12,                                     !- Start Month
   18,                                     !- Start Day
@@ -15030,7 +15060,6 @@ OS:Schedule:Rule,
   ,                                       !- Apply Thursday
   ,                                       !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   1,                                      !- Start Month
   1,                                      !- Start Day
@@ -15078,7 +15107,6 @@ OS:Node,
 
 OS:Connection,
   {4fb00565-e3e1-4ade-b758-97b0d3bf2258}, !- Handle
-  {bfdaf464-3529-4c0c-a028-72d3d8a4e0f2}, !- Name
   {a36df825-f51c-4ac6-8a14-13ebbedde89b}, !- Source Object
   5,                                      !- Outlet Port
   {a707a8c5-6889-45d6-9cb6-59f1487f1d3b}, !- Target Object
@@ -15092,7 +15120,6 @@ OS:Node,
 
 OS:Connection,
   {1f5e58ca-101f-455b-bbd4-ed403ff6803a}, !- Handle
-  {06a37477-b98b-4a77-8413-d94b23c92c94}, !- Name
   {a707a8c5-6889-45d6-9cb6-59f1487f1d3b}, !- Source Object
   3,                                      !- Outlet Port
   {1798c409-8fb4-4f4d-bbe3-61b1c868dde8}, !- Target Object
@@ -15100,7 +15127,6 @@ OS:Connection,
 
 OS:Connection,
   {ab864aaa-1609-42c1-b8d0-8bb8dcdd9830}, !- Handle
-  {c71f2f42-9eaf-4979-a41c-8654a2a1cca4}, !- Name
   {1798c409-8fb4-4f4d-bbe3-61b1c868dde8}, !- Source Object
   6,                                      !- Outlet Port
   {6155c094-2b18-4f07-a2f2-58e836795621}, !- Target Object
@@ -15108,7 +15134,6 @@ OS:Connection,
 
 OS:Connection,
   {d6cf92bd-fc75-4e9b-ac21-9a8a1d978cb6}, !- Handle
-  {2908e31d-30b1-4418-baa1-0f7b90b07e68}, !- Name
   {6155c094-2b18-4f07-a2f2-58e836795621}, !- Source Object
   3,                                      !- Outlet Port
   {a4665836-a18e-404f-9ad1-796d355dce76}, !- Target Object
@@ -15142,7 +15167,7 @@ OS:AirTerminal:SingleDuct:VAV:Reheat,
   0,                                      !- Minimum Hot Water or Steam Flow Rate {m3/s}
   {cf5e26b5-baae-40fe-b7a2-f32d51d1b729}, !- Air Outlet Node Name
   0.001,                                  !- Convergence Tolerance
-  Reverse,                                !- Damper Heating Action
+  ReverseWithLimits,                      !- Damper Heating Action
   ,                                       !- Maximum Flow per Zone Floor Area During Reheat {m3/s-m2}
   ,                                       !- Maximum Flow Fraction During Reheat
   35,                                     !- Maximum Reheat Air Temperature {C}
@@ -15156,7 +15181,6 @@ OS:Node,
 
 OS:Connection,
   {51cb9c5f-5b40-485c-b9a7-be4ffc36cfb6}, !- Handle
-  {81bb5cc5-8660-4a62-94f7-aeff1ec947d6}, !- Name
   {e284b0a1-10f1-441d-a12f-f8bce36fa649}, !- Source Object
   3,                                      !- Outlet Port
   {58603f0b-1cf7-4a0e-a3af-da38cee98e1c}, !- Target Object
@@ -15164,15 +15188,13 @@ OS:Connection,
 
 OS:Connection,
   {6fa9ec0b-7d67-4ed3-b6a7-48f8a161216b}, !- Handle
-  {9de005fe-56ca-476b-8deb-203acdb7bf72}, !- Name
-  {6f6da13e-8cc0-4b66-ba77-f3f7916b1f52}, !- Source Object
-  12,                                     !- Outlet Port
+  {c0fa847c-d186-4c61-9d7a-774a168baa25}, !- Source Object
+  3,                                      !- Outlet Port
   {82a08f27-9069-48f6-b25e-f743193a6005}, !- Target Object
   2;                                      !- Inlet Port
 
 OS:Connection,
   {29213329-728e-44f6-bc09-d09e9d827949}, !- Handle
-  {0e052d6a-effd-48ce-afd3-c13ef7f4cb8e}, !- Name
   {82a08f27-9069-48f6-b25e-f743193a6005}, !- Source Object
   3,                                      !- Outlet Port
   {331bb0d6-91b5-46c1-ada7-4f1773b9a70f}, !- Target Object
@@ -15186,7 +15208,6 @@ OS:Node,
 
 OS:Connection,
   {1ba4107c-ab9a-41cb-a6d7-edeeaf44f43b}, !- Handle
-  {c61c1419-f131-443a-9bdb-fab423218339}, !- Name
   {35ce775b-f149-4fe0-bd75-3d969e4f57d6}, !- Source Object
   3,                                      !- Outlet Port
   {2c604530-8625-4cf3-adba-4964b5267ae1}, !- Target Object
@@ -15194,7 +15215,6 @@ OS:Connection,
 
 OS:Connection,
   {c09f8a6e-5f7e-4e01-b3a6-51fbea32edde}, !- Handle
-  {360d3ddb-611f-4069-bdb2-22d47ec22598}, !- Name
   {2c604530-8625-4cf3-adba-4964b5267ae1}, !- Source Object
   3,                                      !- Outlet Port
   {2a313c2a-c41b-440c-aafd-e4a806e28289}, !- Target Object
@@ -15202,7 +15222,6 @@ OS:Connection,
 
 OS:Connection,
   {cf5e26b5-baae-40fe-b7a2-f32d51d1b729}, !- Handle
-  {82ddd106-3e9d-4e1e-8c0d-bcdb2160505d}, !- Name
   {2a313c2a-c41b-440c-aafd-e4a806e28289}, !- Source Object
   12,                                     !- Outlet Port
   {e284b0a1-10f1-441d-a12f-f8bce36fa649}, !- Target Object
@@ -15212,7 +15231,7 @@ OS:Fan:ZoneExhaust,
   {e212296b-762d-4822-a7f4-643b2cfeb2f7}, !- Handle
   Parking Level 1B ParkingLot Exhaust Fan, !- Name
   {6b5282d2-f8cf-4103-85d4-82e0ebfef4dd}, !- Availability Schedule Name
-  0.6,                                    !- Fan Efficiency
+  0.6,                                    !- Fan Total Efficiency
   716.49,                                 !- Pressure Rise {Pa}
   35.396058225,                           !- Maximum Flow Rate {m3/s}
   {faea7e59-8f49-4848-80ee-6b1074d32fc4}, !- Air Inlet Node Name
@@ -15226,8 +15245,8 @@ OS:Fan:ZoneExhaust,
 OS:ScheduleTypeLimits,
   {4c4a99f4-3598-4aa9-850c-f20b6e8a90fc}, !- Handle
   OnOff,                                  !- Name
-  0,                                      !- Lower Limit Value {BasedOnField A4}
-  1,                                      !- Upper Limit Value {BasedOnField A4}
+  0,                                      !- Lower Limit Value
+  1,                                      !- Upper Limit Value
   Discrete,                               !- Numeric Type
   Availability;                           !- Unit Type
 
@@ -15249,8 +15268,8 @@ OS:Schedule:Day,
 OS:ScheduleTypeLimits,
   {6ddbf2bb-dab8-421f-aa72-09e1c1bab487}, !- Handle
   Dimensionless,                          !- Name
-  0,                                      !- Lower Limit Value {BasedOnField A4}
-  1,                                      !- Upper Limit Value {BasedOnField A4}
+  0,                                      !- Lower Limit Value
+  1,                                      !- Upper Limit Value
   Continuous,                             !- Numeric Type
   Dimensionless;                          !- Unit Type
 
@@ -15262,7 +15281,6 @@ OS:Node,
 
 OS:Connection,
   {ffdd9a9b-56af-458c-9535-c7ea815a547c}, !- Handle
-  {e4a97c1d-70a6-4e49-bbf1-e595394036e9}, !- Name
   {73fbdcf0-4980-4bc9-9283-47a54fbd0cba}, !- Source Object
   3,                                      !- Outlet Port
   {1a5fe072-99c2-49a6-8476-9fd1984ab8f4}, !- Target Object
@@ -15270,7 +15288,6 @@ OS:Connection,
 
 OS:Connection,
   {faea7e59-8f49-4848-80ee-6b1074d32fc4}, !- Handle
-  {9528f6c7-690b-4573-a8dc-15db9845062c}, !- Name
   {1a5fe072-99c2-49a6-8476-9fd1984ab8f4}, !- Source Object
   3,                                      !- Outlet Port
   {e212296b-762d-4822-a7f4-643b2cfeb2f7}, !- Target Object
@@ -15284,7 +15301,6 @@ OS:Node,
 
 OS:Connection,
   {04af760d-e7e3-414c-9af8-112137704968}, !- Handle
-  {a744d06b-47b4-4e9c-b188-6941d1fe5729}, !- Name
   {e212296b-762d-4822-a7f4-643b2cfeb2f7}, !- Source Object
   7,                                      !- Outlet Port
   {ff04d91c-9c80-4797-b164-26ff25bd726c}, !- Target Object
@@ -15294,7 +15310,7 @@ OS:Fan:ZoneExhaust,
   {a571e157-761c-44a3-a21c-9af0f89ae7f3}, !- Handle
   Parking Level 2B ParkingLot Exhaust Fan, !- Name
   {6b5282d2-f8cf-4103-85d4-82e0ebfef4dd}, !- Availability Schedule Name
-  0.6,                                    !- Fan Efficiency
+  0.6,                                    !- Fan Total Efficiency
   908.41,                                 !- Pressure Rise {Pa}
   40.115532655,                           !- Maximum Flow Rate {m3/s}
   {f612422b-2be3-4aa1-98a1-b3e6b6c38f40}, !- Air Inlet Node Name
@@ -15328,7 +15344,6 @@ OS:Node,
 
 OS:Connection,
   {7d7dbb58-5945-4a8d-9a29-df950c2c0f9d}, !- Handle
-  {29f4c158-0887-477d-b6c4-a271e5a0ae9d}, !- Name
   {f2b9fafd-9387-48c0-afc6-fa66d2df6a52}, !- Source Object
   3,                                      !- Outlet Port
   {6e6f5a04-65ca-45da-af35-dca36494fef7}, !- Target Object
@@ -15336,7 +15351,6 @@ OS:Connection,
 
 OS:Connection,
   {f612422b-2be3-4aa1-98a1-b3e6b6c38f40}, !- Handle
-  {81ed7634-cd88-4d4c-b9e4-4808c81db2f9}, !- Name
   {6e6f5a04-65ca-45da-af35-dca36494fef7}, !- Source Object
   3,                                      !- Outlet Port
   {a571e157-761c-44a3-a21c-9af0f89ae7f3}, !- Target Object
@@ -15350,7 +15364,6 @@ OS:Node,
 
 OS:Connection,
   {3b4d03fc-777c-4e0e-b05b-c22865c7eb0b}, !- Handle
-  {9a44e88b-78ea-4617-af51-f2e0a55f7642}, !- Name
   {a571e157-761c-44a3-a21c-9af0f89ae7f3}, !- Source Object
   7,                                      !- Outlet Port
   {eafc8bea-fb00-43e9-91a2-d54c0ff796ac}, !- Target Object
@@ -15410,7 +15423,7 @@ OS:LifeCycleCost,
 
 OS:LifeCycleCost,
   {84710858-b42c-4c84-8c3a-cb6d32de7006}, !- Handle
-  Replace Glazing Constructions,          !- Name
+  Replace Glazing Constructions 1,        !- Name
   Construction,                           !- Category
   Building,                               !- Item Type
   {f73b031c-bb31-4fa0-ad96-2e9846c4d752}, !- Item Name
@@ -15423,7 +15436,7 @@ OS:LifeCycleCost,
 
 OS:LifeCycleCost,
   {b8c24b96-dbbc-4134-a3b5-4a9a2e7dac1c}, !- Handle
-  Replace Glazing Constructions,          !- Name
+  Replace Glazing Constructions 2,        !- Name
   Construction,                           !- Category
   Building,                               !- Item Type
   {f73b031c-bb31-4fa0-ad96-2e9846c4d752}, !- Item Name
@@ -15634,7 +15647,6 @@ OS:Schedule:Rule,
   ,                                       !- Apply Thursday
   ,                                       !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   1,                                      !- Start Month
   1,                                      !- Start Day
@@ -15708,7 +15720,6 @@ OS:Schedule:Rule,
   ,                                       !- Apply Thursday
   ,                                       !- Apply Friday
   ,                                       !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   1,                                      !- Start Month
   1,                                      !- Start Day
@@ -15799,7 +15810,6 @@ OS:Node,
 
 OS:Connection,
   {6b8f98da-466b-4c3e-ac5b-f50253e5dc41}, !- Handle
-  {80b542a0-ec22-4cdd-aa33-5f16c50ac433}, !- Name
   {3989f983-000a-48db-a592-f365eaae1992}, !- Source Object
   4,                                      !- Outlet Port
   {e5b6792f-0f66-4bcb-b742-c688efd502cf}, !- Target Object
@@ -15813,7 +15823,6 @@ OS:Node,
 
 OS:Connection,
   {37abc355-1f51-44c1-a598-960b694762a9}, !- Handle
-  {4053fcbc-e919-417b-8705-004f4cd22da4}, !- Name
   {e5b6792f-0f66-4bcb-b742-c688efd502cf}, !- Source Object
   3,                                      !- Outlet Port
   {8b6a4e1f-4e74-432e-9198-9e9921d913b9}, !- Target Object
@@ -15821,7 +15830,6 @@ OS:Connection,
 
 OS:Connection,
   {5f780a61-a247-44e7-92e4-f0512d89f467}, !- Handle
-  {51351b0f-f66c-4f72-9ba7-6f9a8e9a464f}, !- Name
   {8b6a4e1f-4e74-432e-9198-9e9921d913b9}, !- Source Object
   3,                                      !- Outlet Port
   {d27f9a47-89f2-43c5-9a7b-c72f5653cf6e}, !- Target Object
@@ -15829,7 +15837,6 @@ OS:Connection,
 
 OS:Connection,
   {e4b8f372-0700-46d5-815d-f5ef542fa408}, !- Handle
-  {7fef5ced-7380-466d-a2c0-196623c45745}, !- Name
   {d27f9a47-89f2-43c5-9a7b-c72f5653cf6e}, !- Source Object
   3,                                      !- Outlet Port
   {8caf3cf2-ab3a-4fba-b51a-31c4757f1de5}, !- Target Object
@@ -15857,271 +15864,316 @@ OS:Construction:CfactorUndergroundWall,
   {a6ad788a-10a1-4b26-b28d-e65ff8e574dc}, !- Handle
   Surface 124 C-Factor Construction,      !- Name
   6.47321982,                             !- C-Factor {W/m2-K}
-  6.60400470688325;                       !- Height {m}
+  6.60400470688325,                       !- Height {m}
+  {8801a223-c26c-4954-a0b3-0ae430c5ff44}; !- Surface Rendering Name
 
 OS:Construction:CfactorUndergroundWall,
   {740223b5-443c-41bc-b3fe-8336bb6dd8d9}, !- Handle
   Surface 126 C-Factor Construction,      !- Name
   6.47321982,                             !- C-Factor {W/m2-K}
-  6.60400427817142;                       !- Height {m}
+  6.60400427817142,                       !- Height {m}
+  {05078d8f-1998-474d-a2b9-0ab9c0b68d44}; !- Surface Rendering Name
 
 OS:Construction:CfactorUndergroundWall,
   {8f974f1e-8ff0-4107-9cc5-998b2ae7ed1f}, !- Handle
   Surface 128 C-Factor Construction,      !- Name
   6.47321982,                             !- C-Factor {W/m2-K}
-  6.60400421057925;                       !- Height {m}
+  6.60400421057925,                       !- Height {m}
+  {49182b68-50e0-4332-9e64-6c1723e7ac70}; !- Surface Rendering Name
 
 OS:Construction:CfactorUndergroundWall,
   {bca3dab3-5fba-4866-86aa-7710ca4ffdcb}, !- Handle
   Surface 129 C-Factor Construction,      !- Name
   6.47321982,                             !- C-Factor {W/m2-K}
-  6.60400371066502;                       !- Height {m}
+  6.60400371066502,                       !- Height {m}
+  {fc9243ae-14b0-445a-94d1-cc52121dc090}; !- Surface Rendering Name
 
 OS:Construction:CfactorUndergroundWall,
   {3e1212d5-c487-4743-831b-f50e8f39d667}, !- Handle
   Surface 130 C-Factor Construction,      !- Name
   6.47321982,                             !- C-Factor {W/m2-K}
-  6.60400409214322;                       !- Height {m}
+  6.60400409214322,                       !- Height {m}
+  {806f3853-3a71-424f-84e1-3e397f5eb9ba}; !- Surface Rendering Name
 
 OS:Construction:CfactorUndergroundWall,
   {59fc3a44-2530-44ee-adf1-737819254140}, !- Handle
   Surface 131 C-Factor Construction,      !- Name
   6.47321982,                             !- C-Factor {W/m2-K}
-  6.6040045608065;                        !- Height {m}
+  6.6040045608065,                        !- Height {m}
+  {5949e922-88e7-4ce9-bda2-d3756d9bd714}; !- Surface Rendering Name
 
 OS:Construction:CfactorUndergroundWall,
   {787dacff-e534-4f09-9ae1-ee863a441766}, !- Handle
   Surface 132 C-Factor Construction,      !- Name
   6.47321982,                             !- C-Factor {W/m2-K}
-  6.6040038045904;                        !- Height {m}
+  6.6040038045904,                        !- Height {m}
+  {598d4140-1449-498d-916d-750b6f3d4b8e}; !- Surface Rendering Name
 
 OS:Construction:CfactorUndergroundWall,
   {31066e99-b32d-44cf-a2c1-4092a6bb9b37}, !- Handle
   Surface 133 C-Factor Construction,      !- Name
   6.47321982,                             !- C-Factor {W/m2-K}
-  6.6040038045904;                        !- Height {m}
+  6.6040038045904,                        !- Height {m}
+  {d4c77849-3203-4768-b221-45737bed489f}; !- Surface Rendering Name
 
 OS:Construction:CfactorUndergroundWall,
   {b4781f5e-2304-4eec-b3a0-0116107cc24f}, !- Handle
   Surface 134 C-Factor Construction,      !- Name
   6.47321982,                             !- C-Factor {W/m2-K}
-  6.60400475772694;                       !- Height {m}
+  6.60400475772694,                       !- Height {m}
+  {1c472447-d123-46aa-935e-925fa5205ac3}; !- Surface Rendering Name
 
 OS:Construction:CfactorUndergroundWall,
   {2fc2edb1-2c30-46c6-b9fb-f2a7aa98f996}, !- Handle
   Surface 135 C-Factor Construction,      !- Name
   6.47321982,                             !- C-Factor {W/m2-K}
-  6.60400304710778;                       !- Height {m}
+  6.60400304710778,                       !- Height {m}
+  {eb81a3c6-2e31-4b8a-9f98-3ed142f49cab}; !- Surface Rendering Name
 
 OS:Construction:CfactorUndergroundWall,
   {93b381f8-48d3-4a33-95df-9a047df20c74}, !- Handle
   Surface 138 C-Factor Construction,      !- Name
   6.47321982,                             !- C-Factor {W/m2-K}
-  6.60400470688325;                       !- Height {m}
+  6.60400470688325,                       !- Height {m}
+  {fc4b82be-28c8-4ec1-aa93-98ef87bec333}; !- Surface Rendering Name
 
 OS:Construction:CfactorUndergroundWall,
   {2b4e3834-75bd-4028-9f54-745acb9ea224}, !- Handle
   Surface 139 C-Factor Construction,      !- Name
   6.47321982,                             !- C-Factor {W/m2-K}
-  6.60400342104628;                       !- Height {m}
+  6.60400342104628,                       !- Height {m}
+  {fbfb348d-eb44-4a98-89d5-acf4240d1596}; !- Surface Rendering Name
 
 OS:Construction:CfactorUndergroundWall,
   {d6c40e1c-b7b8-4528-95b1-30a4ed2d457f}, !- Handle
   Surface 152 C-Factor Construction,      !- Name
   6.47321982,                             !- C-Factor {W/m2-K}
-  6.60400304508131;                       !- Height {m}
+  6.60400304508131,                       !- Height {m}
+  {f2a0c068-5c6d-48c5-b59d-d3e4287aaf36}; !- Surface Rendering Name
 
 OS:Construction:CfactorUndergroundWall,
   {5a5d871e-85a1-4042-afe6-1e0a90790409}, !- Handle
   Surface 127 C-Factor Construction,      !- Name
   6.47321982,                             !- C-Factor {W/m2-K}
-  6.60400371066502;                       !- Height {m}
+  6.60400371066502,                       !- Height {m}
+  {c65307ec-490a-42a4-96ce-eb14f893a5aa}; !- Surface Rendering Name
 
 OS:Construction:CfactorUndergroundWall,
   {5a3769ab-65b1-48b7-8d30-36be9f5f0f5f}, !- Handle
   Surface 123 C-Factor Construction,      !- Name
   6.47321982,                             !- C-Factor {W/m2-K}
-  6.60400475772694;                       !- Height {m}
+  6.60400475772694,                       !- Height {m}
+  {b1b7fdb8-621a-4581-b8f4-ae8cb8519d75}; !- Surface Rendering Name
 
 OS:Construction:CfactorUndergroundWall,
   {704ec706-ab30-426a-a9c3-b9e52399036f}, !- Handle
   Surface 125 C-Factor Construction,      !- Name
   6.47321982,                             !- C-Factor {W/m2-K}
-  6.60400456283297;                       !- Height {m}
+  6.60400456283297,                       !- Height {m}
+  {5f8aa015-4bfa-49cf-a889-b72b3cd98bd0}; !- Surface Rendering Name
 
 OS:Construction:CfactorUndergroundWall,
   {bd71aec3-be1c-4f62-8c66-6d0bea9f5cdb}, !- Handle
   Surface 137 C-Factor Construction,      !- Name
   6.47321982,                             !- C-Factor {W/m2-K}
-  6.60400285547574;                       !- Height {m}
+  6.60400285547574,                       !- Height {m}
+  {94a66cb2-fae1-493d-94e3-605c72cef255}; !- Surface Rendering Name
 
 OS:Construction:CfactorUndergroundWall,
   {948bb309-22e8-45ab-b0e1-72c3fe49f336}, !- Handle
   Surface 156 C-Factor Construction,      !- Name
   6.47321982,                             !- C-Factor {W/m2-K}
-  6.60400328003444;                       !- Height {m}
+  6.60400328003444,                       !- Height {m}
+  {7b2603a7-5d65-45da-a2b4-69c0891b59bd}; !- Surface Rendering Name
 
 OS:Construction:CfactorUndergroundWall,
   {384ff9d5-9043-44c9-b1ee-e540d30e40a7}, !- Handle
   Surface 107 C-Factor Construction,      !- Name
   6.47321982,                             !- C-Factor {W/m2-K}
-  3.4544036398399;                        !- Height {m}
+  3.4544036398399,                        !- Height {m}
+  {787b612a-b92a-44f3-a3c1-f074ab3313b4}; !- Surface Rendering Name
 
 OS:Construction:CfactorUndergroundWall,
   {bb8b92f0-f65a-4f75-b079-cacf8d5d8b0f}, !- Handle
   Surface 109 C-Factor Construction,      !- Name
   6.47321982,                             !- C-Factor {W/m2-K}
-  3.4544036398399;                        !- Height {m}
+  3.4544036398399,                        !- Height {m}
+  {35bcc3c8-6ac1-4c73-9ade-4b17ce858162}; !- Surface Rendering Name
 
 OS:Construction:CfactorUndergroundWall,
   {77061614-291e-4a17-aed1-f1a065d7c6c3}, !- Handle
   Surface 110 C-Factor Construction,      !- Name
   6.47321982,                             !- C-Factor {W/m2-K}
-  3.45440496135791;                       !- Height {m}
+  3.45440496135791,                       !- Height {m}
+  {f5752ef7-fc30-44a3-b693-d04fd5d64d79}; !- Surface Rendering Name
 
 OS:Construction:CfactorUndergroundWall,
   {c691ec8b-3cb3-4d08-b607-4b4d28b6ba4d}, !- Handle
   Surface 111 C-Factor Construction,      !- Name
   6.47321982,                             !- C-Factor {W/m2-K}
-  3.45440343475868;                       !- Height {m}
+  3.45440343475868,                       !- Height {m}
+  {b6236083-4ab9-46be-a2e5-33a9a271879c}; !- Surface Rendering Name
 
 OS:Construction:CfactorUndergroundWall,
   {44beac1a-df8b-4a0d-9101-1fc550f2ead0}, !- Handle
   Surface 112 C-Factor Construction,      !- Name
   6.47321982,                             !- C-Factor {W/m2-K}
-  3.45440368902265;                       !- Height {m}
+  3.45440368902265,                       !- Height {m}
+  {9dec4aba-844a-49b7-9ded-b828d3e0b70e}; !- Surface Rendering Name
 
 OS:Construction:CfactorUndergroundWall,
   {aa3f82e6-0731-4b65-aadf-d87219ba5b37}, !- Handle
   Surface 113 C-Factor Construction,      !- Name
   6.47321982,                             !- C-Factor {W/m2-K}
-  3.45440342584958;                       !- Height {m}
+  3.45440342584958,                       !- Height {m}
+  {b4b4a21c-a1ad-4ebe-afa2-0af789bdbc13}; !- Surface Rendering Name
 
 OS:Construction:CfactorUndergroundWall,
   {49c5ac10-d2d4-4e34-82eb-8728ce38ed26}, !- Handle
   Surface 115 C-Factor Construction,      !- Name
   6.47321982,                             !- C-Factor {W/m2-K}
-  3.45440354957678;                       !- Height {m}
+  3.45440354957678,                       !- Height {m}
+  {944d9477-1d1f-4b73-b4b1-af7124188dbe}; !- Surface Rendering Name
 
 OS:Construction:CfactorUndergroundWall,
   {f3a49b84-7f0d-44ce-ad34-8cb02982f87b}, !- Handle
   Surface 116 C-Factor Construction,      !- Name
   6.47321982,                             !- C-Factor {W/m2-K}
-  3.45440336919379;                       !- Height {m}
+  3.45440336919379,                       !- Height {m}
+  {71dcbeb7-d66d-45da-b9a9-68e6a7bf1443}; !- Surface Rendering Name
 
 OS:Construction:CfactorUndergroundWall,
   {22d64635-3109-4026-9d4c-50d4bc622516}, !- Handle
   Surface 118 C-Factor Construction,      !- Name
   6.47321982,                             !- C-Factor {W/m2-K}
-  3.45440333199471;                       !- Height {m}
+  3.45440333199471,                       !- Height {m}
+  {5adce10c-513a-4ebe-b1df-93d5470e3d91}; !- Surface Rendering Name
 
 OS:Construction:CfactorUndergroundWall,
   {8cb101cf-4b4a-4178-b55c-5933f15cae91}, !- Handle
   Surface 119 C-Factor Construction,      !- Name
   6.47321982,                             !- C-Factor {W/m2-K}
-  3.45440333199471;                       !- Height {m}
+  3.45440333199471,                       !- Height {m}
+  {d45ee958-f9fa-4d68-b018-f306adfe87cd}; !- Surface Rendering Name
 
 OS:Construction:CfactorUndergroundWall,
   {2cc672fe-674c-40d4-b1fd-f4f6097e82ed}, !- Handle
   Surface 120 C-Factor Construction,      !- Name
   6.47321982,                             !- C-Factor {W/m2-K}
-  3.45440431635214;                       !- Height {m}
+  3.45440431635214,                       !- Height {m}
+  {29a5ed38-5c20-4a94-bfa1-13d4c0f6bde5}; !- Surface Rendering Name
 
 OS:Construction:CfactorUndergroundWall,
   {b9de4843-54ab-4a67-b883-e51a9b6dc218}, !- Handle
   Surface 121 C-Factor Construction,      !- Name
   6.47321982,                             !- C-Factor {W/m2-K}
-  3.45440496135791;                       !- Height {m}
+  3.45440496135791,                       !- Height {m}
+  {f8f8d947-009e-4c1f-949b-9857fb19a11c}; !- Surface Rendering Name
 
 OS:Construction:CfactorUndergroundWall,
   {9e63a165-91b4-4d01-99ba-f0ed017343a6}, !- Handle
   Surface 167 C-Factor Construction,      !- Name
   6.47321982,                             !- C-Factor {W/m2-K}
-  3.45440431635211;                       !- Height {m}
+  3.45440431635211,                       !- Height {m}
+  {040565f0-6ebd-4e6a-a412-9bcbd482d224}; !- Surface Rendering Name
 
 OS:Construction:CfactorUndergroundWall,
   {ad246149-41f1-4944-a8dc-7515b45385fd}, !- Handle
   Surface 177 C-Factor Construction,      !- Name
   6.47321982,                             !- C-Factor {W/m2-K}
-  3.45440365714115;                       !- Height {m}
+  3.45440365714115,                       !- Height {m}
+  {d000b4c7-5897-4a95-a4b9-e883c6e205fb}; !- Surface Rendering Name
 
 OS:Construction:CfactorUndergroundWall,
   {c68b5d38-26f6-446b-a513-be480d82e728}, !- Handle
   Surface 179 C-Factor Construction,      !- Name
   6.47321982,                             !- C-Factor {W/m2-K}
-  3.45440469089036;                       !- Height {m}
+  3.45440469089036,                       !- Height {m}
+  {60af7add-c0e0-4c9a-9831-0c9ac4329ae6}; !- Surface Rendering Name
 
 OS:Construction:CfactorUndergroundWall,
   {9f7d867a-fe4f-4ed6-bb92-934bc598993a}, !- Handle
   Surface 114 C-Factor Construction,      !- Name
   6.47321982,                             !- C-Factor {W/m2-K}
-  3.45440410724786;                       !- Height {m}
+  3.45440410724786,                       !- Height {m}
+  {ee099858-8d2e-4f5e-8504-c791b774501e}; !- Surface Rendering Name
 
 OS:Construction:CfactorUndergroundWall,
   {97964441-c91d-4a62-88bc-e10f54c097d0}, !- Handle
   Surface 102 C-Factor Construction,      !- Name
   6.47321982,                             !- C-Factor {W/m2-K}
-  3.45440431636142;                       !- Height {m}
+  3.45440431636142,                       !- Height {m}
+  {2c2e39f1-e235-4a7f-ba10-5f66bcd4910b}; !- Surface Rendering Name
 
 OS:Construction:CfactorUndergroundWall,
   {a2810ffe-16bc-4836-ad9d-f7adab11e4a3}, !- Handle
   Surface 148 C-Factor Construction,      !- Name
   6.47321982,                             !- C-Factor {W/m2-K}
-  3.45440431636888;                       !- Height {m}
+  3.45440431636888,                       !- Height {m}
+  {4e76c48d-8d62-48ad-a4d4-ee5963100dd8}; !- Surface Rendering Name
 
 OS:Construction:CfactorUndergroundWall,
   {91d7fe62-ac97-4db2-89d5-b803fe598ae1}, !- Handle
   Surface 276 C-Factor Construction,      !- Name
   6.47321982,                             !- C-Factor {W/m2-K}
-  3.4544046176898;                        !- Height {m}
+  3.4544046176898,                        !- Height {m}
+  {7d8ada64-205f-4f45-bcc6-99ff7e36daf8}; !- Surface Rendering Name
 
 OS:Construction:CfactorUndergroundWall,
   {38501a7f-1654-4db5-9b50-5658ab54ea88}, !- Handle
   Surface 188 C-Factor Construction,      !- Name
   6.47321982,                             !- C-Factor {W/m2-K}
-  3.45440434728592;                       !- Height {m}
+  3.45440434728592,                       !- Height {m}
+  {744c4102-d63f-4b70-9614-266f3d505ab9}; !- Surface Rendering Name
 
 OS:Construction:CfactorUndergroundWall,
   {50141aa0-b7ff-448c-8da2-109184c4e399}, !- Handle
   Surface 175 C-Factor Construction,      !- Name
   6.47321982,                             !- C-Factor {W/m2-K}
-  3.45440431636046;                       !- Height {m}
+  3.45440431636046,                       !- Height {m}
+  {267318e1-20ab-40c1-8430-77a0df8cdf37}; !- Surface Rendering Name
 
 OS:Construction:CfactorUndergroundWall,
   {c3bc8a0a-c183-432b-93bd-7729984c068f}, !- Handle
   Surface 164 C-Factor Construction,      !- Name
   6.47321982,                             !- C-Factor {W/m2-K}
-  3.4544011522762;                        !- Height {m}
+  3.4544011522762,                        !- Height {m}
+  {f59d8019-0537-47e7-8caa-d8cc45d4e52d}; !- Surface Rendering Name
 
 OS:Construction:CfactorUndergroundWall,
   {621b5cb2-cb17-4c86-af09-d13b682bc12b}, !- Handle
   Surface 142 C-Factor Construction,      !- Name
   6.47321982,                             !- C-Factor {W/m2-K}
-  9.75360431636046;                       !- Height {m}
+  9.75360431636046,                       !- Height {m}
+  {4582f988-5af7-4e3b-ad7a-7cffe4cdafc2}; !- Surface Rendering Name
 
 OS:Construction:CfactorUndergroundWall,
   {23ab682d-5063-4c4c-bde5-83069fed6a33}, !- Handle
   Surface 144 C-Factor Construction,      !- Name
   6.47321982,                             !- C-Factor {W/m2-K}
-  9.75360431636046;                       !- Height {m}
+  9.75360431636046,                       !- Height {m}
+  {58b9f691-4e73-4185-a087-ca3de003711a}; !- Surface Rendering Name
 
 OS:Construction:CfactorUndergroundWall,
   {1612e002-1223-4a56-b109-bbf77074a290}, !- Handle
   Surface 145 C-Factor Construction,      !- Name
   6.47321982,                             !- C-Factor {W/m2-K}
-  9.75360431636046;                       !- Height {m}
+  9.75360431636046,                       !- Height {m}
+  {56e870d8-40c7-4a7f-9af4-39e34a1870bf}; !- Surface Rendering Name
 
 OS:Construction:CfactorUndergroundWall,
   {1f632ba8-e09d-428d-9777-75b2d8f8bdbe}, !- Handle
   Surface 146 C-Factor Construction,      !- Name
   6.47321982,                             !- C-Factor {W/m2-K}
-  9.75360431636046;                       !- Height {m}
+  9.75360431636046,                       !- Height {m}
+  {e00e7949-5894-4efa-8320-9fa5410917ff}; !- Surface Rendering Name
 
 OS:Construction:CfactorUndergroundWall,
   {67ea3a7d-9c43-4d4d-a269-60f430d751da}, !- Handle
   Surface 196 C-Factor Construction,      !- Name
   6.47321982,                             !- C-Factor {W/m2-K}
-  3.45440431798272;                       !- Height {m}
+  3.45440431798272,                       !- Height {m}
+  {364a03b9-3f50-471b-8c78-22b9da56dff8}; !- Surface Rendering Name
 
 OS:Schedule:Ruleset,
   {18b5a7bb-b319-4b7a-84da-185434b60bfe}, !- Handle
@@ -16189,7 +16241,6 @@ OS:Schedule:Rule,
   ,                                       !- Apply Thursday
   ,                                       !- Apply Friday
   ,                                       !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   12,                                     !- Start Month
   1,                                      !- Start Day
@@ -16224,7 +16275,6 @@ OS:Schedule:Rule,
   Yes,                                    !- Apply Thursday
   ,                                       !- Apply Friday
   ,                                       !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   12,                                     !- Start Month
   1,                                      !- Start Day
@@ -16256,7 +16306,6 @@ OS:Schedule:Rule,
   ,                                       !- Apply Thursday
   ,                                       !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   12,                                     !- Start Month
   1,                                      !- Start Day
@@ -16344,7 +16393,6 @@ OS:Schedule:Rule,
   ,                                       !- Apply Thursday
   ,                                       !- Apply Friday
   ,                                       !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   12,                                     !- Start Month
   1,                                      !- Start Day
@@ -16379,7 +16427,6 @@ OS:Schedule:Rule,
   Yes,                                    !- Apply Thursday
   ,                                       !- Apply Friday
   ,                                       !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   12,                                     !- Start Month
   1,                                      !- Start Day
@@ -16411,7 +16458,6 @@ OS:Schedule:Rule,
   ,                                       !- Apply Thursday
   ,                                       !- Apply Friday
   Yes,                                    !- Apply Saturday
-  ,                                       !- Apply Holiday
   DateRange,                              !- Date Specification Type
   12,                                     !- Start Month
   1,                                      !- Start Day
@@ -16432,4 +16478,319 @@ OS:Schedule:Day,
   24,                                     !- Hour 3
   0,                                      !- Minute 3
   1;                                      !- Value Until Time 3
+
+OS:Rendering:Color,
+  {29a5ed38-5c20-4a94-bfa1-13d4c0f6bde5}, !- Handle
+  Rendering Color 1,                      !- Name
+  240,                                    !- Rendering Red Value
+  240,                                    !- Rendering Green Value
+  255;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {f8f8d947-009e-4c1f-949b-9857fb19a11c}, !- Handle
+  Rendering Color 2,                      !- Name
+  255,                                    !- Rendering Red Value
+  245,                                    !- Rendering Green Value
+  240;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {040565f0-6ebd-4e6a-a412-9bcbd482d224}, !- Handle
+  Rendering Color 3,                      !- Name
+  135,                                    !- Rendering Red Value
+  250,                                    !- Rendering Green Value
+  206;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {d000b4c7-5897-4a95-a4b9-e883c6e205fb}, !- Handle
+  Rendering Color 4,                      !- Name
+  139,                                    !- Rendering Red Value
+  19,                                     !- Rendering Green Value
+  69;                                     !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {60af7add-c0e0-4c9a-9831-0c9ac4329ae6}, !- Handle
+  Rendering Color 5,                      !- Name
+  60,                                     !- Rendering Red Value
+  113,                                    !- Rendering Green Value
+  179;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {ee099858-8d2e-4f5e-8504-c791b774501e}, !- Handle
+  Rendering Color 7,                      !- Name
+  250,                                    !- Rendering Red Value
+  215,                                    !- Rendering Green Value
+  235;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {2c2e39f1-e235-4a7f-ba10-5f66bcd4910b}, !- Handle
+  Rendering Color 8,                      !- Name
+  176,                                    !- Rendering Red Value
+  230,                                    !- Rendering Green Value
+  224;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {4e76c48d-8d62-48ad-a4d4-ee5963100dd8}, !- Handle
+  Rendering Color 9,                      !- Name
+  135,                                    !- Rendering Red Value
+  250,                                    !- Rendering Green Value
+  206;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {7d8ada64-205f-4f45-bcc6-99ff7e36daf8}, !- Handle
+  Rendering Color 10,                     !- Name
+  255,                                    !- Rendering Red Value
+  220,                                    !- Rendering Green Value
+  248;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {744c4102-d63f-4b70-9614-266f3d505ab9}, !- Handle
+  Rendering Color 11,                     !- Name
+  175,                                    !- Rendering Red Value
+  238,                                    !- Rendering Green Value
+  238;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {267318e1-20ab-40c1-8430-77a0df8cdf37}, !- Handle
+  Rendering Color 12,                     !- Name
+  0,                                      !- Rendering Red Value
+  255,                                    !- Rendering Green Value
+  255;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {f59d8019-0537-47e7-8caa-d8cc45d4e52d}, !- Handle
+  Rendering Color 13,                     !- Name
+  210,                                    !- Rendering Red Value
+  140,                                    !- Rendering Green Value
+  180;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {4582f988-5af7-4e3b-ad7a-7cffe4cdafc2}, !- Handle
+  Rendering Color 14,                     !- Name
+  95,                                     !- Rendering Red Value
+  160,                                    !- Rendering Green Value
+  158;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {58b9f691-4e73-4185-a087-ca3de003711a}, !- Handle
+  Rendering Color 15,                     !- Name
+  210,                                    !- Rendering Red Value
+  140,                                    !- Rendering Green Value
+  180;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {56e870d8-40c7-4a7f-9af4-39e34a1870bf}, !- Handle
+  Rendering Color 16,                     !- Name
+  240,                                    !- Rendering Red Value
+  240,                                    !- Rendering Green Value
+  255;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {e00e7949-5894-4efa-8320-9fa5410917ff}, !- Handle
+  Rendering Color 17,                     !- Name
+  255,                                    !- Rendering Red Value
+  205,                                    !- Rendering Green Value
+  235;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {d45ee958-f9fa-4d68-b018-f306adfe87cd}, !- Handle
+  Rendering Color 18,                     !- Name
+  205,                                    !- Rendering Red Value
+  92,                                     !- Rendering Green Value
+  92;                                     !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {8801a223-c26c-4954-a0b3-0ae430c5ff44}, !- Handle
+  Rendering Color 19,                     !- Name
+  255,                                    !- Rendering Red Value
+  0,                                      !- Rendering Green Value
+  69;                                     !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {05078d8f-1998-474d-a2b9-0ab9c0b68d44}, !- Handle
+  Rendering Color 21,                     !- Name
+  240,                                    !- Rendering Red Value
+  128,                                    !- Rendering Green Value
+  128;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {49182b68-50e0-4332-9e64-6c1723e7ac70}, !- Handle
+  Rendering Color 22,                     !- Name
+  127,                                    !- Rendering Red Value
+  212,                                    !- Rendering Green Value
+  255;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {fc9243ae-14b0-445a-94d1-cc52121dc090}, !- Handle
+  Rendering Color 23,                     !- Name
+  255,                                    !- Rendering Red Value
+  0,                                      !- Rendering Green Value
+  215;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {806f3853-3a71-424f-84e1-3e397f5eb9ba}, !- Handle
+  Rendering Color 24,                     !- Name
+  192,                                    !- Rendering Red Value
+  192,                                    !- Rendering Green Value
+  192;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {5949e922-88e7-4ce9-bda2-d3756d9bd714}, !- Handle
+  Rendering Color 25,                     !- Name
+  255,                                    !- Rendering Red Value
+  225,                                    !- Rendering Green Value
+  228;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {598d4140-1449-498d-916d-750b6f3d4b8e}, !- Handle
+  Rendering Color 26,                     !- Name
+  245,                                    !- Rendering Red Value
+  179,                                    !- Rendering Green Value
+  222;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {d4c77849-3203-4768-b221-45737bed489f}, !- Handle
+  Rendering Color 27,                     !- Name
+  154,                                    !- Rendering Red Value
+  50,                                     !- Rendering Green Value
+  205;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {1c472447-d123-46aa-935e-925fa5205ac3}, !- Handle
+  Rendering Color 29,                     !- Name
+  255,                                    !- Rendering Red Value
+  180,                                    !- Rendering Green Value
+  105;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {eb81a3c6-2e31-4b8a-9f98-3ed142f49cab}, !- Handle
+  Rendering Color 30,                     !- Name
+  0,                                      !- Rendering Red Value
+  255,                                    !- Rendering Green Value
+  0;                                      !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {fc4b82be-28c8-4ec1-aa93-98ef87bec333}, !- Handle
+  Rendering Color 31,                     !- Name
+  250,                                    !- Rendering Red Value
+  210,                                    !- Rendering Green Value
+  250;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {fbfb348d-eb44-4a98-89d5-acf4240d1596}, !- Handle
+  Rendering Color 33,                     !- Name
+  255,                                    !- Rendering Red Value
+  181,                                    !- Rendering Green Value
+  228;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {f2a0c068-5c6d-48c5-b59d-d3e4287aaf36}, !- Handle
+  Rendering Color 34,                     !- Name
+  0,                                      !- Rendering Red Value
+  255,                                    !- Rendering Green Value
+  255;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {c65307ec-490a-42a4-96ce-eb14f893a5aa}, !- Handle
+  Rendering Color 35,                     !- Name
+  0,                                      !- Rendering Red Value
+  139,                                    !- Rendering Green Value
+  0;                                      !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {b1b7fdb8-621a-4581-b8f4-ae8cb8519d75}, !- Handle
+  Rendering Color 36,                     !- Name
+  188,                                    !- Rendering Red Value
+  143,                                    !- Rendering Green Value
+  143;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {5f8aa015-4bfa-49cf-a889-b72b3cd98bd0}, !- Handle
+  Rendering Color 37,                     !- Name
+  65,                                     !- Rendering Red Value
+  225,                                    !- Rendering Green Value
+  105;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {94a66cb2-fae1-493d-94e3-605c72cef255}, !- Handle
+  Rendering Color 38,                     !- Name
+  255,                                    !- Rendering Red Value
+  245,                                    !- Rendering Green Value
+  240;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {7b2603a7-5d65-45da-a2b4-69c0891b59bd}, !- Handle
+  Rendering Color 39,                     !- Name
+  255,                                    !- Rendering Red Value
+  213,                                    !- Rendering Green Value
+  239;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {787b612a-b92a-44f3-a3c1-f074ab3313b4}, !- Handle
+  Rendering Color 40,                     !- Name
+  255,                                    !- Rendering Red Value
+  255,                                    !- Rendering Green Value
+  0;                                      !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {35bcc3c8-6ac1-4c73-9ade-4b17ce858162}, !- Handle
+  Rendering Color 41,                     !- Name
+  250,                                    !- Rendering Red Value
+  215,                                    !- Rendering Green Value
+  235;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {f5752ef7-fc30-44a3-b693-d04fd5d64d79}, !- Handle
+  Rendering Color 42,                     !- Name
+  250,                                    !- Rendering Red Value
+  230,                                    !- Rendering Green Value
+  240;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {b6236083-4ab9-46be-a2e5-33a9a271879c}, !- Handle
+  Rendering Color 43,                     !- Name
+  153,                                    !- Rendering Red Value
+  204,                                    !- Rendering Green Value
+  50;                                     !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {9dec4aba-844a-49b7-9ded-b828d3e0b70e}, !- Handle
+  Rendering Color 44,                     !- Name
+  255,                                    !- Rendering Red Value
+  203,                                    !- Rendering Green Value
+  192;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {b4b4a21c-a1ad-4ebe-afa2-0af789bdbc13}, !- Handle
+  Rendering Color 45,                     !- Name
+  188,                                    !- Rendering Red Value
+  143,                                    !- Rendering Green Value
+  143;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {944d9477-1d1f-4b73-b4b1-af7124188dbe}, !- Handle
+  Rendering Color 46,                     !- Name
+  85,                                     !- Rendering Red Value
+  47,                                     !- Rendering Green Value
+  107;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {71dcbeb7-d66d-45da-b9a9-68e6a7bf1443}, !- Handle
+  Rendering Color 47,                     !- Name
+  255,                                    !- Rendering Red Value
+  71,                                     !- Rendering Green Value
+  99;                                     !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {5adce10c-513a-4ebe-b1df-93d5470e3d91}, !- Handle
+  Rendering Color 48,                     !- Name
+  230,                                    !- Rendering Red Value
+  250,                                    !- Rendering Green Value
+  230;                                    !- Rendering Blue Value
+
+OS:Rendering:Color,
+  {364a03b9-3f50-471b-8c78-22b9da56dff8}, !- Handle
+  Rendering Color 49,                     !- Name
+  139,                                    !- Rendering Red Value
+  0,                                      !- Rendering Green Value
+  0;                                      !- Rendering Blue Value
 


### PR DESCRIPTION
- use 'OS_DistrictHeating_Water', 'OS_DistrictHeating_Steam', not 'OS_DistrictHeatingWater', 'OS_DistrictHeatingSteam'
- fix surface matching issue in bldg_4 test model by making offending surfaces adiabatic