### PR TITLE
Default no ventilation in PTAC and PTHP CBES HVAC

### DIFF
--- a/lib/openstudio-standards/hvac/cbecs_hvac.rb
+++ b/lib/openstudio-standards/hvac/cbecs_hvac.rb
@@ -278,51 +278,73 @@ module OpenstudioStandards
         standard.model_add_hvac_system(model, 'Unit Heaters', ht = 'NaturalGas', znht = nil, cl = nil, heated_zones)
 
       when 'PTAC with baseboard electric'
-        standard.model_add_hvac_system(model, 'PTAC', ht = nil, znht = nil, cl = 'Electricity', system_zones)
+        # default to have no ventilation air
+        standard.model_add_hvac_system(model, 'PTAC', ht = nil, znht = nil, cl = 'Electricity', system_zones,
+                                       zone_equipment_ventilation: false)
         standard.model_add_hvac_system(model, 'Baseboards', ht = 'Electricity', znht = nil, cl = nil, heated_zones)
 
       when 'PTAC with baseboard gas boiler'
-        standard.model_add_hvac_system(model, 'PTAC', ht = nil, znht = nil, cl = 'Electricity', system_zones)
+        # default to have no ventilation air
+        standard.model_add_hvac_system(model, 'PTAC', ht = nil, znht = nil, cl = 'Electricity', system_zones,
+                                       zone_equipment_ventilation: false)
         standard.model_add_hvac_system(model, 'Baseboards', ht = 'NaturalGas', znht = nil, cl = nil, heated_zones)
 
       when 'PTAC with baseboard district hot water'
-        standard.model_add_hvac_system(model, 'PTAC', ht = nil, znht = nil, cl = 'Electricity', system_zones)
+        # default to have no ventilation air
+        standard.model_add_hvac_system(model, 'PTAC', ht = nil, znht = nil, cl = 'Electricity', system_zones,
+                                       zone_equipment_ventilation: false)
         standard.model_add_hvac_system(model, 'Baseboards', ht = 'DistrictHeating', znht = nil, cl = nil, heated_zones)
 
       when 'PTAC with gas unit heaters'
-        standard.model_add_hvac_system(model, 'PTAC', ht = nil, znht = nil, cl = 'Electricity', system_zones)
+        # default to have no ventilation air
+        standard.model_add_hvac_system(model, 'PTAC', ht = nil, znht = nil, cl = 'Electricity', system_zones,
+                                       zone_equipment_ventilation: false)
         standard.model_add_hvac_system(model, 'Unit Heaters', ht = 'NaturalGas', znht = nil, cl = nil, heated_zones)
 
       when 'PTAC with electric coil'
-        standard.model_add_hvac_system(model, 'PTAC', ht = nil, znht = 'Electricity', cl = 'Electricity', system_zones)
+        # default to have no ventilation air
+        standard.model_add_hvac_system(model, 'PTAC', ht = nil, znht = 'Electricity', cl = 'Electricity', system_zones,
+                                       zone_equipment_ventilation: false)
         # use 'Baseboard electric' for heated only zones
         standard.model_add_hvac_system(model, 'Baseboards', ht = 'Electricity', znht = nil, cl = nil, heated_only_zones)
 
       when 'PTAC with gas coil'
-        standard.model_add_hvac_system(model, 'PTAC', ht = nil, znht = 'NaturalGas', cl = 'Electricity', system_zones)
+        # default to have no ventilation air
+        standard.model_add_hvac_system(model, 'PTAC', ht = nil, znht = 'NaturalGas', cl = 'Electricity', system_zones,
+                                       zone_equipment_ventilation: false)
         # use 'Baseboard electric' for heated only zones
         standard.model_add_hvac_system(model, 'Baseboards', ht = 'Electricity', znht = nil, cl = nil, heated_only_zones)
 
       when 'PTAC with gas boiler'
-        standard.model_add_hvac_system(model, 'PTAC', ht = 'NaturalGas', znht = nil, cl = 'Electricity', system_zones)
+        # default to have no ventilation air
+        standard.model_add_hvac_system(model, 'PTAC', ht = 'NaturalGas', znht = nil, cl = 'Electricity', system_zones,
+                                       zone_equipment_ventilation: false)
         # use 'Baseboard gas boiler' for heated only zones
         standard.model_add_hvac_system(model, 'Baseboards', ht = 'NaturalGas', znht = nil, cl = nil, heated_only_zones)
 
       when 'PTAC with central air source heat pump'
-        standard.model_add_hvac_system(model, 'PTAC', ht = 'AirSourceHeatPump', znht = nil, cl = 'Electricity', system_zones)
+        # default to have no ventilation air
+        standard.model_add_hvac_system(model, 'PTAC', ht = 'AirSourceHeatPump', znht = nil, cl = 'Electricity', system_zones,
+                                       zone_equipment_ventilation: false)
         # use 'Baseboard central air source heat pump' for heated only zones
         standard.model_add_hvac_system(model, 'Baseboards', ht = 'AirSourceHeatPump', znht = nil, cl = nil, heated_only_zones)
 
       when 'PTAC with district hot water'
-        standard.model_add_hvac_system(model, 'PTAC', ht = 'DistrictHeating', znht = nil, cl = 'Electricity', system_zones)
+        # default to have no ventilation air
+        standard.model_add_hvac_system(model, 'PTAC', ht = 'DistrictHeating', znht = nil, cl = 'Electricity', system_zones,
+                                       zone_equipment_ventilation: false)
         # use 'Baseboard district hot water heat' for heated only zones
         standard.model_add_hvac_system(model, 'Baseboards', ht = 'DistrictHeating', znht = nil, cl = nil, heated_only_zones)
 
       when 'PTAC with no heat'
-        standard.model_add_hvac_system(model, 'PTAC', ht = nil, znht = nil, cl = 'Electricity', system_zones)
+        # default to have no ventilation air
+        standard.model_add_hvac_system(model, 'PTAC', ht = nil, znht = nil, cl = 'Electricity', system_zones,
+                                       zone_equipment_ventilation: false)
 
       when 'PTHP'
-        standard.model_add_hvac_system(model, 'PTHP', ht = 'Electricity', znht = nil, cl = 'Electricity', system_zones)
+        # default to have no ventilation air
+        standard.model_add_hvac_system(model, 'PTHP', ht = 'Electricity', znht = nil, cl = 'Electricity', system_zones,
+                                       zone_equipment_ventilation: false)
         # use 'Baseboard electric' for heated only zones
         standard.model_add_hvac_system(model, 'Baseboards', ht = 'Electricity', znht = nil, cl = nil, heated_only_zones)
 


### PR DESCRIPTION
Pull request overview
---------------------
This PR sets PTAC and PTHP units to have no zone ventilation by default in the CBES HVAC constructor.

#1789 fixed a bug (#1753), which now meant the zone hvac ventilation control method is called on all models:
```
# zone ventilation occupancy control for systems with ventilation
zone_hvac_component_occupancy_ventilation_control(zone_hvac_component)
```

The default HVAC constructor treats PTAC and PTHP units as having ventilation, which this method then modifies and sets the supply air fan operating schedule to the zone occupancy schedule, rather than "always off" which provides ventilation whenever heating or cooling is active. In practice, most PTAC and PTHP units do not provide ventilation. For buildings that require it, ventilation is usually provided by a DOAS system supplied in corridors with exhaust through bathrooms.
This will not change any of the prototypes, but it will mean ComStock models with PTAC and PTHP systems will no longer have ventilation.

### Pull Request Author
 - [x] Method changes or additions
 - [x] Resolved yard documentation errors for new code (ran `bundle exec rake doc`)
 - [x] Resolved rubocop syntax errors for new code (ran `bundle exec rake rubocop`)
 - [x] All new and existing tests passes

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [x] Perform a code review on GitHub
 - [ ] All related changes have been implemented: method additions, changes, tests
 - [ ] Check rubocop errors
 - [ ] Check yard doc errors
 - [ ] If fixing a defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [x] CI status: all green or justified
