### PR TITLE
Add 90.1-2010 VAV terminal minimum default

### DIFF
--- a/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2010/ashrae_90_1_2010.AirTerminalSingleDuctVAVReheat.rb
+++ b/lib/openstudio-standards/prototypes/ashrae_90_1/ashrae_90_1_2010/ashrae_90_1_2010.AirTerminalSingleDuctVAVReheat.rb
@@ -9,10 +9,10 @@ class ASHRAE9012010 < ASHRAE901
   # @return [Boolean] returns true if successful, false if not
   def air_terminal_single_duct_vav_reheat_apply_initial_prototype_damper_position(air_terminal_single_duct_vav_reheat, zone_oa_per_area)
     min_damper_position = case air_terminal_single_duct_vav_reheat_reheat_type(air_terminal_single_duct_vav_reheat)
-                          when 'HotWater'
-                            0.2
                           when 'Electricity', 'NaturalGas'
                             0.3
+                          else # 'HotWater', other
+                            0.2
                           end
 
     # Set the minimum flow fraction


### PR DESCRIPTION
Pull request overview
---------------------

Change the minimum damper position logic for 90.1-2010 VAV reheat dampers to follow later versions to account for instances where no reheat is supplied, defaulting to 0.2 as the minimum damper position.

 - Fixes #1513 

### Pull Request Author
 - [x] Method changes or additions
 - [x] All new and existing tests passes

### Review Checklist
 - [ ] Perform a code review on GitHub
 - [ ] All related changes have been implemented: method additions, changes, tests
 - [x] If fixing a defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [x] CI status: all green or justified
