### PR TITLE
Fix broken generate_userdata_to_csv

### DIFF
--- a/lib/openstudio-standards/standards/ashrae_90_1_prm/userdata_csv/ashrae_90_1_prm.UserData.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1_prm/userdata_csv/ashrae_90_1_prm.UserData.rb
@@ -6,6 +6,7 @@ class UserDataCSV
   def initialize(model, save_dir)
     @model = model
     @component_name = nil
+    @unique_model_object = false
     unless Dir.exist?(save_dir)
       raise ArgumentError "Saving directory #{save_dir} does not exist!"
     end
@@ -70,6 +71,9 @@ class UserDataCSV
   # subclass shall determine what data group to extract from a modle.
   # @return [Array] array of OpenStudio components.
   def load_component
+    if @unique_model_object
+      return [@model.public_send("get#{@component_name}")]
+    end
     return @model.public_send("get#{@component_name}")
   end
 end
@@ -145,6 +149,7 @@ class UserDataCSVBuilding < UserDataCSV
   def initialize(model, save_dir)
     super
     @component_name = 'Building'
+    @unique_model_object = true
     @file_name = UserDataFiles::BUILDING
   end
 
@@ -274,7 +279,7 @@ class UserDataWaterUseConnection < UserDataCSV
   # @param save_dir [String] directory to save user data files
   def initialize(model, save_dir)
     super
-    @component_name = 'WaterUseConnections'
+    @component_name = 'WaterUseConnectionss'
     @file_name = UserDataFiles::WATERUSE_CONNECTIONS
   end
 


### PR DESCRIPTION
Pull request overview
---------------------

I was trying to use this: https://pnnl.github.io/BEM-for-PRM/user_guide/prm_api_ref/userdata_api/ as a first step to trying out the 2019 PRM. And Immediately bumped into an error.

`generate_userdata_to_csv` from 2019 PRM is broken on master.

### Pull Request Author

<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Method changes or additions
 - [ ] Data changes or additions
 - [ ] Added tests for added methods
 - [ ] If methods have been deprecated, update rest of code to use the new methods
 - [ ] Documented new methods using [yard syntax](https://rubydoc.info/gems/yard/file/docs/GettingStarted.md)
 - [ ] Resolved yard documentation errors for new code (ran `bundle exec rake doc`)
 - [ ] Resolved rubocop syntax errors for new code (ran `bundle exec rake rubocop`)
 - [ ] All new and existing tests passes
 - [ ] If the code adds new `require` statements, ensure these are in core ruby or add to the gemspec

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a code review on GitHub
 - [ ] All related changes have been implemented: method additions, changes, tests
 - [ ] Check rubocop errors
 - [ ] Check yard doc errors
 - [ ] If fixing a defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If a new feature, test the new feature and try creative ways to break it
 - [ ] CI status: all green or justified
