### PR TITLE
Change StatFile design size info to warning

### DIFF
--- a/lib/openstudio-standards/weather/stat_file.rb
+++ b/lib/openstudio-standards/weather/stat_file.rb
@@ -212,7 +212,7 @@ module OpenstudioStandards
 
           # check info size
           if match_info_raw.size != temp_info[:size]
-            OpenStudio.logFree(OpenStudio::Error, 'openstudio.standards.Weather.StatFile', "Expected to find #{temp_info[:size]} #{temp_info[:name]} but found #{match_info_raw.size}. Check data source.")
+            OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.Weather.StatFile', "Expected to find #{temp_info[:size]} #{temp_info[:name]} but found #{match_info_raw.size}. Check data source.")
           end
 
           match_info_raw.each do |val|


### PR DESCRIPTION
Quick PR to change [this line](https://github.com/NREL/openstudio-standards/blob/db6cdd5832bfc586724e40d83c375634e33d4549/lib/openstudio-standards/weather/stat_file.rb#L215) to a warning message instead of an Error, as not all stat files will have the exact some number of design day information in the heading.