### PR TITLE
Fix coil efficiency application to NECB models

### DIFF
--- a/lib/openstudio-standards/standards/Standards.CoilCoolingDXSingleSpeed.rb
+++ b/lib/openstudio-standards/standards/Standards.CoilCoolingDXSingleSpeed.rb
@@ -64,7 +64,7 @@ class Standard
       (template == 'BTAP1980TO2010'))
       if search_criteria.keys.include?('equipment_type')
         equipment_type = search_criteria['equipment_type']
-        if ['PTAC', 'PTHP'].include?(equipment_type)
+        if ['PTAC', 'PTHP'].include?(equipment_type) && template.include?('90.1')
           search_criteria['application'] = coil_dx_packaged_terminal_application(coil_cooling_dx_single_speed)
         end
       elsif !coil_dx_heat_pump?(coil_cooling_dx_single_speed)
@@ -83,7 +83,6 @@ class Standard
     # Lookup efficiencies depending on whether it is a unitary AC or a heat pump
     ac_props = nil
     ac_props = model_find_object(database, search_criteria, capacity_btu_per_hr, Date.today)
-
     # Check to make sure properties were found
     if ac_props.nil?
       OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.CoilCoolingDXSingleSpeed', "For #{coil_cooling_dx_single_speed.name}, cannot find efficiency info using #{search_criteria} and capacity #{capacity_btu_per_hr} btu/hr, cannot apply efficiency standard.")
@@ -238,7 +237,7 @@ class Standard
       (template == 'BTAP1980TO2010'))
       if search_criteria.keys.include?('equipment_type')
         equipment_type = search_criteria['equipment_type']
-        if ['PTAC', 'PTHP'].include?(equipment_type)
+        if ['PTAC', 'PTHP'].include?(equipment_type) && template.include?('90.1')
           search_criteria['application'] = coil_dx_packaged_terminal_application(coil_cooling_dx_single_speed)
         end
       elsif !coil_dx_heat_pump?(coil_cooling_dx_single_speed)
@@ -260,7 +259,7 @@ class Standard
     # Check to make sure properties were found
     if ac_props.nil?
       OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.CoilCoolingDXSingleSpeed', "For #{coil_cooling_dx_single_speed.name}, cannot find efficiency info using #{search_criteria} and capacity #{capacity_btu_per_hr} btu/hr, cannot apply efficiency standard.")
-      return false
+      return sql_db_vars_map
     end
 
     equipment_type_field = search_criteria['equipment_type']

--- a/lib/openstudio-standards/standards/Standards.CoilCoolingDXTwoSpeed.rb
+++ b/lib/openstudio-standards/standards/Standards.CoilCoolingDXTwoSpeed.rb
@@ -174,7 +174,7 @@ class Standard
     # Check to make sure properties were found
     if ac_props.nil?
       OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.CoilCoolingDXTwoSpeed', "For #{coil_cooling_dx_two_speed.name}, cannot find efficiency info using #{search_criteria} and capacity #{capacity_btu_per_hr} btu/hr, cannot apply efficiency standard.")
-      return false
+      return sql_db_vars_map
     end
 
     # Make the total COOL-CAP-FT curve

--- a/lib/openstudio-standards/standards/Standards.CoilHeatingDXSingleSpeed.rb
+++ b/lib/openstudio-standards/standards/Standards.CoilHeatingDXSingleSpeed.rb
@@ -282,7 +282,7 @@ class Standard
     # Check to make sure properties were found
     if hp_props.nil?
       OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.CoilHeatingDXSingleSpeed', "For #{coil_heating_dx_single_speed.name}, cannot find efficiency info using #{search_criteria} and capacity #{capacity_btu_per_hr} btu/hr, cannot apply efficiency standard.")
-      return false
+      return sql_db_vars_map
     end
 
     equipment_type_field = search_criteria['equipment_type']

--- a/lib/openstudio-standards/standards/Standards.Model.rb
+++ b/lib/openstudio-standards/standards/Standards.Model.rb
@@ -159,7 +159,7 @@ class Standard
 
     # loop method
     each_method = use_parallel && degs_from_org.size > 1 ? ->(collection, &block) { Parallel.each(collection, in_process: 4, &block) } : ->(collection, &block) { collection.each(&block) }
-    
+
     # Create baseline model for each orientation
     each_method.call(degs_from_org) do |degs|
       # New baseline model:


### PR DESCRIPTION
Pull request overview
---------------------
The NECB PTAC / PTHP efficiency data doesn't have the 'application'  field, causing the  lookup to return nil, and the efficiency application to return false. Since the vars hash gets successively passed, further methods failing when trying to set variables on the now false hash. Fixes are to return the original hash instead of false in the apply method. And to add a check to only apply the application search field for 90.1 templates.

### Pull Request Author
 - [x] Method changes or additions
 - [x] All new and existing tests passes

### Review Checklist
 - [x] Perform a code review on GitHub
 - [x] All related changes have been implemented: method additions, changes, tests
 - [x] If fixing a defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [x] CI status: all green or justified
