### PR TITLE
Fix capacity rounding

### DIFF
--- a/lib/openstudio-standards/standards/Standards.Model.rb
+++ b/lib/openstudio-standards/standards/Standards.Model.rb
@@ -2401,18 +2401,17 @@ class Standard
       # Skip objects that don't have values specified for minimum_capacity and maximum_capacity
       matching_objects = matching_objects.reject { |object| object['minimum_capacity'].nil? || object['maximum_capacity'].nil? }
 
-      # Round up if capacity is an integer
-      if capacity == capacity.round
-        capacity += (capacity * 0.01)
-      end
+      # Round to nearest integer and convert to a float in case not already
+      capacity = capacity.round(0).to_f
+
       # Skip objects whose the minimum capacity is below or maximum capacity above the specified capacity
-      matching_capacity_objects = matching_objects.reject { |object| capacity.to_f <= object['minimum_capacity'].to_f || capacity.to_f > object['maximum_capacity'].to_f }
+      matching_capacity_objects = matching_objects.reject { |object| capacity <= object['minimum_capacity'].to_f || capacity > object['maximum_capacity'].to_f }
 
       # If no object was found, round the capacity down in case the number fell between the limits in the json file.
       if matching_capacity_objects.empty?
         capacity *= 0.99
         # Skip objects whose minimum capacity is below or maximum capacity above the specified capacity
-        matching_objects = matching_objects.reject { |object| capacity.to_f <= object['minimum_capacity'].to_f || capacity.to_f > object['maximum_capacity'].to_f }
+        matching_objects = matching_objects.reject { |object| capacity <= object['minimum_capacity'].to_f || capacity > object['maximum_capacity'].to_f }
       else
         matching_objects = matching_capacity_objects
       end
@@ -2631,12 +2630,11 @@ class Standard
       # Skip objects that don't have values specified for minimum_capacity and maximum_capacity
       matching_objects = matching_objects.reject { |object| object['minimum_capacity'].nil? || object['maximum_capacity'].nil? }
 
-      # Round up if capacity is an integer
-      if capacity == capacity.round
-        capacity += (capacity * 0.01)
-      end
+      # Round to nearest integer and convert to a float in case not already
+      capacity = capacity.round(0).to_f
+
       # Skip objects whose the minimum capacity is below or maximum capacity above the specified capacity
-      matching_capacity_objects = matching_objects.reject { |object| capacity.to_f <= object['minimum_capacity'].to_f || capacity.to_f > object['maximum_capacity'].to_f }
+      matching_capacity_objects = matching_objects.reject { |object| capacity <= object['minimum_capacity'].to_f || capacity > object['maximum_capacity'].to_f }
 
       # If no object was found, round the capacity down in case the number fell between the limits in the json file.
       if matching_capacity_objects.empty?

--- a/lib/openstudio-standards/standards/Standards.Model.rb
+++ b/lib/openstudio-standards/standards/Standards.Model.rb
@@ -2401,8 +2401,8 @@ class Standard
       # Skip objects that don't have values specified for minimum_capacity and maximum_capacity
       matching_objects = matching_objects.reject { |object| object['minimum_capacity'].nil? || object['maximum_capacity'].nil? }
 
-      # Round to nearest integer and convert to a float in case not already
-      capacity = capacity.round(0).to_f
+      # Convert to a float in case not already
+      capacity = capacity.to_f
 
       # Skip objects whose the minimum capacity is below or maximum capacity above the specified capacity
       matching_capacity_objects = matching_objects.reject { |object| capacity <= object['minimum_capacity'].to_f || capacity > object['maximum_capacity'].to_f }
@@ -2630,8 +2630,8 @@ class Standard
       # Skip objects that don't have values specified for minimum_capacity and maximum_capacity
       matching_objects = matching_objects.reject { |object| object['minimum_capacity'].nil? || object['maximum_capacity'].nil? }
 
-      # Round to nearest integer and convert to a float in case not already
-      capacity = capacity.round(0).to_f
+      # Convert to a float in case not already
+      capacity = capacity.to_f
 
       # Skip objects whose the minimum capacity is below or maximum capacity above the specified capacity
       matching_capacity_objects = matching_objects.reject { |object| capacity <= object['minimum_capacity'].to_f || capacity > object['maximum_capacity'].to_f }

--- a/lib/openstudio-standards/standards/necb/NECB2011/data/standards_data.rb
+++ b/lib/openstudio-standards/standards/necb/NECB2011/data/standards_data.rb
@@ -189,8 +189,8 @@ class StandardsData
     if capacity.nil?
       matching_objects = search_criteria_matching_objects
     else
-      # Round to nearest integer and convert to a float in case not already
-      capacity = capacity.round(0).to_f
+      # Convert to a float in case not already
+      capacity = capacity.to_f
 
       search_criteria_matching_objects.each do |object|
         # Skip objects that don't have fields for minimum_capacity and maximum_capacity
@@ -291,8 +291,8 @@ class StandardsData
     if capacity.nil?
       matching_objects = search_criteria_matching_objects
     else
-      # Round to nearest integer and convert to a float in case not already
-      capacity = capacity.round(0).to_f
+      # Convert to a float in case not already
+      capacity = capacity.to_f
 
       search_criteria_matching_objects.each do |object|
         # Skip objects that don't have fields for minimum_capacity and maximum_capacity

--- a/lib/openstudio-standards/standards/necb/NECB2011/data/standards_data.rb
+++ b/lib/openstudio-standards/standards/necb/NECB2011/data/standards_data.rb
@@ -189,10 +189,9 @@ class StandardsData
     if capacity.nil?
       matching_objects = search_criteria_matching_objects
     else
-      # Round up if capacity is an integer
-      if capacity == capacity.round
-        capacity += (capacity * 0.01)
-      end
+      # Round to nearest integer and convert to a float in case not already
+      capacity = capacity.round(0).to_f
+
       search_criteria_matching_objects.each do |object|
         # Skip objects that don't have fields for minimum_capacity and maximum_capacity
         next if !object.key?('minimum_capacity') || !object.key?('maximum_capacity')
@@ -292,10 +291,9 @@ class StandardsData
     if capacity.nil?
       matching_objects = search_criteria_matching_objects
     else
-      # Round up if capacity is an integer
-      if capacity == capacity.round
-        capacity += (capacity * 0.01)
-      end
+      # Round to nearest integer and convert to a float in case not already
+      capacity = capacity.round(0).to_f
+
       search_criteria_matching_objects.each do |object|
         # Skip objects that don't have fields for minimum_capacity and maximum_capacity
         next if !object.key?('minimum_capacity') || !object.key?('maximum_capacity')


### PR DESCRIPTION
Pull request overview
---------------------

The capacity rounding in case of integer may incorrectly return a larger size class if the capacity is near the threshold. Instead, round to the nearest integer and explicitly convert to a float.

 - Fixes #1677 

### Pull Request Author
 - [x] Method changes or additions
 - [ ] All new and existing tests passes

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [x] Perform a code review on GitHub
 - [ ] All related changes have been implemented: method additions, changes, tests
 - [ ] If fixing a defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [x] CI status: all green or justified
