### PR TITLE
Fix PTHP capacity and VAV minimum damper calculation issues

### DIFF
--- a/lib/openstudio-standards/standards/Standards.AirLoopHVAC.rb
+++ b/lib/openstudio-standards/standards/Standards.AirLoopHVAC.rb
@@ -2139,7 +2139,7 @@ class Standard
       v_dz = v_pz * mdp
 
       # Zone discharge air fraction
-      z_d = (v_dz.zero? || v_oz.zero?) ? 0.0 : v_oz / v_dz
+      z_d = v_dz.zero? || v_oz.zero? ? 0.0 : v_oz / v_dz
 
       # Zone ventilation effectiveness
       e_vz = 1.0 + x_s - z_d
@@ -2162,7 +2162,7 @@ class Standard
 
         # Adjusted minimum damper position
         # default to 0.2 if either values are zero
-        mdp_adj = (v_dz_adj.zero? || v_pz.zero?) ? 0.2 : v_dz_adj / v_pz
+        mdp_adj = v_dz_adj.zero? || v_pz.zero? ? 0.2 : v_dz_adj / v_pz
 
         # Don't allow values > 1
         if mdp_adj > 1.0

--- a/lib/openstudio-standards/standards/Standards.AirLoopHVAC.rb
+++ b/lib/openstudio-standards/standards/Standards.AirLoopHVAC.rb
@@ -2080,7 +2080,7 @@ class Standard
           v_pz = clg_dsn_flow
         end
       else
-        OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.AirLoopHVAC', "For #{air_loop_hvac.name}: #{zone.name} clg_dsn_flow could not be found.")
+        OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.AirLoopHVAC', "For #{air_loop_hvac.name}: #{zone.name}, zone CoolingDesignAirFlowRate could not be found.")
       end
       htg_dsn_flow = zone.autosizedHeatingDesignAirFlowRate
       if htg_dsn_flow.is_initialized
@@ -2089,7 +2089,11 @@ class Standard
           v_pz = htg_dsn_flow
         end
       else
-        OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.AirLoopHVAC', "For #{air_loop_hvac.name}: #{zone.name} htg_dsn_flow could not be found.")
+        OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.AirLoopHVAC', "For #{air_loop_hvac.name}: #{zone.name}, zone HeatingDesignAirFlowRate could not be found.")
+      end
+
+      if v_pz.zero?
+        OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.AirLoopHVAC', "For #{air_loop_hvac.name}: #{zone.name}, neither the CoolingDesignAirFlowRate nor the HeatingDesignAirFlowRate could be found. The primary design air flow rate, v_pz, is zero. The zone may be missing a DesignSpecificationOutdoorAir object, or both heating and cooling load may be zero.")
       end
 
       # Get the minimum damper position
@@ -2135,7 +2139,7 @@ class Standard
       v_dz = v_pz * mdp
 
       # Zone discharge air fraction
-      z_d = v_oz / v_dz
+      z_d = (v_dz.zero? || v_oz.zero?) ? 0.0 : v_oz / v_dz
 
       # Zone ventilation effectiveness
       e_vz = 1.0 + x_s - z_d

--- a/lib/openstudio-standards/standards/Standards.AirLoopHVAC.rb
+++ b/lib/openstudio-standards/standards/Standards.AirLoopHVAC.rb
@@ -2161,7 +2161,8 @@ class Standard
         v_dz_adj = v_oz / z_d_adj
 
         # Adjusted minimum damper position
-        mdp_adj = v_dz_adj / v_pz
+        # default to 0.2 if either values are zero
+        mdp_adj = (v_dz_adj.zero? || v_pz.zero?) ? 0.2 : v_dz_adj / v_pz
 
         # Don't allow values > 1
         if mdp_adj > 1.0

--- a/lib/openstudio-standards/standards/Standards.CoilHeatingDXSingleSpeed.rb
+++ b/lib/openstudio-standards/standards/Standards.CoilHeatingDXSingleSpeed.rb
@@ -139,12 +139,12 @@ class Standard
       if capacity_btu_per_hr.nil?
         capacity_btu_per_hr = 7000.0
         capacity_kbtu_per_hr = capacity_btu_per_hr / 1000.0
-        OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.CoilHeatingDXSingleSpeed', "Cooling Capacity for #{coil_heating_dx_single_speed.name}: #{sub_category} is nil. This zone may not have heating. Using default equipment efficiency for a 7 kBtu/hr unit.")
+        OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.CoilHeatingDXSingleSpeed', "For PTHP units, 90.1 heating efficiency depends on paired cooling capacity. Cooling Capacity for #{coil_heating_dx_single_speed.name}: #{sub_category} is nil. This zone may not have heating. Using default equipment efficiency for a 7 kBtu/hr unit.")
       elsif capacity_btu_per_hr < 7000
         capacity_btu_per_hr = 7000.0
-        OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.CoilHeatingDXSingleSpeed', "Cooling Capacity for #{coil_heating_dx_single_speed.name}: #{sub_category} is #{capacity_btu_per_hr.round} Btu/hr, which is less than the typical minimum equipment size of 7 kBtu/hr. Using default equipment efficiency for a 7 kBtu/hr unit.")
+        OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.CoilHeatingDXSingleSpeed', "For PTHP units, 90.1 heating efficiency depends on paired cooling capacity. Cooling Capacity for #{coil_heating_dx_single_speed.name}: #{sub_category} is #{capacity_btu_per_hr.round} Btu/hr, which is less than the typical minimum equipment size of 7 kBtu/hr. Using default equipment efficiency for a 7 kBtu/hr unit.")
       elsif capacity_btu_per_hr > 15_000
-        OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.CoilHeatingDXSingleSpeed', "Cooling Capacity for #{coil_heating_dx_single_speed.name}: #{sub_category} is #{capacity_btu_per_hr.round} Btu/hr, which is more than the typical maximum equipment size of 15 kBtu/hr. Using default equipment efficiency for a 15 kBtu/hr unit.")
+        OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.CoilHeatingDXSingleSpeed', "For PTHP units, 90.1 heating efficiency depends on paired cooling capacity. Cooling Capacity for #{coil_heating_dx_single_speed.name}: #{sub_category} is #{capacity_btu_per_hr.round} Btu/hr, which is more than the typical maximum equipment size of 15 kBtu/hr. Using default equipment efficiency for a 15 kBtu/hr unit.")
         capacity_btu_per_hr = 15_000.0
       end
 

--- a/lib/openstudio-standards/standards/Standards.CoilHeatingDXSingleSpeed.rb
+++ b/lib/openstudio-standards/standards/Standards.CoilHeatingDXSingleSpeed.rb
@@ -133,12 +133,23 @@ class Standard
       # TABLE 6.8.1D
       # COP = pthp_cop_coeff_1 - (pthp_cop_coeff_2 * Cap / 1000)
       # Note c: Cap means the rated cooling capacity of the product in Btu/h.
-      # If the unit's capacity is less than 7000 Btu/h, use 7000 Btu/h in the calculation.
-      # If the unit's capacity is greater than 15,000 Btu/h, use 15,000 Btu/h in the calculation.
-      capacity_btu_per_hr = 7000 if capacity_btu_per_hr < 7000
-      capacity_btu_per_hr = 15_000 if capacity_btu_per_hr > 15_000
+
+      # If the unit's capacity is nil or less than 7000 Btu/h, use 7000 Btu/h in the calculation
+      # If the unit's capacity is greater than 15,000 Btu/h, use 15,000 Btu/h in the calculation
+      if capacity_btu_per_hr.nil?
+        capacity_btu_per_hr = 7000.0
+        capacity_kbtu_per_hr = capacity_btu_per_hr / 1000.0
+        OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.CoilHeatingDXSingleSpeed', "Cooling Capacity for #{coil_heating_dx_single_speed.name}: #{sub_category} is nil. This zone may not have heating. Using default equipment efficiency for a 7 kBtu/hr unit.")
+      elsif capacity_btu_per_hr < 7000
+        capacity_btu_per_hr = 7000.0
+        OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.CoilHeatingDXSingleSpeed', "Cooling Capacity for #{coil_heating_dx_single_speed.name}: #{sub_category} is #{capacity_btu_per_hr.round} Btu/hr, which is less than the typical minimum equipment size of 7 kBtu/hr. Using default equipment efficiency for a 7 kBtu/hr unit.")
+      elsif capacity_btu_per_hr > 15_000
+        OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.CoilHeatingDXSingleSpeed', "Cooling Capacity for #{coil_heating_dx_single_speed.name}: #{sub_category} is #{capacity_btu_per_hr.round} Btu/hr, which is more than the typical maximum equipment size of 15 kBtu/hr. Using default equipment efficiency for a 15 kBtu/hr unit.")
+        capacity_btu_per_hr = 15_000.0
+      end
+
       min_coph = pthp_cop_coeff_1 - (pthp_cop_coeff_2 * capacity_btu_per_hr / 1000.0)
-      cop = cop_heating_to_cop_heating_no_fan(min_coph, OpenStudio.convert(capacity_kbtu_per_hr, 'kBtu/hr', 'W').get)
+      cop = cop_heating_to_cop_heating_no_fan(min_coph, OpenStudio.convert(capacity_btu_per_hr, 'Btu/hr', 'W').get)
       new_comp_name = "#{coil_heating_dx_single_speed.name} #{capacity_kbtu_per_hr.round} Clg kBtu/hr #{min_coph.round(1)}COPH"
       OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.CoilHeatingDXSingleSpeed', "For #{coil_heating_dx_single_speed.name}: #{sub_category} Cooling Capacity = #{capacity_kbtu_per_hr.round}kBtu/hr; COPH = #{min_coph.round(2)}")
     end


### PR DESCRIPTION
Pull request overview
---------------------
This issues handles two edge cases, one with PTHPs having undefined capacity, and the other where there is no outdoor or zone design airflow rate when setting the minimum vav damper position.
 - Fixes #1590 

### Pull Request Author
 - [x] Method changes or additions
 - [x] Documented new methods using [yard syntax](https://rubydoc.info/gems/yard/file/docs/GettingStarted.md)
 - [x] Resolved yard documentation errors for new code (ran `bundle exec rake doc`)
 - [x] Resolved rubocop syntax errors for new code (ran `bundle exec rake rubocop`)
 - [ ] All new and existing tests passes

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [x] Perform a code review on GitHub
 - [x] All related changes have been implemented: method additions, changes, tests
 - [x] Check rubocop errors
 - [x] Check yard doc errors
 - [x] If fixing a defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] CI status: all green or justified
