### PR TITLE
Fix Comstock PTHP efficiency lookup

### DIFF
--- a/lib/openstudio-standards/standards/Standards.CoilDX.rb
+++ b/lib/openstudio-standards/standards/Standards.CoilDX.rb
@@ -219,8 +219,7 @@ module CoilDX
   #   CoilCoolingDXSingleSpeed, CoilCoolingDXTwoSpeed, CoilCoolingDXMultiSpeed
   # @return [String] PTAC application
   def coil_dx_packaged_terminal_application(coil_dx)
-    case template
-    when '90.1-2004', '90.1-2007'
+    if template.include?('90.1-2004') || template.include?('90.1-2007')
       return 'New Construction'
     else # '90.1-2010', '90.1-2013', '90.1-2016', '90.1-2019', others
       return 'Standard Size'

--- a/lib/openstudio-standards/standards/Standards.CoilHeatingDXSingleSpeed.rb
+++ b/lib/openstudio-standards/standards/Standards.CoilHeatingDXSingleSpeed.rb
@@ -252,7 +252,7 @@ class Standard
       (template == 'BTAP1980TO2010'))
       if search_criteria.keys.include?('equipment_type')
         equipment_type = search_criteria['equipment_type']
-        if ['PTHP'].include?(equipment_type)
+        if ['PTHP'].include?(equipment_type) && template.include?('90.1')
           search_criteria['application'] = coil_dx_packaged_terminal_application(coil_heating_dx_single_speed)
         end
       elsif !coil_dx_heat_pump?(coil_heating_dx_single_speed) # `coil_dx_heat_pump?` returns false when a DX heating coil is wrapped into a AirloopHVAC:UnitarySystem

--- a/test/modules/create_typical/test_create_typical.rb
+++ b/test/modules/create_typical/test_create_typical.rb
@@ -199,7 +199,7 @@ class TestCreateTypical < Minitest::Test
 
   def test_create_typical_building_from_model_comstock_retail_pthp
     # load model and set up weather file
-    template = 'ComStock 90.1-2013'
+    template = 'ComStock 90.1-2007'
     climate_zone = 'ASHRAE 169-2013-4A'
     std = Standard.build(template)
     model = std.safe_load_model("#{File.dirname(__FILE__)}/../../../data/geometry/ASHRAERetailStripmall.osm")


### PR DESCRIPTION
Pull request overview
---------------------
90.1-2004 and 90.1-2007 ASHRAE heat pump heating efficiencies use 'New Construction' and 'Replacements' as the application type, rather than 'Standard Size'. When the template includes ComStock , it uses the ASHRAE 90.1 databases but didn't strictly match the template type, so the efficiency lookup would fail.

### Pull Request Author
 - [x] Method changes or additions
 - [x] Added tests for added methods
 - [x] All new and existing tests passes

### Review Checklist
 - [ ] Perform a code review on GitHub
 - [x] All related changes have been implemented: method additions, changes, tests
 - [x] If fixing a defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [x] CI status: all green or justified
