### PR TITLE
Add a guard clause to FC factor methods

### DIFF
--- a/lib/openstudio-standards/prototypes/common/objects/Prototype.refrigeration.rb
+++ b/lib/openstudio-standards/prototypes/common/objects/Prototype.refrigeration.rb
@@ -170,7 +170,7 @@ class Standard
 
     props = model_find_object(standards_data['refrigeration_walkins'], search_criteria)
     if props.nil?
-      OpenStudio.logFree(OpenStudio::Error, 'openstudio.Model.Model', "Could not find walkin properties for: #{search_criteria}.")
+      OpenStudio.logFree(OpenStudio::Error, 'openstudio.Prototype.refrigeration', "Could not find walkin properties for: #{search_criteria}.")
       return nil
     end
 
@@ -262,6 +262,12 @@ class Standard
     end
     if lighting_power.nil?
       lighting_power = lighting_power_mult * floor_surface_area
+    end
+
+    # Check validity of thermal zone
+    if OpenstudioStandards::ThermalZone.thermal_zone_plenum?(thermal_zone)
+      OpenStudio.logFree(OpenStudio::Error, 'openstudio.Prototype.refrigeration', "Thermal zone #{thermal_zone.name} is a plenum; cannot add walkins to a plenum.")
+      return nil
     end
 
     # Walk-In

--- a/test/doe_prototype/test_add_c_factor_wall.rb
+++ b/test/doe_prototype/test_add_c_factor_wall.rb
@@ -48,9 +48,8 @@ class TestAddCFactorWall < CreateDOEPrototypeBuildingTest
       #parse the modified model for the C-Factor constructions (it should be the only CFactor construction)
       c_factor_construction = model.getCFactorUndergroundWallConstructions[0]
 
-      c_factor_height =  c_factor_construction.height.round(3)
+      c_factor_height = c_factor_construction.height.round(3)
       c_factor_generated = c_factor_construction.cFactor.round(2)
-
 
       asserts = {
           'Height' => [c_factor_height, basement_wall_height],

--- a/test/modules/create_typical/test_create_typical.rb
+++ b/test/modules/create_typical/test_create_typical.rb
@@ -28,7 +28,7 @@ class TestCreateTypical < Minitest::Test
     assert(starting_size < ending_size)
   end
 
-  def test_create_typical_comstock_building_from_model
+  def test_create_typical_building_from_model_comstock
     # load model and set up weather file
     template = 'ComStock DOE Ref 1980-2004'
     climate_zone = 'ASHRAE 169-2013-4A'
@@ -37,7 +37,7 @@ class TestCreateTypical < Minitest::Test
     OpenstudioStandards::Weather.model_set_building_location(model, climate_zone: climate_zone)
 
     # set output directory
-    output_dir = "#{__dir__}/output/test_create_typical_comstock_building_from_model"
+    output_dir = "#{__dir__}/output/test_create_typical_building_from_model_comstock"
     FileUtils.mkdir output_dir unless Dir.exist? output_dir
 
     # apply create typical
@@ -140,6 +140,34 @@ class TestCreateTypical < Minitest::Test
                                                         modify_wknd_op_hrs: true,
                                                         wknd_op_hrs_start_time: 8.00,
                                                         wknd_op_hrs_duration: 6.00,
+                                                        sizing_run_directory: output_dir)
+    ending_size = model.getModelObjects.size
+    assert(result)
+    assert(starting_size < ending_size)
+  end
+
+  def test_create_typical_building_from_model_comstock_restaurant
+    # load model and set up weather file
+    # template = 'ComStock DOE Ref 1980-2004'
+    # climate_zone = 'ASHRAE 169-2013-3C'
+    # geometry_file = 'ASHRAEFullServiceRestaurant.osm'
+
+    template = 'ComStock DEER Pre-1975'
+    climate_zone = 'CEC T24-CEC2'
+    geometry_file = 'DEER_RSD.osm'
+
+    std = Standard.build(template)
+    model = std.safe_load_model("#{File.dirname(__FILE__)}/../../../data/geometry/#{geometry_file}")
+    OpenstudioStandards::Weather.model_set_building_location(model, climate_zone: climate_zone)
+
+    # set output directory
+    output_dir = "#{__dir__}/output/test_create_typical_building_from_model_comstock_restaurant"
+    FileUtils.mkdir output_dir unless Dir.exist? output_dir
+
+    # apply create typical
+    starting_size = model.getModelObjects.size
+    result = @create.create_typical_building_from_model(model, template,
+                                                        climate_zone: climate_zone,
                                                         sizing_run_directory: output_dir)
     ending_size = model.getModelObjects.size
     assert(result)


### PR DESCRIPTION
Pull request overview
---------------------

Add check that construction_data is available; it may not be given some interactions with geometry, template, and climate zone. In that case, the building will use OpenStudio defaults for ground constructions.

### Pull Request Author
 - [x] Method changes or additions
 - [x] Added tests for added methods
 - [x] Resolved yard documentation errors for new code (ran `bundle exec rake doc`)
 - [x] Resolved rubocop syntax errors for new code (ran `bundle exec rake rubocop`)
 - [x] All new and existing tests passes


### Review Checklist

This will not be exhaustively relevant to every PR.
 - [x] Perform a code review on GitHub
 - [x] All related changes have been implemented: method additions, changes, tests
 - [x] Check rubocop errors
 - [x] Check yard doc errors
 - [x] If fixing a defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [x] If a new feature, test the new feature and try creative ways to break it
 - [x] CI status: all green or justified
