### PR TITLE
Fix condenser water loop constructor

### DIFF
--- a/lib/openstudio-standards/prototypes/common/objects/Prototype.hvac_systems.rb
+++ b/lib/openstudio-standards/prototypes/common/objects/Prototype.hvac_systems.rb
@@ -680,11 +680,10 @@ class Standard
                   summer_oat_wbs_f << OpenStudio.convert(summer_oat_wb_c, 'C', 'F').get
                 else
                   if dd.wetBulbOrDewPointAtMaximumDryBulb.is_initialized
-                    summer_oat_wb_c = dd.wetBulbOrDewPointAtMaximumDryBulb
+                    summer_oat_wb_c = dd.wetBulbOrDewPointAtMaximumDryBulb.get
                     summer_oat_wbs_f << OpenStudio.convert(summer_oat_wb_c, 'C', 'F').get
                   end
                 end
-
               end
             end
           end


### PR DESCRIPTION
Pull request overview
---------------------
Small bug fix to get the optional double from design wetbulb conditions for the condenser loop constructor.

### Pull Request Author
 - [x] Method changes or additions
 - [x] Resolved yard documentation errors for new code (ran `bundle exec rake doc`)
 - [x] Resolved rubocop syntax errors for new code (ran `bundle exec rake rubocop`)
 - [x] All new and existing tests passes

### Review Checklist
This will not be exhaustively relevant to every PR.
 - [x] Perform a code review on GitHub
 - [x] All related changes have been implemented: method additions, changes, tests
 - [x] If fixing a defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [x] CI status: all green or justified
