### PR TITLE
Adds structure-based kgCO2-e AdditionalProperty (building)

### DIFF
--- a/lib/openstudio-standards/btap/structure.rb
+++ b/lib/openstudio-standards/btap/structure.rb
@@ -596,28 +596,11 @@ module BTAP
 
       @co2[:structure] += partition_kgm2 * m2 * partition_co2kg
 
+      # Set an AdditionalProperty for tallied CO2-e [kg] (A1-A3):
+      tag = "co2_structure"
+      bldg.additionalProperties.setFeature(tag, @co2[:structure])
+
       true
-    end
-
-    ##
-    # Updates and returns embodied carbon estimates (A1-A3).
-    #
-    # @param model [OpenStudio::Model::Model] a model
-    #
-    # @return [Hash] embodied carbon tally (CO2-e kg, A1-A3)
-    def tallyCO2(model)
-      mth = "BTAP::Structure::#{__callee__}"
-      cl  = OpenStudio::Model::Model
-      lgs = @feedback[:logs]
-
-      unless model.is_a?(cl)
-        lgs << "Invalid OpenStudio model (#{mth})"
-        return 0
-      end
-
-      # @todo
-
-      @co2
     end
   end
 end

--- a/test/necb/unit_tests/tests/test_necb_structures.rb
+++ b/test/necb/unit_tests/tests/test_necb_structures.rb
@@ -33,13 +33,13 @@ class NECB_Structure_Tests < Minitest::Test
       # 'LEEPPointTower',
       # 'LEEPTownHouse',
       # 'LEEPMultiTower',
-      # 'LowriseApartment',
-      'MediumOffice',
+      'LowriseApartment',
+      # 'MediumOffice',
       # 'MidriseApartment',
       # 'Outpatient',
       # 'PrimarySchool',
-      # 'QuickServiceRestaurant',
-      # 'RetailStandalone',
+      'QuickServiceRestaurant',
+      'RetailStandalone',
       # 'RetailStripmall',
       # 'SecondarySchool',
       # 'SmallHotel',
@@ -55,9 +55,12 @@ class NECB_Structure_Tests < Minitest::Test
     ]
 
     @options = [
-      # "",
+      "",
       "structure"
     ]
+
+    tg  = "co2_structure"
+    tag = "space_conditioning_category"
 
     fdback = []
     fdback << ""
@@ -69,14 +72,20 @@ class NECB_Structure_Tests < Minitest::Test
         @templates.sort.each do |template |
           @options.sort.each do |option   |
             cas   = "CASE #{building} (#{template})"
-            cas  += " #" unless option.empty?
-            tag   = "space_conditioning_category"
+            cas  += ":" unless option.empty?
+
             st    = Standard.build(template)
             model = st.model_create_prototype_model(template: template,
                                                     epw_file: epw,
                                                     building_type: building,
                                                     construction_opt: option,
                                                     sizing_run_dir: @sizing_run_dir)
+
+            co2 = model.getBuilding.additionalProperties.getFeatureAsDouble(tg)
+
+            err_msg = "BTAP/TBD: BLDG kgCO2-e (#{cas})?"
+            refute_empty(co2, err_msg)
+            co2 = co2.get
 
             nb  = model.getBuilding.standardsNumberOfAboveGroundStories.get
             nst = nb < 2 ? "#{nb} storey" : "#{nb} stories"
@@ -234,6 +243,9 @@ class NECB_Structure_Tests < Minitest::Test
             end
 
             if @test_passed
+              err_msg = "BTAP::Structure BUILDING kgCO2-e (#{cas})?"
+              assert_equal(s.co2[:structure].round(2), co2.round(2), err_msg)
+
               co2m2 = ": #{(s.co2[:structure]/floor_m2).round} kgCO2-e/m2 (A1-A3)"
               fdback << "#{cas} : #{s.category} (#{s.structure}, #{nst})" + co2m2
             end


### PR DESCRIPTION
As requested, _AdditionalProperty_ "co2_structure" (embodied kgCO2-e), assigned to _building_ object:

- non-modelled structural elements (e.g. columns, bracing)
- non-modelled partitions

In support of costing & embodied carbon updates (branch _nrcan_476_).

Merge whenever ...