### PR TITLE
Add climate zone 0 to NIST infiltration workflow

### DIFF
--- a/lib/openstudio-standards/infiltration/nist_infiltration.rb
+++ b/lib/openstudio-standards/infiltration/nist_infiltration.rb
@@ -218,6 +218,9 @@ module OpenstudioStandards
       # get climate zone number
       climate_zone_number = OpenstudioStandards::Weather.model_get_ashrae_climate_zone_number(model)
 
+      # there is no data for climate zone 0, so use data for climate zone 1
+      climate_zone_number = 1 if climate_zone_number == 0
+
       # get nist building type
       if nist_building_type.nil?
         nist_building_type = model_infer_nist_building_type(model)

--- a/test/modules/infiltration/test_nist_infiltration.rb
+++ b/test/modules/infiltration/test_nist_infiltration.rb
@@ -118,6 +118,12 @@ class TestInfiltration < Minitest::Test
     result = @infiltration.model_set_nist_infiltration(model,
                                                        hvac_schedule_name: 'Complex HVAC Schedule' )
     assert(result)
+
+    # test climate zone 0
+    climate_zone = 'ASHRAE 169-2013-0A'
+    OpenstudioStandards::Weather.model_set_building_location(model, climate_zone: climate_zone)
+    result = @infiltration.model_set_nist_infiltration(model)
+    assert(result)
   end
 
   def test_model_set_nist_infiltration_schedules


### PR DESCRIPTION
Pull request overview
---------------------
Use coefficients for climate zone 1 if the model climate zone is 0.
Fixes #1919 

### Pull Request Author
 - [x] Method changes or additions
 - [x] Added tests for added methods
 - [x] All new and existing tests passes

### Review Checklist
 - [x] Perform a code review on GitHub
 - [x] All related changes have been implemented: method additions, changes, tests
 - [x] If fixing a defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [x] CI status: all green or justified
