### PR TITLE
change default design day sim to true

### DIFF
--- a/lib/openstudio-standards/utilities/simulation.rb
+++ b/lib/openstudio-standards/utilities/simulation.rb
@@ -181,9 +181,9 @@ Standard.class_eval do
   #
   # @param model [OpenStudio::Model::Model] OpenStudio model object
   # @param sizing_run_dir [String] file path location for the sizing run, defaults to 'SR' in the current directory
-  # @param sizing_run_simulation [Boolean] whether to run the simulation for the sizing periods, defaults to false
+  # @param sizing_run_simulation [Boolean] whether to run the simulation for the sizing periods, defaults to true
   # @return [Boolean] returns true if successful, false if not
-  def model_run_sizing_run(model, sizing_run_dir = "#{Dir.pwd}/SR", sizing_run_simulation = false)
+  def model_run_sizing_run(model, sizing_run_dir = "#{Dir.pwd}/SR", sizing_run_simulation = true)
     # Change the simulation to only run the sizing days
     sim_control = model.getSimulationControl
     sim_control.setRunSimulationforSizingPeriods(sizing_run_simulation)


### PR DESCRIPTION
Setting to false causes some issues with SingleSpeed DX coils in the set COP and capacity lookups; possibly related to how the get capacity methods are implemented.

Pull request overview
---------------------
### Pull Request Author
 - [x] Method changes or additions
