### PR TITLE
Allow multiple radiant slab boundary conditions

### DIFF
--- a/lib/openstudio-standards/prototypes/common/objects/Prototype.hvac_systems.rb
+++ b/lib/openstudio-standards/prototypes/common/objects/Prototype.hvac_systems.rb
@@ -5173,16 +5173,19 @@ class Standard
         space.surfaces.each do |surface|
           if radiant_type == 'floor'
             if surface.surfaceType == 'Floor'
-              if surface.outsideBoundaryCondition == 'Ground'
+              if surface.outsideBoundaryCondition.include? 'Ground'
                 surface.setConstruction(radiant_ground_slab_construction)
               elsif surface.outsideBoundaryCondition == 'Outdoors'
                 surface.setConstruction(radiant_exterior_slab_construction)
               else # interior floor
                 surface.setConstruction(radiant_interior_floor_slab_construction)
 
-                # also assign construciton to adjacent surface
-                adjacent_surface = surface.adjacentSurface.get
-                adjacent_surface.setConstruction(rev_radiant_interior_floor_slab_construction)
+                # also assign construction to adjacent surface
+                adjacent_surface = surface.adjacentSurface
+                if adjacent_surface.is_initialized
+                  adjacent_surface = surface.adjacentSurface.get
+                  adjacent_surface.setConstruction(rev_radiant_interior_floor_slab_construction)
+                end
               end
             end
           elsif radiant_type == 'ceiling'
@@ -5192,9 +5195,12 @@ class Standard
               else # interior ceiling
                 surface.setConstruction(radiant_interior_ceiling_slab_construction)
 
-                # also assign construciton to adjacent surface
-                adjacent_surface = surface.adjacentSurface.get
-                adjacent_surface.setConstruction(rev_radiant_interior_ceiling_slab_construction)
+                # also assign construction to adjacent surface
+                adjacent_surface = surface.adjacentSurface
+                if adjacent_surface.is_initialized
+                  adjacent_surface = surface.adjacentSurface.get
+                  adjacent_surface.setConstruction(rev_radiant_interior_ceiling_slab_construction)
+                end
               end
             end
           end


### PR DESCRIPTION
The radiant slab construction was only checking for 'Ground' and 'Outdoors' conditions, and treating everything else and interior. Then it would try to find an adjacent surface. That did not exist for models with the 'GroundFCfactorMethod' boundary condition. Adjust to allow multiple radiant slab ground boundary conditions, and check if an adjacent surface exists before getting it.

Pull request overview
---------------------

### Pull Request Author
 - [x] Method changes or additions
 - [x] Resolved yard documentation errors for new code (ran `bundle exec rake doc`)
 - [x] Resolved rubocop syntax errors for new code (ran `bundle exec rake rubocop`)
 - [x] All new and existing tests passes

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [x] Perform a code review on GitHub
 - [x] All related changes have been implemented: method additions, changes, tests
 - [x] Check rubocop errors
 - [x] Check yard doc errors
 - [x] If fixing a defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [x] CI status: all green or justified
