### PR TITLE
Add check for stat file missing typical week

### DIFF
--- a/lib/openstudio-standards/weather/stat_file.rb
+++ b/lib/openstudio-standards/weather/stat_file.rb
@@ -342,7 +342,7 @@ module OpenstudioStandards
         # week periods
         regex = /Typical Week Period selected:(.*?)C/
         match_data = @text.scan(regex)
-        if match_data.nil?
+        if match_data.nil? || match_data.empty?
           OpenStudio.logFree(OpenStudio::Warn, 'openstudio.Weather.stat_file', "Can't find typical weather weeks in the .stat file.")
         else
           @typical_summer_wet_week = Date.parse("#{match_data[0][0].split(':')[0]} 2000")

--- a/test/modules/weather/data/G0100010.stat
+++ b/test/modules/weather/data/G0100010.stat
@@ -1,0 +1,13 @@
+Statistics for wmo=722265
+ Location -- Maxwell Afb
+      {N 32°22'} {W 86°21' } {GMT -6.0 Hours}
+ Elevation -- 52.0m above sea level
+ Data Source -- MesoWest, NOAA ISD, and NSRDB
+
+ WMO Station 722265
+
+ - Monthly Statistics for Dry Bulb temperatures °C
+
+   Daily Avg   6.6   16.02   13.53   15.75   23.83   26.49   27.13   26.16   26.61   20.78   11.24   10.69
+
+ - Climate type  (ASHRAE Standard 196-2006 Climate Zone)**

--- a/test/modules/weather/test_weather_stat_file.rb
+++ b/test/modules/weather/test_weather_stat_file.rb
@@ -35,4 +35,11 @@ class TestWeatherStatFile < Minitest::Test
       assert_equal(12, stat_file.monthly_dry_bulb.size)
     end
   end
+
+  def test_load_sparse_stat_file
+    model = OpenStudio::Model::Model.new
+    stat_file_path = File.join(File.dirname(__FILE__),'data','G0100010.stat')
+    assert(File.exist?(stat_file_path))
+    stat_file = OpenstudioStandards::Weather::StatFile.new(stat_file_path)
+  end
 end


### PR DESCRIPTION
Pull request overview
---------------------
The ComStock 2018 weather files have incomplete .stat files.
This checks that the typical week content is available before trying to access the data.
Without it causes a failure in methods using ComStock weather files.

### Pull Request Author
 - [x] Method changes or additions
 - [x] Added tests for added methods
 - [x] Resolved yard documentation errors for new code (ran `bundle exec rake doc`)
 - [x] Resolved rubocop syntax errors for new code (ran `bundle exec rake rubocop`)
 - [x] All new and existing tests passes

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [x] Perform a code review on GitHub
 - [x] All related changes have been implemented: method additions, changes, tests
 - [x] Check rubocop errors
 - [x] Check yard doc errors
 - [x] If fixing a defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [x] If a new feature, test the new feature and try creative ways to break it
 - [x] CI status: all green or justified
