### PR TITLE
Fix floating point error in schedule_day_get_hourly_values

### DIFF
--- a/lib/openstudio-standards/schedules/information.rb
+++ b/lib/openstudio-standards/schedules/information.rb
@@ -365,7 +365,7 @@ module OpenstudioStandards
       else
         num_timesteps = model.getTimestep.numberOfTimestepsPerHour
         day_timeseries = schedule_day.timeSeries.values.to_a
-        schedule_values = day_timeseries.each_slice(num_timesteps).map { |slice| slice.sum / slice.size.to_f }
+        schedule_values = day_timeseries.each_slice(num_timesteps).map { |slice| (slice.sum / slice.size.to_f).round(10) }
       end
 
       unless schedule_values.size == 24


### PR DESCRIPTION
Fix a floating point error in the test by rounding the schedule values