### PR TITLE
Fix deer lookup for simple glazing

### DIFF
--- a/lib/openstudio-standards/standards/deer/data/deer.constructions.json
+++ b/lib/openstudio-standards/standards/deer/data/deer.constructions.json
@@ -344,20 +344,20 @@
       "name": "DEER Metal Framed Window",
       "intended_surface_type": "ExteriorWindow",
       "standards_construction_type": "Nonmetal framing (all)",
-      "insulation_layer": "Simple Glazing",
+      "insulation_layer": null,
       "skylight_framing": null,
       "materials": [
-        "Simple Glazing"
+        "Simple Glazing U 1.23 SHGC 0.61 VT 0.25"
       ]
     },
     {
       "name": "DEER Skylight",
       "intended_surface_type": "ExteriorWindow",
       "standards_construction_type": "Nonmetal framing (all)",
-      "insulation_layer": "Simple Glazing",
+      "insulation_layer": null,
       "skylight_framing": null,
       "materials": [
-        "Simple Glazing"
+        "Simple Glazing U 1.23 SHGC 0.61 VT 0.25"
       ]
     },
     {

--- a/test/modules/create_typical/test_create_typical.rb
+++ b/test/modules/create_typical/test_create_typical.rb
@@ -27,6 +27,28 @@ class TestCreateTypical < Minitest::Test
     assert(starting_size < ending_size)
   end
 
+  def test_create_typical_deer_building_from_model
+    # load model and set up weather file
+    template = 'DEER Pre-1975'
+    climate_zone = 'CEC T24-CEC3'
+    std = Standard.build(template)
+    model = std.safe_load_model("#{File.dirname(__FILE__)}/../../../data/geometry/DEER_ESe.osm")
+    OpenstudioStandards::Weather.model_set_building_location(model, climate_zone: climate_zone)
+
+    # set output directory
+    output_dir = "#{__dir__}/output"
+    FileUtils.mkdir output_dir unless Dir.exist? output_dir
+
+    # apply create typical
+    starting_size = model.getModelObjects.size
+    result = @create.create_typical_building_from_model(model, template,
+                                                        climate_zone: climate_zone,
+                                                        sizing_run_directory: output_dir)
+    ending_size = model.getModelObjects.size
+    assert(result)
+    assert(starting_size < ending_size)
+  end
+
   def test_create_space_types_and_constructions
     model = OpenStudio::Model::Model.new
     building_type = 'PrimarySchool'


### PR DESCRIPTION
add a valid lookup for deer simple glazing constructions include properties in name for name parsing

Pull request overview
---------------------
Fixes an issue with DEER templates in create typical

### Pull Request Author

 - [x] Data changes or additions
 - [x] Added tests for added methods
 - [x] Resolved yard documentation errors for new code (ran `bundle exec rake doc`)
 - [x] Resolved rubocop syntax errors for new code (ran `bundle exec rake rubocop`)
 - [x] All new and existing tests passes

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [x] Perform a code review on GitHub
 - [x] All related changes have been implemented: method additions, changes, tests
 - [x] Check rubocop errors
 - [x] Check yard doc errors
 - [x] If fixing a defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] CI status: all green or justified
