### PR TITLE
Add version check for VRF cooling COP setter

### DIFF
--- a/lib/openstudio-standards/prototypes/common/objects/Prototype.AirConditionerVariableRefrigerantFlow.rb
+++ b/lib/openstudio-standards/prototypes/common/objects/Prototype.AirConditionerVariableRefrigerantFlow.rb
@@ -61,7 +61,11 @@ class Standard
     vrf_outdoor_unit.setAvailabilitySchedule(availability_schedule)
 
     # set cops
-    vrf_outdoor_unit.setRatedCoolingCOP(cooling_cop)
+    if model.version < OpenStudio::VersionString.new('2.9.0')
+      vrf_outdoor_unit.setRatedCoolingCOP(cooling_cop)
+    else
+      vrf_outdoor_unit.setGrossRatedCoolingCOP(cooling_cop)
+    end
     vrf_outdoor_unit.setRatedHeatingCOP(heating_cop)
 
     # heat recovery

--- a/lib/openstudio-standards/standards/necb/ECMS/hvac_systems.rb
+++ b/lib/openstudio-standards/standards/necb/ECMS/hvac_systems.rb
@@ -270,7 +270,11 @@ class ECMS
     outdoor_vrf_unit.setName('VRF Outdoor Unit')
     outdoor_vrf_unit.setHeatPumpWasteHeatRecovery(true)
     outdoor_vrf_unit.setRatedHeatingCOP(4.0)
-    outdoor_vrf_unit.setRatedCoolingCOP(4.0)
+    if model.version < OpenStudio::VersionString.new('2.9.0')
+      outdoor_vrf_unit.setRatedCoolingCOP(4.0)
+    else
+      outdoor_vrf_unit.setGrossRatedCoolingCOP(4.0)
+    end
     outdoor_vrf_unit.setMinimumOutdoorTemperatureinHeatingMode(-25.0)
     outdoor_vrf_unit.setHeatingPerformanceCurveOutdoorTemperatureType('WetBulbTemperature')
     outdoor_vrf_unit.setMasterThermostatPriorityControlType('ThermostatOffsetPriority')
@@ -2946,8 +2950,13 @@ class ECMS
     end
 
     # Set COP
-    airconditioner_variablerefrigerantflow.setRatedCoolingCOP(cop.to_f) unless cop.nil?
-
+    unless cop.nil?
+      if model.version < OpenStudio::VersionString.new('2.9.0')
+        airconditioner_variablerefrigerantflow.setRatedCoolingCOP(cop.to_f)
+      else
+        airconditioner_variablerefrigerantflow.setGrossRatedCoolingCOP(cop.to_f)
+      end
+    end
   end
 
   # =============================================================================================================================

--- a/lib/openstudio-standards/standards/necb/ECMS/hvac_systems.rb
+++ b/lib/openstudio-standards/standards/necb/ECMS/hvac_systems.rb
@@ -2951,7 +2951,7 @@ class ECMS
 
     # Set COP
     unless cop.nil?
-      if model.version < OpenStudio::VersionString.new('2.9.0')
+      if airconditioner_variablerefrigerantflow.model.version < OpenStudio::VersionString.new('2.9.0')
         airconditioner_variablerefrigerantflow.setRatedCoolingCOP(cop.to_f)
       else
         airconditioner_variablerefrigerantflow.setGrossRatedCoolingCOP(cop.to_f)


### PR DESCRIPTION
Pull request overview
---------------------
`setRatedCoolingCOP` was deprecated in OS v2.9.0 and replaced with `setGrossRatedCoolingCOP`
 - Fixes #1871

### Pull Request Author
 - [x] Method changes or additions
 - [x] All new and existing tests passes

### Review Checklist
 - [x] Perform a code review on GitHub
 - [x] All related changes have been implemented: method additions, changes, tests
 - [x] If fixing a defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [x] CI status: all green or justified
