### PR TITLE
correct call to headered_pumps_variable_speed_set_control_type

### DIFF
--- a/lib/openstudio-standards/standards/Standards.PlantLoop.rb
+++ b/lib/openstudio-standards/standards/Standards.PlantLoop.rb
@@ -830,7 +830,7 @@ class Standard
         pump_variable_speed_set_control_type(pump, pri_control_type)
       elsif sc.to_HeaderedPumpsVariableSpeed.is_initialized
         pump = sc.to_HeaderedPumpsVariableSpeed.get
-        headered_pump_variable_speed_set_control_type(pump, pri_control_type)
+        headered_pumps_variable_speed_set_control_type(pump, pri_control_type)
       end
     end
 
@@ -841,7 +841,7 @@ class Standard
         pump_variable_speed_set_control_type(pump, sec_control_type)
       elsif sc.to_HeaderedPumpsVariableSpeed.is_initialized
         pump = sc.to_HeaderedPumpsVariableSpeed.get
-        headered_pump_variable_speed_set_control_type(pump, sec_control_type)
+        headered_pumps_variable_speed_set_control_type(pump, sec_control_type)
       end
     end
 
@@ -903,7 +903,7 @@ class Standard
         pump_variable_speed_set_control_type(pump, control_type)
       elsif sc.to_HeaderedPumpsVariableSpeed.is_initialized
         pump = sc.to_HeaderedPumpsVariableSpeed.get
-        headered_pump_variable_speed_set_control_type(pump, control_type)
+        headered_pumps_variable_speed_set_control_type(pump, control_type)
       end
     end
 

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2004/ashrae_90_1_2004.PlantLoop.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2004/ashrae_90_1_2004.PlantLoop.rb
@@ -38,7 +38,7 @@ class ASHRAE9012004 < ASHRAE901
         pump_variable_speed_set_control_type(pump, pri_control_type)
       elsif sc.to_HeaderedPumpsVariableSpeed.is_initialized
         pump = sc.to_HeaderedPumpsVariableSpeed.get
-        headered_pump_variable_speed_set_control_type(pump, control_type)
+        headered_pumps_variable_speed_set_control_type(pump, control_type)
       end
     end
 
@@ -49,7 +49,7 @@ class ASHRAE9012004 < ASHRAE901
         pump_variable_speed_set_control_type(pump, sec_control_type)
       elsif sc.to_HeaderedPumpsVariableSpeed.is_initialized
         pump = sc.to_HeaderedPumpsVariableSpeed.get
-        headered_pump_variable_speed_set_control_type(pump, control_type)
+        headered_pumps_variable_speed_set_control_type(pump, control_type)
       end
     end
 

--- a/lib/openstudio-standards/standards/ashrae_90_1/nrel_zne_ready_2017/nrel_zne_ready_2017.PlantLoop.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/nrel_zne_ready_2017/nrel_zne_ready_2017.PlantLoop.rb
@@ -18,7 +18,7 @@ class NRELZNEReady2017 < ASHRAE901
         has_secondary_pump = true
       elsif sc.to_HeaderedPumpsVariableSpeed.is_initialized
         pump = sc.to_HeaderedPumpsVariableSpeed.get
-        headered_pump_variable_speed_set_control_type(pump, control_type)
+        headered_pumps_variable_speed_set_control_type(pump, control_type)
         has_secondary_pump = true
       end
     end
@@ -33,7 +33,7 @@ class NRELZNEReady2017 < ASHRAE901
         pump_variable_speed_set_control_type(pump, pri_control_type)
       elsif sc.to_HeaderedPumpsVariableSpeed.is_initialized
         pump = sc.to_HeaderedPumpsVariableSpeed.get
-        headered_pump_variable_speed_set_control_type(pump, control_type)
+        headered_pumps_variable_speed_set_control_type(pump, control_type)
       end
     end
 


### PR DESCRIPTION
Pull request overview
---------------------

Replaces calls to nonexistent `headered_pump_variable_speed_set_control_type` with proper `headered_pumps_variable_speed_set_control_type`. 

 - Fixes https://github.com/NREL/openstudio-standards/issues/1750
 
### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Method changes or additions
 - [ ] Data changes or additions
 - [ ] Added tests for added methods
 - [ ] If methods have been deprecated, update rest of code to use the new methods
 - [ ] Documented new methods using [yard syntax](https://rubydoc.info/gems/yard/file/docs/GettingStarted.md)
 - [ ] Resolved yard documentation errors for new code (ran `bundle exec rake doc`)
 - [ ] Resolved rubocop syntax errors for new code (ran `bundle exec rake rubocop`)
 - [ ] All new and existing tests passes
 - [ ] If the code adds new `require` statements, ensure these are in core ruby or add to the gemspec

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a code review on GitHub
 - [ ] All related changes have been implemented: method additions, changes, tests
 - [ ] Check rubocop errors
 - [ ] Check yard doc errors
 - [ ] If fixing a defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If a new feature, test the new feature and try creative ways to break it
 - [ ] CI status: all green or justified
