### PR TITLE
Fix hours of operation schedule profiles missing for weekends

### DIFF
--- a/lib/openstudio-standards/schedules/parametric.rb
+++ b/lib/openstudio-standards/schedules/parametric.rb
@@ -210,11 +210,11 @@ module OpenstudioStandards
           thermostat = zone.thermostatSetpointDualSetpoint.get
           if thermostat.heatingSetpointTemperatureSchedule.is_initialized && thermostat.heatingSetpointTemperatureSchedule.get.to_ScheduleRuleset.is_initialized
             schedule = thermostat.heatingSetpointTemperatureSchedule.get.to_ScheduleRuleset.get
-            OpenstudioStandards::Schedules.schedule_ruleset_get_parametric_inputs(schedule, thermostat, parametric_inputs, hours_of_operation, gather_data_only: gather_data_only, hoo_var_method: 'tstat')
+            OpenstudioStandards::Schedules.schedule_ruleset_get_parametric_inputs(schedule, thermostat, parametric_inputs, hours_of_operation, gather_data_only:, hoo_var_method: 'tstat')
           end
           if thermostat.coolingSetpointTemperatureSchedule.is_initialized && thermostat.coolingSetpointTemperatureSchedule.get.to_ScheduleRuleset.is_initialized
             schedule = thermostat.coolingSetpointTemperatureSchedule.get.to_ScheduleRuleset.get
-            OpenstudioStandards::Schedules.schedule_ruleset_get_parametric_inputs(schedule, thermostat, parametric_inputs, hours_of_operation, gather_data_only: gather_data_only, hoo_var_method: 'tstat')
+            OpenstudioStandards::Schedules.schedule_ruleset_get_parametric_inputs(schedule, thermostat, parametric_inputs, hours_of_operation, gather_data_only:, hoo_var_method: 'tstat')
           end
         end
       end
@@ -231,7 +231,7 @@ module OpenstudioStandards
         air_loop_hash[air_loop] = hours_of_operation
         if air_loop.availabilitySchedule.to_ScheduleRuleset.is_initialized
           schedule = air_loop.availabilitySchedule.to_ScheduleRuleset.get
-          OpenstudioStandards::Schedules.schedule_ruleset_get_parametric_inputs(schedule, air_loop, parametric_inputs, hours_of_operation, gather_data_only: gather_data_only, hoo_var_method: hoo_var_method)
+          OpenstudioStandards::Schedules.schedule_ruleset_get_parametric_inputs(schedule, air_loop, parametric_inputs, hours_of_operation, gather_data_only:, hoo_var_method:)
         end
         avail_mgrs = air_loop.availabilityManagers
         avail_mgrs.sort.each do |avail_mgr|
@@ -241,7 +241,7 @@ module OpenstudioStandards
           resources.sort.each do |resource|
             if resource.to_ScheduleRuleset.is_initialized
               schedule = resource.to_ScheduleRuleset.get
-              OpenstudioStandards::Schedules.schedule_ruleset_get_parametric_inputs(schedule, avail_mgr, parametric_inputs, hours_of_operation, gather_data_only: gather_data_only, hoo_var_method: hoo_var_method)
+              OpenstudioStandards::Schedules.schedule_ruleset_get_parametric_inputs(schedule, avail_mgr, parametric_inputs, hours_of_operation, gather_data_only:, hoo_var_method:)
             end
           end
         end
@@ -299,7 +299,7 @@ module OpenstudioStandards
             OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.Parametric.Model', "Cannot identify where #{component.name.get} is in system. Will not gather parametric inputs for #{schedule.name.get}")
             next
           end
-          OpenstudioStandards::Schedules.schedule_ruleset_get_parametric_inputs(schedule, component, parametric_inputs, hours_of_operation, gather_data_only: gather_data_only, hoo_var_method: hoo_var_method)
+          OpenstudioStandards::Schedules.schedule_ruleset_get_parametric_inputs(schedule, component, parametric_inputs, hours_of_operation, gather_data_only:, hoo_var_method:)
         end
       end
 
@@ -317,11 +317,11 @@ module OpenstudioStandards
           if opt_space.is_initialized
             space = space.get
             hours_of_operation = OpenstudioStandards::Space.space_hours_of_operation(space)
-            OpenstudioStandards::Schedules.schedule_ruleset_get_parametric_inputs(schedule, water_use_equipment, parametric_inputs, hours_of_operation, gather_data_only: gather_data_only, hoo_var_method: hoo_var_method)
+            OpenstudioStandards::Schedules.schedule_ruleset_get_parametric_inputs(schedule, water_use_equipment, parametric_inputs, hours_of_operation, gather_data_only:, hoo_var_method:)
           else
             hours_of_operation = OpenstudioStandards::Space.spaces_hours_of_operation(model.getSpaces)
             if !hours_of_operation.nil?
-              OpenstudioStandards::Schedules.schedule_ruleset_get_parametric_inputs(schedule, water_use_equipment, parametric_inputs, hours_of_operation, gather_data_only: gather_data_only, hoo_var_method: hoo_var_method)
+              OpenstudioStandards::Schedules.schedule_ruleset_get_parametric_inputs(schedule, water_use_equipment, parametric_inputs, hours_of_operation, gather_data_only:, hoo_var_method:)
             end
           end
 
@@ -410,7 +410,7 @@ module OpenstudioStandards
     def self.spaces_space_types_get_parametric_schedule_inputs(spaces_space_types, parametric_inputs, gather_data_only)
       spaces_space_types.each do |space_type|
         # get hours of operation for space type once
-        next if space_type.class == 'OpenStudio::Model::SpaceTypes' && space_type.floorArea == 0
+        next if space_type.instance_of?(OpenStudio::Model::SpaceType) && space_type.floorArea == 0
 
         hours_of_operation = Space.space_hours_of_operation(space_type)
         if hours_of_operation.nil?
@@ -440,7 +440,7 @@ module OpenstudioStandards
           OpenstudioStandards::Space.space_load_instance_get_parametric_schedule_inputs(space_load_instance, parametric_inputs, hours_of_operation, gather_data_only)
           if space_load_instance.activityLevelSchedule.is_initialized && space_load_instance.activityLevelSchedule.get.to_ScheduleRuleset.is_initialized
             act_sch = space_load_instance.activityLevelSchedule.get.to_ScheduleRuleset.get
-            OpenstudioStandards::Schedules.schedule_ruleset_get_parametric_inputs(act_sch, space_load_instance, parametric_inputs, hours_of_operation, gather_data_only: gather_data_only, hoo_var_method: 'hours')
+            OpenstudioStandards::Schedules.schedule_ruleset_get_parametric_inputs(act_sch, space_load_instance, parametric_inputs, hours_of_operation, gather_data_only:, hoo_var_method: 'hours')
           end
         end
         space_type.spaceInfiltrationDesignFlowRates.each do |space_load_instance|
@@ -493,11 +493,9 @@ module OpenstudioStandards
                                                     min_ramp_dur_hr: 2.0,
                                                     gather_data_only: false,
                                                     hoo_var_method: 'hours')
-      if parametric_inputs.key?(schedule_ruleset)
-        if hours_of_operation != parametric_inputs[schedule_ruleset][:hoo_inputs] # don't warn if the hours of operation between old and new schedule are equivalent
-          # OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.Parametric.Schedule', "#{space_load_instance.name} uses #{schedule_ruleset.name} but parametric inputs have already been setup based on hours of operation for #{parametric_inputs[schedule_ruleset][:target].name}.")
-          return nil
-        end
+      if parametric_inputs.key?(schedule_ruleset) && (hours_of_operation != parametric_inputs[schedule_ruleset][:hoo_inputs]) # don't warn if the hours of operation between old and new schedule are equivalent
+        # OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.Parametric.Schedule', "#{space_load_instance.name} uses #{schedule_ruleset.name} but parametric inputs have already been setup based on hours of operation for #{parametric_inputs[schedule_ruleset][:target].name}.")
+        return nil
       end
 
       # gather and store data for scheduleRuleset
@@ -1058,7 +1056,7 @@ module OpenstudioStandards
             remainder = days_to_fill - value[:days_used]
             day_for_rule = days_to_fill - remainder
             if remainder.size < days_to_fill.size
-              autogen_rules[profile_index] = { days_to_fill: day_for_rule, hoo_start: hoo_start, hoo_end: hoo_end }
+              autogen_rules[profile_index] = { days_to_fill: day_for_rule, hoo_start:, hoo_end: }
             end
             days_to_fill = remainder
           end

--- a/lib/openstudio-standards/space/space.rb
+++ b/lib/openstudio-standards/space/space.rb
@@ -426,6 +426,9 @@ module OpenstudioStandards
         return false
       end
 
+      model = spaces.first.model
+      year = model.getYearDescription.assumedYear
+
       unless sch_name.nil?
         OpenStudio.logFree(OpenStudio::Debug, 'openstudio.standards.space', "Finding space schedules for #{sch_name}.")
       end
@@ -525,12 +528,20 @@ module OpenstudioStandards
         occ_status_vals = daily_combined_occ_fracs.map { |day_array| day_array.map { |day_val| day_val >= occupied_percentage_threshold ? 1 : 0 } }
       end
 
-      # get unique daily profiles
-      unique_profiles = occ_status_vals.uniq
-      profile_days_hash = {} # hash of unique profile => array of day indeces
-      unique_profiles.each do |day_profile|
-        days_with_profile = occ_status_vals.each_with_index.filter_map { |day, i| i + 1 if day == day_profile }
-        profile_days_hash[day_profile] = days_with_profile
+      # get unique daily profiles for weekdays, saturdays and sundays
+      wd_profile_days = Hash.new { |h, k| h[k] = [] }
+      sat_profile_days = Hash.new { |h, k| h[k] = [] }
+      sun_profile_days = Hash.new { |h, k| h[k] = [] }
+
+      occ_status_vals.each_with_index do |day_profile, i|
+        day_type = OpenStudio::Date.fromDayOfYear(i + 1, year).dayOfWeek.valueName
+        if day_type == 'Saturday'
+          sat_profile_days[day_profile] << (i + 1)
+        elsif day_type == 'Sunday'
+          sun_profile_days[day_profile] << (i + 1)
+        else
+          wd_profile_days[day_profile] << (i + 1)
+        end
       end
 
       # create schedule
@@ -556,17 +567,20 @@ module OpenstudioStandards
       day_sch.setName("#{sch_name} Summer Design Day")
       day_sch.addValue(OpenStudio::Time.new(0, 24, 0, 0), 1)
 
-      # set most used profile to default day
-      most_used_profile = profile_days_hash.max_by { |k, v| v.size }.first
+      # set most used weekday profile to default day
+      most_used_wd_profile = wd_profile_days.max_by { |k, v| v.size }.first
       default_day = schedule_ruleset.defaultDaySchedule
       default_day.setName("#{sch_name} Default")
-      OpenstudioStandards::Schedules.schedule_day_populate_from_array_of_values(default_day, most_used_profile)
+      OpenstudioStandards::Schedules.schedule_day_populate_from_array_of_values(default_day, most_used_wd_profile)
 
-      # create rules from remaining profiles
-      remaining_profiles = profile_days_hash.slice(*profile_days_hash.keys.reject { |k| k == most_used_profile })
-      remaining_profiles.each do |profile, days_used|
+      # create rules from remaining weekday, saturday and sunday profiles
+      remaining_wd_profiles = wd_profile_days.slice(*wd_profile_days.keys.reject { |k| k == most_used_wd_profile })
+
+      [remaining_wd_profiles, sat_profile_days, sun_profile_days].each do |profile_hash|
+        profile_hash.each do |profile, days_used|
         rules = OpenstudioStandards::Schedules.schedule_ruleset_create_rules_from_day_list(schedule_ruleset, days_used)
         rules.each { |rule| OpenstudioStandards::Schedules.schedule_day_populate_from_array_of_values(rule.daySchedule, profile) }
+      end
       end
 
       return schedule_ruleset

--- a/lib/openstudio-standards/space/space.rb
+++ b/lib/openstudio-standards/space/space.rb
@@ -578,9 +578,9 @@ module OpenstudioStandards
 
       [remaining_wd_profiles, sat_profile_days, sun_profile_days].each do |profile_hash|
         profile_hash.each do |profile, days_used|
-        rules = OpenstudioStandards::Schedules.schedule_ruleset_create_rules_from_day_list(schedule_ruleset, days_used)
-        rules.each { |rule| OpenstudioStandards::Schedules.schedule_day_populate_from_array_of_values(rule.daySchedule, profile) }
-      end
+          rules = OpenstudioStandards::Schedules.schedule_ruleset_create_rules_from_day_list(schedule_ruleset, days_used)
+          rules.each { |rule| OpenstudioStandards::Schedules.schedule_day_populate_from_array_of_values(rule.daySchedule, profile) }
+        end
       end
 
       return schedule_ruleset
@@ -599,9 +599,9 @@ module OpenstudioStandards
     # @param gather_data_only [Boolean]
     # @return [Hash]
     def self.space_load_instance_get_parametric_schedule_inputs(space_load_instance, parametric_inputs, hours_of_operation, gather_data_only)
-      if space_load_instance.class.to_s == 'OpenStudio::Model::People'
+      if space_load_instance.instance_of?(OpenStudio::Model::People)
         opt_sch = space_load_instance.numberofPeopleSchedule
-      elsif space_load_instance.class.to_s == 'OpenStudio::Model::DesignSpecificationOutdoorAir'
+      elsif space_load_instance.instance_of?(OpenStudio::Model::DesignSpecificationOutdoorAir)
         opt_sch = space_load_instance.outdoorAirFlowRateFractionSchedule
       else
         opt_sch = space_load_instance.schedule
@@ -610,7 +610,7 @@ module OpenstudioStandards
         return nil
       end
 
-      OpenstudioStandards::Schedules.schedule_ruleset_get_parametric_inputs(opt_sch.get.to_ScheduleRuleset.get, space_load_instance, parametric_inputs, hours_of_operation, gather_data_only: gather_data_only, hoo_var_method: 'hours')
+      OpenstudioStandards::Schedules.schedule_ruleset_get_parametric_inputs(opt_sch.get.to_ScheduleRuleset.get, space_load_instance, parametric_inputs, hours_of_operation, gather_data_only:, hoo_var_method: 'hours')
 
       return parametric_inputs
     end

--- a/test/modules/schedules/test_schedules_parametric.rb
+++ b/test/modules/schedules/test_schedules_parametric.rb
@@ -299,6 +299,50 @@ class TestSchedulesParametric < Minitest::Test
     Dir.chdir(orig_dir)
   end
 
+  def test_comstock_bldg_hours_of_operation_days
+    puts "\n######\nTEST:#{__method__}\n######\n"
+
+    run_dir = "#{@test_dir}/building_hoo_schs"
+
+    types = []
+    types << 'SecondarySchool'
+    types << 'PrimarySchool'
+    types << 'SmallOffice'
+    types << 'MediumOffice'
+    types << 'LargeOffice'
+    types << 'SmallHotel'
+    types << 'LargeHotel'
+    types << 'Warehouse'
+    types << 'RetailStandalone'
+    types << 'RetailStripmall'
+    types << 'QuickServiceRestaurant'
+    types << 'FullServiceRestaurant'
+    types << 'Hospital'
+    types << 'Outpatient'
+
+    types.each do |type|
+      # don't modify schedules
+      create_simple_comstock_model_with_schedule_mod(type, 8.0, 12.0, 10.0, 6.0, false)
+
+      # create building hours of operation schedule
+      op_sch = OpenstudioStandards::Schedules.model_infer_hours_of_operation_building(@model)
+
+      # osm_path = "#{run_dir}/#{type}_nomod_hoo.osm"
+      # assert(@model.save(osm_path, true))
+      
+      rule_days = []
+      op_sch.scheduleRules.each do |rule|
+        if rule.applySaturday
+          rule_days << 'Saturday'
+        elsif rule.applySunday
+          rule_days << 'Sunday'
+        end
+      end
+      assert_includes(rule_days, 'Saturday', "#{op_sch.name.get} does not include Saturday rule!")
+      assert_includes(rule_days, 'Sunday', "#{op_sch.name.get} does not include Sunday rule!")
+    end
+  end
+
   def test_comstock_schedule_mod
     puts "\n######\nTEST:#{__method__}\n######\n"
 
@@ -324,8 +368,8 @@ class TestSchedulesParametric < Minitest::Test
       create_simple_comstock_model_with_schedule_mod(type, 8.0, 12.0, 10.0, 6.0)
       # create_simple_comstock_model_with_schedule_mod(type, 8.0, 12.0, 10.0, 6.0, false)
 
-      osm_path = "#{run_dir}/#{type}_modified_fix.osm"
-      assert(@model.save(osm_path, true))
+      # osm_path = "#{run_dir}/#{type}_modified_fix2.osm"
+      # assert(@model.save(osm_path, true))
 
       # test that hours_of_operation index found for all schedule days
       logs = get_logs(log_type = OpenStudio::Error)


### PR DESCRIPTION
Pull request overview
---------------------

<!--- DESCRIBE PURPOSE OF THIS PULL REQUEST -->

Observed in ComStock standards update test run that Hours of Operation schedules that had previously included separate Saturday and Sunday profiles, were now missing one, instead applying the default schedule to one of the weekend days. Since the 'weekend_start_time/duration' inputs are meant to operate on weekend schedules, but if the Hours of Operation schedule is missing a weekend rule, then that doesn't happen. This PR fixes the issue by ensuring that a separate saturday and sunday hours of operation schedule are created, even if those profiles end up being initially the same as the weekday (default) profile.

### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [x] Method changes or additions
 - [ ] Data changes or additions
 - [ ] Added tests for added methods
 - [ ] If methods have been deprecated, update rest of code to use the new methods
 - [ ] Documented new methods using [yard syntax](https://rubydoc.info/gems/yard/file/docs/GettingStarted.md)
 - [ ] Resolved yard documentation errors for new code (ran `bundle exec rake doc`)
 - [ ] Resolved rubocop syntax errors for new code (ran `bundle exec rake rubocop`)
 - [x] All new and existing tests passes
 - [ ] If the code adds new `require` statements, ensure these are in core ruby or add to the gemspec

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [x] Perform a code review on GitHub
 - [ ] All related changes have been implemented: method additions, changes, tests
 - [ ] Check rubocop errors
 - [ ] Check yard doc errors
 - [ ] If fixing a defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If a new feature, test the new feature and try creative ways to break it
 - [ ] CI status: all green or justified
