### PR TITLE
Fix geometry story height typo

### DIFF
--- a/lib/openstudio-standards/geometry/create_bar.rb
+++ b/lib/openstudio-standards/geometry/create_bar.rb
@@ -1444,7 +1444,7 @@ module OpenstudioStandards
           final_floor_area = ratio_of_bldg_total * total_bldg_floor_area_si # I think I can just pass ratio but passing in area is cleaner
 
           # only add custom height space if 0 is used for floor_height
-          if defaulted_args.include?(:floor_height) && hash.key?(:story_height) && args[:custom_height_bar]
+          if defaulted_args.include?('floor_height') && hash.key?(:story_height) && args[:custom_height_bar]
             multi_height_space_types_hash[space_type] = { floor_area: final_floor_area, space_type: space_type, story_height: hash[:story_height] }
             if hash.key?(:orig_ratio) then multi_height_space_types_hash[space_type][:orig_ratio] = hash[:orig_ratio] end
             custom_story_heights << hash[:story_height]
@@ -1924,7 +1924,7 @@ module OpenstudioStandards
         OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.Geometry.Create', 'Target facade area by orientation not validated when partial top story is used')
       elsif dual_bar_calc_approach == 'stretched'
         OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.Geometry.Create', 'Target facade area by orientation not validated when single stretched bar has to be used to meet target minimum perimeter multiplier')
-      elsif defaulted_args.include?(:floor_height) && args[:custom_height_bar] && !multi_height_space_types_hash.empty?
+      elsif defaulted_args.include?('floor_height') && args[:custom_height_bar] && !multi_height_space_types_hash.empty?
         OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.Geometry.Create', 'Target facade area by orientation not validated when a dedicated bar is added for space types with custom heights')
       elsif args[:bar_width] > 0
         OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.Geometry.Create', 'Target facade area by orientation not validated when a dedicated custom bar width is defined')

--- a/test/modules/geometry/test_geometry_create_bar.rb
+++ b/test/modules/geometry/test_geometry_create_bar.rb
@@ -3,6 +3,7 @@ require_relative '../../helpers/minitest_helper'
 class TestGeometryCreateBar < Minitest::Test
   def setup
     @geo = OpenstudioStandards::Geometry
+    FileUtils.mkdir "#{__dir__}/output" unless Dir.exist? "#{__dir__}/output"
   end
 
   def test_create_bar_from_space_type_ratios
@@ -50,6 +51,31 @@ class TestGeometryCreateBar < Minitest::Test
     args['wwr'] = 0.3
     result = @geo.create_bar_from_building_type_ratios(model, args)
     assert(result)
+  end
+
+  def test_create_bar_from_building_type_ratios_secondary_school
+    model = OpenStudio::Model::Model.new
+
+    args = {}
+    args['total_bldg_floor_area'] = 37500.0
+    args['bldg_type_a'] = 'SecondarySchool'
+    args['template'] = "ComStock DOE Ref Pre-1980"
+    result = @geo.create_bar_from_building_type_ratios(model, args)
+    assert(result)
+    model.save("#{__dir__}/output/test_create_bar_from_building_type_ratios_secondary_school.osm", true)
+  end
+
+  def test_create_bar_from_building_type_ratios_warehouse
+    model = OpenStudio::Model::Model.new
+
+    args = {}
+    args['total_bldg_floor_area'] = 37500.0
+    args['bldg_type_a'] = 'Warehouse'
+    args['ns_to_ew_ratio'] = 2.0
+    args['template'] = "ComStock DOE Ref Pre-1980"
+    result = @geo.create_bar_from_building_type_ratios(model, args)
+    assert(result)
+    model.save("#{__dir__}/output/test_create_bar_from_building_type_ratios_warehouse.osm", true)
   end
 
   def test_create_bar_from_building_type_ratios_doe_deer_mix


### PR DESCRIPTION
Pull request overview
---------------------

This fixes in a typo in the create bar method that was preventing spaces with different default heights from being created.

### Pull Request Author
 - [x] Method changes or additions
 - [x] Added tests for added methods
 - [x] All new and existing tests passes

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a code review on GitHub
 - [ ] All related changes have been implemented: method additions, changes, tests
 - [ ] Check rubocop errors
 - [ ] Check yard doc errors
 - [ ] If fixing a defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If a new feature, test the new feature and try creative ways to break it
 - [ ] CI status: all green or justified
