### PR TITLE
Add methods to rename surfaces and subsurfaces

### DIFF
--- a/lib/openstudio-standards/geometry/create_bar.rb
+++ b/lib/openstudio-standards/geometry/create_bar.rb
@@ -2129,6 +2129,9 @@ module OpenstudioStandards
       args[:primary_building_type] = bldg_type_a
       OpenstudioStandards::Geometry.create_bar_from_args_and_building_type_hash(model, args, building_type_hash)
 
+      # rename all surfaces and subsurfaces
+      OpenstudioStandards::Geometry.model_rename_surfaces_and_subsurfaces(model)
+
       return true
     end
 

--- a/lib/openstudio-standards/geometry/modify.rb
+++ b/lib/openstudio-standards/geometry/modify.rb
@@ -87,6 +87,47 @@ module OpenstudioStandards
 
     # @!endgroup Modify:SubSurface
 
+    # @!group Modify:Space
+
+    # Rename space surfaces using the convention 'SpaceName SurfaceType #'.
+    # Rename sub surfaces using the convention 'SurfaceName SubSurfaceType #'.
+    #
+    # @param space [OpenStudio::Model::Space] OpenStudio space object
+    # @return [Boolean] returns true if successful, false if not
+    def self.space_rename_surfaces_and_subsurfaces(space)
+      # reset names
+      surf_i = 1
+      space.surfaces.each do |surface|
+        surface.setName("temp surf #{surf_i}")
+        sub_i = 1
+        surface.subSurfaces.each do |sub_surface|
+          sub_surface.setName("#{surface.name} sub #{sub_i}")
+          sub_i += 1
+        end
+        surf_i += 1
+      end
+
+      # rename surfaces based on space name and surface type
+      surface_type_counter = Hash.new(0)
+      space.surfaces.each do |surface|
+        surface_type = surface.surfaceType
+        surface_type_counter[surface_type] += 1
+        surface.setName("#{space.name} #{surface_type} #{surface_type_counter[surface_type]}")
+
+        # rename sub surfaces based on surface name and subsurface type
+        sub_surface_type_counter = Hash.new(0)
+        surface.subSurfaces.each do |sub_surface|
+          sub_surface_type = sub_surface.subSurfaceType
+          sub_surface_type_counter[sub_surface_type] += 1
+          sub_surface.setName("#{surface.name} #{sub_surface_type} #{sub_surface_type_counter[sub_surface_type]}")
+        end
+      end
+
+      return true
+    end
+
+    # @!endgroup Modify:Space
+
     # @!group Modify:Model
 
     # Assign each space in the model to a building story based on common z (height) values.
@@ -133,6 +174,17 @@ module OpenstudioStandards
           OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.Model', "Space #{space[0].name} was not assigned to a story by the user.  It has been assigned to #{story.name}.")
         end
       end
+
+      return true
+    end
+
+    # Rename all model surfaces using the convention 'SpaceName SurfaceType #'.
+    # Rename all model sub surfaces using the convention 'SurfaceName SubSurfaceType #'.
+    #
+    # @param model [OpenStudio::Model::Model] OpenStudio model object
+    # @return [Boolean] returns true if successful, false if not
+    def self.model_rename_surfaces_and_subsurfaces(model)
+      model.getSpaces.each { |space| OpenstudioStandards::Geometry.space_rename_surfaces_and_subsurfaces(space) }
 
       return true
     end

--- a/lib/openstudio-standards/geometry/modify.rb
+++ b/lib/openstudio-standards/geometry/modify.rb
@@ -109,14 +109,14 @@ module OpenstudioStandards
 
       # rename surfaces based on space name and surface type
       surface_type_counter = Hash.new(0)
-      space.surfaces.each do |surface|
+      space.surfaces.sort.each do |surface|
         surface_type = surface.surfaceType
         surface_type_counter[surface_type] += 1
         surface.setName("#{space.name} #{surface_type} #{surface_type_counter[surface_type]}")
 
         # rename sub surfaces based on surface name and subsurface type
         sub_surface_type_counter = Hash.new(0)
-        surface.subSurfaces.each do |sub_surface|
+        surface.subSurfaces.sort.each do |sub_surface|
           sub_surface_type = sub_surface.subSurfaceType
           sub_surface_type_counter[sub_surface_type] += 1
           sub_surface.setName("#{surface.name} #{sub_surface_type} #{sub_surface_type_counter[sub_surface_type]}")

--- a/test/modules/geometry/test_geometry_modify.rb
+++ b/test/modules/geometry/test_geometry_modify.rb
@@ -90,14 +90,32 @@ class TestGeometryModify < Minitest::Test
     assert_in_delta(starting_area * 0.6, ending_area, 0.1)
   end
 
-  def test_model_set_building_north_axis
-    result = @geo.model_set_building_north_axis(@model, 45.0)
-    assert(result)
-    assert(45.0, @model.getBuilding.northAxis)
+  def test_space_rename_surfaces_and_subsurfaces
+    space = @model.getSpaceByName('Gym_ZN_1_FLR_1').get
+    result = @geo.space_rename_surfaces_and_subsurfaces(space)
+    surface = @model.getSurfaceByName('Gym_ZN_1_FLR_1 RoofCeiling 1')
+    assert(surface.is_initialized)
+    sub_surface = @model.getSubSurfaceByName('Gym_ZN_1_FLR_1 RoofCeiling 1 Skylight 1')
+    assert(sub_surface.is_initialized)
   end
 
   def test_model_assign_spaces_to_building_stories
     result = @geo.model_assign_spaces_to_building_stories(@model)
     assert(result)
+  end
+
+  def test_model_rename_surfaces_and_subsurfaces
+    result = @geo.model_rename_surfaces_and_subsurfaces(@model)
+    surface = @model.getSurfaceByName('Gym_ZN_1_FLR_1 RoofCeiling 1')
+    assert(surface.is_initialized)
+    sub_surface = @model.getSubSurfaceByName('Gym_ZN_1_FLR_1 RoofCeiling 1 Skylight 1')
+    assert(sub_surface.is_initialized)
+    assert(result)
+  end
+
+  def test_model_set_building_north_axis
+    result = @geo.model_set_building_north_axis(@model, 45.0)
+    assert(result)
+    assert(45.0, @model.getBuilding.northAxis)
   end
 end


### PR DESCRIPTION
Pull request overview
---------------------
Add `space_rename_surfaces_and_subsurfaces(space)` and `model_rename_surfaces_and_subsurfaces(model)` methods rename surfaces and subsurfaces. Call `model_rename_surfaces_and_subsurfaces(model)` at the end of create bar so surfaces and subsurfaces have non-generic names.

 - Fixes #1803 

### Pull Request Author
 - [x] Method changes or additions
 - [x] Added tests for added methods
 - [x] Documented new methods using [yard syntax](https://rubydoc.info/gems/yard/file/docs/GettingStarted.md)
 - [x] Resolved yard documentation errors for new code (ran `bundle exec rake doc`)
 - [x] Resolved rubocop syntax errors for new code (ran `bundle exec rake rubocop`)
 - [x] All new and existing tests passes

### Review Checklist
 - [x] Perform a code review on GitHub
 - [x] All related changes have been implemented: method additions, changes, tests
 - [x] Check rubocop errors
 - [x] Check yard doc errors
 - [ ] If a new feature, test the new feature and try creative ways to break it
 - [x] CI status: all green or justified
