### PR TITLE
subclassing `plant_loop_prm_baseline_condenser_water_temperatures` for 90.1-2016 and 2019

### DIFF
--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2016/ashrae_90_1_2016.PlantLoop.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2016/ashrae_90_1_2016.PlantLoop.rb
@@ -1,0 +1,41 @@
+class ASHRAE9012016 < ASHRAE901
+  # @!group PlantLoop
+
+  # Determine the performance rating method specified
+  # design condenser water temperature, approach, and range
+  #
+  # @param plant_loop [OpenStudio::Model::PlantLoop] the condenser water loop
+  # @param design_oat_wb_c [Double] the design OA wetbulb temperature (C)
+  # @return [Array<Double>] [leaving_cw_t_c, approach_k, range_k]
+  def plant_loop_prm_baseline_condenser_water_temperatures(plant_loop, design_oat_wb_c)
+    design_oat_wb_f = OpenStudio.convert(design_oat_wb_c, 'C', 'F').get
+
+    # G3.1.3.11 - CW supply temp shall be evaluated at 0.4% evaporative design OATwb
+    # per the formulat approach_F = 25.72 - (0.24 * OATwb_F)
+    # 55F <= OATwb <= 90F
+    # Design range = 10F.
+    range_r = 10
+
+    # Limit the OATwb
+    if design_oat_wb_f < 55
+      design_oat_wb_f = 55
+      OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.PlantLoop', "For #{plant_loop.name}, a design OATwb of 55F will be used for sizing the cooling towers because the actual design value is below the limit in G3.1.3.11.")
+    elsif design_oat_wb_f > 90
+      design_oat_wb_f = 90
+      OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.PlantLoop', "For #{plant_loop.name}, a design OATwb of 90F will be used for sizing the cooling towers because the actual design value is above the limit in G3.1.3.11.")
+    end
+
+    # Calculate the approach
+    approach_r = 25.72 - (0.24 * design_oat_wb_f)
+
+    # Calculate the leaving CW temp
+    leaving_cw_t_f = design_oat_wb_f + approach_r
+
+    # Convert to SI units
+    leaving_cw_t_c = OpenStudio.convert(leaving_cw_t_f, 'F', 'C').get
+    approach_k = OpenStudio.convert(approach_r, 'R', 'K').get
+    range_k = OpenStudio.convert(range_r, 'R', 'K').get
+
+    return [leaving_cw_t_c, approach_k, range_k]
+  end
+end

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2019/ashrae_90_1_2019.PlantLoop.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2019/ashrae_90_1_2019.PlantLoop.rb
@@ -1,0 +1,41 @@
+class ASHRAE9012019 < ASHRAE901
+  # @!group PlantLoop
+
+  # Determine the performance rating method specified
+  # design condenser water temperature, approach, and range
+  #
+  # @param plant_loop [OpenStudio::Model::PlantLoop] the condenser water loop
+  # @param design_oat_wb_c [Double] the design OA wetbulb temperature (C)
+  # @return [Array<Double>] [leaving_cw_t_c, approach_k, range_k]
+  def plant_loop_prm_baseline_condenser_water_temperatures(plant_loop, design_oat_wb_c)
+    design_oat_wb_f = OpenStudio.convert(design_oat_wb_c, 'C', 'F').get
+
+    # G3.1.3.11 - CW supply temp shall be evaluated at 0.4% evaporative design OATwb
+    # per the formulat approach_F = 25.72 - (0.24 * OATwb_F)
+    # 55F <= OATwb <= 90F
+    # Design range = 10F.
+    range_r = 10
+
+    # Limit the OATwb
+    if design_oat_wb_f < 55
+      design_oat_wb_f = 55
+      OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.PlantLoop', "For #{plant_loop.name}, a design OATwb of 55F will be used for sizing the cooling towers because the actual design value is below the limit in G3.1.3.11.")
+    elsif design_oat_wb_f > 90
+      design_oat_wb_f = 90
+      OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.PlantLoop', "For #{plant_loop.name}, a design OATwb of 90F will be used for sizing the cooling towers because the actual design value is above the limit in G3.1.3.11.")
+    end
+
+    # Calculate the approach
+    approach_r = 25.72 - (0.24 * design_oat_wb_f)
+
+    # Calculate the leaving CW temp
+    leaving_cw_t_f = design_oat_wb_f + approach_r
+
+    # Convert to SI units
+    leaving_cw_t_c = OpenStudio.convert(leaving_cw_t_f, 'F', 'C').get
+    approach_k = OpenStudio.convert(approach_r, 'R', 'K').get
+    range_k = OpenStudio.convert(range_r, 'R', 'K').get
+
+    return [leaving_cw_t_c, approach_k, range_k]
+  end
+end


### PR DESCRIPTION
Pull request overview
---------------------

- coming from this: https://github.com/NREL/openstudio-standards/issues/1915

- adding subclasses in 90.1-2016 and 2019

- for this method: `plant_loop_prm_baseline_condenser_water_temperatures`

- which reflects this section:

![image](https://github.com/user-attachments/assets/be386ba1-2219-48ba-a88a-5e583c9d2587)

- unsure if it is really the right fix tho.

### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Method changes or additions
 - [ ] Data changes or additions
 - [ ] Added tests for added methods
 - [ ] If methods have been deprecated, update rest of code to use the new methods
 - [ ] Documented new methods using [yard syntax](https://rubydoc.info/gems/yard/file/docs/GettingStarted.md)
 - [ ] Resolved yard documentation errors for new code (ran `bundle exec rake doc`)
 - [ ] Resolved rubocop syntax errors for new code (ran `bundle exec rake rubocop`)
 - [ ] All new and existing tests passes
 - [ ] If the code adds new `require` statements, ensure these are in core ruby or add to the gemspec

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a code review on GitHub
 - [ ] All related changes have been implemented: method additions, changes, tests
 - [ ] Check rubocop errors
 - [ ] Check yard doc errors
 - [ ] If fixing a defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If a new feature, test the new feature and try creative ways to break it
 - [ ] CI status: all green or justified
