### PR TITLE
Add supermarket ratios to create typical

### DIFF
--- a/lib/openstudio-standards/create_typical/space_type_ratios.rb
+++ b/lib/openstudio-standards/create_typical/space_type_ratios.rb
@@ -285,20 +285,19 @@ module OpenstudioStandards
         hash['Toilet'] = { ratio: 0.0193, space_type_gen: true, default: false }
         hash['Undeveloped'] = { ratio: 0.0835, space_type_gen: false, default: false }
         hash['Xray'] = { ratio: 0.0220, space_type_gen: true, default: false }
-      when 'SuperMarket'
-        # @todo populate ratios for SuperMarket
-        hash['Bakery'] = { ratio: 0.99, space_type_gen: true, default: false }
-        hash['Deli'] = { ratio: 0.99, space_type_gen: true, default: false }
-        hash['DryStorage'] = { ratio: 0.99, space_type_gen: true, default: false }
-        hash['Office'] = { ratio: 0.99, space_type_gen: true, default: false }
-        hash['Produce'] = { ratio: 0.99, space_type_gen: true, default: true }
-        hash['Sales'] = { ratio: 0.99, space_type_gen: true, default: true }
-        hash['Corridor'] = { ratio: 0.99, space_type_gen: true, default: true }
-        hash['Dining'] = { ratio: 0.99, space_type_gen: true, default: true }
-        hash['Elec/MechRoom'] = { ratio: 0.99, space_type_gen: true, default: true }
-        hash['Meeting'] = { ratio: 0.99, space_type_gen: true, default: true }
-        hash['Restroom'] = { ratio: 0.99, space_type_gen: true, default: true }
-        hash['Vestibule'] = { ratio: 0.99, space_type_gen: true, default: true }
+      when 'SuperMarket', 'GroceryStore'
+        hash['Bakery'] = { ratio: 0.05, space_type_gen: true, default: false }
+        hash['Deli'] = { ratio: 0.0537, space_type_gen: true, default: false }
+        hash['DryStorage'] = { ratio: 0.1010, space_type_gen: true, default: false }
+        hash['Office'] = { ratio: 0.0067, space_type_gen: true, default: false }
+        hash['Produce'] = { ratio: 0.1701, space_type_gen: true, default: true }
+        hash['Sales'] = { ratio: 0.5495, space_type_gen: true, default: true }
+        hash['Corridor'] = { ratio: 0.0118, space_type_gen: true, default: true }
+        hash['Dining'] = { ratio: 0.0111, space_type_gen: true, default: true }
+        hash['Elec/MechRoom'] = { ratio: 0.0133, space_type_gen: true, default: true }
+        hash['Meeting'] = { ratio: 0.0111, space_type_gen: true, default: true }
+        hash['Restroom'] = { ratio: 0.0150, space_type_gen: true, default: true }
+        hash['Vestibule'] = { ratio: 0.0067, space_type_gen: true, default: true }
       when 'Laboratory'
         hash['Office'] = { ratio: 0.50, space_type_gen: true, default: true }
         hash['Open lab'] = { ratio: 0.35, space_type_gen: true, default: true }

--- a/test/modules/create_typical/test_create_typical.rb
+++ b/test/modules/create_typical/test_create_typical.rb
@@ -219,16 +219,38 @@ class TestCreateTypical < Minitest::Test
     assert(starting_size < ending_size)
   end
 
-  def test_create_typical_supermarket
+  def test_create_typical_comstock_supermarket
     # load model and set up weather file
-    template = '90.1-2013'
+    template = 'ComStock 90.1-2013'
     climate_zone = 'ASHRAE 169-2013-4A'
     std = Standard.build(template)
     model = std.safe_load_model("#{File.dirname(__FILE__)}/../../../data/geometry/ASHRAESuperMarket.osm")
     OpenstudioStandards::Weather.model_set_building_location(model, climate_zone: climate_zone)
 
     # set output directory
-    output_dir = "#{__dir__}/output/test_create_typical_supermarket"
+    output_dir = "#{__dir__}/output/test_create_typical_comstock_supermarket"
+    FileUtils.mkdir output_dir unless Dir.exist? output_dir
+
+    # apply create typical
+    starting_size = model.getModelObjects.size
+    result = @create.create_typical_building_from_model(model, template,
+                                                        climate_zone: climate_zone,
+                                                        sizing_run_directory: output_dir)
+    ending_size = model.getModelObjects.size
+    assert(result)
+    assert(starting_size < ending_size)
+  end
+
+  def test_create_typical_deer_gro
+    # load model and set up weather file
+    template = 'ComStock DEER Pre-1975'
+    climate_zone = 'CEC T24-CEC6'
+    std = Standard.build(template)
+    model = std.safe_load_model("#{File.dirname(__FILE__)}/../../../data/geometry/DEER_Gro.osm")
+    OpenstudioStandards::Weather.model_set_building_location(model, climate_zone: climate_zone)
+
+    # set output directory
+    output_dir = "#{__dir__}/output/test_create_typical_deer_gro"
     FileUtils.mkdir output_dir unless Dir.exist? output_dir
 
     # apply create typical

--- a/test/modules/create_typical/test_create_typical.rb
+++ b/test/modules/create_typical/test_create_typical.rb
@@ -218,4 +218,26 @@ class TestCreateTypical < Minitest::Test
     assert(result)
     assert(starting_size < ending_size)
   end
+
+  def test_create_typical_supermarket
+    # load model and set up weather file
+    template = '90.1-2013'
+    climate_zone = 'ASHRAE 169-2013-4A'
+    std = Standard.build(template)
+    model = std.safe_load_model("#{File.dirname(__FILE__)}/../../../data/geometry/ASHRAESuperMarket.osm")
+    OpenstudioStandards::Weather.model_set_building_location(model, climate_zone: climate_zone)
+
+    # set output directory
+    output_dir = "#{__dir__}/output/test_create_typical_supermarket"
+    FileUtils.mkdir output_dir unless Dir.exist? output_dir
+
+    # apply create typical
+    starting_size = model.getModelObjects.size
+    result = @create.create_typical_building_from_model(model, template,
+                                                        climate_zone: climate_zone,
+                                                        sizing_run_directory: output_dir)
+    ending_size = model.getModelObjects.size
+    assert(result)
+    assert(starting_size < ending_size)
+  end
 end

--- a/test/modules/geometry/test_geometry_create_bar.rb
+++ b/test/modules/geometry/test_geometry_create_bar.rb
@@ -79,6 +79,20 @@ class TestGeometryCreateBar < Minitest::Test
     model.save("#{__dir__}/output/test_create_bar_from_building_type_ratios_warehouse.osm", true)
   end
 
+  def test_create_bar_from_building_type_ratios_supermarket
+    model = OpenStudio::Model::Model.new
+
+    args = {}
+    args['total_bldg_floor_area'] = 37500.0
+    args['bldg_type_a'] = 'SuperMarket'
+    args['ns_to_ew_ratio'] = 2.0
+    args['num_stories_above_grade'] = 1.0
+    args['template'] = 'ComStock DOE Ref Pre-1980'
+    result = @geo.create_bar_from_building_type_ratios(model, args)
+    assert(result)
+    model.save("#{__dir__}/output/test_create_bar_from_building_type_ratios_supermarket.osm", true)
+  end
+
   def test_create_bar_from_building_type_ratios_doe_deer_mix
     model = OpenStudio::Model::Model.new
 


### PR DESCRIPTION
Pull request overview
---------------------
Updates create typical space type ratios to allow for supermarket models in create bar method. Add tests for SuperMarket and DEER Gro building types.

### Pull Request Author
 - [X] Method changes or additions
 - [X] Data changes or additions
 - [X] Added tests for added methods
 - [X] Resolved rubocop syntax errors for new code (ran `bundle exec rake rubocop`)
 - [ ] All new and existing tests passes

### Review Checklist
 - [ ] Perform a code review on GitHub
 - [ ] All related changes have been implemented: method additions, changes, tests
 - [X] Check rubocop errors
 - [ ] If a new feature, test the new feature and try creative ways to break it
 - [ ] CI status: all green or justified
