### PR TITLE
Correct prm lighting calculation

### DIFF
--- a/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.SpaceType.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.SpaceType.rb
@@ -552,7 +552,7 @@ class ASHRAE901PRM < Standard
       space_area = space.floorArea
       space_height = OpenStudio.convert(space_volume / space_area, 'm', 'ft').get
       # calculate the new lpd values
-      space_lighting_per_area = (lighting_per_length * space_height) + lighting_per_area
+      space_lighting_per_area = ((lighting_per_length * space_height) / space_area) + lighting_per_area
 
       # Adjust the occupancy control sensor reduction factor from dataset
       if manon_or_partauto == 1
@@ -652,7 +652,7 @@ class ASHRAE901PRM < Standard
         space_area = space.floorArea
         space_height = OpenStudio.convert(space_volume / space_area, 'm', 'ft').get
         # calculate and add new lpd values
-        user_space_type_lighting_per_area = ((lighting_per_length * space_height) + lighting_per_area) * sub_space_type_frac
+        user_space_type_lighting_per_area = (((lighting_per_length * space_height) / space_area) + lighting_per_area) * sub_space_type_frac
         space_lighting_per_area += user_space_type_lighting_per_area
 
         # Adjust the occupancy control sensor reduction factor from dataset

--- a/test/90_1_prm/prm_check.rb
+++ b/test/90_1_prm/prm_check.rb
@@ -1391,10 +1391,13 @@ class AppendixGPRMTests < Minitest::Test
         elsif user_data_dir == 'userdata_lpd_02'
           space_name_to_lpd_target = {}
           space_name_to_lpd_target['Attic'] = 0.0
+          space_name_to_lpd_target['Perimeter_ZN_2'] = 10.255
+          space_name_to_lpd_target['Perimeter_ZN_4'] = 10.2557
+          space_name_to_lpd_target['Core_ZN'] = 10.2392
 
           model_baseline.getSpaces.each do |space|
             space_name = space.name.get
-            target_lpd = 12.2452724
+            target_lpd = 10.2435
             if space_name_to_lpd_target.key?(space_name)
               target_lpd = space_name_to_lpd_target[space_name]
             end

--- a/test/90_1_prm/prm_check.rb
+++ b/test/90_1_prm/prm_check.rb
@@ -1353,7 +1353,7 @@ class AppendixGPRMTests < Minitest::Test
       # Check LPD against expected LPD
       space_name.each do |key, value|
         value_si = OpenStudio.convert(value, 'W/ft^2', 'W/m^2').get
-        assert(((lpd_baseline[key] - value_si).abs < 0.001), "Baseline U-value for the #{building_type}, #{template}, #{climate_zone} model is incorrect. The LPD of the #{key} is #{lpd_baseline[key]} but should be #{value_si}.")
+        assert(((lpd_baseline[key] - value_si).abs < 0.001), "Baseline LPD the #{building_type}, #{template}, #{climate_zone} model is incorrect. The LPD of #{key} is #{lpd_baseline[key]} but should be #{value_si}.")
       end
     end
   end
@@ -1386,7 +1386,7 @@ class AppendixGPRMTests < Minitest::Test
             lights_obj = model_baseline.getLightsByName(lights_name).get
             model_lpd = lights_obj.lightsDefinition.wattsperSpaceFloorArea.get
             # model_lpd = space.spaceType.get.lights[0].lightsDefinition.wattsperSpaceFloorArea.get
-            assert((target_lpd - model_lpd).abs < 0.001, "Baseline LPD for the #{building_type}, #{template}, #{climate_zone} model with user data #{user_data_dir} is incorrect. The LPD of the #{space_name} is #{target_lpd} but should be #{model_lpd}.")
+            assert((target_lpd - model_lpd).abs < 0.001, "Baseline LPD for #{building_type}, #{template}, #{climate_zone} model with user data #{user_data_dir} is incorrect. The LPD of #{space_name} is #{target_lpd} but should be #{model_lpd}.")
           end
         elsif user_data_dir == 'userdata_lpd_02'
           space_name_to_lpd_target = {}
@@ -1401,7 +1401,7 @@ class AppendixGPRMTests < Minitest::Test
             lights_name = space.spaceType.get.additionalProperties.getFeatureAsString('regulated_lights_name').to_s
             lights_obj = model_baseline.getLightsByName(lights_name).get
             model_lpd = lights_obj.lightsDefinition.wattsperSpaceFloorArea.get
-            assert((target_lpd - model_lpd).abs < 0.001, "Baseline U-value for the #{building_type}, #{template}, #{climate_zone} model with user data #{user_data_dir} is incorrect. The LPD of the #{space_name} is #{target_lpd} but should be #{model_lpd}.")
+            assert((target_lpd - model_lpd).abs < 0.001, "Baseline LPD for #{building_type}, #{template}, #{climate_zone} model with user data #{user_data_dir} is incorrect. The LPD of #{space_name} is #{target_lpd} but should be #{model_lpd}.")
           end
         end
       end


### PR DESCRIPTION
`space_lighting_per_area = (lighting_per_length * space_height) + lighting_per_area` is dimensionally inconsistent. Need to divide by area to get W/m2. This was @dmaddoxwhite's suggestion. Fixes #1506.

### Pull Request Author
 - [x] Method changes or additions
 - [x] Resolved rubocop syntax errors for new code (ran `bundle exec rake rubocop`)
 - [x] All new and existing tests passes

### Review Checklist
 - [x] Perform a code review on GitHub
 - [ ] All related changes have been implemented: method additions, changes, tests
 - [ ] Check rubocop errors
 - [ ] If fixing a defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If a new feature, test the new feature and try creative ways to break it
 - [x] CI status: all green or justified
