### PR TITLE
Add parallel option in the measure to parallelize the baseline sizing…

### DIFF
--- a/lib/openstudio-standards/standards/Standards.Model.rb
+++ b/lib/openstudio-standards/standards/Standards.Model.rb
@@ -1,5 +1,6 @@
 require 'csv'
 require 'date'
+require 'parallel'
 
 class Standard
   attr_accessor :space_multiplier_map, :standards_data
@@ -66,8 +67,9 @@ class Standard
   # @param sizing_run_dir [String] the directory where the sizing runs will be performed
   # @param run_all_orients [Boolean] indicate weather a baseline model should be created for all 4 orientations: same as user model, +90 deg, +180 deg, +270 deg
   # @param debug [Boolean] If true, will report out more detailed debugging output
+  # @param use_parallel [Boolean] If true, when measure will run simulation for four orientations in parallel, else keep runinig one at a time.
   # @return [Boolean] returns true if successful, false if not
-  def model_create_prm_any_baseline_building(user_model, building_type, climate_zone, hvac_building_type = 'All others', wwr_building_type = 'All others', swh_building_type = 'All others', model_deep_copy = false, create_proposed_model = false, custom = nil, sizing_run_dir = Dir.pwd, run_all_orients = false, unmet_load_hours_check = true, debug = false)
+  def model_create_prm_any_baseline_building(user_model, building_type, climate_zone, hvac_building_type = 'All others', wwr_building_type = 'All others', swh_building_type = 'All others', model_deep_copy = false, create_proposed_model = false, custom = nil, sizing_run_dir = Dir.pwd, run_all_orients = false, unmet_load_hours_check = true, debug = false, use_parallel=false)
     # User data process
     # bldg_type_hvac_zone_hash could be an empty hash if all zones in the models are unconditioned
     # TODO - move this portion to the top of the function
@@ -155,8 +157,11 @@ class Standard
     # Need to run proposed model sizing simulation if no sql data is available
     degs_from_org = run_all_orientations(run_all_orients, user_model) ? [0, 90, 180, 270] : [0]
 
+    # loop method
+    each_method = use_parallel && degs_from_org.size > 1 ? ->(collection, &block) { Parallel.each(collection, in_process: 4, &block) } : ->(collection, &block) { collection.each(&block) }
+    
     # Create baseline model for each orientation
-    degs_from_org.each do |degs|
+    each_method.call(degs_from_org) do |degs|
       # New baseline model:
       # Starting point is the original proposed model
       # Create a deep copy of the user model if requested
@@ -429,7 +434,7 @@ class Standard
       end
 
       # Run sizing run with the HVAC equipment
-      if model_run_sizing_run(model, "#{sizing_run_dir}/SR1") == false
+      if model_run_sizing_run(model, "#{sizing_run_dir}/SR1-#{degs}") == false
         return false
       end
 
@@ -471,7 +476,7 @@ class Standard
       end
 
       # Run sizing run with the new chillers, boilers, and cooling towers to determine capacities
-      if model_run_sizing_run(model, "#{sizing_run_dir}/SR2") == false
+      if model_run_sizing_run(model, "#{sizing_run_dir}/SR2-#{degs}") == false
         return false
       end
 

--- a/test/90_1_prm/prm_test_model_generator.rb
+++ b/test/90_1_prm/prm_test_model_generator.rb
@@ -220,7 +220,8 @@ class AppendixGPRMTests < Minitest::Test
                                                                                  sizing_run_dir = run_dir_baseline,
                                                                                  run_all_orients = true,
                                                                                  unmet_load_hours_check = false,
-                                                                                 debug = GENERATE_PRM_LOG)
+                                                                                 debug = GENERATE_PRM_LOG,
+                                                                                 use_parallel = false)
 
       # Check if baseline model could be created
       assert(model_baseline, "Baseline model could not be generated for #{building_type}, #{template}, #{climate_zone}.")


### PR DESCRIPTION
… run based on orientation.

disable parallel in CI testing

Pull request overview
---------------------

Parallelize the baseline orientation run.

 - Fixes #ISSUENUMBERHERE (IF THIS IS A DEFECT)

### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [x] Method changes or additions
 - [ ] Data changes or additions
 - [ ] Added tests for added methods
 - [ ] If methods have been deprecated, update rest of code to use the new methods
 - [ ] Documented new methods using [yard syntax](https://rubydoc.info/gems/yard/file/docs/GettingStarted.md)
 - [ ] Resolved yard documentation errors for new code (ran `bundle exec rake doc`)
 - [ ] Resolved rubocop syntax errors for new code (ran `bundle exec rake rubocop`)
 - [ ] All new and existing tests passes
 - [ ] If the code adds new `require` statements, ensure these are in core ruby or add to the gemspec

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a code review on GitHub
 - [ ] All related changes have been implemented: method additions, changes, tests
 - [ ] Check rubocop errors
 - [ ] Check yard doc errors
 - [ ] If fixing a defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If a new feature, test the new feature and try creative ways to break it
 - [ ] CI status: all green or justified
