### PR TITLE
Fix: Parametric schedules error when profiles not matched

### DIFF
--- a/lib/openstudio-standards/schedules/parametric.rb
+++ b/lib/openstudio-standards/schedules/parametric.rb
@@ -511,14 +511,12 @@ module OpenstudioStandards
       # set scheduleRuleset properties
       props = schedule_ruleset.additionalProperties
 
-      if props.getFeatureAsString('param_sch_ver') == '0.0.1'
-        # don't need to gather more than once
-        return parametric_inputs
-      else
-        props.setFeature('param_sch_ver', '0.0.1') # this is needed to see if formulas are in sync with version of standards that processes them also used to flag schedule as parametric
-        props.setFeature('param_sch_floor', min_max['min'])
-        props.setFeature('param_sch_ceiling', min_max['max'])
-      end
+      # don't need to gather more than once
+      return parametric_inputs if props.getFeatureAsString('param_sch_ver') == '0.0.1'
+
+      props.setFeature('param_sch_ver', '0.0.1') # this is needed to see if formulas are in sync with version of standards that processes them also used to flag schedule as parametric
+      props.setFeature('param_sch_floor', min_max['min'])
+      props.setFeature('param_sch_ceiling', min_max['max'])
 
       # cleanup existing profiles
       OpenstudioStandards::Schedules.schedule_ruleset_cleanup_profiles(schedule_ruleset)
@@ -575,7 +573,7 @@ module OpenstudioStandards
       end
       # new rules are created at top of list - cleanup old rules
       if !(new_rule_ct == 0 || new_rule_ct == schedule_ruleset.scheduleRules.size)
-        schedule_ruleset.scheduleRules[new_rule_ct..-1].each(&:remove)
+        schedule_ruleset.scheduleRules[new_rule_ct..].each(&:remove)
       end
 
       # re-collect new schedule rules

--- a/lib/openstudio-standards/schedules/parametric.rb
+++ b/lib/openstudio-standards/schedules/parametric.rb
@@ -510,9 +510,15 @@ module OpenstudioStandards
 
       # set scheduleRuleset properties
       props = schedule_ruleset.additionalProperties
-      props.setFeature('param_sch_ver', '0.0.1') # this is needed to see if formulas are in sync with version of standards that processes them also used to flag schedule as parametric
-      props.setFeature('param_sch_floor', min_max['min'])
-      props.setFeature('param_sch_ceiling', min_max['max'])
+
+      if props.getFeatureAsString('param_sch_ver') == '0.0.1'
+        # don't need to gather more than once
+        return parametric_inputs
+      else
+        props.setFeature('param_sch_ver', '0.0.1') # this is needed to see if formulas are in sync with version of standards that processes them also used to flag schedule as parametric
+        props.setFeature('param_sch_floor', min_max['min'])
+        props.setFeature('param_sch_ceiling', min_max['max'])
+      end
 
       # cleanup existing profiles
       OpenstudioStandards::Schedules.schedule_ruleset_cleanup_profiles(schedule_ruleset)
@@ -525,8 +531,11 @@ module OpenstudioStandards
       sch_ruleset_days_used = OpenstudioStandards::Schedules.schedule_ruleset_get_annual_days_used(schedule_ruleset)
 
       # match up schedule rule days with hours of operation days
+      # sch_day_map is a hash where keys are the rule indices of the schedule
+      # and values are hashes where keys are the hours of operation rule index, and values are arrays of days that the shcedu
       sch_day_map = {}
       sch_ruleset_days_used.each do |sch_index, sch_days|
+        # first create a hash that maps each day index to the hoo index that covers that day
         day_map = {}
         sch_days.each do |day|
           # find the hour of operation rule that contains the day number
@@ -555,6 +564,8 @@ module OpenstudioStandards
           # skip if rules already match
           if (sch_ruleset_days_used[sch_index] - day_group).empty?
             OpenStudio.logFree(OpenStudio::Debug, 'openstudio.standards.Parametric.Schedules', "in #{__method__}: #{schedule_ruleset.name} rule #{sch_index} already matches hours of operation rule #{hoo_index}; new rule won't be created.")
+            # iterate new_rule_ct anyway to keep these rules
+            new_rule_ct += 1 unless sch_index == -1
             next
           end
           # create new rules
@@ -563,7 +574,9 @@ module OpenstudioStandards
         end
       end
       # new rules are created at top of list - cleanup old rules
-      schedule_ruleset.scheduleRules[new_rule_ct..-1].each(&:remove) unless new_rule_ct == 0
+      if !(new_rule_ct == 0 || new_rule_ct == schedule_ruleset.scheduleRules.size)
+        schedule_ruleset.scheduleRules[new_rule_ct..-1].each(&:remove)
+      end
 
       # re-collect new schedule rules
       schedule_days = OpenstudioStandards::Schedules.schedule_ruleset_get_schedule_day_rule_indices(schedule_ruleset)

--- a/lib/openstudio-standards/weather/modify.rb
+++ b/lib/openstudio-standards/weather/modify.rb
@@ -74,6 +74,10 @@ module OpenstudioStandards
         stat_file = OpenstudioStandards::Weather::StatFile.load(weather_file_path.sub('.epw', '.stat'))
       end
 
+      if stat_file.monthly_undis_ground_temps_0p5m.empty?
+        return false
+      end
+
       # set ground temperature shallow values based on .stat file
       ground_temperature_shallow = OpenStudio::Model::SiteGroundTemperatureShallow.new(model)
       ground_temperature_shallow.setJanuarySurfaceGroundTemperature(stat_file.monthly_undis_ground_temps_0p5m[0])
@@ -102,6 +106,10 @@ module OpenstudioStandards
       if stat_file.nil?
         weather_file_path = model.getWeatherFile.path.get.to_s
         stat_file = OpenstudioStandards::Weather::StatFile.load(weather_file_path.sub('.epw', '.stat'))
+      end
+
+      if stat_file.monthly_undis_ground_temps_4p0m.empty?
+        return false
       end
 
       # set ground temperature deep values based on .stat file
@@ -364,7 +372,7 @@ module OpenstudioStandards
                                          ddy_list: nil)
       # check that either weather_file_path or climate_zone provided
       if weather_file_path.nil? && climate_zone.nil?
-        OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.Weather.modify', 'model_set_building_location must be called with either the weather_file_path or climate_zone argument specified.')
+        OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.Weather.modify', "#{__method__} must be called with either the weather_file_path or climate_zone argument specified.")
         return false
       end
 
@@ -389,8 +397,14 @@ module OpenstudioStandards
       if File.file?(stat_file_path)
         stat_file = OpenstudioStandards::Weather::StatFile.load(stat_file_path)
         OpenstudioStandards::Weather.model_set_site_water_mains_temperature(model, stat_file: stat_file)
-        OpenstudioStandards::Weather.model_set_undisturbed_ground_temperature_shallow(model, stat_file: stat_file)
-        OpenstudioStandards::Weather.model_set_undisturbed_ground_temperature_deep(model, stat_file: stat_file)
+        if !OpenstudioStandards::Weather.model_set_undisturbed_ground_temperature_shallow(model, stat_file: stat_file)
+          OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.Weather.modify', "Could not find undisturbed shallow ground temps in .stat file at #{stat_file_path}. Unable to set undisturbed ground temperatures.")
+        end
+
+        if !OpenstudioStandards::Weather.model_set_undisturbed_ground_temperature_deep(model, stat_file: stat_file)
+          OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.Weather.modify', "Could not find undisturbed deep ground temps in .stat file at #{stat_file_path}. Unable to set undisturbed ground temperatures.")
+        end
+
         stat_file_climate_zone = stat_file.climate_zone
       else
         OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.Weather.modify', "Could not find .stat file at #{stat_file_path}. Unable to set site water mains temperature and undisturbed ground temperatures.")


### PR DESCRIPTION
Pull request overview
---------------------
@mdahlhausen reported that some ComStock workflows were failing with errors such as:
```
 "[openstudio.standards.Parametric.Schedules] In schedule_ruleset_get_parametric_inputs, schedule Mercantile_Retail BLDG_LIGHT_EndUseData Default has no hours_of_operation target index. Won't be modified",
 "[openstudio.standards.Parametric.Schedules] In schedule_ruleset_get_parametric_inputs, schedule FullServiceRestaurant Gas Equip Default has no hours_of_operation target index. Won't be modified",
 "[openstudio.standards.Parametric.Schedules] In schedule_ruleset_get_parametric_inputs, schedule RestaurantSitDown Kitchen_Exhaust_SCH Default has no hours_of_operation target index. Won't be modified",
```
This was due to some already-matched ScheduleRules were being removed after new ScheduleRules (matched with building hours of operation ScheduleRules) were created. This PR fixes the issue. 

It also includes some minor modification to the StatFile class to catch cases (such as in ComStock) where weather .stat files do not contain undisturbed ground temperatures, and does not try to set the missing info.

### Pull Request Author
 - [x] Method changes or additions
 - [ ] Added tests for added methods
 - [x] Resolved yard documentation errors for new code (ran `bundle exec rake doc`)
 - [ ] Resolved rubocop syntax errors for new code (ran `bundle exec rake rubocop`)
 - [x] All new and existing tests passes

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [x] Perform a code review on GitHub
 - [x] All related changes have been implemented: method additions, changes, tests
 - [ ] Check rubocop errors
 - [x] Check yard doc errors
 - [ ] If fixing a defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [x] If a new feature, test the new feature and try creative ways to break it
 - [x] CI status: all green or justified
