### PR TITLE
Add DEER service water assumptions

### DIFF
--- a/lib/openstudio-standards/service_water_heating/data/typical_water_use_equipment.csv
+++ b/lib/openstudio-standards/service_water_heating/data/typical_water_use_equipment.csv
@@ -52,3 +52,29 @@ Strip mall - type 2,StripMall,,1.8,,One Per Space,110,RetailStripmall Type2_SWH_
 Strip mall - type 3,StripMall,,1.8,,One Per Space,110,RetailStripmall Type3_SWH_SCH,0.2,0.05
 Bakery,SuperMarket,,,0.002141786,Shared,110,SuperMarket Bldg Swh,0.2,0.05
 Deli,SuperMarket,,,0.002141786,Shared,110,SuperMarket Bldg Swh,0.2,0.05
+OfficeGeneral,Asm,,,0.036321959,Shared,135,D_Asm_All_DHW_DHW_Yr,0.2,0.05
+OfficeGeneral,Asm,,,0.036321959,Shared,135,D_Asm_All_DHW_DHW_Yr,0.2,0.05
+Kitchen,ECC,,,0.200390499,One Per Space,135,D_ECC_All_DHW_DHW_Yr,0.2,0.05
+Kitchen,EPr,,,0.0476755,One Per Space,135,D_EPr_All_DHW_DHW_Yr,0.2,0.05
+Classroom,ERC,,,0.007802747,Shared,135,D_ERC_All_DHW_DHW_Yr,0.2,0.05
+Kitchen,ESe,,,0.106434595,One Per Space,135,D_ESe_All_DHW_DHW_Yr,0.2,0.05
+DormitoryRoom,EUn,,,0.004358811,Shared,110,D_EUn_All_DHW_DHW_Yr,0.2,0.05
+Kitchen,EUn,,,0.206848891,One Per Space,135,D_EUn_All_DHW_DHW_Yr,0.2,0.05
+Kitchen,Hsp,,,0.742112849,One Per Space,135,D_Hsp_All_DHW_DHW_Yr,0.2,0.05
+GuestRmOcc,Htl,,,0.004130108,Shared,110,D_Htl_All_DHW_DHW_Yr,0.2,0.05
+Kitchen,Htl,,,0.169299412,One Per Space,135,D_Htl_All_DHW_DHW_Yr,0.2,0.05
+OfficeOpen,MBT,,,0.004856812,Shared,135,D_MBT_All_DHW_DHW_Yr,0.2,0.05
+ResBedroom,MFm,,3.48,0.003663158,One Per Unit,110,ApartmentMidRise APT_DHW_SCH,0.2,0.05
+ResLiving,MFm,,3.48,0.003663158,One Per Unit,110,ApartmentMidRise APT_DHW_SCH,0.2,0.05
+Work,MLI,,,0.001934756,Shared,135,D_MLI_All_DHW_DHW_Yr,0.2,0.05
+Laundry,Mtl,,,0.135305351,Dedicated,135,D_Mtl_All_DHW_DHW_Yr,0.2,0.05
+Kitchen,Nrs,,,0.116349097,Dedicated,135,D_Nrs_All_DHW_DHW_Yr,0.2,0.05
+OfficeOpen,OfL,,,0.001699689,Shared,135,D_OfL_All_DHW_DHW_Yr,0.2,0.05
+OfficeSmall,OfS,,,0.001311762,Shared,135,D_OfS_All_DHW_DHW_Yr,0.2,0.05
+Kitchen,RFF,,,0.034460537,One Per Space,135,D_RFF_All_DHW_DHW_Yr,0.2,0.05
+Kitchen,RSD,,,0.03112423,One Per Space,135,D_RSD_All_DHW_DHW_Yr,0.2,0.05
+RetailSales,Rt3,,,0.0002815,Shared,135,D_Rt3_All_DHW_DHW_Yr,0.2,0.05
+RetailSales,RtL,,,0.000350744,Shared,135,D_RtL_All_DHW_DHW_Yr,0.2,0.05
+RetailSales,RtS,,,0.000674871,Shared,135,D_RtS_All_DHW_DHW_Yr,0.2,0.05
+WarehouseCond,SCn,,,0.000104042,Shared,135,D_SCn_All_DHW_DHW_Yr,0.2,0.05
+WarehouseUnCond,SUn,,,0.000104042,Shared,135,D_SUn_All_DHW_DHW_Yr,0.2,0.05

--- a/lib/openstudio-standards/service_water_heating/data/typical_water_use_equipment.json
+++ b/lib/openstudio-standards/service_water_heating/data/typical_water_use_equipment.json
@@ -805,6 +805,416 @@
           "latent_fraction": 0.05
         }
       ]
+    },
+    {
+      "space_type": "OfficeGeneral",
+      "building_type": "Asm",
+      "water_use_equipment": [
+        {
+          "equipment_name": null,
+          "peak_flow_rate_gph": null,
+          "peak_flow_rate_gph_per_floor_area_ft2": 0.036321959,
+          "loop_type": "Shared",
+          "mixed_water_temperature_f": 135.0,
+          "flow_rate_schedule": "D_Asm_All_DHW_DHW_Yr",
+          "sensible_fraction": 0.2,
+          "latent_fraction": 0.05
+        },
+        {
+          "equipment_name": null,
+          "peak_flow_rate_gph": null,
+          "peak_flow_rate_gph_per_floor_area_ft2": 0.036321959,
+          "loop_type": "Shared",
+          "mixed_water_temperature_f": 135.0,
+          "flow_rate_schedule": "D_Asm_All_DHW_DHW_Yr",
+          "sensible_fraction": 0.2,
+          "latent_fraction": 0.05
+        }
+      ]
+    },
+    {
+      "space_type": "Kitchen",
+      "building_type": "ECC",
+      "water_use_equipment": [
+        {
+          "equipment_name": null,
+          "peak_flow_rate_gph": null,
+          "peak_flow_rate_gph_per_floor_area_ft2": 0.200390499,
+          "loop_type": "One Per Space",
+          "mixed_water_temperature_f": 135.0,
+          "flow_rate_schedule": "D_ECC_All_DHW_DHW_Yr",
+          "sensible_fraction": 0.2,
+          "latent_fraction": 0.05
+        }
+      ]
+    },
+    {
+      "space_type": "Kitchen",
+      "building_type": "EPr",
+      "water_use_equipment": [
+        {
+          "equipment_name": null,
+          "peak_flow_rate_gph": null,
+          "peak_flow_rate_gph_per_floor_area_ft2": 0.0476755,
+          "loop_type": "One Per Space",
+          "mixed_water_temperature_f": 135.0,
+          "flow_rate_schedule": "D_EPr_All_DHW_DHW_Yr",
+          "sensible_fraction": 0.2,
+          "latent_fraction": 0.05
+        }
+      ]
+    },
+    {
+      "space_type": "Classroom",
+      "building_type": "ERC",
+      "water_use_equipment": [
+        {
+          "equipment_name": null,
+          "peak_flow_rate_gph": null,
+          "peak_flow_rate_gph_per_floor_area_ft2": 0.007802747,
+          "loop_type": "Shared",
+          "mixed_water_temperature_f": 135.0,
+          "flow_rate_schedule": "D_ERC_All_DHW_DHW_Yr",
+          "sensible_fraction": 0.2,
+          "latent_fraction": 0.05
+        }
+      ]
+    },
+    {
+      "space_type": "Kitchen",
+      "building_type": "ESe",
+      "water_use_equipment": [
+        {
+          "equipment_name": null,
+          "peak_flow_rate_gph": null,
+          "peak_flow_rate_gph_per_floor_area_ft2": 0.106434595,
+          "loop_type": "One Per Space",
+          "mixed_water_temperature_f": 135.0,
+          "flow_rate_schedule": "D_ESe_All_DHW_DHW_Yr",
+          "sensible_fraction": 0.2,
+          "latent_fraction": 0.05
+        }
+      ]
+    },
+    {
+      "space_type": "DormitoryRoom",
+      "building_type": "EUn",
+      "water_use_equipment": [
+        {
+          "equipment_name": null,
+          "peak_flow_rate_gph": null,
+          "peak_flow_rate_gph_per_floor_area_ft2": 0.004358811,
+          "loop_type": "Shared",
+          "mixed_water_temperature_f": 110.0,
+          "flow_rate_schedule": "D_EUn_All_DHW_DHW_Yr",
+          "sensible_fraction": 0.2,
+          "latent_fraction": 0.05
+        }
+      ]
+    },
+    {
+      "space_type": "Kitchen",
+      "building_type": "EUn",
+      "water_use_equipment": [
+        {
+          "equipment_name": null,
+          "peak_flow_rate_gph": null,
+          "peak_flow_rate_gph_per_floor_area_ft2": 0.206848891,
+          "loop_type": "One Per Space",
+          "mixed_water_temperature_f": 135.0,
+          "flow_rate_schedule": "D_EUn_All_DHW_DHW_Yr",
+          "sensible_fraction": 0.2,
+          "latent_fraction": 0.05
+        }
+      ]
+    },
+    {
+      "space_type": "Kitchen",
+      "building_type": "Hsp",
+      "water_use_equipment": [
+        {
+          "equipment_name": null,
+          "peak_flow_rate_gph": null,
+          "peak_flow_rate_gph_per_floor_area_ft2": 0.742112849,
+          "loop_type": "One Per Space",
+          "mixed_water_temperature_f": 135.0,
+          "flow_rate_schedule": "D_Hsp_All_DHW_DHW_Yr",
+          "sensible_fraction": 0.2,
+          "latent_fraction": 0.05
+        }
+      ]
+    },
+    {
+      "space_type": "GuestRmOcc",
+      "building_type": "Htl",
+      "water_use_equipment": [
+        {
+          "equipment_name": null,
+          "peak_flow_rate_gph": null,
+          "peak_flow_rate_gph_per_floor_area_ft2": 0.004130108,
+          "loop_type": "Shared",
+          "mixed_water_temperature_f": 110.0,
+          "flow_rate_schedule": "D_Htl_All_DHW_DHW_Yr",
+          "sensible_fraction": 0.2,
+          "latent_fraction": 0.05
+        }
+      ]
+    },
+    {
+      "space_type": "Kitchen",
+      "building_type": "Htl",
+      "water_use_equipment": [
+        {
+          "equipment_name": null,
+          "peak_flow_rate_gph": null,
+          "peak_flow_rate_gph_per_floor_area_ft2": 0.169299412,
+          "loop_type": "One Per Space",
+          "mixed_water_temperature_f": 135.0,
+          "flow_rate_schedule": "D_Htl_All_DHW_DHW_Yr",
+          "sensible_fraction": 0.2,
+          "latent_fraction": 0.05
+        }
+      ]
+    },
+    {
+      "space_type": "OfficeOpen",
+      "building_type": "MBT",
+      "water_use_equipment": [
+        {
+          "equipment_name": null,
+          "peak_flow_rate_gph": null,
+          "peak_flow_rate_gph_per_floor_area_ft2": 0.004856812,
+          "loop_type": "Shared",
+          "mixed_water_temperature_f": 135.0,
+          "flow_rate_schedule": "D_MBT_All_DHW_DHW_Yr",
+          "sensible_fraction": 0.2,
+          "latent_fraction": 0.05
+        }
+      ]
+    },
+    {
+      "space_type": "ResBedroom",
+      "building_type": "MFm",
+      "water_use_equipment": [
+        {
+          "equipment_name": null,
+          "peak_flow_rate_gph": 3.48,
+          "peak_flow_rate_gph_per_floor_area_ft2": 0.003663158,
+          "loop_type": "One Per Unit",
+          "mixed_water_temperature_f": 110.0,
+          "flow_rate_schedule": "ApartmentMidRise APT_DHW_SCH",
+          "sensible_fraction": 0.2,
+          "latent_fraction": 0.05
+        }
+      ]
+    },
+    {
+      "space_type": "ResLiving",
+      "building_type": "MFm",
+      "water_use_equipment": [
+        {
+          "equipment_name": null,
+          "peak_flow_rate_gph": 3.48,
+          "peak_flow_rate_gph_per_floor_area_ft2": 0.003663158,
+          "loop_type": "One Per Unit",
+          "mixed_water_temperature_f": 110.0,
+          "flow_rate_schedule": "ApartmentMidRise APT_DHW_SCH",
+          "sensible_fraction": 0.2,
+          "latent_fraction": 0.05
+        }
+      ]
+    },
+    {
+      "space_type": "Work",
+      "building_type": "MLI",
+      "water_use_equipment": [
+        {
+          "equipment_name": null,
+          "peak_flow_rate_gph": null,
+          "peak_flow_rate_gph_per_floor_area_ft2": 0.001934756,
+          "loop_type": "Shared",
+          "mixed_water_temperature_f": 135.0,
+          "flow_rate_schedule": "D_MLI_All_DHW_DHW_Yr",
+          "sensible_fraction": 0.2,
+          "latent_fraction": 0.05
+        }
+      ]
+    },
+    {
+      "space_type": "Laundry",
+      "building_type": "Mtl",
+      "water_use_equipment": [
+        {
+          "equipment_name": null,
+          "peak_flow_rate_gph": null,
+          "peak_flow_rate_gph_per_floor_area_ft2": 0.135305351,
+          "loop_type": "Dedicated",
+          "mixed_water_temperature_f": 135.0,
+          "flow_rate_schedule": "D_Mtl_All_DHW_DHW_Yr",
+          "sensible_fraction": 0.2,
+          "latent_fraction": 0.05
+        }
+      ]
+    },
+    {
+      "space_type": "Kitchen",
+      "building_type": "Nrs",
+      "water_use_equipment": [
+        {
+          "equipment_name": null,
+          "peak_flow_rate_gph": null,
+          "peak_flow_rate_gph_per_floor_area_ft2": 0.116349097,
+          "loop_type": "Dedicated",
+          "mixed_water_temperature_f": 135.0,
+          "flow_rate_schedule": "D_Nrs_All_DHW_DHW_Yr",
+          "sensible_fraction": 0.2,
+          "latent_fraction": 0.05
+        }
+      ]
+    },
+    {
+      "space_type": "OfficeOpen",
+      "building_type": "OfL",
+      "water_use_equipment": [
+        {
+          "equipment_name": null,
+          "peak_flow_rate_gph": null,
+          "peak_flow_rate_gph_per_floor_area_ft2": 0.001699689,
+          "loop_type": "Shared",
+          "mixed_water_temperature_f": 135.0,
+          "flow_rate_schedule": "D_OfL_All_DHW_DHW_Yr",
+          "sensible_fraction": 0.2,
+          "latent_fraction": 0.05
+        }
+      ]
+    },
+    {
+      "space_type": "OfficeSmall",
+      "building_type": "OfS",
+      "water_use_equipment": [
+        {
+          "equipment_name": null,
+          "peak_flow_rate_gph": null,
+          "peak_flow_rate_gph_per_floor_area_ft2": 0.001311762,
+          "loop_type": "Shared",
+          "mixed_water_temperature_f": 135.0,
+          "flow_rate_schedule": "D_OfS_All_DHW_DHW_Yr",
+          "sensible_fraction": 0.2,
+          "latent_fraction": 0.05
+        }
+      ]
+    },
+    {
+      "space_type": "Kitchen",
+      "building_type": "RFF",
+      "water_use_equipment": [
+        {
+          "equipment_name": null,
+          "peak_flow_rate_gph": null,
+          "peak_flow_rate_gph_per_floor_area_ft2": 0.034460537,
+          "loop_type": "One Per Space",
+          "mixed_water_temperature_f": 135.0,
+          "flow_rate_schedule": "D_RFF_All_DHW_DHW_Yr",
+          "sensible_fraction": 0.2,
+          "latent_fraction": 0.05
+        }
+      ]
+    },
+    {
+      "space_type": "Kitchen",
+      "building_type": "RSD",
+      "water_use_equipment": [
+        {
+          "equipment_name": null,
+          "peak_flow_rate_gph": null,
+          "peak_flow_rate_gph_per_floor_area_ft2": 0.03112423,
+          "loop_type": "One Per Space",
+          "mixed_water_temperature_f": 135.0,
+          "flow_rate_schedule": "D_RSD_All_DHW_DHW_Yr",
+          "sensible_fraction": 0.2,
+          "latent_fraction": 0.05
+        }
+      ]
+    },
+    {
+      "space_type": "RetailSales",
+      "building_type": "Rt3",
+      "water_use_equipment": [
+        {
+          "equipment_name": null,
+          "peak_flow_rate_gph": null,
+          "peak_flow_rate_gph_per_floor_area_ft2": 0.0002815,
+          "loop_type": "Shared",
+          "mixed_water_temperature_f": 135.0,
+          "flow_rate_schedule": "D_Rt3_All_DHW_DHW_Yr",
+          "sensible_fraction": 0.2,
+          "latent_fraction": 0.05
+        }
+      ]
+    },
+    {
+      "space_type": "RetailSales",
+      "building_type": "RtL",
+      "water_use_equipment": [
+        {
+          "equipment_name": null,
+          "peak_flow_rate_gph": null,
+          "peak_flow_rate_gph_per_floor_area_ft2": 0.000350744,
+          "loop_type": "Shared",
+          "mixed_water_temperature_f": 135.0,
+          "flow_rate_schedule": "D_RtL_All_DHW_DHW_Yr",
+          "sensible_fraction": 0.2,
+          "latent_fraction": 0.05
+        }
+      ]
+    },
+    {
+      "space_type": "RetailSales",
+      "building_type": "RtS",
+      "water_use_equipment": [
+        {
+          "equipment_name": null,
+          "peak_flow_rate_gph": null,
+          "peak_flow_rate_gph_per_floor_area_ft2": 0.000674871,
+          "loop_type": "Shared",
+          "mixed_water_temperature_f": 135.0,
+          "flow_rate_schedule": "D_RtS_All_DHW_DHW_Yr",
+          "sensible_fraction": 0.2,
+          "latent_fraction": 0.05
+        }
+      ]
+    },
+    {
+      "space_type": "WarehouseCond",
+      "building_type": "SCn",
+      "water_use_equipment": [
+        {
+          "equipment_name": null,
+          "peak_flow_rate_gph": null,
+          "peak_flow_rate_gph_per_floor_area_ft2": 0.000104042,
+          "loop_type": "Shared",
+          "mixed_water_temperature_f": 135.0,
+          "flow_rate_schedule": "D_SCn_All_DHW_DHW_Yr",
+          "sensible_fraction": 0.2,
+          "latent_fraction": 0.05
+        }
+      ]
+    },
+    {
+      "space_type": "WarehouseUnCond",
+      "building_type": "SUn",
+      "water_use_equipment": [
+        {
+          "equipment_name": null,
+          "peak_flow_rate_gph": null,
+          "peak_flow_rate_gph_per_floor_area_ft2": 0.000104042,
+          "loop_type": "Shared",
+          "mixed_water_temperature_f": 135.0,
+          "flow_rate_schedule": "D_SUn_All_DHW_DHW_Yr",
+          "sensible_fraction": 0.2,
+          "latent_fraction": 0.05
+        }
+      ]
     }
   ]
 }

--- a/test/modules/service_water_heating/test_create_typical.rb
+++ b/test/modules/service_water_heating/test_create_typical.rb
@@ -247,4 +247,22 @@ class TestCreateTypicalServiceWaterHeating < Minitest::Test
 
     model.save("#{output_dir}/out.osm", true)
   end
+
+  def test_create_typical_service_water_heating_deer_school
+    # set output directory
+    output_dir = "#{__dir__}/output/#{__method__}"
+    FileUtils.mkdir_p output_dir
+
+    model = @std.safe_load_model("#{__dir__}/../../deer_prototype/models/epr_test.osm")
+    model.save("#{output_dir}/in.osm", true)
+
+    # remove swh loops
+    model.getPlantLoops.each { |swh_loop| swh_loop.remove unless (swh_loop.name == 'Hot Water Loop') }
+
+    # default water heater
+    created_loops = @swh.create_typical_service_water_heating(model)
+    assert(created_loops.size > 1, "Expected more than 1 service water heating loop.")
+
+    model.save("#{output_dir}/out.osm", true)
+  end
 end


### PR DESCRIPTION
Pull request overview
---------------------
Add back in the existing DEER data in openstudio-standards to the service water heating module.
There is no attempt at reconciliation of differences between typical service water with ASHRAE prototypes

Fixes issue of California ComStock models not having service water heating.

### Pull Request Author
 - [x] Data changes or additions
 - [x] Added tests for added methods
 - [x] All new and existing tests passes

### Review Checklist
 - [x] Perform a code review on GitHub
 - [x] All related changes have been implemented: method additions, changes, tests
 - [x] If fixing a defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [x] CI status: all green or justified
