### PR TITLE
Update NECB CI .json format

### DIFF
--- a/test/necb/unit_tests/expected_results/ceiling_test_expected_results.json
+++ b/test/necb/unit_tests/expected_results/ceiling_test_expected_results.json
@@ -1448,9 +1448,7 @@
     "roof_area": 783.6479192300001
   },
   "TZ-F2 Corridor",
-  [
-
-  ],
+  [],
   "TZ-F2 N1 Apartment",
   [
     {
@@ -1572,9 +1570,7 @@
     }
   ],
   "TZ-F3 Corridor",
-  [
-
-  ],
+  [],
   "TZ-F3 NE Apartment",
   [
     {
@@ -1666,9 +1662,7 @@
     }
   ],
   "TZ-F4 Corridor",
-  [
-
-  ],
+  [],
   "TZ-F4 N1 Apartment",
   [
     {
@@ -1790,9 +1784,7 @@
     }
   ],
   "TZ-F6 Corridor",
-  [
-
-  ],
+  [],
   "TZ-F6 NE Apartment",
   [
     {
@@ -1884,9 +1876,7 @@
     }
   ],
   "TZ-F7 Corridor",
-  [
-
-  ],
+  [],
   "TZ-F7 N1 Apartment",
   [
     {
@@ -2020,9 +2010,7 @@
     }
   ],
   "TZ-F8 Corridor",
-  [
-
-  ],
+  [],
   "TZ-F8 N1 Apartment",
   [
     {
@@ -2144,9 +2132,7 @@
     }
   ],
   "TZ-F9 Corridor",
-  [
-
-  ],
+  [],
   "TZ-F9 N1 Apartment",
   [
     {
@@ -2268,9 +2254,7 @@
     }
   ],
   "TZ-G Corridor",
-  [
-
-  ],
+  [],
   "TZ-G N1 Apartment",
   [
     {
@@ -2377,9 +2361,7 @@
     }
   ],
   "TZ-M Corridor",
-  [
-
-  ],
+  [],
   "TZ-M N1 Apartment",
   [
     {
@@ -2501,13 +2483,9 @@
     }
   ],
   "TZ-Office",
-  [
-
-  ],
+  [],
   "TZ-T Corridor",
-  [
-
-  ],
+  [],
   "TZ-T N1 Apartment",
   [
     {
@@ -2702,9 +2680,7 @@
     "roof_area": 783.6479192300001
   },
   "TZ-F2 Corridor",
-  [
-
-  ],
+  [],
   "TZ-F2 N1 Apartment",
   [
     {
@@ -2826,9 +2802,7 @@
     }
   ],
   "TZ-F3 Corridor",
-  [
-
-  ],
+  [],
   "TZ-F3 NE Apartment",
   [
     {
@@ -2920,9 +2894,7 @@
     }
   ],
   "TZ-F4 Corridor",
-  [
-
-  ],
+  [],
   "TZ-F4 N1 Apartment",
   [
     {
@@ -3044,9 +3016,7 @@
     }
   ],
   "TZ-F6 Corridor",
-  [
-
-  ],
+  [],
   "TZ-F6 NE Apartment",
   [
     {
@@ -3138,9 +3108,7 @@
     }
   ],
   "TZ-F7 Corridor",
-  [
-
-  ],
+  [],
   "TZ-F7 N1 Apartment",
   [
     {
@@ -3274,9 +3242,7 @@
     }
   ],
   "TZ-F8 Corridor",
-  [
-
-  ],
+  [],
   "TZ-F8 N1 Apartment",
   [
     {
@@ -3398,9 +3364,7 @@
     }
   ],
   "TZ-F9 Corridor",
-  [
-
-  ],
+  [],
   "TZ-F9 N1 Apartment",
   [
     {
@@ -3522,9 +3486,7 @@
     }
   ],
   "TZ-G Corridor",
-  [
-
-  ],
+  [],
   "TZ-G N1 Apartment",
   [
     {
@@ -3631,9 +3593,7 @@
     }
   ],
   "TZ-M Corridor",
-  [
-
-  ],
+  [],
   "TZ-M N1 Apartment",
   [
     {
@@ -3755,13 +3715,9 @@
     }
   ],
   "TZ-Office",
-  [
-
-  ],
+  [],
   "TZ-T Corridor",
-  [
-
-  ],
+  [],
   "TZ-T N1 Apartment",
   [
     {

--- a/test/necb/unit_tests/expected_results/qaqc_report_expected_result.json
+++ b/test/necb/unit_tests/expected_results/qaqc_report_expected_result.json
@@ -378,9 +378,7 @@
           "type": "Space Function - undefined -"
         }
       ],
-      "equipment": [
-
-      ]
+      "equipment": []
     },
     {
       "name": "ALL_ST=Dining - family space_FL=Building Story 1_SCH=B",

--- a/test/necb/unit_tests/expected_results/qaqc_report_expected_result.json
+++ b/test/necb/unit_tests/expected_results/qaqc_report_expected_result.json
@@ -481,8 +481,7 @@
         "coil_heating_electric": [],
         "coil_heating_water": []
       },
-      "heat_exchanger": {
-      }
+      "heat_exchanger": {}
     },
     {
       "name": "sys_3|mixed|shr>none|sc>dx|sh>c-g|ssf>cv|zh>b-hw|zc>none|srf>none| 1",
@@ -529,8 +528,7 @@
         "coil_heating_electric": [],
         "coil_heating_water": []
       },
-      "heat_exchanger": {
-      }
+      "heat_exchanger": {}
     }
   ],
   "plant_loops": [

--- a/test/necb/unit_tests/expected_results/qaqc_report_expected_result.json
+++ b/test/necb/unit_tests/expected_results/qaqc_report_expected_result.json
@@ -466,12 +466,8 @@
             "nominal_total_capacity_w": 65653.65
           }
         ],
-        "dx_two_speed": [
-
-        ],
-        "coil_cooling_water": [
-
-        ]
+        "dx_two_speed": [],
+        "coil_cooling_water": []
       },
       "heating_coils": {
         "coil_heating_gas": [
@@ -482,12 +478,8 @@
             "nominal_capacity": 209949.22
           }
         ],
-        "coil_heating_electric": [
-
-        ],
-        "coil_heating_water": [
-
-        ]
+        "coil_heating_electric": [],
+        "coil_heating_water": []
       },
       "heat_exchanger": {
       }
@@ -522,12 +514,8 @@
             "nominal_total_capacity_w": 9939.64
           }
         ],
-        "dx_two_speed": [
-
-        ],
-        "coil_cooling_water": [
-
-        ]
+        "dx_two_speed": [],
+        "coil_cooling_water": []
       },
       "heating_coils": {
         "coil_heating_gas": [
@@ -538,12 +526,8 @@
             "nominal_capacity": 22010.39
           }
         ],
-        "coil_heating_electric": [
-
-        ],
-        "coil_heating_water": [
-
-        ]
+        "coil_heating_electric": [],
+        "coil_heating_water": []
       },
       "heat_exchanger": {
       }
@@ -578,15 +562,9 @@
           "nominal_capacity": 0.001
         }
       ],
-      "chiller_electric_eir": [
-
-      ],
-      "cooling_tower_single_speed": [
-
-      ],
-      "water_heater_mixed": [
-
-      ]
+      "chiller_electric_eir": [],
+      "cooling_tower_single_speed": [],
+      "water_heater_mixed": []
     },
     {
       "name": "Main Service Water Loop",
@@ -602,15 +580,9 @@
           "motor_efficency": 0.7
         }
       ],
-      "boilers": [
-
-      ],
-      "chiller_electric_eir": [
-
-      ],
-      "cooling_tower_single_speed": [
-
-      ],
+      "boilers": [],
+      "chiller_electric_eir": [],
+      "cooling_tower_single_speed": [],
       "water_heater_mixed": [
         {
           "name": "49gal NaturalGas Water Heater - 33kBtu/hr 0.82 Therm Eff",
@@ -653,12 +625,8 @@
       "The resource referenced by LifeCycleCost:UsePriceEscalation= \"U.S. AVG  COMMERCIAL-NATURAL GAS\" has no energy cost.   ... It is likely that the wrong resource is used. The resource should match the meter used in Utility:Tariff.",
       "The resource referenced by LifeCycleCost:UsePriceEscalation= \"U.S. AVG  COMMERCIAL-COAL\" has no energy cost.   ... It is likely that the wrong resource is used. The resource should match the meter used in Utility:Tariff."
     ],
-    "fatal": [
-
-    ],
-    "severe": [
-
-    ]
+    "fatal": [],
+    "severe": []
   },
   "ruby_warnings": [
     "space.spaceType.get.defaultScheduleSet.get.numberofPeopleSchedule is empty for attic",

--- a/test/necb/unit_tests/expected_results/qaqc_report_expected_result.json
+++ b/test/necb/unit_tests/expected_results/qaqc_report_expected_result.json
@@ -250,9 +250,7 @@
         "infiltration_method": "Flow/ExteriorArea",
         "infiltration_flow_per_m2": 0.00025,
         "occupancy_schedule": null,
-        "waterUseEquipment": [
-
-        ]
+        "waterUseEquipment": []
       },
       {
         "name": "Dining",
@@ -314,9 +312,7 @@
       "infiltration_method": "Flow/ExteriorArea",
       "infiltration_flow_per_m2": 0.00025,
       "occupancy_schedule": null,
-      "waterUseEquipment": [
-
-      ]
+      "waterUseEquipment": []
     },
     {
       "name": "Dining",


### PR DESCRIPTION
The pretty_generate method in the rubygem  json 2.8.1 changed the default formatting for empty brackets versus what was in earlier json gem versions

Minor fix to NECB CI testing.

### Pull Request Author
 - [x] Data changes or additions
 - [x] All new and existing tests passes

### Review Checklist
This will not be exhaustively relevant to every PR.
 - [x] Perform a code review on GitHub
 - [x] CI status: all green or justified
