### PR TITLE
Fixes TBD unit test for good/bad derating cases

### DIFF
--- a/lib/openstudio-standards/btap/structure.rb
+++ b/lib/openstudio-standards/btap/structure.rb
@@ -201,8 +201,8 @@ module BTAP
     #  "recreation"  gymnastics, ice arena, indoor soccer/pool
     #      "robust"  penitentiary, parking garage (i.e. heavyduty, resistant)
     #
-    # Each CATEGORY holds "small"-scale and "large"-scale STRUCTURE options by
-    # defaults, depending on the characteristics of the building.
+    # Each CATEGORY holds default "small"-scale and "large"-scale STRUCTURE
+    # options, set based on building characteristics.
     @@data[:category]               = {}
     @@data[:category]["housing"   ] = {small: :wood    , large: :concrete}
     @@data[:category]["lodging"   ] = {small: :wood    , large: :concrete}
@@ -303,7 +303,7 @@ module BTAP
       cat = activity.category
       lload = activity.liveload
 
-      if cat.respond_to?(:to_s)
+      if cat.respond_to?(:to_sym)
         cat = cat.to_s.downcase
 
         if cat.empty?
@@ -411,19 +411,22 @@ module BTAP
       iwall_m2  = TBD.facets(cspaces, "surface", "wall").map(&:grossArea).sum
 
       # In OpenStudio, partitions are usually limited to interzone walls between
-      # zones, in order to save on simulation times. Partitions typically absent
-      # from a model include walls surrounding lobbies, stairwells, WCs and
-      # technical rooms, as well as separations between similar rooms (e.g.
-      # multiple, side-by-side enclosed offices, a row of hotel rooms).
-      # Comparing BTAP prototype models and samples of building plans for
-      # similar facilities suggest matching modelled partition m2 (or total
-      # floor m2) as a suitable basis to determine the weight of non-modelled
-      # partitions. As this estimate may be more on the high side for many
-      # prototype models, fixed appliances (e.g. fixtures, counters, doors and
-      # windows) are considered included.
-      # partition_m2 = iwall_m2
-      # partition_m2 = floor_m2 if partition_m2 > floor_m2
-      partition_m2 = floor_m2
+      # zones to save on simulation times. Partitions typically absent from a
+      # model include walls surrounding lobbies, stairwells, WCs and technical
+      # rooms, as well as separations between similar rooms (e.g. multiple,
+      # side-by-side enclosed offices, a row of hotel rooms). Comparing BTAP
+      # prototype models and samples of building plans for similar facilities
+      # suggests matching modelled partition m2 with floor m2 as a suitable
+      # basis to determine the mass of non-modelled partitions. As this estimate
+      # may be more on the high side for many prototype models, fixed appliances
+      # (e.g. fixtures, counters, doors and windows) are considered included.
+      # Adjust for larger spaces, based on building category.
+      case @@data[:category]
+      when "commerce"   then partition_m2 = floor_m2 / 2
+      when "industry"   then partition_m2 = floor_m2 / 4
+      when "recreation" then partition_m2 = floor_m2 / 3
+      else                   partition_m2 = floor_m2
+      end
 
       # For wood-framed partitions, representative material volumes (per m2):
       #  - 16% wood-framing: 0.0224 m3/m2 x 540 kg/m3 =  12.1 kg/m2 (35.7%)
@@ -467,11 +470,12 @@ module BTAP
       #     - if structure :wood
       #       - 1/2 :clt                              =  48 kg/m
 
-      # Fetch approx. total column height (m) in building (including plenums).
+      # Fetch approx. total column height (m).
       column_m = 0
 
       model.getSpaces.each do |space|
-        column_m += BTAP::Geometry::Spaces.space_height(space) * 15 / 1000
+        height    = BTAP::Geometry::Spaces.space_height(space)
+        column_m += height * space.floorArea * 15 / 1000
       end
 
       case @structure
@@ -555,80 +559,42 @@ module BTAP
         mass.setSpace(space)
       end
 
-      # Embodied CO2-e kg (A1-A3) of a model is tallied separately as follows:
-      @co2              = {}
-      @co2[:structure ] = 0
-      @co2[:insulation] = 0
-      @co2[:cladding  ] = 0
-
-      # The :structure key/value pair includes above grade 'structures' (e.g.
-      # slabs, columns) and 'framing' (e.g. wood-framed vs steel-framed). Why
-      # grouped together? In many smaller-scale facilities, structure and
-      # framing are synonymous, or at least tightly coupled, e.g.:
-      #   - load-bearing wood-framed walls in small-scale residential
-      #   - load-bearing CMU walls in small-scale industrial
-      #   - metal buildings
+      # Embodied CO2-e kg (A1-A3?) of a model's structure includes:
+      #   - non-modelled above grade items (e.g. columns)
+      #   - non-modelled partitions
       #
       # Below-grade structures (rebar + poured concrete) are ignored - no
       # alternative options are considered for the moment, e.g. lower carbon
       # concrete mixes.
-      #
-      # Upon initialization, only the :structure tally is set. It is assumed
-      # that structure (and main framing) do not change with NECB U-factor
-      # requirements, e.g.:
-      #   - NECB 2011 vs 2020
-      #   - Vancouver vs Calgary
-      #
-      # Once default construction sets are (later) established (+), followed by
-      # TBD uprating assemblies as per NECB 2017 & 2020 requirements (++),
-      # embodied carbon tallies can be updated/reset, which would include:
-      #   - cladding
-      #   - insulation
-      #   - secondary framing (proportional to insulation thicknesses)
-      #
-      #  (+) openstudio-standards/standards/necb/NECB2011/building_envelope.rb
-      # (++) openstudio-standards/btap/bridging.rb
+      @co2 = {structure: 0}
 
-      # Start with occupied floors & roofs (exclude slabs on grade).
-      m2 = ofloor_m2 + ifloor_m2 + roof_m2
-
+      # Add columns.
       case @structure
-      when :wood     then # engineered I-joists + plywood
-        floor_kg    = 50.0 * m2
-        floor_m3    = floor_kg / 540.0                  # kg/m3
-        floor_co2kg = floor_m3 * 55.0 / floor_kg        # kgCO2-e/kg
-      when :concrete then # 200mm flat slab, 3% rebar + accessories
-        floor_m3    = 0.200 * m2
-        floor_kgm3  = (0.03 * 7850.0) + (0.97 * 2240.0) # kg/m3
-        floor_co2kg = (0.03 * 0.854 ) + (0.97 *  0.250) # kgCO2-e/kg
-        floor_kg    = floor_m3 * floor_kgm3
-      else # :steel, includes joists/fasteners
-        floor_m3    = 0.125 * m2
-        floor_kgm3  = (0.08 * 7850.0) + (0.92 * 2240.0) # kg/m3
-        floor_co2kg = (0.08 * 0.854 ) + (0.92 *  0.250) # kgCO2-e/kg
-        floor_kg    = floor_m3 * floor_kgm3
+      when :steel then cl_co2 =  0.854 * (column_m * 190) # 0.854 kgCO2-e/kg
+      when :metal then cl_co2 =  0.854 * (column_m * 190) # 0.854 kgCO2-e/kg
+      when :wood  then cl_co2 = 55.000 * (column_m *  48) / 540 # 55 kgCO2-e/m3
+      when :clt   then cl_co2 = 55.000 * (column_m *  96) / 540 # 55 kgCO2-e/m3
+      else             cl_co2 =  0.268 * (column_m *  96) # 0.268 kgCO2-e/kg
       end
 
-      @co2[:structure] += floor_co2kg * floor_kg
+      @co2[:structure] += cl_co2
 
-      # Add exposed walls and interior partitions.
-      m2 = wall_m2 + iwall_m2 + partition_m2
+      # Add interior partitions.
+      m2 = partition_m2
 
       case @framing
-      when :wood then # basic 2x6 construction, 16% of framing cavity
-        wall_kg    =  12.1 * m2
-        wall_co2kg =  55.0 / 540.0 # 55 kgCO2-e/m3 / density
+      when :wood then
+        partition_co2kg = 55.0 / 540.0 # 55 kgCO2-e/m3 / density
       when :cmu  then # 250mm medium weight CMU, 200 kgCO2-e/m3
-        wall_m3    = 0.250 * m2    # nominal m3
-        wall_kg    = 250.0 * m2    # volume-weighted concrete/air/grout
-        wall_kgm3  = 0.250 / 250.0
-        wall_co2kg = 200.0 / wall_kgm3 # 200 kgCO2-e/m3 / density
-      else # :steel, 1% lightweight steel-framing
-        wall_kg    =   4.7 * m2
-        wall_co2kg = 2.440
+        partition_m3    = 0.250 * m2 # nominal m3
+        partition_kg    = 250.0 * m2 # volume-weighted concrete/air/grout
+        partition_kgm3  = pt_kg / partition_m3
+        partition_co2kg = 200.0 / partition_kgm3 # 200 kgCO2-e/m3 / density
+      else # :steel, 1% lightweight steel-framing + drywall
+        partition_co2kg = 2.440
       end
 
-      @co2[:structure] += wall_co2kg * wall_kg
+      @co2[:structure] += partition_kgm2 * m2 * partition_co2kg
 
       true
     end

--- a/test/necb/unit_tests/tests/test_NECB_TBD.rb
+++ b/test/necb/unit_tests/tests/test_NECB_TBD.rb
@@ -24,7 +24,7 @@ class NECB_TBD_Tests < Minitest::Test
 
     # Range of test options.
     @templates = [
-      # 'NECB2011',
+      'NECB2011',
       # 'NECB2015',
       # 'NECB2017',
       'NECB2020'
@@ -52,8 +52,8 @@ class NECB_TBD_Tests < Minitest::Test
       # 'RetailStripmall',
       # 'SecondarySchool',
       # 'SmallHotel',
-      # 'SmallOffice',
-      # 'Warehouse'
+      'SmallOffice',
+      'Warehouse'
     ]
 
     # (*) 'NorthernEducation' and 'NorthernHealthCare' have neither:
@@ -64,7 +64,7 @@ class NECB_TBD_Tests < Minitest::Test
     #         BTAP::Activity features - @todo.
 
     @structure = [
-      # '',
+      '',
       'structure'
     ]
 
@@ -82,8 +82,8 @@ class NECB_TBD_Tests < Minitest::Test
     #        surfaces with their initial, code-required Uo factors.
     #
     @options = [
-      # 'none',
-      # 'bad',
+      'none',
+      'bad',
       # 'good',
       'uprate'
     ]
@@ -161,6 +161,7 @@ class NECB_TBD_Tests < Minitest::Test
                   assert(surface.isConstructionDefaulted, err_msg)
 
                   lc      = surface.construction
+                  film    = surface.filmResistance
                   err_msg = "BTAP/TBD: #{id} construction (#{cas})?"
                   refute_empty(lc, err_msg)
                   lc      = lc.get.to_LayeredConstruction
@@ -207,12 +208,12 @@ class NECB_TBD_Tests < Minitest::Test
                   # So there's quite a gap between insulated vs uninsulated
                   # constructions when working with the NECBs. A potentially
                   # simple way of determining whether an assembly is indeed
-                  # insulated/costed: if rsi > 1.0.
+                  # insulated/costed: if TBD.rsi() > 1.0.
                   err_msg = "BTAP/TBD: #{id} attic rsi (#{cas})?"
 
                   if attic
                     if boundary == "outdoors"
-                      assert(TBD.rsi(lc) < 1.0, err_msg) # uninsulated
+                      assert(TBD.rsi(lc, film) < 1.0, err_msg) # uninsulated
                     else
                       adjacent = surface.adjacentSurface
                       err_msg  = "BTAP/TBD: #{id} adjacent (#{cas})?"
@@ -229,18 +230,18 @@ class NECB_TBD_Tests < Minitest::Test
                       refute_empty(prop, err_msg)
 
                       if other.partofTotalFloorArea
-                        assert(TBD.rsi(lc) > 1.0, err_msg) # insulated
+                        assert(TBD.rsi(lc, film) > 1.0, err_msg)   # insulated
                       else
-                        if prop.get.downcase == "unconditioned" # another attic?
-                          assert(TBD.rsi(lc) < 1.0, err_msg)    # uninsulated
+                        if prop.get.downcase == "unconditioned"    # 2nd attic?
+                          assert(TBD.rsi(lc, film) < 1.0, err_msg) # uninsulated
                         else
-                          assert(TBD.rsi(lc) > 1.0, err_msg)    # insulated
+                          assert(TBD.rsi(lc, film) > 1.0, err_msg) # insulated
                         end
                       end
                     end
                   else
                     if boundary == "outdoors"
-                      assert(TBD.rsi(lc) > 1.0, err_msg) # insulated
+                      assert(TBD.rsi(lc, film) > 1.0, err_msg) # insulated
                     end
                   end
                 end
@@ -291,6 +292,7 @@ class NECB_TBD_Tests < Minitest::Test
                   next unless surfaces[id][:heatloss ].abs > TBD::TOL
 
                   lc      = surface.construction
+                  film    = surface.filmResistance
                   err_msg = "BTAP/TBD: #{id} construction (#{cas})?"
                   refute_empty(lc, err_msg)
                   lc      = lc.get.to_LayeredConstruction
@@ -301,25 +303,28 @@ class NECB_TBD_Tests < Minitest::Test
                   err_msg = "Failed TBD processes (#{cas})?"
                   assert_includes(nom, " c tbd", err_msg)
 
-                  prop    = surface.additionalProperties.getFeatureAsDouble(tg)
+                  prop = surface.additionalProperties.getFeatureAsDouble(tg)
                   err_msg = "BTAP/TBD: #{id} uprated Uo (#{cas})?"
-                  refute_empty(prop, err_msg)
 
-                  # Initial, uprated Uo, e.g. (FullServiceRestaurant):
-                  #   0:1:1:0:1:Dining : 0.130 (R44) # skylight well wall
-                  #   0:1:1:Dining     : 0.100 (R57) # insulated attic ceiling
-                  uo = prop.get
-                  # puts "#{id} : #{uo.round(3)} vs #{(1/TBD.rsi(lc)).round(3)}"
+                  unless option == 'uprate'
+                    assert_empty(prop, err_msg)
+                  else
+                    refute_empty(prop, err_msg)
 
-                  err_msg = "BTAP/TBD: #{id} Uo vs U (#{cas})?"
-                  assert(uo < 1/TBD.rsi(lc))
+                    # Initial, uprated Uo, e.g. (FullServiceRestaurant):
+                    #   0:1:1:0:1:Dining : 0.130 (R44) # skylight well wall
+                    #   0:1:1:Dining     : 0.100 (R57) # insulated attic ceiling
+                    uo = prop.get
+                    # puts "#{id} : #{uo.round(3)} vs #{(1/TBD.rsi(lc, film)).round(3)}"
+
+                    err_msg = "BTAP/TBD: #{id} Uo vs U (#{cas})?"
+                    assert(uo < 1/TBD.rsi(lc, film))
+                  end
                 end
 
-                st.tbd.feedback[:logs].each do |log|
-                  fdback << log
-                  # NOTE: BTAP/TBD feedback logs are simple strings. Look up
-                  # st.tbd.tally Hash to extract quantities for costing.
-                end
+                # Note: BTAP/TBD feedback logs are simple strings. Look up
+                #       st.tbd.tally Hash to extract quantities for costing.
+                st.tbd.feedback[:logs].each { |log| fdback << log }
               end
             end                # |inter    |
           end                  # |option   |

--- a/test/necb/unit_tests/tests/test_necb_structures.rb
+++ b/test/necb/unit_tests/tests/test_necb_structures.rb
@@ -123,7 +123,7 @@ class NECB_Structure_Tests < Minitest::Test
                 else
                   id = c.layers.last.nameString
                   err_msg = "BTAP::Structure #{id} insulation layer (#{cas})?"
-                  assert_includes(id, "cellulose", err_msg)
+                  assert_includes(id, "OSut:K", err_msg)
                 end
               end
             end

--- a/test/necb/unit_tests/tests/test_necb_structures.rb
+++ b/test/necb/unit_tests/tests/test_necb_structures.rb
@@ -33,16 +33,16 @@ class NECB_Structure_Tests < Minitest::Test
       # 'LEEPPointTower',
       # 'LEEPTownHouse',
       # 'LEEPMultiTower',
-      'LowriseApartment',
+      # 'LowriseApartment',
       'MediumOffice',
-      'MidriseApartment',
+      # 'MidriseApartment',
       # 'Outpatient',
       # 'PrimarySchool',
-      'QuickServiceRestaurant',
-      'RetailStandalone',
-      'RetailStripmall',
+      # 'QuickServiceRestaurant',
+      # 'RetailStandalone',
+      # 'RetailStripmall',
       # 'SecondarySchool',
-      'SmallHotel',
+      # 'SmallHotel',
       'SmallOffice',
       'Warehouse'
     ]
@@ -55,7 +55,7 @@ class NECB_Structure_Tests < Minitest::Test
     ]
 
     @options = [
-      "",
+      # "",
       "structure"
     ]
 


### PR DESCRIPTION
In support of branch _nrcan_476_:

 - fixes TBD unit test to cover simple _derating_ cases: "good" and "bad" PSI factor sets
 - preps for embodied carbon estimates of non-modelled structural elements (e.g. columns, bracing, cabinets)
 - embodied GHG (structure, non-modelled partitions) may need tweaking at some point - _OK for now_

@nicholaspneu : merge with _nrcan_476_ at your convenience.
