### PR TITLE
Add lookup for larger DEER motors

### DIFF
--- a/lib/openstudio-standards/standards/deer/deer_1985/data/deer_1985.motors.json
+++ b/lib/openstudio-standards/standards/deer/deer_1985/data/deer_1985.motors.json
@@ -246,7 +246,17 @@
       "type": "Enclosed",
       "synchronous_speed": 3600.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.941,
+      "notes": "Mapped from 'Standard' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER 1985",
+      "number_of_poles": 2.0,
+      "type": "Enclosed",
+      "synchronous_speed": 3600.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.941,
       "notes": "Mapped from 'Standard' eff from DEER (2017.08.30)"
     },
@@ -496,7 +506,17 @@
       "type": "Open",
       "synchronous_speed": 3600.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.941,
+      "notes": "Mapped from 'Standard' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER 1985",
+      "number_of_poles": 2.0,
+      "type": "Open",
+      "synchronous_speed": 3600.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.941,
       "notes": "Mapped from 'Standard' eff from DEER (2017.08.30)"
     },
@@ -746,7 +766,17 @@
       "type": "Enclosed",
       "synchronous_speed": 1800.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.945,
+      "notes": "Mapped from 'Standard' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER 1985",
+      "number_of_poles": 4.0,
+      "type": "Enclosed",
+      "synchronous_speed": 1800.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.945,
       "notes": "Mapped from 'Standard' eff from DEER (2017.08.30)"
     },
@@ -996,7 +1026,17 @@
       "type": "Open",
       "synchronous_speed": 1800.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.945,
+      "notes": "Mapped from 'Standard' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER 1985",
+      "number_of_poles": 4.0,
+      "type": "Open",
+      "synchronous_speed": 1800.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.945,
       "notes": "Mapped from 'Standard' eff from DEER (2017.08.30)"
     },
@@ -1246,7 +1286,17 @@
       "type": "Enclosed",
       "synchronous_speed": 1200.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.941,
+      "notes": "Mapped from 'Standard' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER 1985",
+      "number_of_poles": 6.0,
+      "type": "Enclosed",
+      "synchronous_speed": 1200.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.941,
       "notes": "Mapped from 'Standard' eff from DEER (2017.08.30)"
     },
@@ -1496,7 +1546,17 @@
       "type": "Open",
       "synchronous_speed": 1200.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.941,
+      "notes": "Mapped from 'Standard' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER 1985",
+      "number_of_poles": 6.0,
+      "type": "Open",
+      "synchronous_speed": 1200.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.941,
       "notes": "Mapped from 'Standard' eff from DEER (2017.08.30)"
     },
@@ -1746,7 +1806,17 @@
       "type": "Enclosed",
       "synchronous_speed": 900.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.941,
+      "notes": "Mapped from 'Standard' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER 1985",
+      "number_of_poles": 8.0,
+      "type": "Enclosed",
+      "synchronous_speed": 900.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.941,
       "notes": "Mapped from 'Standard' eff from DEER (2017.08.30)"
     },
@@ -1996,7 +2066,17 @@
       "type": "Open",
       "synchronous_speed": 900.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.941,
+      "notes": "Mapped from 'Standard' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER 1985",
+      "number_of_poles": 8.0,
+      "type": "Open",
+      "synchronous_speed": 900.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.941,
       "notes": "Mapped from 'Standard' eff from DEER (2017.08.30)"
     }

--- a/lib/openstudio-standards/standards/deer/deer_1996/data/deer_1996.motors.json
+++ b/lib/openstudio-standards/standards/deer/deer_1996/data/deer_1996.motors.json
@@ -246,7 +246,17 @@
       "type": "Enclosed",
       "synchronous_speed": 3600.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.954,
+      "notes": "Mapped from 'HiEff' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER 1996",
+      "number_of_poles": 2.0,
+      "type": "Enclosed",
+      "synchronous_speed": 3600.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.954,
       "notes": "Mapped from 'HiEff' eff from DEER (2017.08.30)"
     },
@@ -496,7 +506,17 @@
       "type": "Open",
       "synchronous_speed": 3600.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.958,
+      "notes": "Mapped from 'HiEff' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER 1996",
+      "number_of_poles": 2.0,
+      "type": "Open",
+      "synchronous_speed": 3600.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.958,
       "notes": "Mapped from 'HiEff' eff from DEER (2017.08.30)"
     },
@@ -746,7 +766,17 @@
       "type": "Enclosed",
       "synchronous_speed": 1800.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.958,
+      "notes": "Mapped from 'HiEff' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER 1996",
+      "number_of_poles": 4.0,
+      "type": "Enclosed",
+      "synchronous_speed": 1800.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.958,
       "notes": "Mapped from 'HiEff' eff from DEER (2017.08.30)"
     },
@@ -996,7 +1026,17 @@
       "type": "Open",
       "synchronous_speed": 1800.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.958,
+      "notes": "Mapped from 'HiEff' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER 1996",
+      "number_of_poles": 4.0,
+      "type": "Open",
+      "synchronous_speed": 1800.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.958,
       "notes": "Mapped from 'HiEff' eff from DEER (2017.08.30)"
     },
@@ -1246,7 +1286,17 @@
       "type": "Enclosed",
       "synchronous_speed": 1200.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.958,
+      "notes": "Mapped from 'HiEff' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER 1996",
+      "number_of_poles": 6.0,
+      "type": "Enclosed",
+      "synchronous_speed": 1200.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.958,
       "notes": "Mapped from 'HiEff' eff from DEER (2017.08.30)"
     },
@@ -1496,7 +1546,17 @@
       "type": "Open",
       "synchronous_speed": 1200.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.958,
+      "notes": "Mapped from 'HiEff' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER 1996",
+      "number_of_poles": 6.0,
+      "type": "Open",
+      "synchronous_speed": 1200.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.958,
       "notes": "Mapped from 'HiEff' eff from DEER (2017.08.30)"
     },
@@ -1746,7 +1806,17 @@
       "type": "Enclosed",
       "synchronous_speed": 900.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.954,
+      "notes": "Mapped from 'HiEff' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER 1996",
+      "number_of_poles": 8.0,
+      "type": "Enclosed",
+      "synchronous_speed": 900.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.954,
       "notes": "Mapped from 'HiEff' eff from DEER (2017.08.30)"
     },
@@ -1996,7 +2066,17 @@
       "type": "Open",
       "synchronous_speed": 900.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.958,
+      "notes": "Mapped from 'HiEff' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER 1996",
+      "number_of_poles": 8.0,
+      "type": "Open",
+      "synchronous_speed": 900.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.958,
       "notes": "Mapped from 'HiEff' eff from DEER (2017.08.30)"
     }

--- a/lib/openstudio-standards/standards/deer/deer_2003/data/deer_2003.motors.json
+++ b/lib/openstudio-standards/standards/deer/deer_2003/data/deer_2003.motors.json
@@ -246,7 +246,17 @@
       "type": "Enclosed",
       "synchronous_speed": 3600.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.954,
+      "notes": "Mapped from 'HiEff' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER 2003",
+      "number_of_poles": 2.0,
+      "type": "Enclosed",
+      "synchronous_speed": 3600.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.954,
       "notes": "Mapped from 'HiEff' eff from DEER (2017.08.30)"
     },
@@ -496,7 +506,17 @@
       "type": "Open",
       "synchronous_speed": 3600.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.958,
+      "notes": "Mapped from 'HiEff' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER 2003",
+      "number_of_poles": 2.0,
+      "type": "Open",
+      "synchronous_speed": 3600.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.958,
       "notes": "Mapped from 'HiEff' eff from DEER (2017.08.30)"
     },
@@ -746,7 +766,17 @@
       "type": "Enclosed",
       "synchronous_speed": 1800.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.958,
+      "notes": "Mapped from 'HiEff' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER 2003",
+      "number_of_poles": 4.0,
+      "type": "Enclosed",
+      "synchronous_speed": 1800.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.958,
       "notes": "Mapped from 'HiEff' eff from DEER (2017.08.30)"
     },
@@ -996,7 +1026,17 @@
       "type": "Open",
       "synchronous_speed": 1800.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.958,
+      "notes": "Mapped from 'HiEff' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER 2003",
+      "number_of_poles": 4.0,
+      "type": "Open",
+      "synchronous_speed": 1800.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.958,
       "notes": "Mapped from 'HiEff' eff from DEER (2017.08.30)"
     },
@@ -1246,7 +1286,17 @@
       "type": "Enclosed",
       "synchronous_speed": 1200.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.958,
+      "notes": "Mapped from 'HiEff' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER 2003",
+      "number_of_poles": 6.0,
+      "type": "Enclosed",
+      "synchronous_speed": 1200.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.958,
       "notes": "Mapped from 'HiEff' eff from DEER (2017.08.30)"
     },
@@ -1496,7 +1546,17 @@
       "type": "Open",
       "synchronous_speed": 1200.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.958,
+      "notes": "Mapped from 'HiEff' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER 2003",
+      "number_of_poles": 6.0,
+      "type": "Open",
+      "synchronous_speed": 1200.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.958,
       "notes": "Mapped from 'HiEff' eff from DEER (2017.08.30)"
     },
@@ -1746,7 +1806,17 @@
       "type": "Enclosed",
       "synchronous_speed": 900.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.954,
+      "notes": "Mapped from 'HiEff' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER 2003",
+      "number_of_poles": 8.0,
+      "type": "Enclosed",
+      "synchronous_speed": 900.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.954,
       "notes": "Mapped from 'HiEff' eff from DEER (2017.08.30)"
     },
@@ -1996,7 +2066,17 @@
       "type": "Open",
       "synchronous_speed": 900.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.958,
+      "notes": "Mapped from 'HiEff' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER 2003",
+      "number_of_poles": 8.0,
+      "type": "Open",
+      "synchronous_speed": 900.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.958,
       "notes": "Mapped from 'HiEff' eff from DEER (2017.08.30)"
     }

--- a/lib/openstudio-standards/standards/deer/deer_2007/data/deer_2007.motors.json
+++ b/lib/openstudio-standards/standards/deer/deer_2007/data/deer_2007.motors.json
@@ -246,7 +246,17 @@
       "type": "Enclosed",
       "synchronous_speed": 3600.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.954,
+      "notes": "Mapped from 'HiEff' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER 2007",
+      "number_of_poles": 2.0,
+      "type": "Enclosed",
+      "synchronous_speed": 3600.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.954,
       "notes": "Mapped from 'HiEff' eff from DEER (2017.08.30)"
     },
@@ -496,7 +506,17 @@
       "type": "Open",
       "synchronous_speed": 3600.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.958,
+      "notes": "Mapped from 'HiEff' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER 2007",
+      "number_of_poles": 2.0,
+      "type": "Open",
+      "synchronous_speed": 3600.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.958,
       "notes": "Mapped from 'HiEff' eff from DEER (2017.08.30)"
     },
@@ -746,7 +766,17 @@
       "type": "Enclosed",
       "synchronous_speed": 1800.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.958,
+      "notes": "Mapped from 'HiEff' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER 2007",
+      "number_of_poles": 4.0,
+      "type": "Enclosed",
+      "synchronous_speed": 1800.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.958,
       "notes": "Mapped from 'HiEff' eff from DEER (2017.08.30)"
     },
@@ -996,7 +1026,17 @@
       "type": "Open",
       "synchronous_speed": 1800.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.958,
+      "notes": "Mapped from 'HiEff' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER 2007",
+      "number_of_poles": 4.0,
+      "type": "Open",
+      "synchronous_speed": 1800.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.958,
       "notes": "Mapped from 'HiEff' eff from DEER (2017.08.30)"
     },
@@ -1246,7 +1286,17 @@
       "type": "Enclosed",
       "synchronous_speed": 1200.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.958,
+      "notes": "Mapped from 'HiEff' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER 2007",
+      "number_of_poles": 6.0,
+      "type": "Enclosed",
+      "synchronous_speed": 1200.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.958,
       "notes": "Mapped from 'HiEff' eff from DEER (2017.08.30)"
     },
@@ -1496,7 +1546,17 @@
       "type": "Open",
       "synchronous_speed": 1200.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.958,
+      "notes": "Mapped from 'HiEff' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER 2007",
+      "number_of_poles": 6.0,
+      "type": "Open",
+      "synchronous_speed": 1200.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.958,
       "notes": "Mapped from 'HiEff' eff from DEER (2017.08.30)"
     },
@@ -1746,7 +1806,17 @@
       "type": "Enclosed",
       "synchronous_speed": 900.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.954,
+      "notes": "Mapped from 'HiEff' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER 2007",
+      "number_of_poles": 8.0,
+      "type": "Enclosed",
+      "synchronous_speed": 900.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.954,
       "notes": "Mapped from 'HiEff' eff from DEER (2017.08.30)"
     },
@@ -1996,7 +2066,17 @@
       "type": "Open",
       "synchronous_speed": 900.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.958,
+      "notes": "Mapped from 'HiEff' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER 2007",
+      "number_of_poles": 8.0,
+      "type": "Open",
+      "synchronous_speed": 900.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.958,
       "notes": "Mapped from 'HiEff' eff from DEER (2017.08.30)"
     }

--- a/lib/openstudio-standards/standards/deer/deer_2011/data/deer_2011.motors.json
+++ b/lib/openstudio-standards/standards/deer/deer_2011/data/deer_2011.motors.json
@@ -246,7 +246,17 @@
       "type": "Enclosed",
       "synchronous_speed": 3600.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.954,
+      "notes": "Mapped from 'HiEff' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER 2011",
+      "number_of_poles": 2.0,
+      "type": "Enclosed",
+      "synchronous_speed": 3600.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.954,
       "notes": "Mapped from 'HiEff' eff from DEER (2017.08.30)"
     },
@@ -496,7 +506,17 @@
       "type": "Open",
       "synchronous_speed": 3600.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.958,
+      "notes": "Mapped from 'HiEff' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER 2011",
+      "number_of_poles": 2.0,
+      "type": "Open",
+      "synchronous_speed": 3600.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.958,
       "notes": "Mapped from 'HiEff' eff from DEER (2017.08.30)"
     },
@@ -746,7 +766,17 @@
       "type": "Enclosed",
       "synchronous_speed": 1800.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.958,
+      "notes": "Mapped from 'HiEff' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER 2011",
+      "number_of_poles": 4.0,
+      "type": "Enclosed",
+      "synchronous_speed": 1800.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.958,
       "notes": "Mapped from 'HiEff' eff from DEER (2017.08.30)"
     },
@@ -996,7 +1026,17 @@
       "type": "Open",
       "synchronous_speed": 1800.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.958,
+      "notes": "Mapped from 'HiEff' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER 2011",
+      "number_of_poles": 4.0,
+      "type": "Open",
+      "synchronous_speed": 1800.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.958,
       "notes": "Mapped from 'HiEff' eff from DEER (2017.08.30)"
     },
@@ -1246,7 +1286,17 @@
       "type": "Enclosed",
       "synchronous_speed": 1200.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.958,
+      "notes": "Mapped from 'HiEff' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER 2011",
+      "number_of_poles": 6.0,
+      "type": "Enclosed",
+      "synchronous_speed": 1200.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.958,
       "notes": "Mapped from 'HiEff' eff from DEER (2017.08.30)"
     },
@@ -1496,7 +1546,17 @@
       "type": "Open",
       "synchronous_speed": 1200.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.958,
+      "notes": "Mapped from 'HiEff' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER 2011",
+      "number_of_poles": 6.0,
+      "type": "Open",
+      "synchronous_speed": 1200.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.958,
       "notes": "Mapped from 'HiEff' eff from DEER (2017.08.30)"
     },
@@ -1746,7 +1806,17 @@
       "type": "Enclosed",
       "synchronous_speed": 900.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.954,
+      "notes": "Mapped from 'HiEff' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER 2011",
+      "number_of_poles": 8.0,
+      "type": "Enclosed",
+      "synchronous_speed": 900.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.954,
       "notes": "Mapped from 'HiEff' eff from DEER (2017.08.30)"
     },
@@ -1996,7 +2066,17 @@
       "type": "Open",
       "synchronous_speed": 900.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.958,
+      "notes": "Mapped from 'HiEff' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER 2011",
+      "number_of_poles": 8.0,
+      "type": "Open",
+      "synchronous_speed": 900.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.958,
       "notes": "Mapped from 'HiEff' eff from DEER (2017.08.30)"
     }

--- a/lib/openstudio-standards/standards/deer/deer_2014/data/deer_2014.motors.json
+++ b/lib/openstudio-standards/standards/deer/deer_2014/data/deer_2014.motors.json
@@ -246,7 +246,17 @@
       "type": "Enclosed",
       "synchronous_speed": 3600.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.958,
+      "notes": "Mapped from 'Premium' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER 2014",
+      "number_of_poles": 2.0,
+      "type": "Enclosed",
+      "synchronous_speed": 3600.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.958,
       "notes": "Mapped from 'Premium' eff from DEER (2017.08.30)"
     },
@@ -496,7 +506,17 @@
       "type": "Open",
       "synchronous_speed": 3600.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.958,
+      "notes": "Mapped from 'Premium' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER 2014",
+      "number_of_poles": 2.0,
+      "type": "Open",
+      "synchronous_speed": 3600.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.958,
       "notes": "Mapped from 'Premium' eff from DEER (2017.08.30)"
     },
@@ -746,7 +766,17 @@
       "type": "Enclosed",
       "synchronous_speed": 1800.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.962,
+      "notes": "Mapped from 'Premium' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER 2014",
+      "number_of_poles": 4.0,
+      "type": "Enclosed",
+      "synchronous_speed": 1800.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.962,
       "notes": "Mapped from 'Premium' eff from DEER (2017.08.30)"
     },
@@ -996,7 +1026,17 @@
       "type": "Open",
       "synchronous_speed": 1800.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.962,
+      "notes": "Mapped from 'Premium' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER 2014",
+      "number_of_poles": 4.0,
+      "type": "Open",
+      "synchronous_speed": 1800.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.962,
       "notes": "Mapped from 'Premium' eff from DEER (2017.08.30)"
     },
@@ -1246,7 +1286,17 @@
       "type": "Enclosed",
       "synchronous_speed": 1200.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.958,
+      "notes": "Mapped from 'Premium' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER 2014",
+      "number_of_poles": 6.0,
+      "type": "Enclosed",
+      "synchronous_speed": 1200.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.958,
       "notes": "Mapped from 'Premium' eff from DEER (2017.08.30)"
     },
@@ -1496,7 +1546,17 @@
       "type": "Open",
       "synchronous_speed": 1200.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.962,
+      "notes": "Mapped from 'Premium' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER 2014",
+      "number_of_poles": 6.0,
+      "type": "Open",
+      "synchronous_speed": 1200.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.962,
       "notes": "Mapped from 'Premium' eff from DEER (2017.08.30)"
     },
@@ -1746,7 +1806,17 @@
       "type": "Enclosed",
       "synchronous_speed": 900.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.954,
+      "notes": "Mapped from 'Premium' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER 2014",
+      "number_of_poles": 8.0,
+      "type": "Enclosed",
+      "synchronous_speed": 900.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.954,
       "notes": "Mapped from 'Premium' eff from DEER (2017.08.30)"
     },
@@ -1996,7 +2066,17 @@
       "type": "Open",
       "synchronous_speed": 900.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.958,
+      "notes": "Mapped from 'Premium' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER 2014",
+      "number_of_poles": 8.0,
+      "type": "Open",
+      "synchronous_speed": 900.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.958,
       "notes": "Mapped from 'Premium' eff from DEER (2017.08.30)"
     }

--- a/lib/openstudio-standards/standards/deer/deer_2015/data/deer_2015.motors.json
+++ b/lib/openstudio-standards/standards/deer/deer_2015/data/deer_2015.motors.json
@@ -246,7 +246,17 @@
       "type": "Enclosed",
       "synchronous_speed": 3600.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.958,
+      "notes": "Mapped from 'Premium' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER 2015",
+      "number_of_poles": 2.0,
+      "type": "Enclosed",
+      "synchronous_speed": 3600.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.958,
       "notes": "Mapped from 'Premium' eff from DEER (2017.08.30)"
     },
@@ -496,7 +506,17 @@
       "type": "Open",
       "synchronous_speed": 3600.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.958,
+      "notes": "Mapped from 'Premium' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER 2015",
+      "number_of_poles": 2.0,
+      "type": "Open",
+      "synchronous_speed": 3600.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.958,
       "notes": "Mapped from 'Premium' eff from DEER (2017.08.30)"
     },
@@ -746,7 +766,17 @@
       "type": "Enclosed",
       "synchronous_speed": 1800.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.962,
+      "notes": "Mapped from 'Premium' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER 2015",
+      "number_of_poles": 4.0,
+      "type": "Enclosed",
+      "synchronous_speed": 1800.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.962,
       "notes": "Mapped from 'Premium' eff from DEER (2017.08.30)"
     },
@@ -996,7 +1026,17 @@
       "type": "Open",
       "synchronous_speed": 1800.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.962,
+      "notes": "Mapped from 'Premium' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER 2015",
+      "number_of_poles": 4.0,
+      "type": "Open",
+      "synchronous_speed": 1800.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.962,
       "notes": "Mapped from 'Premium' eff from DEER (2017.08.30)"
     },
@@ -1246,7 +1286,17 @@
       "type": "Enclosed",
       "synchronous_speed": 1200.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.958,
+      "notes": "Mapped from 'Premium' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER 2015",
+      "number_of_poles": 6.0,
+      "type": "Enclosed",
+      "synchronous_speed": 1200.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.958,
       "notes": "Mapped from 'Premium' eff from DEER (2017.08.30)"
     },
@@ -1496,7 +1546,17 @@
       "type": "Open",
       "synchronous_speed": 1200.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.962,
+      "notes": "Mapped from 'Premium' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER 2015",
+      "number_of_poles": 6.0,
+      "type": "Open",
+      "synchronous_speed": 1200.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.962,
       "notes": "Mapped from 'Premium' eff from DEER (2017.08.30)"
     },
@@ -1746,7 +1806,17 @@
       "type": "Enclosed",
       "synchronous_speed": 900.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.954,
+      "notes": "Mapped from 'Premium' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER 2015",
+      "number_of_poles": 8.0,
+      "type": "Enclosed",
+      "synchronous_speed": 900.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.954,
       "notes": "Mapped from 'Premium' eff from DEER (2017.08.30)"
     },
@@ -1996,7 +2066,17 @@
       "type": "Open",
       "synchronous_speed": 900.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.958,
+      "notes": "Mapped from 'Premium' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER 2015",
+      "number_of_poles": 8.0,
+      "type": "Open",
+      "synchronous_speed": 900.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.958,
       "notes": "Mapped from 'Premium' eff from DEER (2017.08.30)"
     }

--- a/lib/openstudio-standards/standards/deer/deer_2017/data/deer_2017.motors.json
+++ b/lib/openstudio-standards/standards/deer/deer_2017/data/deer_2017.motors.json
@@ -246,7 +246,17 @@
       "type": "Enclosed",
       "synchronous_speed": 3600.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.958,
+      "notes": "Mapped from 'Premium' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER 2017",
+      "number_of_poles": 2.0,
+      "type": "Enclosed",
+      "synchronous_speed": 3600.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.958,
       "notes": "Mapped from 'Premium' eff from DEER (2017.08.30)"
     },
@@ -496,7 +506,17 @@
       "type": "Open",
       "synchronous_speed": 3600.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.958,
+      "notes": "Mapped from 'Premium' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER 2017",
+      "number_of_poles": 2.0,
+      "type": "Open",
+      "synchronous_speed": 3600.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.958,
       "notes": "Mapped from 'Premium' eff from DEER (2017.08.30)"
     },
@@ -746,7 +766,17 @@
       "type": "Enclosed",
       "synchronous_speed": 1800.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.962,
+      "notes": "Mapped from 'Premium' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER 2017",
+      "number_of_poles": 4.0,
+      "type": "Enclosed",
+      "synchronous_speed": 1800.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.962,
       "notes": "Mapped from 'Premium' eff from DEER (2017.08.30)"
     },
@@ -996,7 +1026,17 @@
       "type": "Open",
       "synchronous_speed": 1800.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.962,
+      "notes": "Mapped from 'Premium' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER 2017",
+      "number_of_poles": 4.0,
+      "type": "Open",
+      "synchronous_speed": 1800.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.962,
       "notes": "Mapped from 'Premium' eff from DEER (2017.08.30)"
     },
@@ -1246,7 +1286,17 @@
       "type": "Enclosed",
       "synchronous_speed": 1200.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.958,
+      "notes": "Mapped from 'Premium' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER 2017",
+      "number_of_poles": 6.0,
+      "type": "Enclosed",
+      "synchronous_speed": 1200.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.958,
       "notes": "Mapped from 'Premium' eff from DEER (2017.08.30)"
     },
@@ -1496,7 +1546,17 @@
       "type": "Open",
       "synchronous_speed": 1200.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.962,
+      "notes": "Mapped from 'Premium' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER 2017",
+      "number_of_poles": 6.0,
+      "type": "Open",
+      "synchronous_speed": 1200.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.962,
       "notes": "Mapped from 'Premium' eff from DEER (2017.08.30)"
     },
@@ -1746,7 +1806,17 @@
       "type": "Enclosed",
       "synchronous_speed": 900.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.954,
+      "notes": "Mapped from 'Premium' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER 2017",
+      "number_of_poles": 8.0,
+      "type": "Enclosed",
+      "synchronous_speed": 900.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.954,
       "notes": "Mapped from 'Premium' eff from DEER (2017.08.30)"
     },
@@ -1996,7 +2066,17 @@
       "type": "Open",
       "synchronous_speed": 900.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.958,
+      "notes": "Mapped from 'Premium' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER 2017",
+      "number_of_poles": 8.0,
+      "type": "Open",
+      "synchronous_speed": 900.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.958,
       "notes": "Mapped from 'Premium' eff from DEER (2017.08.30)"
     }

--- a/lib/openstudio-standards/standards/deer/deer_2020/data/deer_2020.motors.json
+++ b/lib/openstudio-standards/standards/deer/deer_2020/data/deer_2020.motors.json
@@ -246,7 +246,17 @@
       "type": "Enclosed",
       "synchronous_speed": 3600.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.960053,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2020",
+      "number_of_poles": 2.0,
+      "type": "Enclosed",
+      "synchronous_speed": 3600.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.960053,
       "notes": "Forecast for LA100 project"
     },
@@ -496,7 +506,17 @@
       "type": "Open",
       "synchronous_speed": 3600.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.962109,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2020",
+      "number_of_poles": 2.0,
+      "type": "Open",
+      "synchronous_speed": 3600.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.962109,
       "notes": "Forecast for LA100 project"
     },
@@ -746,7 +766,17 @@
       "type": "Enclosed",
       "synchronous_speed": 1800.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.964053,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2020",
+      "number_of_poles": 4.0,
+      "type": "Enclosed",
+      "synchronous_speed": 1800.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.964053,
       "notes": "Forecast for LA100 project"
     },
@@ -996,7 +1026,17 @@
       "type": "Open",
       "synchronous_speed": 1800.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.964053,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2020",
+      "number_of_poles": 4.0,
+      "type": "Open",
+      "synchronous_speed": 1800.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.964053,
       "notes": "Forecast for LA100 project"
     },
@@ -1246,7 +1286,17 @@
       "type": "Enclosed",
       "synchronous_speed": 1200.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.962109,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2020",
+      "number_of_poles": 6.0,
+      "type": "Enclosed",
+      "synchronous_speed": 1200.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.962109,
       "notes": "Forecast for LA100 project"
     },
@@ -1496,7 +1546,17 @@
       "type": "Open",
       "synchronous_speed": 1200.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.965019,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2020",
+      "number_of_poles": 6.0,
+      "type": "Open",
+      "synchronous_speed": 1200.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.965019,
       "notes": "Forecast for LA100 project"
     },
@@ -1746,7 +1806,17 @@
       "type": "Enclosed",
       "synchronous_speed": 900.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.957142,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2020",
+      "number_of_poles": 8.0,
+      "type": "Enclosed",
+      "synchronous_speed": 900.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.957142,
       "notes": "Forecast for LA100 project"
     },
@@ -1996,7 +2066,17 @@
       "type": "Open",
       "synchronous_speed": 900.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.962109,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2020",
+      "number_of_poles": 8.0,
+      "type": "Open",
+      "synchronous_speed": 900.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.962109,
       "notes": "Forecast for LA100 project"
     }

--- a/lib/openstudio-standards/standards/deer/deer_2025/data/deer_2025.motors.json
+++ b/lib/openstudio-standards/standards/deer/deer_2025/data/deer_2025.motors.json
@@ -246,7 +246,17 @@
       "type": "Enclosed",
       "synchronous_speed": 3600.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.962233,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2025",
+      "number_of_poles": 2.0,
+      "type": "Enclosed",
+      "synchronous_speed": 3600.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.962233,
       "notes": "Forecast for LA100 project"
     },
@@ -496,7 +506,17 @@
       "type": "Open",
       "synchronous_speed": 3600.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.96437,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2025",
+      "number_of_poles": 2.0,
+      "type": "Open",
+      "synchronous_speed": 3600.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.96437,
       "notes": "Forecast for LA100 project"
     },
@@ -746,7 +766,17 @@
       "type": "Enclosed",
       "synchronous_speed": 1800.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.966233,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2025",
+      "number_of_poles": 4.0,
+      "type": "Enclosed",
+      "synchronous_speed": 1800.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.966233,
       "notes": "Forecast for LA100 project"
     },
@@ -996,7 +1026,17 @@
       "type": "Open",
       "synchronous_speed": 1800.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.966233,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2025",
+      "number_of_poles": 4.0,
+      "type": "Open",
+      "synchronous_speed": 1800.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.966233,
       "notes": "Forecast for LA100 project"
     },
@@ -1246,7 +1286,17 @@
       "type": "Enclosed",
       "synchronous_speed": 1200.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.96437,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2025",
+      "number_of_poles": 6.0,
+      "type": "Enclosed",
+      "synchronous_speed": 1200.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.96437,
       "notes": "Forecast for LA100 project"
     },
@@ -1496,7 +1546,17 @@
       "type": "Open",
       "synchronous_speed": 1200.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.967732,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2025",
+      "number_of_poles": 6.0,
+      "type": "Open",
+      "synchronous_speed": 1200.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.967732,
       "notes": "Forecast for LA100 project"
     },
@@ -1746,7 +1806,17 @@
       "type": "Enclosed",
       "synchronous_speed": 900.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.958871,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2025",
+      "number_of_poles": 8.0,
+      "type": "Enclosed",
+      "synchronous_speed": 900.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.958871,
       "notes": "Forecast for LA100 project"
     },
@@ -1996,7 +2066,17 @@
       "type": "Open",
       "synchronous_speed": 900.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.96437,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2025",
+      "number_of_poles": 8.0,
+      "type": "Open",
+      "synchronous_speed": 900.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.96437,
       "notes": "Forecast for LA100 project"
     }

--- a/lib/openstudio-standards/standards/deer/deer_2030/data/deer_2030.motors.json
+++ b/lib/openstudio-standards/standards/deer/deer_2030/data/deer_2030.motors.json
@@ -246,7 +246,17 @@
       "type": "Enclosed",
       "synchronous_speed": 3600.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.964414,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2030",
+      "number_of_poles": 2.0,
+      "type": "Enclosed",
+      "synchronous_speed": 3600.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.964414,
       "notes": "Forecast for LA100 project"
     },
@@ -496,7 +506,17 @@
       "type": "Open",
       "synchronous_speed": 3600.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.96663,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2030",
+      "number_of_poles": 2.0,
+      "type": "Open",
+      "synchronous_speed": 3600.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.96663,
       "notes": "Forecast for LA100 project"
     },
@@ -746,7 +766,17 @@
       "type": "Enclosed",
       "synchronous_speed": 1800.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.968414,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2030",
+      "number_of_poles": 4.0,
+      "type": "Enclosed",
+      "synchronous_speed": 1800.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.968414,
       "notes": "Forecast for LA100 project"
     },
@@ -996,7 +1026,17 @@
       "type": "Open",
       "synchronous_speed": 1800.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.968414,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2030",
+      "number_of_poles": 4.0,
+      "type": "Open",
+      "synchronous_speed": 1800.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.968414,
       "notes": "Forecast for LA100 project"
     },
@@ -1246,7 +1286,17 @@
       "type": "Enclosed",
       "synchronous_speed": 1200.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.96663,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2030",
+      "number_of_poles": 6.0,
+      "type": "Enclosed",
+      "synchronous_speed": 1200.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.96663,
       "notes": "Forecast for LA100 project"
     },
@@ -1496,7 +1546,17 @@
       "type": "Open",
       "synchronous_speed": 1200.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.970445,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2030",
+      "number_of_poles": 6.0,
+      "type": "Open",
+      "synchronous_speed": 1200.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.970445,
       "notes": "Forecast for LA100 project"
     },
@@ -1746,7 +1806,17 @@
       "type": "Enclosed",
       "synchronous_speed": 900.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.9606,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2030",
+      "number_of_poles": 8.0,
+      "type": "Enclosed",
+      "synchronous_speed": 900.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.9606,
       "notes": "Forecast for LA100 project"
     },
@@ -1996,7 +2066,17 @@
       "type": "Open",
       "synchronous_speed": 900.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.96663,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2030",
+      "number_of_poles": 8.0,
+      "type": "Open",
+      "synchronous_speed": 900.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.96663,
       "notes": "Forecast for LA100 project"
     }

--- a/lib/openstudio-standards/standards/deer/deer_2035/data/deer_2035.motors.json
+++ b/lib/openstudio-standards/standards/deer/deer_2035/data/deer_2035.motors.json
@@ -246,7 +246,17 @@
       "type": "Enclosed",
       "synchronous_speed": 3600.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.966595,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2035",
+      "number_of_poles": 2.0,
+      "type": "Enclosed",
+      "synchronous_speed": 3600.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.966595,
       "notes": "Forecast for LA100 project"
     },
@@ -496,7 +506,17 @@
       "type": "Open",
       "synchronous_speed": 3600.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.968891,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2035",
+      "number_of_poles": 2.0,
+      "type": "Open",
+      "synchronous_speed": 3600.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.968891,
       "notes": "Forecast for LA100 project"
     },
@@ -746,7 +766,17 @@
       "type": "Enclosed",
       "synchronous_speed": 1800.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.970595,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2035",
+      "number_of_poles": 4.0,
+      "type": "Enclosed",
+      "synchronous_speed": 1800.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.970595,
       "notes": "Forecast for LA100 project"
     },
@@ -996,7 +1026,17 @@
       "type": "Open",
       "synchronous_speed": 1800.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.970595,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2035",
+      "number_of_poles": 4.0,
+      "type": "Open",
+      "synchronous_speed": 1800.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.970595,
       "notes": "Forecast for LA100 project"
     },
@@ -1246,7 +1286,17 @@
       "type": "Enclosed",
       "synchronous_speed": 1200.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.968891,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2035",
+      "number_of_poles": 6.0,
+      "type": "Enclosed",
+      "synchronous_speed": 1200.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.968891,
       "notes": "Forecast for LA100 project"
     },
@@ -1496,7 +1546,17 @@
       "type": "Open",
       "synchronous_speed": 1200.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.973157,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2035",
+      "number_of_poles": 6.0,
+      "type": "Open",
+      "synchronous_speed": 1200.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.973157,
       "notes": "Forecast for LA100 project"
     },
@@ -1746,7 +1806,17 @@
       "type": "Enclosed",
       "synchronous_speed": 900.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.962328,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2035",
+      "number_of_poles": 8.0,
+      "type": "Enclosed",
+      "synchronous_speed": 900.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.962328,
       "notes": "Forecast for LA100 project"
     },
@@ -1996,7 +2066,17 @@
       "type": "Open",
       "synchronous_speed": 900.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.968891,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2035",
+      "number_of_poles": 8.0,
+      "type": "Open",
+      "synchronous_speed": 900.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.968891,
       "notes": "Forecast for LA100 project"
     }

--- a/lib/openstudio-standards/standards/deer/deer_2040/data/deer_2040.motors.json
+++ b/lib/openstudio-standards/standards/deer/deer_2040/data/deer_2040.motors.json
@@ -246,7 +246,17 @@
       "type": "Enclosed",
       "synchronous_speed": 3600.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.968775,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2040",
+      "number_of_poles": 2.0,
+      "type": "Enclosed",
+      "synchronous_speed": 3600.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.968775,
       "notes": "Forecast for LA100 project"
     },
@@ -496,7 +506,17 @@
       "type": "Open",
       "synchronous_speed": 3600.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.971151,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2040",
+      "number_of_poles": 2.0,
+      "type": "Open",
+      "synchronous_speed": 3600.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.971151,
       "notes": "Forecast for LA100 project"
     },
@@ -746,7 +766,17 @@
       "type": "Enclosed",
       "synchronous_speed": 1800.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.972775,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2040",
+      "number_of_poles": 4.0,
+      "type": "Enclosed",
+      "synchronous_speed": 1800.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.972775,
       "notes": "Forecast for LA100 project"
     },
@@ -996,7 +1026,17 @@
       "type": "Open",
       "synchronous_speed": 1800.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.972775,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2040",
+      "number_of_poles": 4.0,
+      "type": "Open",
+      "synchronous_speed": 1800.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.972775,
       "notes": "Forecast for LA100 project"
     },
@@ -1246,7 +1286,17 @@
       "type": "Enclosed",
       "synchronous_speed": 1200.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.971151,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2040",
+      "number_of_poles": 6.0,
+      "type": "Enclosed",
+      "synchronous_speed": 1200.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.971151,
       "notes": "Forecast for LA100 project"
     },
@@ -1496,7 +1546,17 @@
       "type": "Open",
       "synchronous_speed": 1200.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.97587,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2040",
+      "number_of_poles": 6.0,
+      "type": "Open",
+      "synchronous_speed": 1200.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.97587,
       "notes": "Forecast for LA100 project"
     },
@@ -1746,7 +1806,17 @@
       "type": "Enclosed",
       "synchronous_speed": 900.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.964057,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2040",
+      "number_of_poles": 8.0,
+      "type": "Enclosed",
+      "synchronous_speed": 900.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.964057,
       "notes": "Forecast for LA100 project"
     },
@@ -1996,7 +2066,17 @@
       "type": "Open",
       "synchronous_speed": 900.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.971151,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2040",
+      "number_of_poles": 8.0,
+      "type": "Open",
+      "synchronous_speed": 900.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.971151,
       "notes": "Forecast for LA100 project"
     }

--- a/lib/openstudio-standards/standards/deer/deer_2045/data/deer_2045.motors.json
+++ b/lib/openstudio-standards/standards/deer/deer_2045/data/deer_2045.motors.json
@@ -246,7 +246,17 @@
       "type": "Enclosed",
       "synchronous_speed": 3600.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.970956,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2045",
+      "number_of_poles": 2.0,
+      "type": "Enclosed",
+      "synchronous_speed": 3600.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.970956,
       "notes": "Forecast for LA100 project"
     },
@@ -496,7 +506,17 @@
       "type": "Open",
       "synchronous_speed": 3600.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.973412,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2045",
+      "number_of_poles": 2.0,
+      "type": "Open",
+      "synchronous_speed": 3600.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.973412,
       "notes": "Forecast for LA100 project"
     },
@@ -746,7 +766,17 @@
       "type": "Enclosed",
       "synchronous_speed": 1800.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.974956,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2045",
+      "number_of_poles": 4.0,
+      "type": "Enclosed",
+      "synchronous_speed": 1800.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.974956,
       "notes": "Forecast for LA100 project"
     },
@@ -996,7 +1026,17 @@
       "type": "Open",
       "synchronous_speed": 1800.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.974956,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2045",
+      "number_of_poles": 4.0,
+      "type": "Open",
+      "synchronous_speed": 1800.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.974956,
       "notes": "Forecast for LA100 project"
     },
@@ -1246,7 +1286,17 @@
       "type": "Enclosed",
       "synchronous_speed": 1200.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.973412,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2045",
+      "number_of_poles": 6.0,
+      "type": "Enclosed",
+      "synchronous_speed": 1200.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.973412,
       "notes": "Forecast for LA100 project"
     },
@@ -1496,7 +1546,17 @@
       "type": "Open",
       "synchronous_speed": 1200.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.978582,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2045",
+      "number_of_poles": 6.0,
+      "type": "Open",
+      "synchronous_speed": 1200.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.978582,
       "notes": "Forecast for LA100 project"
     },
@@ -1746,7 +1806,17 @@
       "type": "Enclosed",
       "synchronous_speed": 900.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.965786,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2045",
+      "number_of_poles": 8.0,
+      "type": "Enclosed",
+      "synchronous_speed": 900.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.965786,
       "notes": "Forecast for LA100 project"
     },
@@ -1996,7 +2066,17 @@
       "type": "Open",
       "synchronous_speed": 900.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.973412,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2045",
+      "number_of_poles": 8.0,
+      "type": "Open",
+      "synchronous_speed": 900.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.973412,
       "notes": "Forecast for LA100 project"
     }

--- a/lib/openstudio-standards/standards/deer/deer_2050/data/deer_2050.motors.json
+++ b/lib/openstudio-standards/standards/deer/deer_2050/data/deer_2050.motors.json
@@ -246,7 +246,17 @@
       "type": "Enclosed",
       "synchronous_speed": 3600.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.973137,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2050",
+      "number_of_poles": 2.0,
+      "type": "Enclosed",
+      "synchronous_speed": 3600.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.973137,
       "notes": "Forecast for LA100 project"
     },
@@ -496,7 +506,17 @@
       "type": "Open",
       "synchronous_speed": 3600.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.975673,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2050",
+      "number_of_poles": 2.0,
+      "type": "Open",
+      "synchronous_speed": 3600.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.975673,
       "notes": "Forecast for LA100 project"
     },
@@ -746,7 +766,17 @@
       "type": "Enclosed",
       "synchronous_speed": 1800.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.977137,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2050",
+      "number_of_poles": 4.0,
+      "type": "Enclosed",
+      "synchronous_speed": 1800.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.977137,
       "notes": "Forecast for LA100 project"
     },
@@ -996,7 +1026,17 @@
       "type": "Open",
       "synchronous_speed": 1800.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.977137,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2050",
+      "number_of_poles": 4.0,
+      "type": "Open",
+      "synchronous_speed": 1800.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.977137,
       "notes": "Forecast for LA100 project"
     },
@@ -1246,7 +1286,17 @@
       "type": "Enclosed",
       "synchronous_speed": 1200.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.975673,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2050",
+      "number_of_poles": 6.0,
+      "type": "Enclosed",
+      "synchronous_speed": 1200.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.975673,
       "notes": "Forecast for LA100 project"
     },
@@ -1496,7 +1546,17 @@
       "type": "Open",
       "synchronous_speed": 1200.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.981295,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2050",
+      "number_of_poles": 6.0,
+      "type": "Open",
+      "synchronous_speed": 1200.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.981295,
       "notes": "Forecast for LA100 project"
     },
@@ -1746,7 +1806,17 @@
       "type": "Enclosed",
       "synchronous_speed": 900.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.967514,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2050",
+      "number_of_poles": 8.0,
+      "type": "Enclosed",
+      "synchronous_speed": 900.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.967514,
       "notes": "Forecast for LA100 project"
     },
@@ -1996,7 +2066,17 @@
       "type": "Open",
       "synchronous_speed": 900.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.975673,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2050",
+      "number_of_poles": 8.0,
+      "type": "Open",
+      "synchronous_speed": 900.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.975673,
       "notes": "Forecast for LA100 project"
     }

--- a/lib/openstudio-standards/standards/deer/deer_2055/data/deer_2055.motors.json
+++ b/lib/openstudio-standards/standards/deer/deer_2055/data/deer_2055.motors.json
@@ -246,7 +246,17 @@
       "type": "Enclosed",
       "synchronous_speed": 3600.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.975317,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2055",
+      "number_of_poles": 2.0,
+      "type": "Enclosed",
+      "synchronous_speed": 3600.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.975317,
       "notes": "Forecast for LA100 project"
     },
@@ -496,7 +506,17 @@
       "type": "Open",
       "synchronous_speed": 3600.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.977933,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2055",
+      "number_of_poles": 2.0,
+      "type": "Open",
+      "synchronous_speed": 3600.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.977933,
       "notes": "Forecast for LA100 project"
     },
@@ -746,7 +766,17 @@
       "type": "Enclosed",
       "synchronous_speed": 1800.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.979317,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2055",
+      "number_of_poles": 4.0,
+      "type": "Enclosed",
+      "synchronous_speed": 1800.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.979317,
       "notes": "Forecast for LA100 project"
     },
@@ -996,7 +1026,17 @@
       "type": "Open",
       "synchronous_speed": 1800.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.979317,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2055",
+      "number_of_poles": 4.0,
+      "type": "Open",
+      "synchronous_speed": 1800.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.979317,
       "notes": "Forecast for LA100 project"
     },
@@ -1246,7 +1286,17 @@
       "type": "Enclosed",
       "synchronous_speed": 1200.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.977933,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2055",
+      "number_of_poles": 6.0,
+      "type": "Enclosed",
+      "synchronous_speed": 1200.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.977933,
       "notes": "Forecast for LA100 project"
     },
@@ -1496,7 +1546,17 @@
       "type": "Open",
       "synchronous_speed": 1200.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.984007,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2055",
+      "number_of_poles": 6.0,
+      "type": "Open",
+      "synchronous_speed": 1200.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.984007,
       "notes": "Forecast for LA100 project"
     },
@@ -1746,7 +1806,17 @@
       "type": "Enclosed",
       "synchronous_speed": 900.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.969243,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2055",
+      "number_of_poles": 8.0,
+      "type": "Enclosed",
+      "synchronous_speed": 900.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.969243,
       "notes": "Forecast for LA100 project"
     },
@@ -1996,7 +2066,17 @@
       "type": "Open",
       "synchronous_speed": 900.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.977933,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2055",
+      "number_of_poles": 8.0,
+      "type": "Open",
+      "synchronous_speed": 900.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.977933,
       "notes": "Forecast for LA100 project"
     }

--- a/lib/openstudio-standards/standards/deer/deer_2060/data/deer_2060.motors.json
+++ b/lib/openstudio-standards/standards/deer/deer_2060/data/deer_2060.motors.json
@@ -246,7 +246,17 @@
       "type": "Enclosed",
       "synchronous_speed": 3600.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.977498,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2060",
+      "number_of_poles": 2.0,
+      "type": "Enclosed",
+      "synchronous_speed": 3600.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.977498,
       "notes": "Forecast for LA100 project"
     },
@@ -496,7 +506,17 @@
       "type": "Open",
       "synchronous_speed": 3600.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.980194,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2060",
+      "number_of_poles": 2.0,
+      "type": "Open",
+      "synchronous_speed": 3600.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.980194,
       "notes": "Forecast for LA100 project"
     },
@@ -746,7 +766,17 @@
       "type": "Enclosed",
       "synchronous_speed": 1800.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.981498,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2060",
+      "number_of_poles": 4.0,
+      "type": "Enclosed",
+      "synchronous_speed": 1800.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.981498,
       "notes": "Forecast for LA100 project"
     },
@@ -996,7 +1026,17 @@
       "type": "Open",
       "synchronous_speed": 1800.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.981498,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2060",
+      "number_of_poles": 4.0,
+      "type": "Open",
+      "synchronous_speed": 1800.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.981498,
       "notes": "Forecast for LA100 project"
     },
@@ -1246,7 +1286,17 @@
       "type": "Enclosed",
       "synchronous_speed": 1200.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.980194,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2060",
+      "number_of_poles": 6.0,
+      "type": "Enclosed",
+      "synchronous_speed": 1200.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.980194,
       "notes": "Forecast for LA100 project"
     },
@@ -1496,7 +1546,17 @@
       "type": "Open",
       "synchronous_speed": 1200.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.98672,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2060",
+      "number_of_poles": 6.0,
+      "type": "Open",
+      "synchronous_speed": 1200.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.98672,
       "notes": "Forecast for LA100 project"
     },
@@ -1746,7 +1806,17 @@
       "type": "Enclosed",
       "synchronous_speed": 900.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.970972,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2060",
+      "number_of_poles": 8.0,
+      "type": "Enclosed",
+      "synchronous_speed": 900.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.970972,
       "notes": "Forecast for LA100 project"
     },
@@ -1996,7 +2066,17 @@
       "type": "Open",
       "synchronous_speed": 900.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.980194,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2060",
+      "number_of_poles": 8.0,
+      "type": "Open",
+      "synchronous_speed": 900.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.980194,
       "notes": "Forecast for LA100 project"
     }

--- a/lib/openstudio-standards/standards/deer/deer_2065/data/deer_2065.motors.json
+++ b/lib/openstudio-standards/standards/deer/deer_2065/data/deer_2065.motors.json
@@ -246,7 +246,17 @@
       "type": "Enclosed",
       "synchronous_speed": 3600.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.979679,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2065",
+      "number_of_poles": 2.0,
+      "type": "Enclosed",
+      "synchronous_speed": 3600.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.979679,
       "notes": "Forecast for LA100 project"
     },
@@ -496,7 +506,17 @@
       "type": "Open",
       "synchronous_speed": 3600.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.982454,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2065",
+      "number_of_poles": 2.0,
+      "type": "Open",
+      "synchronous_speed": 3600.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.982454,
       "notes": "Forecast for LA100 project"
     },
@@ -746,7 +766,17 @@
       "type": "Enclosed",
       "synchronous_speed": 1800.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.983679,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2065",
+      "number_of_poles": 4.0,
+      "type": "Enclosed",
+      "synchronous_speed": 1800.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.983679,
       "notes": "Forecast for LA100 project"
     },
@@ -996,7 +1026,17 @@
       "type": "Open",
       "synchronous_speed": 1800.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.983679,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2065",
+      "number_of_poles": 4.0,
+      "type": "Open",
+      "synchronous_speed": 1800.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.983679,
       "notes": "Forecast for LA100 project"
     },
@@ -1246,7 +1286,17 @@
       "type": "Enclosed",
       "synchronous_speed": 1200.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.982454,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2065",
+      "number_of_poles": 6.0,
+      "type": "Enclosed",
+      "synchronous_speed": 1200.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.982454,
       "notes": "Forecast for LA100 project"
     },
@@ -1496,7 +1546,17 @@
       "type": "Open",
       "synchronous_speed": 1200.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.989432,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2065",
+      "number_of_poles": 6.0,
+      "type": "Open",
+      "synchronous_speed": 1200.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.989432,
       "notes": "Forecast for LA100 project"
     },
@@ -1746,7 +1806,17 @@
       "type": "Enclosed",
       "synchronous_speed": 900.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.9727,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2065",
+      "number_of_poles": 8.0,
+      "type": "Enclosed",
+      "synchronous_speed": 900.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.9727,
       "notes": "Forecast for LA100 project"
     },
@@ -1996,7 +2066,17 @@
       "type": "Open",
       "synchronous_speed": 900.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.982454,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2065",
+      "number_of_poles": 8.0,
+      "type": "Open",
+      "synchronous_speed": 900.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.982454,
       "notes": "Forecast for LA100 project"
     }

--- a/lib/openstudio-standards/standards/deer/deer_2070/data/deer_2070.motors.json
+++ b/lib/openstudio-standards/standards/deer/deer_2070/data/deer_2070.motors.json
@@ -246,7 +246,17 @@
       "type": "Enclosed",
       "synchronous_speed": 3600.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.981859,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2070",
+      "number_of_poles": 2.0,
+      "type": "Enclosed",
+      "synchronous_speed": 3600.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.981859,
       "notes": "Forecast for LA100 project"
     },
@@ -496,7 +506,17 @@
       "type": "Open",
       "synchronous_speed": 3600.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.984715,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2070",
+      "number_of_poles": 2.0,
+      "type": "Open",
+      "synchronous_speed": 3600.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.984715,
       "notes": "Forecast for LA100 project"
     },
@@ -746,7 +766,17 @@
       "type": "Enclosed",
       "synchronous_speed": 1800.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.985859,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2070",
+      "number_of_poles": 4.0,
+      "type": "Enclosed",
+      "synchronous_speed": 1800.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.985859,
       "notes": "Forecast for LA100 project"
     },
@@ -996,7 +1026,17 @@
       "type": "Open",
       "synchronous_speed": 1800.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.985859,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2070",
+      "number_of_poles": 4.0,
+      "type": "Open",
+      "synchronous_speed": 1800.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.985859,
       "notes": "Forecast for LA100 project"
     },
@@ -1246,7 +1286,17 @@
       "type": "Enclosed",
       "synchronous_speed": 1200.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.984715,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2070",
+      "number_of_poles": 6.0,
+      "type": "Enclosed",
+      "synchronous_speed": 1200.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.984715,
       "notes": "Forecast for LA100 project"
     },
@@ -1496,7 +1546,17 @@
       "type": "Open",
       "synchronous_speed": 1200.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.992145,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2070",
+      "number_of_poles": 6.0,
+      "type": "Open",
+      "synchronous_speed": 1200.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.992145,
       "notes": "Forecast for LA100 project"
     },
@@ -1746,7 +1806,17 @@
       "type": "Enclosed",
       "synchronous_speed": 900.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.974429,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2070",
+      "number_of_poles": 8.0,
+      "type": "Enclosed",
+      "synchronous_speed": 900.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.974429,
       "notes": "Forecast for LA100 project"
     },
@@ -1996,7 +2066,17 @@
       "type": "Open",
       "synchronous_speed": 900.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.984715,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2070",
+      "number_of_poles": 8.0,
+      "type": "Open",
+      "synchronous_speed": 900.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.984715,
       "notes": "Forecast for LA100 project"
     }

--- a/lib/openstudio-standards/standards/deer/deer_2075/data/deer_2075.motors.json
+++ b/lib/openstudio-standards/standards/deer/deer_2075/data/deer_2075.motors.json
@@ -246,7 +246,17 @@
       "type": "Enclosed",
       "synchronous_speed": 3600.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.98404,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2075",
+      "number_of_poles": 2.0,
+      "type": "Enclosed",
+      "synchronous_speed": 3600.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.98404,
       "notes": "Forecast for LA100 project"
     },
@@ -496,7 +506,17 @@
       "type": "Open",
       "synchronous_speed": 3600.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.986976,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2075",
+      "number_of_poles": 2.0,
+      "type": "Open",
+      "synchronous_speed": 3600.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.986976,
       "notes": "Forecast for LA100 project"
     },
@@ -746,7 +766,17 @@
       "type": "Enclosed",
       "synchronous_speed": 1800.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.98804,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2075",
+      "number_of_poles": 4.0,
+      "type": "Enclosed",
+      "synchronous_speed": 1800.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.98804,
       "notes": "Forecast for LA100 project"
     },
@@ -996,7 +1026,17 @@
       "type": "Open",
       "synchronous_speed": 1800.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.98804,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2075",
+      "number_of_poles": 4.0,
+      "type": "Open",
+      "synchronous_speed": 1800.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.98804,
       "notes": "Forecast for LA100 project"
     },
@@ -1246,7 +1286,17 @@
       "type": "Enclosed",
       "synchronous_speed": 1200.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.986976,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2075",
+      "number_of_poles": 6.0,
+      "type": "Enclosed",
+      "synchronous_speed": 1200.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.986976,
       "notes": "Forecast for LA100 project"
     },
@@ -1496,7 +1546,17 @@
       "type": "Open",
       "synchronous_speed": 1200.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.994858,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2075",
+      "number_of_poles": 6.0,
+      "type": "Open",
+      "synchronous_speed": 1200.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.994858,
       "notes": "Forecast for LA100 project"
     },
@@ -1746,7 +1806,17 @@
       "type": "Enclosed",
       "synchronous_speed": 900.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.976158,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2075",
+      "number_of_poles": 8.0,
+      "type": "Enclosed",
+      "synchronous_speed": 900.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.976158,
       "notes": "Forecast for LA100 project"
     },
@@ -1996,7 +2066,17 @@
       "type": "Open",
       "synchronous_speed": 900.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.986976,
+      "notes": "Forecast for LA100 project"
+    },
+    {
+      "template": "DEER 2075",
+      "number_of_poles": 8.0,
+      "type": "Open",
+      "synchronous_speed": 900.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.986976,
       "notes": "Forecast for LA100 project"
     }

--- a/lib/openstudio-standards/standards/deer/deer_pre_1975/data/deer_pre_1975.motors.json
+++ b/lib/openstudio-standards/standards/deer/deer_pre_1975/data/deer_pre_1975.motors.json
@@ -246,7 +246,17 @@
       "type": "Enclosed",
       "synchronous_speed": 3600.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.941,
+      "notes": "Mapped from 'Standard' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER Pre-1975",
+      "number_of_poles": 2.0,
+      "type": "Enclosed",
+      "synchronous_speed": 3600.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.941,
       "notes": "Mapped from 'Standard' eff from DEER (2017.08.30)"
     },
@@ -496,7 +506,17 @@
       "type": "Open",
       "synchronous_speed": 3600.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.941,
+      "notes": "Mapped from 'Standard' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER Pre-1975",
+      "number_of_poles": 2.0,
+      "type": "Open",
+      "synchronous_speed": 3600.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.941,
       "notes": "Mapped from 'Standard' eff from DEER (2017.08.30)"
     },
@@ -746,7 +766,17 @@
       "type": "Enclosed",
       "synchronous_speed": 1800.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.945,
+      "notes": "Mapped from 'Standard' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER Pre-1975",
+      "number_of_poles": 4.0,
+      "type": "Enclosed",
+      "synchronous_speed": 1800.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.945,
       "notes": "Mapped from 'Standard' eff from DEER (2017.08.30)"
     },
@@ -996,7 +1026,17 @@
       "type": "Open",
       "synchronous_speed": 1800.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.945,
+      "notes": "Mapped from 'Standard' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER Pre-1975",
+      "number_of_poles": 4.0,
+      "type": "Open",
+      "synchronous_speed": 1800.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.945,
       "notes": "Mapped from 'Standard' eff from DEER (2017.08.30)"
     },
@@ -1246,7 +1286,17 @@
       "type": "Enclosed",
       "synchronous_speed": 1200.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.941,
+      "notes": "Mapped from 'Standard' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER Pre-1975",
+      "number_of_poles": 6.0,
+      "type": "Enclosed",
+      "synchronous_speed": 1200.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.941,
       "notes": "Mapped from 'Standard' eff from DEER (2017.08.30)"
     },
@@ -1496,7 +1546,17 @@
       "type": "Open",
       "synchronous_speed": 1200.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.941,
+      "notes": "Mapped from 'Standard' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER Pre-1975",
+      "number_of_poles": 6.0,
+      "type": "Open",
+      "synchronous_speed": 1200.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.941,
       "notes": "Mapped from 'Standard' eff from DEER (2017.08.30)"
     },
@@ -1746,7 +1806,17 @@
       "type": "Enclosed",
       "synchronous_speed": 900.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.941,
+      "notes": "Mapped from 'Standard' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER Pre-1975",
+      "number_of_poles": 8.0,
+      "type": "Enclosed",
+      "synchronous_speed": 900.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.941,
       "notes": "Mapped from 'Standard' eff from DEER (2017.08.30)"
     },
@@ -1996,7 +2066,17 @@
       "type": "Open",
       "synchronous_speed": 900.0,
       "minimum_capacity": 450.0,
-      "maximum_capacity": 500.0,
+      "maximum_capacity": 499.999,
+      "nominal_full_load_efficiency": 0.941,
+      "notes": "Mapped from 'Standard' eff from DEER (2017.08.30)"
+    },
+    {
+      "template": "DEER Pre-1975",
+      "number_of_poles": 8.0,
+      "type": "Open",
+      "synchronous_speed": 900.0,
+      "minimum_capacity": 500.0,
+      "maximum_capacity": 9999.0,
       "nominal_full_load_efficiency": 0.941,
       "notes": "Mapped from 'Standard' eff from DEER (2017.08.30)"
     }


### PR DESCRIPTION
Pull request overview
---------------------
The DEER motor efficiency .jsons cap out at 500 hp. Add a lookup for 500 - 9999 hp, similar to the ASHRAE 90.1 motor efficiency .jsons.

### Pull Request Author
 - [x] Data changes or additions
 - [x] All new and existing tests passes

### Review Checklist
 - [ ] Perform a code review on GitHub
 - [x] All related changes have been implemented: method additions, changes, tests
 - [x] CI status: all green or justified
